### PR TITLE
Fruit machines: Update layouts with fixes and improvements

### DIFF
--- a/src/mame/layout/j2adnote.lay
+++ b/src/mame/layout/j2adnote.lay
@@ -4571,9 +4571,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2always.lay
+++ b/src/mame/layout/j2always.lay
@@ -2844,9 +2844,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2bankch.lay
+++ b/src/mame/layout/j2bankch.lay
@@ -3930,9 +3930,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2bigbnk.lay
+++ b/src/mame/layout/j2bigbnk.lay
@@ -4386,9 +4386,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2bigbox.lay
+++ b/src/mame/layout/j2bigbox.lay
@@ -4222,9 +4222,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2blustr.lay
+++ b/src/mame/layout/j2blustr.lay
@@ -3936,9 +3936,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cashbn.lay
+++ b/src/mame/layout/j2cashbn.lay
@@ -4129,9 +4129,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cashrl.lay
+++ b/src/mame/layout/j2cashrl.lay
@@ -4072,9 +4072,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cashro.lay
+++ b/src/mame/layout/j2cashro.lay
@@ -4334,9 +4334,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cashrv.lay
+++ b/src/mame/layout/j2cashrv.lay
@@ -3648,9 +3648,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cashtk.lay
+++ b/src/mame/layout/j2cashtk.lay
@@ -3997,9 +3997,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2coinsh.lay
+++ b/src/mame/layout/j2coinsh.lay
@@ -3670,9 +3670,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2coppot.lay
+++ b/src/mame/layout/j2coppot.lay
@@ -4097,9 +4097,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cprndx.lay
+++ b/src/mame/layout/j2cprndx.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
@@ -3062,9 +3064,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
@@ -3088,7 +3090,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="733" height="680"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j2criscr.lay
+++ b/src/mame/layout/j2criscr.lay
@@ -2964,9 +2964,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2crown.lay
+++ b/src/mame/layout/j2crown.lay
@@ -2540,9 +2540,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cshalm.lay
+++ b/src/mame/layout/j2cshalm.lay
@@ -4002,9 +4002,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cshcrd.lay
+++ b/src/mame/layout/j2cshcrd.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
@@ -4058,9 +4060,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
@@ -4084,7 +4086,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="943" height="693"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j2cshfil.lay
+++ b/src/mame/layout/j2cshfil.lay
@@ -4050,9 +4050,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cshnud.lay
+++ b/src/mame/layout/j2cshnud.lay
@@ -2848,9 +2848,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cshsmh.lay
+++ b/src/mame/layout/j2cshsmh.lay
@@ -4274,9 +4274,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2cvault.lay
+++ b/src/mame/layout/j2cvault.lay
@@ -4212,9 +4212,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2droplt.lay
+++ b/src/mame/layout/j2droplt.lay
@@ -3410,9 +3410,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2ewn.lay
+++ b/src/mame/layout/j2ewn.lay
@@ -2836,9 +2836,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2ews.lay
+++ b/src/mame/layout/j2ews.lay
@@ -2820,9 +2820,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2exec.lay
+++ b/src/mame/layout/j2exec.lay
@@ -3775,9 +3775,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2fasttk.lay
+++ b/src/mame/layout/j2fasttk.lay
@@ -4622,9 +4622,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2fiveal.lay
+++ b/src/mame/layout/j2fiveal.lay
@@ -4196,9 +4196,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2fiveln.lay
+++ b/src/mame/layout/j2fiveln.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_299_1_border" defstate="0">
 		<rect state="1">
@@ -3208,9 +3210,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
@@ -3234,7 +3236,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="750" height="860"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j2fqueen.lay
+++ b/src/mame/layout/j2fqueen.lay
@@ -3791,9 +3791,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2frucnx.lay
+++ b/src/mame/layout/j2frucnx.lay
@@ -3658,9 +3658,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2fullhs.lay
+++ b/src/mame/layout/j2fullhs.lay
@@ -3681,9 +3681,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2fws.lay
+++ b/src/mame/layout/j2fws.lay
@@ -3446,9 +3446,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2ghostb.lay
+++ b/src/mame/layout/j2ghostb.lay
@@ -2566,9 +2566,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2gldchy.lay
+++ b/src/mame/layout/j2gldchy.lay
@@ -2752,9 +2752,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2goldbr.lay
+++ b/src/mame/layout/j2goldbr.lay
@@ -2706,9 +2706,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2hilocl.lay
+++ b/src/mame/layout/j2hilocl.lay
@@ -3781,9 +3781,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2hinote.lay
+++ b/src/mame/layout/j2hinote.lay
@@ -4217,9 +4217,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2hiroll.lay
+++ b/src/mame/layout/j2hiroll.lay
@@ -4161,9 +4161,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2hitmon.lay
+++ b/src/mame/layout/j2hitmon.lay
@@ -4092,9 +4092,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2hotpot.lay
+++ b/src/mame/layout/j2hotpot.lay
@@ -3398,9 +3398,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2hotsht.lay
+++ b/src/mame/layout/j2hotsht.lay
@@ -3961,9 +3961,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2hypnot.lay
+++ b/src/mame/layout/j2hypnot.lay
@@ -4855,9 +4855,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2jackbr.lay
+++ b/src/mame/layout/j2jackbr.lay
@@ -2606,9 +2606,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2kingcl.lay
+++ b/src/mame/layout/j2kingcl.lay
@@ -2967,9 +2967,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2litean.lay
+++ b/src/mame/layout/j2litean.lay
@@ -2880,9 +2880,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2litnot.lay
+++ b/src/mame/layout/j2litnot.lay
@@ -3717,9 +3717,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2lovshd.lay
+++ b/src/mame/layout/j2lovshd.lay
@@ -3602,9 +3602,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2lovsht.lay
+++ b/src/mame/layout/j2lovsht.lay
@@ -3662,9 +3662,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2luckar.lay
+++ b/src/mame/layout/j2luckar.lay
@@ -2698,9 +2698,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2lucky2.lay
+++ b/src/mame/layout/j2lucky2.lay
@@ -3268,9 +3268,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2maxima.lay
+++ b/src/mame/layout/j2maxima.lay
@@ -2630,9 +2630,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2missis.lay
+++ b/src/mame/layout/j2missis.lay
@@ -3521,9 +3521,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2monblt.lay
+++ b/src/mame/layout/j2monblt.lay
@@ -3704,9 +3704,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2mongam.lay
+++ b/src/mame/layout/j2mongam.lay
@@ -4145,9 +4145,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2montrp.lay
+++ b/src/mame/layout/j2montrp.lay
@@ -3382,9 +3382,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2nolimt.lay
+++ b/src/mame/layout/j2nolimt.lay
@@ -3140,9 +3140,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2notesh.lay
+++ b/src/mame/layout/j2notesh.lay
@@ -4678,9 +4678,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2nudbnz.lay
+++ b/src/mame/layout/j2nudbnz.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
@@ -3670,9 +3672,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
@@ -3696,7 +3698,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="627" height="677"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j2nudfev.lay
+++ b/src/mame/layout/j2nudfev.lay
@@ -3790,9 +3790,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2nudmon.lay
+++ b/src/mame/layout/j2nudmon.lay
@@ -5042,9 +5042,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2nudshf.lay
+++ b/src/mame/layout/j2nudshf.lay
@@ -3738,9 +3738,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2paypkt.lay
+++ b/src/mame/layout/j2paypkt.lay
@@ -3900,9 +3900,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2penny.lay
+++ b/src/mame/layout/j2penny.lay
@@ -3518,9 +3518,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2plsmnd.lay
+++ b/src/mame/layout/j2plsmnd.lay
@@ -4067,9 +4067,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2plsnud.lay
+++ b/src/mame/layout/j2plsnud.lay
@@ -3340,9 +3340,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2pndrsh.lay
+++ b/src/mame/layout/j2pndrsh.lay
@@ -4508,9 +4508,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2rdclb.lay
+++ b/src/mame/layout/j2rdclb.lay
@@ -3639,9 +3639,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2reelbn.lay
+++ b/src/mame/layout/j2reelbn.lay
@@ -3639,9 +3639,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2reelbo.lay
+++ b/src/mame/layout/j2reelbo.lay
@@ -3587,9 +3587,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2reelcz.lay
+++ b/src/mame/layout/j2reelcz.lay
@@ -3350,9 +3350,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2reelmc.lay
+++ b/src/mame/layout/j2reelmc.lay
@@ -3989,9 +3989,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2reelmo.lay
+++ b/src/mame/layout/j2reelmo.lay
@@ -4268,9 +4268,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2silvcl.lay
+++ b/src/mame/layout/j2silvcl.lay
@@ -2596,9 +2596,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2silvsh.lay
+++ b/src/mame/layout/j2silvsh.lay
@@ -2596,9 +2596,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2sldgld.lay
+++ b/src/mame/layout/j2sldgld.lay
@@ -4059,9 +4059,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2slvrgh.lay
+++ b/src/mame/layout/j2slvrgh.lay
@@ -2738,9 +2738,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2spcrsv.lay
+++ b/src/mame/layout/j2spcrsv.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
@@ -3730,9 +3732,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
@@ -3756,7 +3758,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="624" height="651"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j2sstrea.lay
+++ b/src/mame/layout/j2sstrea.lay
@@ -3998,9 +3998,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2stahed.lay
+++ b/src/mame/layout/j2stahed.lay
@@ -3073,9 +3073,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2supfrc.lay
+++ b/src/mame/layout/j2supfrc.lay
@@ -3127,9 +3127,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2suprsh.lay
+++ b/src/mame/layout/j2suprsh.lay
@@ -3534,9 +3534,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2supsft.lay
+++ b/src/mame/layout/j2supsft.lay
@@ -5196,9 +5196,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2supstp.lay
+++ b/src/mame/layout/j2supstp.lay
@@ -3323,9 +3323,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2suptrk.lay
+++ b/src/mame/layout/j2suptrk.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_2_1_border" defstate="0">
 		<rect state="1">
@@ -4014,9 +4016,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
@@ -4040,7 +4042,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1019" height="668"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j2swbank.lay
+++ b/src/mame/layout/j2swbank.lay
@@ -4390,9 +4390,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2take2.lay
+++ b/src/mame/layout/j2take2.lay
@@ -3390,9 +3390,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2trail.lay
+++ b/src/mame/layout/j2trail.lay
@@ -3828,9 +3828,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j2tstplt.lay
+++ b/src/mame/layout/j2tstplt.lay
@@ -4672,9 +4672,9 @@
 		</text>
 	</element>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j6bnkrcl.lay
+++ b/src/mame/layout/j6bnkrcl.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="reel_background">
 		<rect>
@@ -2160,7 +2162,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="763" height="948"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j6swpdrp.lay
+++ b/src/mame/layout/j6swpdrp.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
@@ -4220,7 +4222,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="664" height="701"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j6twst.lay
+++ b/src/mame/layout/j6twst.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
@@ -3882,7 +3884,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="669" height="702"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/j80golds.lay
+++ b/src/mame/layout/j80golds.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
@@ -2658,7 +2660,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="584" height="425"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m1albsqp.lay
+++ b/src/mame/layout/m1albsqp.lay
@@ -8,11424 +8,7191 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="pauline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="pauline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="cindy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="cindy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="grant">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="grant">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="ian">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="ian">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="bridge street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="bridge street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TRICKY dicky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRICKY dicky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="frANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="frANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TRICKY dicky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRICKY dicky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="arthur">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="arthur">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="albert Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="albert Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="fruit stall feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="fruit stall feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="fruit stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="fruit stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="albert">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="albert">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Garage Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Garage Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Empty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Empty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="The Queen Victoria">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="The Queen Victoria">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="m.o.t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="m.o.t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="service">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="service">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose Your Stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose Your Stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Pay a Bribe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pay a Bribe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="cafe feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="cafe feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_192_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_192">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="dosh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_199_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_199">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_200_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_200">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_201_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_201">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="exCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_202_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_202">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_203_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_203">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_204_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_204">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_205_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_205">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_9">
 		<text string="nudge pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_176">
 		<text string="TRICKY dicky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_190">
 		<text string="3 Albert Squares on winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Awards Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_191">
 		<text string="http://www.reelfruits.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="918" height="685">
-			</bounds>
+			<bounds x="0" y="0" width="918" height="685"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="223" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="223" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="223.0000" y="463.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="223.0000" y="463.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="226.3333" y="464.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="226.3333" y="464.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="229.6667" y="466.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="229.6667" y="466.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="233.0000" y="468.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="233.0000" y="468.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="236.3333" y="470.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="236.3333" y="470.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="239.6667" y="472.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="239.6667" y="472.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="223.0000" y="509.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="223.0000" y="509.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="226.3333" y="511.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="226.3333" y="511.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="229.6667" y="513.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="229.6667" y="513.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="233.0000" y="515.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="233.0000" y="515.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="236.3333" y="517.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="236.3333" y="517.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="239.6667" y="519.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="239.6667" y="519.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="223.0000" y="556.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="223.0000" y="556.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="226.3333" y="558.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="226.3333" y="558.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="229.6667" y="560.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="229.6667" y="560.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="233.0000" y="562.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="233.0000" y="562.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="236.3333" y="564.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="236.3333" y="564.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="239.6667" y="566.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="239.6667" y="566.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="223" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="223" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="305" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="305" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="305.0000" y="463.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="305.0000" y="463.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="308.3333" y="464.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="308.3333" y="464.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="311.6667" y="466.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="311.6667" y="466.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="315.0000" y="468.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="315.0000" y="468.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="318.3333" y="470.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="318.3333" y="470.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="321.6667" y="472.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="321.6667" y="472.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="305.0000" y="509.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="305.0000" y="509.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="308.3333" y="511.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="308.3333" y="511.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="311.6667" y="513.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="311.6667" y="513.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="315.0000" y="515.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="315.0000" y="515.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="318.3333" y="517.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="318.3333" y="517.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="321.6667" y="519.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="321.6667" y="519.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="305.0000" y="556.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="305.0000" y="556.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="308.3333" y="558.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="308.3333" y="558.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="311.6667" y="560.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="311.6667" y="560.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="315.0000" y="562.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="315.0000" y="562.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="318.3333" y="564.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="318.3333" y="564.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="321.6667" y="566.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="321.6667" y="566.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="305" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="305" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="387" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="387" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="387.0000" y="463.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="387.0000" y="463.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="390.3333" y="464.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="390.3333" y="464.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="393.6667" y="466.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="393.6667" y="466.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="397.0000" y="468.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="397.0000" y="468.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="400.3333" y="470.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="400.3333" y="470.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="403.6667" y="472.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="403.6667" y="472.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="387.0000" y="509.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="387.0000" y="509.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="390.3333" y="511.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="390.3333" y="511.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="393.6667" y="513.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="393.6667" y="513.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="397.0000" y="515.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="397.0000" y="515.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="400.3333" y="517.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="400.3333" y="517.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="403.6667" y="519.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="403.6667" y="519.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="387.0000" y="556.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="387.0000" y="556.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="390.3333" y="558.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="390.3333" y="558.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="393.6667" y="560.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="393.6667" y="560.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="397.0000" y="562.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="397.0000" y="562.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="400.3333" y="564.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="400.3333" y="564.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="403.6667" y="566.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="403.6667" y="566.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="387" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="387" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="166" y="368" width="80" height="56">
-			</bounds>
+			<bounds x="166" y="368" width="80" height="56"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="166.0000" y="368.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="166.0000" y="368.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="169.3333" y="370.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="169.3333" y="370.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="172.6667" y="372.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="172.6667" y="372.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="176.0000" y="375.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="176.0000" y="375.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="179.3333" y="377.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="179.3333" y="377.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="182.6667" y="379.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="182.6667" y="379.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="166" y="368" width="80" height="56">
-			</bounds>
+			<bounds x="166" y="368" width="80" height="56"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="40" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="40" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="42" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="42" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="102" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="102" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="104" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="104" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="164" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="164" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="166" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="166" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="226" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="226" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="228" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="228" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="287" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="287" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="289" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="289" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="350" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="350" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="352" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="352" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="412" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="412" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="414" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="414" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="474" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="474" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="476" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="476" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="536" y="311" width="62" height="32">
-			</bounds>
+			<bounds x="536" y="311" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="538" y="313" width="58" height="28">
-			</bounds>
+			<bounds x="538" y="313" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="532" y="276" width="62" height="32">
-			</bounds>
+			<bounds x="532" y="276" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="534" y="278" width="58" height="28">
-			</bounds>
+			<bounds x="534" y="278" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="517" y="178" width="62" height="32">
-			</bounds>
+			<bounds x="517" y="178" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="519" y="180" width="58" height="28">
-			</bounds>
+			<bounds x="519" y="180" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="521" y="211" width="62" height="32">
-			</bounds>
+			<bounds x="521" y="211" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="523" y="213" width="58" height="28">
-			</bounds>
+			<bounds x="523" y="213" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="527" y="244" width="62" height="32">
-			</bounds>
+			<bounds x="527" y="244" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="529" y="246" width="58" height="28">
-			</bounds>
+			<bounds x="529" y="246" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="512" y="146" width="62" height="32">
-			</bounds>
+			<bounds x="512" y="146" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="514" y="148" width="58" height="28">
-			</bounds>
+			<bounds x="514" y="148" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="507" y="114" width="62" height="32">
-			</bounds>
+			<bounds x="507" y="114" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="509" y="116" width="58" height="28">
-			</bounds>
+			<bounds x="509" y="116" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="502" y="81" width="62" height="32">
-			</bounds>
+			<bounds x="502" y="81" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="504" y="83" width="58" height="28">
-			</bounds>
+			<bounds x="504" y="83" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="497" y="47" width="62" height="32">
-			</bounds>
+			<bounds x="497" y="47" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="499" y="49" width="58" height="28">
-			</bounds>
+			<bounds x="499" y="49" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="428" y="47" width="62" height="32">
-			</bounds>
+			<bounds x="428" y="47" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="430" y="49" width="58" height="28">
-			</bounds>
+			<bounds x="430" y="49" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="359" y="47" width="62" height="32">
-			</bounds>
+			<bounds x="359" y="47" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="361" y="49" width="58" height="28">
-			</bounds>
+			<bounds x="361" y="49" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="284" y="47" width="62" height="32">
-			</bounds>
+			<bounds x="284" y="47" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="286" y="49" width="58" height="28">
-			</bounds>
+			<bounds x="286" y="49" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="217" y="46" width="62" height="32">
-			</bounds>
+			<bounds x="217" y="46" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="219" y="48" width="58" height="28">
-			</bounds>
+			<bounds x="219" y="48" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="149" y="47" width="62" height="32">
-			</bounds>
+			<bounds x="149" y="47" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="151" y="49" width="58" height="28">
-			</bounds>
+			<bounds x="151" y="49" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="80" y="47" width="62" height="32">
-			</bounds>
+			<bounds x="80" y="47" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="82" y="49" width="58" height="28">
-			</bounds>
+			<bounds x="82" y="49" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="75" y="80" width="62" height="32">
-			</bounds>
+			<bounds x="75" y="80" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="77" y="82" width="58" height="28">
-			</bounds>
+			<bounds x="77" y="82" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="70" y="113" width="62" height="32">
-			</bounds>
+			<bounds x="70" y="113" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="72" y="115" width="58" height="28">
-			</bounds>
+			<bounds x="72" y="115" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="65" y="146" width="62" height="32">
-			</bounds>
+			<bounds x="65" y="146" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="67" y="148" width="58" height="28">
-			</bounds>
+			<bounds x="67" y="148" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="60" y="179" width="62" height="32">
-			</bounds>
+			<bounds x="60" y="179" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="62" y="181" width="58" height="28">
-			</bounds>
+			<bounds x="62" y="181" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="55" y="212" width="62" height="32">
-			</bounds>
+			<bounds x="55" y="212" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="57" y="214" width="58" height="28">
-			</bounds>
+			<bounds x="57" y="214" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="50" y="245" width="62" height="32">
-			</bounds>
+			<bounds x="50" y="245" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="52" y="247" width="58" height="28">
-			</bounds>
+			<bounds x="52" y="247" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="45" y="278" width="62" height="32">
-			</bounds>
+			<bounds x="45" y="278" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="47" y="280" width="58" height="28">
-			</bounds>
+			<bounds x="47" y="280" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="264" y="608" width="182" height="37">
-			</bounds>
+			<bounds x="264" y="608" width="182" height="37"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="266" y="610" width="178" height="33">
-			</bounds>
+			<bounds x="266" y="610" width="178" height="33"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="489" y="506" width="52" height="27">
-			</bounds>
+			<bounds x="489" y="506" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="491" y="508" width="48" height="23">
-			</bounds>
+			<bounds x="491" y="508" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="489" y="533" width="52" height="27">
-			</bounds>
+			<bounds x="489" y="533" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="491" y="535" width="48" height="23">
-			</bounds>
+			<bounds x="491" y="535" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="582" y="596" width="77" height="27">
-			</bounds>
+			<bounds x="582" y="596" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="584" y="598" width="73" height="23">
-			</bounds>
+			<bounds x="584" y="598" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="677" y="422" width="92" height="32">
-			</bounds>
+			<bounds x="677" y="422" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="679" y="424" width="88" height="28">
-			</bounds>
+			<bounds x="679" y="424" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="725" y="624" width="102" height="19">
-			</bounds>
+			<bounds x="725" y="624" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="727" y="626" width="98" height="15">
-			</bounds>
+			<bounds x="727" y="626" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="294" y="158" width="47" height="42">
-			</bounds>
+			<bounds x="294" y="158" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="296" y="160" width="43" height="38">
-			</bounds>
+			<bounds x="296" y="160" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="295" y="240" width="47" height="42">
-			</bounds>
+			<bounds x="295" y="240" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="297" y="242" width="43" height="38">
-			</bounds>
+			<bounds x="297" y="242" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="340" y="199" width="47" height="42">
-			</bounds>
+			<bounds x="340" y="199" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="342" y="201" width="43" height="38">
-			</bounds>
+			<bounds x="342" y="201" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="248" y="199" width="47" height="42">
-			</bounds>
+			<bounds x="248" y="199" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="250" y="201" width="43" height="38">
-			</bounds>
+			<bounds x="250" y="201" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="51" y="587" width="62" height="32">
-			</bounds>
+			<bounds x="51" y="587" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="53" y="589" width="58" height="28">
-			</bounds>
+			<bounds x="53" y="589" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="56" y="555" width="52" height="32">
-			</bounds>
+			<bounds x="56" y="555" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="58" y="557" width="48" height="28">
-			</bounds>
+			<bounds x="58" y="557" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="56" y="523" width="52" height="32">
-			</bounds>
+			<bounds x="56" y="523" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="58" y="525" width="48" height="28">
-			</bounds>
+			<bounds x="58" y="525" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="56" y="491" width="52" height="32">
-			</bounds>
+			<bounds x="56" y="491" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="58" y="493" width="48" height="28">
-			</bounds>
+			<bounds x="58" y="493" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="56" y="459" width="52" height="32">
-			</bounds>
+			<bounds x="56" y="459" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="58" y="461" width="48" height="28">
-			</bounds>
+			<bounds x="58" y="461" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="167" y="5" width="152" height="37">
-			</bounds>
+			<bounds x="167" y="5" width="152" height="37"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="169" y="7" width="148" height="33">
-			</bounds>
+			<bounds x="169" y="7" width="148" height="33"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="320" y="6" width="152" height="37">
-			</bounds>
+			<bounds x="320" y="6" width="152" height="37"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="322" y="8" width="148" height="33">
-			</bounds>
+			<bounds x="322" y="8" width="148" height="33"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="726" y="71" width="52" height="37">
-			</bounds>
+			<bounds x="726" y="71" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="728" y="73" width="48" height="33">
-			</bounds>
+			<bounds x="728" y="73" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="815" y="327" width="82" height="32">
-			</bounds>
+			<bounds x="815" y="327" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="817" y="329" width="78" height="28">
-			</bounds>
+			<bounds x="817" y="329" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="778" y="71" width="52" height="37">
-			</bounds>
+			<bounds x="778" y="71" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="780" y="73" width="48" height="33">
-			</bounds>
+			<bounds x="780" y="73" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="674" y="71" width="52" height="37">
-			</bounds>
+			<bounds x="674" y="71" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="676" y="73" width="48" height="33">
-			</bounds>
+			<bounds x="676" y="73" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="622" y="71" width="52" height="37">
-			</bounds>
+			<bounds x="622" y="71" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="624" y="73" width="48" height="33">
-			</bounds>
+			<bounds x="624" y="73" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="647" y="108" width="152" height="27">
-			</bounds>
+			<bounds x="647" y="108" width="152" height="27"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="649" y="110" width="148" height="23">
-			</bounds>
+			<bounds x="649" y="110" width="148" height="23"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="825" y="193" width="82" height="32">
-			</bounds>
+			<bounds x="825" y="193" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="827" y="195" width="78" height="28">
-			</bounds>
+			<bounds x="827" y="195" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="825" y="225" width="82" height="32">
-			</bounds>
+			<bounds x="825" y="225" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="827" y="227" width="78" height="28">
-			</bounds>
+			<bounds x="827" y="227" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="825" y="257" width="82" height="32">
-			</bounds>
+			<bounds x="825" y="257" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="827" y="259" width="78" height="28">
-			</bounds>
+			<bounds x="827" y="259" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="825" y="289" width="82" height="32">
-			</bounds>
+			<bounds x="825" y="289" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="827" y="291" width="78" height="28">
-			</bounds>
+			<bounds x="827" y="291" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="825" y="171" width="82" height="22">
-			</bounds>
+			<bounds x="825" y="171" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="827" y="173" width="78" height="18">
-			</bounds>
+			<bounds x="827" y="173" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="743" y="225" width="82" height="32">
-			</bounds>
+			<bounds x="743" y="225" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="745" y="227" width="78" height="28">
-			</bounds>
+			<bounds x="745" y="227" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="743" y="193" width="82" height="32">
-			</bounds>
+			<bounds x="743" y="193" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="745" y="195" width="78" height="28">
-			</bounds>
+			<bounds x="745" y="195" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="743" y="289" width="82" height="32">
-			</bounds>
+			<bounds x="743" y="289" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="745" y="291" width="78" height="28">
-			</bounds>
+			<bounds x="745" y="291" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="743" y="257" width="82" height="32">
-			</bounds>
+			<bounds x="743" y="257" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="745" y="259" width="78" height="28">
-			</bounds>
+			<bounds x="745" y="259" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="743" y="171" width="82" height="22">
-			</bounds>
+			<bounds x="743" y="171" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="745" y="173" width="78" height="18">
-			</bounds>
+			<bounds x="745" y="173" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="624" y="294" width="92" height="32">
-			</bounds>
+			<bounds x="624" y="294" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="626" y="296" width="88" height="28">
-			</bounds>
+			<bounds x="626" y="296" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="625" y="353" width="92" height="32">
-			</bounds>
+			<bounds x="625" y="353" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="627" y="355" width="88" height="28">
-			</bounds>
+			<bounds x="627" y="355" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="626" y="183" width="82" height="32">
-			</bounds>
+			<bounds x="626" y="183" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="628" y="185" width="78" height="28">
-			</bounds>
+			<bounds x="628" y="185" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="774" y="596" width="52" height="27">
-			</bounds>
+			<bounds x="774" y="596" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="776" y="598" width="48" height="23">
-			</bounds>
+			<bounds x="776" y="598" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="774" y="461" width="52" height="27">
-			</bounds>
+			<bounds x="774" y="461" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="776" y="463" width="48" height="23">
-			</bounds>
+			<bounds x="776" y="463" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="774" y="488" width="52" height="27">
-			</bounds>
+			<bounds x="774" y="488" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="776" y="490" width="48" height="23">
-			</bounds>
+			<bounds x="776" y="490" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="774" y="515" width="52" height="27">
-			</bounds>
+			<bounds x="774" y="515" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="776" y="517" width="48" height="23">
-			</bounds>
+			<bounds x="776" y="517" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="774" y="542" width="52" height="27">
-			</bounds>
+			<bounds x="774" y="542" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="776" y="544" width="48" height="23">
-			</bounds>
+			<bounds x="776" y="544" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="774" y="569" width="52" height="27">
-			</bounds>
+			<bounds x="774" y="569" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="776" y="571" width="48" height="23">
-			</bounds>
+			<bounds x="776" y="571" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_192_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="835" y="22" width="75" height="27">
-			</bounds>
+			<bounds x="835" y="22" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_192" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="837" y="24" width="71" height="23">
-			</bounds>
+			<bounds x="837" y="24" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp239" element="colour_button_193_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="563" y="411" width="75" height="27">
-			</bounds>
+			<bounds x="563" y="411" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp239" element="colour_button_193" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="565" y="413" width="71" height="23">
-			</bounds>
+			<bounds x="565" y="413" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_199_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="835" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="835" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_199" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="837" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="837" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_200_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="528" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="528" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_200" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="530" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="530" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_201_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="673" y="654" width="81" height="27">
-			</bounds>
+			<bounds x="673" y="654" width="81" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_201" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="675" y="656" width="77" height="23">
-			</bounds>
+			<bounds x="675" y="656" width="77" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_202_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="395" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="395" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_202" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="397" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="397" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_203_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="303" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="303" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_203" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="305" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="305" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_204_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="217" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="217" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_204" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="219" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="219" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_205_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="18" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="18" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_205" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="20" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="20" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="483" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="483" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="486" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="486" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="500" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="500" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="500" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="500" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="486" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="486" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="486" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="486" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="486" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="486" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="486" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="486" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="503" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="503" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="486" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="486" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="500" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="500" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="500" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="500" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="486" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="486" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="486" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="486" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="486" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="486" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="486" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="486" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="503" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="503" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="507" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="507" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="510" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="524" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="524" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="524" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="524" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="510" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="510" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="510" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="510" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="510" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="510" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="527" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="527" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="510" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="524" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="524" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="524" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="524" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="510" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="510" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="510" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="510" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="510" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="510" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="527" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="527" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="531" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="531" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="534" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="534" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="548" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="548" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="548" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="548" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="534" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="534" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="534" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="534" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="534" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="534" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="534" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="534" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="551" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="551" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="534" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="534" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="548" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="548" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="548" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="548" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="534" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="534" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="534" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="534" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="534" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="534" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="534" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="534" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="551" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="551" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="408" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="408" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off120" element="led_off">
-			<bounds x="411" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="411" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="425" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="425" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="425" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="425" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="411" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="411" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="411" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="411" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="411" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="411" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="411" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="411" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off127" element="led_dot_off">
-			<bounds x="428" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="428" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp120" element="led_on">
-			<bounds x="411" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="411" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="425" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="425" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="425" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="425" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="411" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="411" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="411" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="411" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="411" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="411" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="411" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="411" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp127" element="led_dot_on">
-			<bounds x="428" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="428" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="384" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="384" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off112" element="led_off">
-			<bounds x="387" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off113" element="led_off">
-			<bounds x="401" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="401" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off114" element="led_off">
-			<bounds x="401" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="401" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off115" element="led_off">
-			<bounds x="387" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off116" element="led_off">
-			<bounds x="387" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="387" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off117" element="led_off">
-			<bounds x="387" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="387" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off118" element="led_off">
-			<bounds x="387" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off119" element="led_dot_off">
-			<bounds x="404" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="404" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp112" element="led_on">
-			<bounds x="387" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp113" element="led_on">
-			<bounds x="401" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="401" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp114" element="led_on">
-			<bounds x="401" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="401" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp115" element="led_on">
-			<bounds x="387" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp116" element="led_on">
-			<bounds x="387" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="387" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp117" element="led_on">
-			<bounds x="387" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="387" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp118" element="led_on">
-			<bounds x="387" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp119" element="led_dot_on">
-			<bounds x="404" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="404" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="632" y="217" width="24" height="32">
-			</bounds>
+			<bounds x="632" y="217" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="635" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="649" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="649" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="649" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="649" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="635" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="635" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="635" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="635" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="635" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="635" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="652" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="652" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="635" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="649" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="649" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="649" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="649" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="635" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="635" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="635" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="635" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="635" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="635" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="652" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="652" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="656" y="217" width="24" height="32">
-			</bounds>
+			<bounds x="656" y="217" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off208" element="led_off">
-			<bounds x="659" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="659" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off209" element="led_off">
-			<bounds x="673" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="673" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off210" element="led_off">
-			<bounds x="673" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="673" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off211" element="led_off">
-			<bounds x="659" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="659" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off212" element="led_off">
-			<bounds x="659" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="659" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off213" element="led_off">
-			<bounds x="659" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="659" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off214" element="led_off">
-			<bounds x="659" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="659" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off215" element="led_dot_off">
-			<bounds x="676" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="676" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp208" element="led_on">
-			<bounds x="659" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="659" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp209" element="led_on">
-			<bounds x="673" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="673" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp210" element="led_on">
-			<bounds x="673" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="673" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp211" element="led_on">
-			<bounds x="659" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="659" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp212" element="led_on">
-			<bounds x="659" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="659" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp213" element="led_on">
-			<bounds x="659" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="659" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp214" element="led_on">
-			<bounds x="659" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="659" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp215" element="led_dot_on">
-			<bounds x="676" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="676" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="680" y="217" width="24" height="32">
-			</bounds>
+			<bounds x="680" y="217" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off216" element="led_off">
-			<bounds x="683" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="683" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off217" element="led_off">
-			<bounds x="697" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="697" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off218" element="led_off">
-			<bounds x="697" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="697" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off219" element="led_off">
-			<bounds x="683" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="683" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off220" element="led_off">
-			<bounds x="683" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="683" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off221" element="led_off">
-			<bounds x="683" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="683" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off222" element="led_off">
-			<bounds x="683" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="683" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off223" element="led_dot_off">
-			<bounds x="700" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="700" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp216" element="led_on">
-			<bounds x="683" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="683" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp217" element="led_on">
-			<bounds x="697" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="697" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp218" element="led_on">
-			<bounds x="697" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="697" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp219" element="led_on">
-			<bounds x="683" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="683" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp220" element="led_on">
-			<bounds x="683" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="683" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp221" element="led_on">
-			<bounds x="683" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="683" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp222" element="led_on">
-			<bounds x="683" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="683" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp223" element="led_dot_on">
-			<bounds x="700" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="700" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="322" y="354" width="272" height="30">
-			</bounds>
+			<bounds x="322" y="354" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="322" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="322" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="339" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="339" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="356" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="356" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="373" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="373" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="390" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="390" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="407" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="407" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="424" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="424" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="441" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="441" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="458" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="458" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="475" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="475" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="492" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="492" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="509" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="509" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="526" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="526" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="543" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="543" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="560" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="560" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="577" y="354" width="17" height="30">
-			</bounds>
+			<bounds x="577" y="354" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label9" element="label_9">
-			<bounds x="326" y="414" width="39" height="32">
-			</bounds>
+			<bounds x="326" y="414" width="39" height="32"/>
 		</backdrop>
 		<backdrop name="label176" element="label_176">
-			<bounds x="645" y="325" width="40" height="28">
-			</bounds>
+			<bounds x="645" y="325" width="40" height="28"/>
 		</backdrop>
 		<backdrop name="label190" element="label_190">
-			<bounds x="742" y="390" width="125" height="22">
-			</bounds>
+			<bounds x="742" y="390" width="125" height="22"/>
 		</backdrop>
 		<backdrop name="label191" element="label_191">
-			<bounds x="702" y="2" width="149" height="14">
-			</bounds>
+			<bounds x="702" y="2" width="149" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_button" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1apollo2.lay
+++ b/src/mame/layout/m1apollo2.lay
@@ -8,16082 +8,9070 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Game Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Game Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Winsp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Winsp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Feature Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Feature Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Minus Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Minus Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Plus Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Plus Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Cash Multiplier">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Cash Multiplier">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Skill Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Skill Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Game Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Game Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Lucky Dip">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Lucky Dip">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="1 Winspin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="1 Winspin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Go For Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Go For Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Game Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Game Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2 Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2 Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3 Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3 Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5 Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="5 Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4 Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="4 Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="10 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="8 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="6 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1 Knockout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1 Knockout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1 Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1 Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repea">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repea">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Number Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Number Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Skill stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Skill stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Selector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Selector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Random Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Random Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="All 6 lit pays Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="All 6 lit pays Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Hi Lo Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Hi Lo Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Mystery Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Mystery Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="x3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="x3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="x4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="x4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="x5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="x5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string=" Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string=" Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Twister">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Twister">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Lucky 4 Some">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Lucky 4 Some">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Cash Dash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Cash Dash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Choose a Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Choose a Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_175_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_175">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Insert &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_176_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_176">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_177_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_177">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Hold/Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_178_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_178">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Hold/Nudge/Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_179_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_179">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Hold/Nudge/Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_186_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_186">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_187_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_187">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_188_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_188">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Collect/Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_189_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_189">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.27"/>
 		</text>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1016" height="689">
-			</bounds>
+			<bounds x="0" y="0" width="1016" height="689"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="113" y="486" width="80" height="140">
-			</bounds>
+			<bounds x="113" y="486" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="113.0000" y="486.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="113.0000" y="486.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="116.3333" y="487.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="116.3333" y="487.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="119.6667" y="489.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="119.6667" y="489.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="123.0000" y="491.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="123.0000" y="491.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="126.3333" y="493.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="126.3333" y="493.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="129.6667" y="495.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="129.6667" y="495.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="113.0000" y="532.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="113.0000" y="532.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="116.3333" y="534.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="116.3333" y="534.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="119.6667" y="536.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="119.6667" y="536.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="123.0000" y="538.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="123.0000" y="538.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="126.3333" y="540.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="126.3333" y="540.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="129.6667" y="542.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="129.6667" y="542.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="113.0000" y="579.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="113.0000" y="579.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="116.3333" y="581.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="116.3333" y="581.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="119.6667" y="583.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="119.6667" y="583.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="123.0000" y="585.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="123.0000" y="585.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="126.3333" y="587.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="126.3333" y="587.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="129.6667" y="589.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="129.6667" y="589.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="113" y="486" width="80" height="140">
-			</bounds>
+			<bounds x="113" y="486" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="205" y="486" width="80" height="140">
-			</bounds>
+			<bounds x="205" y="486" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="486.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="486.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="487.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="487.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="489.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="489.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="491.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="491.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="493.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="493.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="495.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="495.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="532.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="532.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="534.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="534.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="536.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="536.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="538.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="538.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="540.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="540.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="542.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="542.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="579.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="579.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="581.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="581.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="583.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="583.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="585.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="585.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="587.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="587.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="589.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="589.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="205" y="486" width="80" height="140">
-			</bounds>
+			<bounds x="205" y="486" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="297" y="486" width="80" height="140">
-			</bounds>
+			<bounds x="297" y="486" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="297.0000" y="486.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="297.0000" y="486.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="300.3333" y="487.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="300.3333" y="487.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="303.6667" y="489.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="303.6667" y="489.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="307.0000" y="491.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="307.0000" y="491.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="310.3333" y="493.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="310.3333" y="493.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="313.6667" y="495.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="313.6667" y="495.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="297.0000" y="532.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="297.0000" y="532.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="300.3333" y="534.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="300.3333" y="534.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="303.6667" y="536.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="303.6667" y="536.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="307.0000" y="538.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="307.0000" y="538.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="310.3333" y="540.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="310.3333" y="540.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="313.6667" y="542.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="313.6667" y="542.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="297.0000" y="579.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="297.0000" y="579.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="300.3333" y="581.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="300.3333" y="581.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="303.6667" y="583.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="303.6667" y="583.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="307.0000" y="585.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="307.0000" y="585.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="310.3333" y="587.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="310.3333" y="587.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="313.6667" y="589.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="313.6667" y="589.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="297" y="486" width="80" height="140">
-			</bounds>
+			<bounds x="297" y="486" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="816" y="24" width="80" height="80">
-			</bounds>
+			<bounds x="816" y="24" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="816.0000" y="24.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="816.0000" y="24.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="819.3333" y="27.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="819.3333" y="27.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="822.6667" y="30.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="822.6667" y="30.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="826.0000" y="34.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="826.0000" y="34.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="829.3333" y="37.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="829.3333" y="37.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="832.6667" y="40.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="832.6667" y="40.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="816" y="24" width="80" height="80">
-			</bounds>
+			<bounds x="816" y="24" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="139" y="43" width="42" height="42">
-			</bounds>
+			<bounds x="139" y="43" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="141" y="45" width="38" height="38">
-			</bounds>
+			<bounds x="141" y="45" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="687" y="355" width="62" height="62">
-			</bounds>
+			<bounds x="687" y="355" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="689" y="357" width="58" height="58">
-			</bounds>
+			<bounds x="689" y="357" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="943" y="615" width="62" height="42">
-			</bounds>
+			<bounds x="943" y="615" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="945" y="617" width="58" height="38">
-			</bounds>
+			<bounds x="945" y="617" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="186" y="320" width="112" height="42">
-			</bounds>
+			<bounds x="186" y="320" width="112" height="42"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="188" y="322" width="108" height="38">
-			</bounds>
+			<bounds x="188" y="322" width="108" height="38"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="239" y="289" width="112" height="42">
-			</bounds>
+			<bounds x="239" y="289" width="112" height="42"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="241" y="291" width="108" height="38">
-			</bounds>
+			<bounds x="241" y="291" width="108" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="86" y="199" width="112" height="42">
-			</bounds>
+			<bounds x="86" y="199" width="112" height="42"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="88" y="201" width="108" height="38">
-			</bounds>
+			<bounds x="88" y="201" width="108" height="38"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="227" y="113" width="112" height="42">
-			</bounds>
+			<bounds x="227" y="113" width="112" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="229" y="115" width="108" height="38">
-			</bounds>
+			<bounds x="229" y="115" width="108" height="38"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="177" y="81" width="112" height="42">
-			</bounds>
+			<bounds x="177" y="81" width="112" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="179" y="83" width="108" height="38">
-			</bounds>
+			<bounds x="179" y="83" width="108" height="38"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="453" y="98" width="112" height="42">
-			</bounds>
+			<bounds x="453" y="98" width="112" height="42"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="455" y="100" width="108" height="38">
-			</bounds>
+			<bounds x="455" y="100" width="108" height="38"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="583" y="201" width="112" height="42">
-			</bounds>
+			<bounds x="583" y="201" width="112" height="42"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="585" y="203" width="108" height="38">
-			</bounds>
+			<bounds x="585" y="203" width="108" height="38"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="627" y="327" width="72" height="28">
-			</bounds>
+			<bounds x="627" y="327" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="629" y="329" width="68" height="24">
-			</bounds>
+			<bounds x="629" y="329" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="451" y="309" width="112" height="42">
-			</bounds>
+			<bounds x="451" y="309" width="112" height="42"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="453" y="311" width="108" height="38">
-			</bounds>
+			<bounds x="453" y="311" width="108" height="38"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="327" y="199" width="128" height="47">
-			</bounds>
+			<bounds x="327" y="199" width="128" height="47"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="329" y="201" width="124" height="43">
-			</bounds>
+			<bounds x="329" y="201" width="124" height="43"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="643" y="355" width="42" height="42">
-			</bounds>
+			<bounds x="643" y="355" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="645" y="357" width="38" height="38">
-			</bounds>
+			<bounds x="645" y="357" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="599" y="359" width="42" height="42">
-			</bounds>
+			<bounds x="599" y="359" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="601" y="361" width="38" height="38">
-			</bounds>
+			<bounds x="601" y="361" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="511" y="35" width="42" height="42">
-			</bounds>
+			<bounds x="511" y="35" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="513" y="37" width="38" height="38">
-			</bounds>
+			<bounds x="513" y="37" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="7" y="223" width="42" height="42">
-			</bounds>
+			<bounds x="7" y="223" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="9" y="225" width="38" height="38">
-			</bounds>
+			<bounds x="9" y="225" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="583" y="301" width="72" height="28">
-			</bounds>
+			<bounds x="583" y="301" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="585" y="303" width="68" height="24">
-			</bounds>
+			<bounds x="585" y="303" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="543" y="275" width="72" height="28">
-			</bounds>
+			<bounds x="543" y="275" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="545" y="277" width="68" height="24">
-			</bounds>
+			<bounds x="545" y="277" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="455" y="223" width="72" height="28">
-			</bounds>
+			<bounds x="455" y="223" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="457" y="225" width="68" height="24">
-			</bounds>
+			<bounds x="457" y="225" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="499" y="249" width="72" height="28">
-			</bounds>
+			<bounds x="499" y="249" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="501" y="251" width="68" height="24">
-			</bounds>
+			<bounds x="501" y="251" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="455" y="195" width="72" height="28">
-			</bounds>
+			<bounds x="455" y="195" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="457" y="197" width="68" height="24">
-			</bounds>
+			<bounds x="457" y="197" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="499" y="169" width="72" height="28">
-			</bounds>
+			<bounds x="499" y="169" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="501" y="171" width="68" height="24">
-			</bounds>
+			<bounds x="501" y="171" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="543" y="143" width="72" height="28">
-			</bounds>
+			<bounds x="543" y="143" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="545" y="145" width="68" height="24">
-			</bounds>
+			<bounds x="545" y="145" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="583" y="117" width="72" height="28">
-			</bounds>
+			<bounds x="583" y="117" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="585" y="119" width="68" height="24">
-			</bounds>
+			<bounds x="585" y="119" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="627" y="91" width="72" height="28">
-			</bounds>
+			<bounds x="627" y="91" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="629" y="93" width="68" height="24">
-			</bounds>
+			<bounds x="629" y="93" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="271" y="31" width="42" height="42">
-			</bounds>
+			<bounds x="271" y="31" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="273" y="33" width="38" height="38">
-			</bounds>
+			<bounds x="273" y="33" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="95" y="355" width="42" height="42">
-			</bounds>
+			<bounds x="95" y="355" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="97" y="357" width="38" height="38">
-			</bounds>
+			<bounds x="97" y="357" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="687" y="27" width="62" height="62">
-			</bounds>
+			<bounds x="687" y="27" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="689" y="29" width="58" height="58">
-			</bounds>
+			<bounds x="689" y="29" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="643" y="47" width="42" height="42">
-			</bounds>
+			<bounds x="643" y="47" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="645" y="49" width="38" height="38">
-			</bounds>
+			<bounds x="645" y="49" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="95" y="47" width="42" height="42">
-			</bounds>
+			<bounds x="95" y="47" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="97" y="49" width="38" height="38">
-			</bounds>
+			<bounds x="97" y="49" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="467" y="371" width="42" height="42">
-			</bounds>
+			<bounds x="467" y="371" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="469" y="373" width="38" height="38">
-			</bounds>
+			<bounds x="469" y="373" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="731" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="731" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="733" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="733" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="359" y="7" width="62" height="62">
-			</bounds>
+			<bounds x="359" y="7" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="361" y="9" width="58" height="58">
-			</bounds>
+			<bounds x="361" y="9" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="359" y="244" width="62" height="28">
-			</bounds>
+			<bounds x="359" y="244" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="361" y="246" width="58" height="24">
-			</bounds>
+			<bounds x="361" y="246" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="359" y="270" width="62" height="28">
-			</bounds>
+			<bounds x="359" y="270" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="361" y="272" width="58" height="24">
-			</bounds>
+			<bounds x="361" y="272" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="359" y="375" width="62" height="62">
-			</bounds>
+			<bounds x="359" y="375" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="361" y="377" width="58" height="58">
-			</bounds>
+			<bounds x="361" y="377" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="315" y="375" width="42" height="42">
-			</bounds>
+			<bounds x="315" y="375" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="317" y="377" width="38" height="38">
-			</bounds>
+			<bounds x="317" y="377" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="183" y="363" width="42" height="42">
-			</bounds>
+			<bounds x="183" y="363" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="185" y="365" width="38" height="38">
-			</bounds>
+			<bounds x="185" y="365" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="23" y="311" width="42" height="42">
-			</bounds>
+			<bounds x="23" y="311" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="25" y="313" width="38" height="38">
-			</bounds>
+			<bounds x="25" y="313" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="23" y="91" width="42" height="42">
-			</bounds>
+			<bounds x="23" y="91" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="25" y="93" width="38" height="38">
-			</bounds>
+			<bounds x="25" y="93" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="315" y="27" width="42" height="42">
-			</bounds>
+			<bounds x="315" y="27" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="317" y="29" width="38" height="38">
-			</bounds>
+			<bounds x="317" y="29" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="423" y="27" width="42" height="42">
-			</bounds>
+			<bounds x="423" y="27" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="425" y="29" width="38" height="38">
-			</bounds>
+			<bounds x="425" y="29" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="555" y="39" width="42" height="42">
-			</bounds>
+			<bounds x="555" y="39" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="557" y="41" width="38" height="38">
-			</bounds>
+			<bounds x="557" y="41" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="715" y="91" width="42" height="42">
-			</bounds>
+			<bounds x="715" y="91" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="717" y="93" width="38" height="38">
-			</bounds>
+			<bounds x="717" y="93" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="715" y="311" width="42" height="42">
-			</bounds>
+			<bounds x="715" y="311" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="717" y="313" width="38" height="38">
-			</bounds>
+			<bounds x="717" y="313" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="511" y="367" width="42" height="42">
-			</bounds>
+			<bounds x="511" y="367" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="513" y="369" width="38" height="38">
-			</bounds>
+			<bounds x="513" y="369" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="422" y="375" width="42" height="42">
-			</bounds>
+			<bounds x="422" y="375" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="424" y="377" width="38" height="38">
-			</bounds>
+			<bounds x="424" y="377" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="250" y="223" width="77" height="28">
-			</bounds>
+			<bounds x="250" y="223" width="77" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="252" y="225" width="73" height="24">
-			</bounds>
+			<bounds x="252" y="225" width="73" height="24"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="211" y="249" width="77" height="28">
-			</bounds>
+			<bounds x="211" y="249" width="77" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="213" y="251" width="73" height="24">
-			</bounds>
+			<bounds x="213" y="251" width="73" height="24"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="167" y="275" width="77" height="28">
-			</bounds>
+			<bounds x="167" y="275" width="77" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="169" y="277" width="73" height="24">
-			</bounds>
+			<bounds x="169" y="277" width="73" height="24"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="123" y="301" width="77" height="28">
-			</bounds>
+			<bounds x="123" y="301" width="77" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="125" y="303" width="73" height="24">
-			</bounds>
+			<bounds x="125" y="303" width="73" height="24"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="79" y="327" width="72" height="28">
-			</bounds>
+			<bounds x="79" y="327" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="81" y="329" width="68" height="24">
-			</bounds>
+			<bounds x="81" y="329" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="227" y="367" width="42" height="42">
-			</bounds>
+			<bounds x="227" y="367" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="229" y="369" width="38" height="38">
-			</bounds>
+			<bounds x="229" y="369" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="555" y="363" width="42" height="42">
-			</bounds>
+			<bounds x="555" y="363" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="557" y="365" width="38" height="38">
-			</bounds>
+			<bounds x="557" y="365" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="599" y="43" width="42" height="42">
-			</bounds>
+			<bounds x="599" y="43" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="601" y="45" width="38" height="38">
-			</bounds>
+			<bounds x="601" y="45" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="15" y="135" width="42" height="42">
-			</bounds>
+			<bounds x="15" y="135" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="17" y="137" width="38" height="38">
-			</bounds>
+			<bounds x="17" y="137" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="26" y="355" width="67" height="62">
-			</bounds>
+			<bounds x="26" y="355" width="67" height="62"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="28" y="357" width="63" height="58">
-			</bounds>
+			<bounds x="28" y="357" width="63" height="58"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="719" y="135" width="42" height="42">
-			</bounds>
+			<bounds x="719" y="135" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="721" y="137" width="38" height="38">
-			</bounds>
+			<bounds x="721" y="137" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="467" y="31" width="42" height="42">
-			</bounds>
+			<bounds x="467" y="31" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="469" y="33" width="38" height="38">
-			</bounds>
+			<bounds x="469" y="33" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="271" y="371" width="42" height="42">
-			</bounds>
+			<bounds x="271" y="371" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="273" y="373" width="38" height="38">
-			</bounds>
+			<bounds x="273" y="373" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="15" y="267" width="42" height="42">
-			</bounds>
+			<bounds x="15" y="267" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="17" y="269" width="38" height="38">
-			</bounds>
+			<bounds x="17" y="269" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="731" y="223" width="42" height="42">
-			</bounds>
+			<bounds x="731" y="223" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="733" y="225" width="38" height="38">
-			</bounds>
+			<bounds x="733" y="225" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="139" y="359" width="42" height="42">
-			</bounds>
+			<bounds x="139" y="359" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="141" y="361" width="38" height="38">
-			</bounds>
+			<bounds x="141" y="361" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="7" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="7" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="9" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="9" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="250" y="195" width="77" height="28">
-			</bounds>
+			<bounds x="250" y="195" width="77" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="252" y="197" width="73" height="24">
-			</bounds>
+			<bounds x="252" y="197" width="73" height="24"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="211" y="169" width="72" height="28">
-			</bounds>
+			<bounds x="211" y="169" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="213" y="171" width="68" height="24">
-			</bounds>
+			<bounds x="213" y="171" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="166" y="143" width="72" height="28">
-			</bounds>
+			<bounds x="166" y="143" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="168" y="145" width="68" height="24">
-			</bounds>
+			<bounds x="168" y="145" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="123" y="117" width="72" height="28">
-			</bounds>
+			<bounds x="123" y="117" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="125" y="119" width="68" height="24">
-			</bounds>
+			<bounds x="125" y="119" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="79" y="91" width="72" height="28">
-			</bounds>
+			<bounds x="79" y="91" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="81" y="93" width="68" height="24">
-			</bounds>
+			<bounds x="81" y="93" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="26" y="27" width="67" height="62">
-			</bounds>
+			<bounds x="26" y="27" width="67" height="62"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="28" y="29" width="63" height="58">
-			</bounds>
+			<bounds x="28" y="29" width="63" height="58"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="721" y="266" width="42" height="42">
-			</bounds>
+			<bounds x="721" y="266" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="723" y="268" width="38" height="38">
-			</bounds>
+			<bounds x="723" y="268" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="227" y="35" width="42" height="42">
-			</bounds>
+			<bounds x="227" y="35" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="229" y="37" width="38" height="38">
-			</bounds>
+			<bounds x="229" y="37" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="183" y="39" width="42" height="42">
-			</bounds>
+			<bounds x="183" y="39" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="185" y="41" width="38" height="38">
-			</bounds>
+			<bounds x="185" y="41" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="923" y="231" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="231" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="925" y="233" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="233" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="923" y="255" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="255" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="925" y="257" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="257" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="923" y="279" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="279" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="925" y="281" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="281" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="923" y="303" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="303" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="925" y="305" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="305" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="923" y="399" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="399" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="925" y="401" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="401" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="923" y="375" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="375" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="925" y="377" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="377" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="923" y="351" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="351" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="925" y="353" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="353" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="923" y="327" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="327" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="925" y="329" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="329" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="923" y="207" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="207" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="925" y="209" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="209" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="923" y="183" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="183" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="925" y="185" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="185" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="923" y="159" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="159" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="925" y="161" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="161" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="943" y="67" width="62" height="42">
-			</bounds>
+			<bounds x="943" y="67" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="945" y="69" width="58" height="38">
-			</bounds>
+			<bounds x="945" y="69" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="943" y="111" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="111" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="945" y="113" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="113" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="943" y="135" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="135" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="945" y="137" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="137" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="923" y="135" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="135" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="925" y="137" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="137" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="923" y="111" width="19" height="19">
-			</bounds>
+			<bounds x="923" y="111" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="925" y="113" width="15" height="15">
-			</bounds>
+			<bounds x="925" y="113" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="943" y="279" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="279" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="945" y="281" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="281" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="943" y="303" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="303" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="945" y="305" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="305" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="943" y="327" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="327" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="945" y="329" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="329" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="943" y="351" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="351" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="945" y="353" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="353" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="943" y="375" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="375" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="945" y="377" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="377" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="943" y="399" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="399" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="945" y="401" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="401" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="943" y="471" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="471" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="945" y="473" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="473" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="943" y="495" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="495" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="945" y="497" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="497" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="943" y="519" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="519" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="945" y="521" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="521" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="943" y="543" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="543" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="945" y="545" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="545" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="943" y="567" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="567" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="945" y="569" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="569" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="943" y="591" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="591" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="945" y="593" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="593" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="943" y="423" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="423" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="945" y="425" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="425" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="943" y="447" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="447" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="945" y="449" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="449" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="943" y="255" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="255" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="945" y="257" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="257" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="943" y="231" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="231" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="945" y="233" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="233" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="943" y="207" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="207" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="945" y="209" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="209" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="943" y="183" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="183" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="945" y="185" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="185" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="943" y="159" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="159" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="945" y="161" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="161" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="823" y="523" width="82" height="22">
-			</bounds>
+			<bounds x="823" y="523" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="825" y="525" width="78" height="18">
-			</bounds>
+			<bounds x="825" y="525" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="739" y="499" width="82" height="22">
-			</bounds>
+			<bounds x="739" y="499" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="741" y="501" width="78" height="18">
-			</bounds>
+			<bounds x="741" y="501" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="739" y="547" width="82" height="22">
-			</bounds>
+			<bounds x="739" y="547" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="741" y="549" width="78" height="18">
-			</bounds>
+			<bounds x="741" y="549" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="823" y="499" width="82" height="22">
-			</bounds>
+			<bounds x="823" y="499" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="825" y="501" width="78" height="18">
-			</bounds>
+			<bounds x="825" y="501" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="739" y="523" width="82" height="22">
-			</bounds>
+			<bounds x="739" y="523" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="741" y="525" width="78" height="18">
-			</bounds>
+			<bounds x="741" y="525" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="823" y="547" width="82" height="22">
-			</bounds>
+			<bounds x="823" y="547" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="825" y="549" width="78" height="18">
-			</bounds>
+			<bounds x="825" y="549" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="779" y="71" width="32" height="32">
-			</bounds>
+			<bounds x="779" y="71" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="781" y="73" width="28" height="28">
-			</bounds>
+			<bounds x="781" y="73" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="779" y="27" width="32" height="32">
-			</bounds>
+			<bounds x="779" y="27" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="781" y="29" width="28" height="28">
-			</bounds>
+			<bounds x="781" y="29" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="471" y="579" width="156" height="17">
-			</bounds>
+			<bounds x="471" y="579" width="156" height="17"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="473" y="581" width="152" height="13">
-			</bounds>
+			<bounds x="473" y="581" width="152" height="13"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="407" y="519" width="112" height="22">
-			</bounds>
+			<bounds x="407" y="519" width="112" height="22"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="409" y="521" width="108" height="18">
-			</bounds>
+			<bounds x="409" y="521" width="108" height="18"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="476" y="541" width="32" height="32">
-			</bounds>
+			<bounds x="476" y="541" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="478" y="543" width="28" height="28">
-			</bounds>
+			<bounds x="478" y="543" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="445" y="541" width="32" height="32">
-			</bounds>
+			<bounds x="445" y="541" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="447" y="543" width="28" height="28">
-			</bounds>
+			<bounds x="447" y="543" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="414" y="541" width="32" height="32">
-			</bounds>
+			<bounds x="414" y="541" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="416" y="543" width="28" height="28">
-			</bounds>
+			<bounds x="416" y="543" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="592" y="542" width="32" height="32">
-			</bounds>
+			<bounds x="592" y="542" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="594" y="544" width="28" height="28">
-			</bounds>
+			<bounds x="594" y="544" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="623" y="542" width="32" height="32">
-			</bounds>
+			<bounds x="623" y="542" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="625" y="544" width="28" height="28">
-			</bounds>
+			<bounds x="625" y="544" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="654" y="542" width="32" height="32">
-			</bounds>
+			<bounds x="654" y="542" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="656" y="544" width="28" height="28">
-			</bounds>
+			<bounds x="656" y="544" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="583" y="519" width="112" height="22">
-			</bounds>
+			<bounds x="583" y="519" width="112" height="22"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="585" y="521" width="108" height="18">
-			</bounds>
+			<bounds x="585" y="521" width="108" height="18"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="871" y="419" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="419" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="873" y="421" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="421" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="871" y="319" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="319" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="873" y="321" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="321" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="871" y="299" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="299" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="873" y="301" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="301" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="871" y="279" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="279" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="873" y="281" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="281" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="871" y="259" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="259" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="873" y="261" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="261" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="871" y="239" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="239" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="873" y="241" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="241" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="871" y="339" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="339" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="873" y="341" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="341" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="871" y="359" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="359" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="873" y="361" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="361" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="871" y="379" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="379" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="873" y="381" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="381" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="871" y="399" width="32" height="22">
-			</bounds>
+			<bounds x="871" y="399" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="873" y="401" width="28" height="18">
-			</bounds>
+			<bounds x="873" y="401" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="808" y="131" width="22" height="22">
-			</bounds>
+			<bounds x="808" y="131" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="810" y="133" width="18" height="18">
-			</bounds>
+			<bounds x="810" y="133" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="829" y="131" width="22" height="22">
-			</bounds>
+			<bounds x="829" y="131" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="831" y="133" width="18" height="18">
-			</bounds>
+			<bounds x="831" y="133" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="850" y="131" width="22" height="22">
-			</bounds>
+			<bounds x="850" y="131" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="852" y="133" width="18" height="18">
-			</bounds>
+			<bounds x="852" y="133" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="871" y="131" width="22" height="22">
-			</bounds>
+			<bounds x="871" y="131" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="873" y="133" width="18" height="18">
-			</bounds>
+			<bounds x="873" y="133" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="24" y="585" width="62" height="42">
-			</bounds>
+			<bounds x="24" y="585" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="26" y="587" width="58" height="38">
-			</bounds>
+			<bounds x="26" y="587" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="24" y="561" width="62" height="22">
-			</bounds>
+			<bounds x="24" y="561" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="26" y="563" width="58" height="18">
-			</bounds>
+			<bounds x="26" y="563" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="24" y="537" width="62" height="22">
-			</bounds>
+			<bounds x="24" y="537" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="26" y="539" width="58" height="18">
-			</bounds>
+			<bounds x="26" y="539" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="24" y="513" width="62" height="22">
-			</bounds>
+			<bounds x="24" y="513" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="26" y="515" width="58" height="18">
-			</bounds>
+			<bounds x="26" y="515" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="24" y="489" width="62" height="22">
-			</bounds>
+			<bounds x="24" y="489" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="26" y="491" width="58" height="18">
-			</bounds>
+			<bounds x="26" y="491" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="359" y="348" width="62" height="28">
-			</bounds>
+			<bounds x="359" y="348" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="361" y="350" width="58" height="24">
-			</bounds>
+			<bounds x="361" y="350" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="359" y="322" width="62" height="28">
-			</bounds>
+			<bounds x="359" y="322" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="361" y="324" width="58" height="24">
-			</bounds>
+			<bounds x="361" y="324" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="359" y="296" width="62" height="28">
-			</bounds>
+			<bounds x="359" y="296" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="361" y="298" width="58" height="24">
-			</bounds>
+			<bounds x="361" y="298" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="347" y="173" width="87" height="28">
-			</bounds>
+			<bounds x="347" y="173" width="87" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="349" y="175" width="83" height="24">
-			</bounds>
+			<bounds x="349" y="175" width="83" height="24"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="347" y="121" width="87" height="28">
-			</bounds>
+			<bounds x="347" y="121" width="87" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="349" y="123" width="83" height="24">
-			</bounds>
+			<bounds x="349" y="123" width="83" height="24"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="347" y="147" width="87" height="28">
-			</bounds>
+			<bounds x="347" y="147" width="87" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="349" y="149" width="83" height="24">
-			</bounds>
+			<bounds x="349" y="149" width="83" height="24"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="347" y="95" width="87" height="28">
-			</bounds>
+			<bounds x="347" y="95" width="87" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="349" y="97" width="83" height="24">
-			</bounds>
+			<bounds x="349" y="97" width="83" height="24"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="347" y="69" width="87" height="28">
-			</bounds>
+			<bounds x="347" y="69" width="87" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="349" y="71" width="83" height="24">
-			</bounds>
+			<bounds x="349" y="71" width="83" height="24"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_175_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="935" y="35" width="75" height="27">
-			</bounds>
+			<bounds x="935" y="35" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_175" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="937" y="37" width="71" height="23">
-			</bounds>
+			<bounds x="937" y="37" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_176_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="7" y="635" width="92" height="27">
-			</bounds>
+			<bounds x="7" y="635" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_176" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="9" y="637" width="88" height="23">
-			</bounds>
+			<bounds x="9" y="637" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_177_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="107" y="635" width="92" height="27">
-			</bounds>
+			<bounds x="107" y="635" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_177" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="109" y="637" width="88" height="23">
-			</bounds>
+			<bounds x="109" y="637" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_178_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="199" y="635" width="92" height="27">
-			</bounds>
+			<bounds x="199" y="635" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_178" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="201" y="637" width="88" height="23">
-			</bounds>
+			<bounds x="201" y="637" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_179_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="291" y="635" width="92" height="27">
-			</bounds>
+			<bounds x="291" y="635" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_179" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="293" y="637" width="88" height="23">
-			</bounds>
+			<bounds x="293" y="637" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_186_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="779" y="635" width="92" height="27">
-			</bounds>
+			<bounds x="779" y="635" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_186" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="781" y="637" width="88" height="23">
-			</bounds>
+			<bounds x="781" y="637" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_187_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="595" y="635" width="92" height="27">
-			</bounds>
+			<bounds x="595" y="635" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_187" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="597" y="637" width="88" height="23">
-			</bounds>
+			<bounds x="597" y="637" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_188_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="415" y="635" width="92" height="27">
-			</bounds>
+			<bounds x="415" y="635" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_188" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="417" y="637" width="88" height="23">
-			</bounds>
+			<bounds x="417" y="637" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp238" element="colour_button_189_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="520" y="512" width="62" height="62">
-			</bounds>
+			<bounds x="520" y="512" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp238" element="colour_button_189" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="522" y="514" width="58" height="58">
-			</bounds>
+			<bounds x="522" y="514" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="865" y="156" width="24" height="32">
-			</bounds>
+			<bounds x="865" y="156" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="868" y="158" width="17" height="2">
-			</bounds>
+			<bounds x="868" y="158" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="882" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="882" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="882" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="882" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="868" y="182" width="17" height="2">
-			</bounds>
+			<bounds x="868" y="182" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="868" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="868" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="868" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="868" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="868" y="170" width="17" height="2">
-			</bounds>
+			<bounds x="868" y="170" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="885" y="182" width="3" height="2">
-			</bounds>
+			<bounds x="885" y="182" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="868" y="158" width="17" height="2">
-			</bounds>
+			<bounds x="868" y="158" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="882" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="882" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="882" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="882" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="868" y="182" width="17" height="2">
-			</bounds>
+			<bounds x="868" y="182" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="868" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="868" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="868" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="868" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="868" y="170" width="17" height="2">
-			</bounds>
+			<bounds x="868" y="170" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="885" y="182" width="3" height="2">
-			</bounds>
+			<bounds x="885" y="182" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="841" y="156" width="24" height="32">
-			</bounds>
+			<bounds x="841" y="156" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="844" y="158" width="17" height="2">
-			</bounds>
+			<bounds x="844" y="158" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="858" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="858" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="858" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="858" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="844" y="182" width="17" height="2">
-			</bounds>
+			<bounds x="844" y="182" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="844" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="844" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="844" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="844" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="844" y="170" width="17" height="2">
-			</bounds>
+			<bounds x="844" y="170" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="861" y="182" width="3" height="2">
-			</bounds>
+			<bounds x="861" y="182" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="844" y="158" width="17" height="2">
-			</bounds>
+			<bounds x="844" y="158" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="858" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="858" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="858" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="858" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="844" y="182" width="17" height="2">
-			</bounds>
+			<bounds x="844" y="182" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="844" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="844" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="844" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="844" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="844" y="170" width="17" height="2">
-			</bounds>
+			<bounds x="844" y="170" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="861" y="182" width="3" height="2">
-			</bounds>
+			<bounds x="861" y="182" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="817" y="156" width="24" height="32">
-			</bounds>
+			<bounds x="817" y="156" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="820" y="158" width="17" height="2">
-			</bounds>
+			<bounds x="820" y="158" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="834" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="834" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="834" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="834" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="820" y="182" width="17" height="2">
-			</bounds>
+			<bounds x="820" y="182" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="820" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="820" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="820" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="820" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="820" y="170" width="17" height="2">
-			</bounds>
+			<bounds x="820" y="170" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="837" y="182" width="3" height="2">
-			</bounds>
+			<bounds x="837" y="182" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="820" y="158" width="17" height="2">
-			</bounds>
+			<bounds x="820" y="158" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="834" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="834" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="834" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="834" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="820" y="182" width="17" height="2">
-			</bounds>
+			<bounds x="820" y="182" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="820" y="170" width="3" height="14">
-			</bounds>
+			<bounds x="820" y="170" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="820" y="158" width="3" height="14">
-			</bounds>
+			<bounds x="820" y="158" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="820" y="170" width="17" height="2">
-			</bounds>
+			<bounds x="820" y="170" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="837" y="182" width="3" height="2">
-			</bounds>
+			<bounds x="837" y="182" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="410" y="451" width="272" height="30">
-			</bounds>
+			<bounds x="410" y="451" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="410" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="410" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="427" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="427" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="444" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="444" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="461" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="461" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="478" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="478" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="495" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="495" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="512" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="512" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="529" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="529" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="546" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="546" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="563" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="563" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="580" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="580" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="597" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="597" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="614" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="614" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="631" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="631" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="648" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="648" y="451" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="665" y="451" width="17" height="30">
-			</bounds>
+			<bounds x="665" y="451" width="17" height="30"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_button" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1bargnc.lay
+++ b/src/mame/layout/m1bargnc.lay
@@ -8,10712 +8,6886 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_158_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SCORE HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SCORE HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="d">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="d">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="c">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="c">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string=" WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string=" WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="NUDGE TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="NUDGE TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string=" BARS ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OR SEVENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string=" BARS ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OR SEVENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="NEAREST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="NEAREST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_107_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_107">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string=" 20p ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Token">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_108_border">
 		<rect state="1">
-			<color red="0.33" green="0.33" blue="0.16">
-			</color>
+			<color red="0.33" green="0.33" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.08" blue="0.04">
-			</color>
+			<color red="0.08" green="0.08" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_108">
 		<rect state="1">
-			<color red="0.65" green="0.65" blue="0.33">
-			</color>
+			<color red="0.65" green="0.65" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.16" blue="0.08">
-			</color>
+			<color red="0.16" green="0.16" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_109_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_109">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_110_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_110">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" HOLD ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_111_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_111">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" HOLD HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_112_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_112">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" HOLD LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_113_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_113">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_114_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_114">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_28">
 		<text string="ANY 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_29">
 		<text string="MIXED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_30">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_31">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_50">
 		<text string="+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_51">
 		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_69">
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_81">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_97">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_99">
 		<text string="-----">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="559" height="695">
-			</bounds>
+			<bounds x="0" y="0" width="559" height="695"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="59" y="167" width="70" height="70">
-			</bounds>
+			<bounds x="59" y="167" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="59.0000" y="167.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="59.0000" y="167.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="61.9167" y="169.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="61.9167" y="169.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="64.8333" y="172.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="64.8333" y="172.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="67.7500" y="175.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="67.7500" y="175.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="70.6667" y="178.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="70.6667" y="178.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="73.5833" y="181.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="73.5833" y="181.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="59" y="167" width="70" height="70">
-			</bounds>
+			<bounds x="59" y="167" width="70" height="70"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="70" y="389" width="70" height="150">
-			</bounds>
+			<bounds x="70" y="389" width="70" height="150"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="70.0000" y="389.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="70.0000" y="389.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="72.9167" y="391.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="72.9167" y="391.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="75.8333" y="393.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="75.8333" y="393.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="78.7500" y="395.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="78.7500" y="395.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="81.6667" y="397.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="81.6667" y="397.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="84.5833" y="399.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="84.5833" y="399.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="70.0000" y="439.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="70.0000" y="439.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="72.9167" y="441.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="72.9167" y="441.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="75.8333" y="443.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="75.8333" y="443.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="78.7500" y="445.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="78.7500" y="445.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="81.6667" y="447.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="81.6667" y="447.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="84.5833" y="449.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="84.5833" y="449.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="70.0000" y="489.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="70.0000" y="489.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="72.9167" y="491.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="72.9167" y="491.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="75.8333" y="493.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="75.8333" y="493.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="78.7500" y="495.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="78.7500" y="495.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="81.6667" y="497.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="81.6667" y="497.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="84.5833" y="499.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="84.5833" y="499.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="70" y="389" width="70" height="150">
-			</bounds>
+			<bounds x="70" y="389" width="70" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="168" y="389" width="70" height="150">
-			</bounds>
+			<bounds x="168" y="389" width="70" height="150"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="168.0000" y="389.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="168.0000" y="389.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="170.9167" y="391.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="170.9167" y="391.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="173.8333" y="393.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="173.8333" y="393.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="176.7500" y="395.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="176.7500" y="395.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="179.6667" y="397.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="179.6667" y="397.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="182.5833" y="399.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="182.5833" y="399.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="168.0000" y="439.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="168.0000" y="439.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="170.9167" y="441.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="170.9167" y="441.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="173.8333" y="443.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="173.8333" y="443.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="176.7500" y="445.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="176.7500" y="445.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="179.6667" y="447.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="179.6667" y="447.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="182.5833" y="449.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="182.5833" y="449.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="168.0000" y="489.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="168.0000" y="489.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="170.9167" y="491.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="170.9167" y="491.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="173.8333" y="493.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="173.8333" y="493.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="176.7500" y="495.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="176.7500" y="495.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="179.6667" y="497.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="179.6667" y="497.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="182.5833" y="499.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="182.5833" y="499.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="168" y="389" width="70" height="150">
-			</bounds>
+			<bounds x="168" y="389" width="70" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="266" y="389" width="70" height="150">
-			</bounds>
+			<bounds x="266" y="389" width="70" height="150"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="266.0000" y="389.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="266.0000" y="389.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="268.9167" y="391.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="268.9167" y="391.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.8333" y="393.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="271.8333" y="393.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="274.7500" y="395.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="274.7500" y="395.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="277.6667" y="397.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="277.6667" y="397.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="280.5833" y="399.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="280.5833" y="399.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="266.0000" y="439.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="266.0000" y="439.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="268.9167" y="441.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="268.9167" y="441.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.8333" y="443.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="271.8333" y="443.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="274.7500" y="445.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="274.7500" y="445.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="277.6667" y="447.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="277.6667" y="447.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="280.5833" y="449.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="280.5833" y="449.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="266.0000" y="489.0000" width="70.0000" height="50.0000">
-			</bounds>
+			<bounds x="266.0000" y="489.0000" width="70.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="268.9167" y="491.0833" width="64.1667" height="45.8333">
-			</bounds>
+			<bounds x="268.9167" y="491.0833" width="64.1667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.8333" y="493.1667" width="58.3333" height="41.6667">
-			</bounds>
+			<bounds x="271.8333" y="493.1667" width="58.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="274.7500" y="495.2500" width="52.5000" height="37.5000">
-			</bounds>
+			<bounds x="274.7500" y="495.2500" width="52.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="277.6667" y="497.3333" width="46.6667" height="33.3333">
-			</bounds>
+			<bounds x="277.6667" y="497.3333" width="46.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="280.5833" y="499.4167" width="40.8333" height="29.1667">
-			</bounds>
+			<bounds x="280.5833" y="499.4167" width="40.8333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="266" y="389" width="70" height="150">
-			</bounds>
+			<bounds x="266" y="389" width="70" height="150"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="197" y="22" width="56" height="18">
-			</bounds>
+			<bounds x="197" y="22" width="56" height="18"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="199" y="24" width="52" height="14">
-			</bounds>
+			<bounds x="199" y="24" width="52" height="14"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="284" y="22" width="38" height="18">
-			</bounds>
+			<bounds x="284" y="22" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="286" y="24" width="34" height="14">
-			</bounds>
+			<bounds x="286" y="24" width="34" height="14"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="140" y="22" width="21" height="19">
-			</bounds>
+			<bounds x="140" y="22" width="21" height="19"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="142" y="24" width="17" height="15">
-			</bounds>
+			<bounds x="142" y="24" width="17" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="143" y="168" width="30" height="30">
-			</bounds>
+			<bounds x="143" y="168" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="145" y="170" width="26" height="26">
-			</bounds>
+			<bounds x="145" y="170" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="143" y="206" width="30" height="30">
-			</bounds>
+			<bounds x="143" y="206" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="145" y="208" width="26" height="26">
-			</bounds>
+			<bounds x="145" y="208" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="411" y="442" width="52" height="22">
-			</bounds>
+			<bounds x="411" y="442" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="413" y="444" width="48" height="18">
-			</bounds>
+			<bounds x="413" y="444" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="425" y="423" width="22" height="22">
-			</bounds>
+			<bounds x="425" y="423" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="427" y="425" width="18" height="18">
-			</bounds>
+			<bounds x="427" y="425" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="456" y="423" width="52" height="22">
-			</bounds>
+			<bounds x="456" y="423" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="458" y="425" width="48" height="18">
-			</bounds>
+			<bounds x="458" y="425" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="470" y="405" width="22" height="22">
-			</bounds>
+			<bounds x="470" y="405" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="472" y="407" width="18" height="18">
-			</bounds>
+			<bounds x="472" y="407" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="366" y="461" width="52" height="22">
-			</bounds>
+			<bounds x="366" y="461" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="368" y="463" width="48" height="18">
-			</bounds>
+			<bounds x="368" y="463" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="380" y="442" width="22" height="22">
-			</bounds>
+			<bounds x="380" y="442" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="382" y="444" width="18" height="18">
-			</bounds>
+			<bounds x="382" y="444" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="412" y="206" width="36" height="28">
-			</bounds>
+			<bounds x="412" y="206" width="36" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="414" y="208" width="32" height="24">
-			</bounds>
+			<bounds x="414" y="208" width="32" height="24"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2_border" state="0">
-			<bounds x="445" y="206" width="40" height="28">
-			</bounds>
+			<bounds x="445" y="206" width="40" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2" state="0">
-			<bounds x="447" y="208" width="36" height="24">
-			</bounds>
+			<bounds x="447" y="208" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="445" y="170" width="40" height="28">
-			</bounds>
+			<bounds x="445" y="170" width="40" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="447" y="172" width="36" height="24">
-			</bounds>
+			<bounds x="447" y="172" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_2_border" state="0">
-			<bounds x="412" y="170" width="36" height="28">
-			</bounds>
+			<bounds x="412" y="170" width="36" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_2" state="0">
-			<bounds x="414" y="172" width="32" height="24">
-			</bounds>
+			<bounds x="414" y="172" width="32" height="24"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="445" y="133" width="40" height="28">
-			</bounds>
+			<bounds x="445" y="133" width="40" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="447" y="135" width="36" height="24">
-			</bounds>
+			<bounds x="447" y="135" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_2_border" state="0">
-			<bounds x="412" y="133" width="36" height="28">
-			</bounds>
+			<bounds x="412" y="133" width="36" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_2" state="0">
-			<bounds x="414" y="135" width="32" height="24">
-			</bounds>
+			<bounds x="414" y="135" width="32" height="24"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="445" y="97" width="40" height="28">
-			</bounds>
+			<bounds x="445" y="97" width="40" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="447" y="99" width="36" height="24">
-			</bounds>
+			<bounds x="447" y="99" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2_border" state="0">
-			<bounds x="412" y="97" width="36" height="28">
-			</bounds>
+			<bounds x="412" y="97" width="36" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2" state="0">
-			<bounds x="414" y="99" width="32" height="24">
-			</bounds>
+			<bounds x="414" y="99" width="32" height="24"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="445" y="241" width="40" height="28">
-			</bounds>
+			<bounds x="445" y="241" width="40" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="447" y="243" width="36" height="24">
-			</bounds>
+			<bounds x="447" y="243" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_2_border" state="0">
-			<bounds x="412" y="241" width="36" height="28">
-			</bounds>
+			<bounds x="412" y="241" width="36" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_2" state="0">
-			<bounds x="414" y="243" width="32" height="24">
-			</bounds>
+			<bounds x="414" y="243" width="32" height="24"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="412" y="61" width="36" height="28">
-			</bounds>
+			<bounds x="412" y="61" width="36" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="414" y="63" width="32" height="24">
-			</bounds>
+			<bounds x="414" y="63" width="32" height="24"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_2_border" state="0">
-			<bounds x="445" y="61" width="40" height="28">
-			</bounds>
+			<bounds x="445" y="61" width="40" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_2" state="0">
-			<bounds x="447" y="63" width="36" height="24">
-			</bounds>
+			<bounds x="447" y="63" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="381" y="66" width="19" height="19">
-			</bounds>
+			<bounds x="381" y="66" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="383" y="68" width="15" height="15">
-			</bounds>
+			<bounds x="383" y="68" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="381" y="102" width="19" height="19">
-			</bounds>
+			<bounds x="381" y="102" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="383" y="104" width="15" height="15">
-			</bounds>
+			<bounds x="383" y="104" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="381" y="138" width="19" height="19">
-			</bounds>
+			<bounds x="381" y="138" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="383" y="140" width="15" height="15">
-			</bounds>
+			<bounds x="383" y="140" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="381" y="174" width="19" height="19">
-			</bounds>
+			<bounds x="381" y="174" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="383" y="176" width="15" height="15">
-			</bounds>
+			<bounds x="383" y="176" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="381" y="210" width="19" height="19">
-			</bounds>
+			<bounds x="381" y="210" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="383" y="212" width="15" height="15">
-			</bounds>
+			<bounds x="383" y="212" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="381" y="246" width="19" height="19">
-			</bounds>
+			<bounds x="381" y="246" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="383" y="248" width="15" height="15">
-			</bounds>
+			<bounds x="383" y="248" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_2_border" state="0">
-			<bounds x="348" y="58" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="58" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_2" state="0">
-			<bounds x="350" y="60" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="60" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_2_border" state="0">
-			<bounds x="348" y="94" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="94" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_2" state="0">
-			<bounds x="350" y="96" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="96" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_2_border" state="0">
-			<bounds x="348" y="130" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="130" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_2" state="0">
-			<bounds x="350" y="132" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="132" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2_border" state="0">
-			<bounds x="348" y="166" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="166" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2" state="0">
-			<bounds x="350" y="168" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="168" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_2_border" state="0">
-			<bounds x="348" y="202" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="202" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_2" state="0">
-			<bounds x="350" y="204" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="204" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_2_border" state="0">
-			<bounds x="348" y="238" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="238" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_2" state="0">
-			<bounds x="350" y="240" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="240" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="348" y="382" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="382" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="350" y="384" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="384" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="348" y="346" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="346" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="350" y="348" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="348" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="348" y="310" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="310" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="350" y="312" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="312" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="348" y="274" width="34" height="34">
-			</bounds>
+			<bounds x="348" y="274" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="350" y="276" width="30" height="30">
-			</bounds>
+			<bounds x="350" y="276" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="416" y="299" width="42" height="30">
-			</bounds>
+			<bounds x="416" y="299" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="418" y="301" width="38" height="26">
-			</bounds>
+			<bounds x="418" y="301" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="68" y="126" width="52" height="25">
-			</bounds>
+			<bounds x="68" y="126" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="70" y="128" width="48" height="21">
-			</bounds>
+			<bounds x="70" y="128" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="68" y="126" width="52" height="25">
-			</bounds>
+			<bounds x="68" y="126" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="70" y="128" width="48" height="21">
-			</bounds>
+			<bounds x="70" y="128" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="68" y="42" width="52" height="25">
-			</bounds>
+			<bounds x="68" y="42" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="70" y="44" width="48" height="21">
-			</bounds>
+			<bounds x="70" y="44" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="68" y="42" width="52" height="25">
-			</bounds>
+			<bounds x="68" y="42" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="70" y="44" width="48" height="21">
-			</bounds>
+			<bounds x="70" y="44" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="288" y="559" width="32" height="32">
-			</bounds>
+			<bounds x="288" y="559" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="290" y="561" width="28" height="28">
-			</bounds>
+			<bounds x="290" y="561" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="254" y="559" width="32" height="32">
-			</bounds>
+			<bounds x="254" y="559" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="256" y="561" width="28" height="28">
-			</bounds>
+			<bounds x="256" y="561" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="220" y="559" width="32" height="32">
-			</bounds>
+			<bounds x="220" y="559" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="222" y="561" width="28" height="28">
-			</bounds>
+			<bounds x="222" y="561" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="186" y="559" width="32" height="32">
-			</bounds>
+			<bounds x="186" y="559" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="188" y="561" width="28" height="28">
-			</bounds>
+			<bounds x="188" y="561" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="152" y="559" width="32" height="32">
-			</bounds>
+			<bounds x="152" y="559" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="154" y="561" width="28" height="28">
-			</bounds>
+			<bounds x="154" y="561" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="118" y="559" width="32" height="32">
-			</bounds>
+			<bounds x="118" y="559" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="120" y="561" width="28" height="28">
-			</bounds>
+			<bounds x="120" y="561" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="84" y="559" width="32" height="32">
-			</bounds>
+			<bounds x="84" y="559" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="86" y="561" width="28" height="28">
-			</bounds>
+			<bounds x="86" y="561" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="285" y="601" width="54" height="35">
-			</bounds>
+			<bounds x="285" y="601" width="54" height="35"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="287" y="603" width="50" height="31">
-			</bounds>
+			<bounds x="287" y="603" width="50" height="31"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="229" y="601" width="54" height="35">
-			</bounds>
+			<bounds x="229" y="601" width="54" height="35"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="231" y="603" width="50" height="31">
-			</bounds>
+			<bounds x="231" y="603" width="50" height="31"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="173" y="601" width="54" height="35">
-			</bounds>
+			<bounds x="173" y="601" width="54" height="35"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="175" y="603" width="50" height="31">
-			</bounds>
+			<bounds x="175" y="603" width="50" height="31"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="53" y="601" width="54" height="35">
-			</bounds>
+			<bounds x="53" y="601" width="54" height="35"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="55" y="603" width="50" height="31">
-			</bounds>
+			<bounds x="55" y="603" width="50" height="31"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="109" y="601" width="62" height="19">
-			</bounds>
+			<bounds x="109" y="601" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="111" y="603" width="58" height="15">
-			</bounds>
+			<bounds x="111" y="603" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="109" y="617" width="62" height="19">
-			</bounds>
+			<bounds x="109" y="617" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="111" y="619" width="58" height="15">
-			</bounds>
+			<bounds x="111" y="619" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="142" y="288" width="36" height="52">
-			</bounds>
+			<bounds x="142" y="288" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="144" y="290" width="32" height="48">
-			</bounds>
+			<bounds x="144" y="290" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="109" y="288" width="36" height="52">
-			</bounds>
+			<bounds x="109" y="288" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="111" y="290" width="32" height="48">
-			</bounds>
+			<bounds x="111" y="290" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="76" y="288" width="36" height="52">
-			</bounds>
+			<bounds x="76" y="288" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="78" y="290" width="32" height="48">
-			</bounds>
+			<bounds x="78" y="290" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="292" y="288" width="36" height="52">
-			</bounds>
+			<bounds x="292" y="288" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="294" y="290" width="32" height="48">
-			</bounds>
+			<bounds x="294" y="290" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="259" y="288" width="36" height="52">
-			</bounds>
+			<bounds x="259" y="288" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="261" y="290" width="32" height="48">
-			</bounds>
+			<bounds x="261" y="290" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="226" y="288" width="36" height="52">
-			</bounds>
+			<bounds x="226" y="288" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="228" y="290" width="32" height="48">
-			</bounds>
+			<bounds x="228" y="290" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="194" y="288" width="36" height="52">
-			</bounds>
+			<bounds x="194" y="288" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="196" y="290" width="32" height="48">
-			</bounds>
+			<bounds x="196" y="290" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_107_border" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="402" y="6" width="43" height="43">
-			</bounds>
+			<bounds x="402" y="6" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_107" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="404" y="8" width="39" height="39">
-			</bounds>
+			<bounds x="404" y="8" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_108_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="447" y="6" width="43" height="43">
-			</bounds>
+			<bounds x="447" y="6" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_108" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="449" y="8" width="39" height="39">
-			</bounds>
+			<bounds x="449" y="8" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_109_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="10" y="649" width="75" height="41">
-			</bounds>
+			<bounds x="10" y="649" width="75" height="41"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_109" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="12" y="651" width="71" height="37">
-			</bounds>
+			<bounds x="12" y="651" width="71" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_110_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="92" y="649" width="75" height="41">
-			</bounds>
+			<bounds x="92" y="649" width="75" height="41"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_110" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="94" y="651" width="71" height="37">
-			</bounds>
+			<bounds x="94" y="651" width="71" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_111_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="167" y="649" width="75" height="41">
-			</bounds>
+			<bounds x="167" y="649" width="75" height="41"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_111" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="169" y="651" width="71" height="37">
-			</bounds>
+			<bounds x="169" y="651" width="71" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_112_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="242" y="649" width="75" height="41">
-			</bounds>
+			<bounds x="242" y="649" width="75" height="41"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_112" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="244" y="651" width="71" height="37">
-			</bounds>
+			<bounds x="244" y="651" width="71" height="37"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_113_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="325" y="649" width="75" height="41">
-			</bounds>
+			<bounds x="325" y="649" width="75" height="41"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_113" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="327" y="651" width="71" height="37">
-			</bounds>
+			<bounds x="327" y="651" width="71" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_114_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="408" y="649" width="75" height="41">
-			</bounds>
+			<bounds x="408" y="649" width="75" height="41"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_114" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="410" y="651" width="71" height="37">
-			</bounds>
+			<bounds x="410" y="651" width="71" height="37"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="370" y="509" width="20" height="28">
-			</bounds>
+			<bounds x="370" y="509" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off168" element="led_off">
-			<bounds x="372" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="372" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off169" element="led_off">
-			<bounds x="384" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="384" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off170" element="led_off">
-			<bounds x="384" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="384" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off171" element="led_off">
-			<bounds x="372" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="372" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off172" element="led_off">
-			<bounds x="372" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="372" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off173" element="led_off">
-			<bounds x="372" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="372" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off174" element="led_off">
-			<bounds x="372" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="372" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off175" element="led_dot_off">
-			<bounds x="387" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="387" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp168" element="led_on">
-			<bounds x="372" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="372" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp169" element="led_on">
-			<bounds x="384" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="384" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp170" element="led_on">
-			<bounds x="384" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="384" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp171" element="led_on">
-			<bounds x="372" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="372" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp172" element="led_on">
-			<bounds x="372" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="372" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp173" element="led_on">
-			<bounds x="372" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="372" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp174" element="led_on">
-			<bounds x="372" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="372" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp175" element="led_dot_on">
-			<bounds x="387" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="387" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="390" y="509" width="20" height="28">
-			</bounds>
+			<bounds x="390" y="509" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off176" element="led_off">
-			<bounds x="392" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="392" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off177" element="led_off">
-			<bounds x="404" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="404" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off178" element="led_off">
-			<bounds x="404" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="404" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off179" element="led_off">
-			<bounds x="392" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="392" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off180" element="led_off">
-			<bounds x="392" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="392" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off181" element="led_off">
-			<bounds x="392" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="392" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off182" element="led_off">
-			<bounds x="392" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="392" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off183" element="led_dot_off">
-			<bounds x="407" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="407" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp176" element="led_on">
-			<bounds x="392" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="392" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp177" element="led_on">
-			<bounds x="404" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="404" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp178" element="led_on">
-			<bounds x="404" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="404" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp179" element="led_on">
-			<bounds x="392" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="392" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp180" element="led_on">
-			<bounds x="392" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="392" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp181" element="led_on">
-			<bounds x="392" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="392" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp182" element="led_on">
-			<bounds x="392" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="392" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp183" element="led_dot_on">
-			<bounds x="407" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="407" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="430" y="509" width="20" height="28">
-			</bounds>
+			<bounds x="430" y="509" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off192" element="led_off">
-			<bounds x="432" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="432" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off193" element="led_off">
-			<bounds x="444" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="444" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off194" element="led_off">
-			<bounds x="444" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="444" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off195" element="led_off">
-			<bounds x="432" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="432" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off196" element="led_off">
-			<bounds x="432" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="432" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off197" element="led_off">
-			<bounds x="432" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="432" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off198" element="led_off">
-			<bounds x="432" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="432" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off199" element="led_dot_off">
-			<bounds x="447" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="447" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp192" element="led_on">
-			<bounds x="432" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="432" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp193" element="led_on">
-			<bounds x="444" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="444" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp194" element="led_on">
-			<bounds x="444" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="444" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp195" element="led_on">
-			<bounds x="432" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="432" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp196" element="led_on">
-			<bounds x="432" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="432" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp197" element="led_on">
-			<bounds x="432" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="432" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp198" element="led_on">
-			<bounds x="432" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="432" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp199" element="led_dot_on">
-			<bounds x="447" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="447" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="410" y="509" width="20" height="28">
-			</bounds>
+			<bounds x="410" y="509" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off184" element="led_off">
-			<bounds x="412" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="412" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off185" element="led_off">
-			<bounds x="424" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="424" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off186" element="led_off">
-			<bounds x="424" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="424" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off187" element="led_off">
-			<bounds x="412" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="412" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off188" element="led_off">
-			<bounds x="412" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="412" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off189" element="led_off">
-			<bounds x="412" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="412" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off190" element="led_off">
-			<bounds x="412" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="412" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off191" element="led_dot_off">
-			<bounds x="427" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="427" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp184" element="led_on">
-			<bounds x="412" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="412" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp185" element="led_on">
-			<bounds x="424" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="424" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp186" element="led_on">
-			<bounds x="424" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="424" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp187" element="led_on">
-			<bounds x="412" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="412" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp188" element="led_on">
-			<bounds x="412" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="412" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp189" element="led_on">
-			<bounds x="412" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="412" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp190" element="led_on">
-			<bounds x="412" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="412" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp191" element="led_dot_on">
-			<bounds x="427" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="427" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="486" y="509" width="20" height="28">
-			</bounds>
+			<bounds x="486" y="509" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off208" element="led_off">
-			<bounds x="488" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="488" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off209" element="led_off">
-			<bounds x="500" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="500" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off210" element="led_off">
-			<bounds x="500" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="500" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off211" element="led_off">
-			<bounds x="488" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="488" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off212" element="led_off">
-			<bounds x="488" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="488" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off213" element="led_off">
-			<bounds x="488" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="488" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off214" element="led_off">
-			<bounds x="488" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="488" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off215" element="led_dot_off">
-			<bounds x="503" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="503" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp208" element="led_on">
-			<bounds x="488" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="488" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp209" element="led_on">
-			<bounds x="500" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="500" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp210" element="led_on">
-			<bounds x="500" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="500" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp211" element="led_on">
-			<bounds x="488" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="488" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp212" element="led_on">
-			<bounds x="488" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="488" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp213" element="led_on">
-			<bounds x="488" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="488" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp214" element="led_on">
-			<bounds x="488" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="488" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp215" element="led_dot_on">
-			<bounds x="503" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="503" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="466" y="509" width="20" height="28">
-			</bounds>
+			<bounds x="466" y="509" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="468" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="468" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="480" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="480" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="480" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="480" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="468" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="468" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="468" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="468" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="468" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="468" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="468" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="468" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="483" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="483" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="468" y="511" width="14" height="2">
-			</bounds>
+			<bounds x="468" y="511" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="480" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="480" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="480" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="480" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="468" y="531" width="14" height="2">
-			</bounds>
+			<bounds x="468" y="531" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="468" y="521" width="2" height="12">
-			</bounds>
+			<bounds x="468" y="521" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="468" y="511" width="2" height="12">
-			</bounds>
+			<bounds x="468" y="511" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="468" y="521" width="14" height="2">
-			</bounds>
+			<bounds x="468" y="521" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="483" y="531" width="2" height="2">
-			</bounds>
+			<bounds x="483" y="531" width="2" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="82" y="352" width="240" height="23">
-			</bounds>
+			<bounds x="82" y="352" width="240" height="23"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="82" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="82" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="97" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="97" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="112" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="112" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="127" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="127" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="142" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="142" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="157" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="157" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="172" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="172" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="187" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="187" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="202" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="202" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="217" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="217" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="232" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="232" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="247" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="247" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="262" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="262" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="277" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="277" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="292" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="292" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="307" y="352" width="15" height="23">
-			</bounds>
+			<bounds x="307" y="352" width="15" height="23"/>
 		</backdrop>
 		<backdrop name="label28" element="label_28">
-			<bounds x="199" y="228" width="28" height="12">
-			</bounds>
+			<bounds x="199" y="228" width="28" height="12"/>
 		</backdrop>
 		<backdrop name="label29" element="label_29">
-			<bounds x="279" y="228" width="28" height="12">
-			</bounds>
+			<bounds x="279" y="228" width="28" height="12"/>
 		</backdrop>
 		<backdrop name="label30" element="label_30">
-			<bounds x="349" y="505" width="20" height="37">
-			</bounds>
+			<bounds x="349" y="505" width="20" height="37"/>
 		</backdrop>
 		<backdrop name="label31" element="label_31">
-			<bounds x="384" y="542" width="56" height="13">
-			</bounds>
+			<bounds x="384" y="542" width="56" height="13"/>
 		</backdrop>
 		<backdrop name="label50" element="label_50">
-			<bounds x="488" y="66" width="8" height="13">
-			</bounds>
+			<bounds x="488" y="66" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label51" element="label_51">
-			<bounds x="496" y="62" width="54" height="26">
-			</bounds>
+			<bounds x="496" y="62" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="label69" element="label_69">
-			<bounds x="66" y="112" width="59" height="15">
-			</bounds>
+			<bounds x="66" y="112" width="59" height="15"/>
 		</backdrop>
 		<backdrop name="label81" element="label_81">
-			<bounds x="470" y="541" width="34" height="13">
-			</bounds>
+			<bounds x="470" y="541" width="34" height="13"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="239" y="459" width="29" height="13">
-			</bounds>
+			<bounds x="239" y="459" width="29" height="13"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="142" y="459" width="26" height="13">
-			</bounds>
+			<bounds x="142" y="459" width="26" height="13"/>
 		</backdrop>
 		<backdrop name="label99" element="label_99">
-			<bounds x="178" y="306" width="15" height="13">
-			</bounds>
+			<bounds x="178" y="306" width="15" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_button" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_button" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1105.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1110.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1115.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1120.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1125.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1bghou.lay
+++ b/src/mame/layout/m1bghou.lay
@@ -8,11436 +8,7085 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="RANDOM STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="RANDOM STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="6 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="6 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="FRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="FRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="AKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="AKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="KILLER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="KILLER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BLOOD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BLOOD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="MONSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="MONSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CREAPY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="CREAPY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="FREAKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="FREAKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="NASTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="NASTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="URES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="URES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="SKULL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="SKULL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STOPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="DEAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CERT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="DEAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CERT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RISER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RISER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CRAZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REELS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="CRAZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REELS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="FRENZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="FRENZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="NUMBERS IN VIEW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="NUMBERS IN VIEW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="SELECTA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="SELECTA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="ADD AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="ADD AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="SKILL SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="SKILL SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="16 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="16 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="12 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="12 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="8 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="8 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="FETURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="FETURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="5 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="5 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Ghoulies">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Ghoulies">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Freaky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Freaky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Nice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Number">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Nice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Number">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Spooky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Spooky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="US">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="US">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_110_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_110">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_111_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_111">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_112_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_112">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_113_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_113">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_115_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_115">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_116_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_116">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_117_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_117">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_118_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_118">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_119_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_119">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_120_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_120">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_121_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_121">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_126_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_126">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_127_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_127">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_128_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_128">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_129_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_129">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_130_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_130">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_108">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_109">
 		<text string="CREDIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="914" height="681">
-			</bounds>
+			<bounds x="0" y="0" width="914" height="681"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="224" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="224" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="224.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="224.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="227.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="227.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="230.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="230.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="234.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="234.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="237.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="237.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="240.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="240.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="224.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="224.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="227.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="227.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="230.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="230.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="234.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="234.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="237.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="237.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="240.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="240.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="224.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="224.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="227.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="227.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="230.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="230.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="234.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="234.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="237.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="237.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="240.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="240.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="224" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="224" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="333" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="333" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="333.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="336.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="339.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="343.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="346.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="349.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="333.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="336.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="339.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="343.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="346.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="349.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="333.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="336.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="339.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="343.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="346.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="349.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="333" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="333" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="442" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="442" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="442.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="442.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="445.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="445.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="448.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="448.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="452.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="452.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="455.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="455.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="458.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="458.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="442.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="442.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="445.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="445.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="448.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="448.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="452.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="452.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="455.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="455.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="458.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="458.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="442.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="442.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="445.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="445.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="448.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="448.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="452.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="452.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="455.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="455.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="458.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="458.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="442" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="442" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="268" y="148" width="80" height="60">
-			</bounds>
+			<bounds x="268" y="148" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="268.0000" y="148.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="268.0000" y="148.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="271.3333" y="150.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="271.3333" y="150.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="274.6667" y="153.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="274.6667" y="153.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="278.0000" y="155.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="278.0000" y="155.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="281.3333" y="158.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="281.3333" y="158.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="284.6667" y="160.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="284.6667" y="160.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="268" y="148" width="80" height="60">
-			</bounds>
+			<bounds x="268" y="148" width="80" height="60"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="402" y="148" width="80" height="60">
-			</bounds>
+			<bounds x="402" y="148" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="402.0000" y="148.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="402.0000" y="148.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="405.3333" y="150.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="405.3333" y="150.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="408.6667" y="153.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="408.6667" y="153.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="412.0000" y="155.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="412.0000" y="155.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="415.3333" y="158.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="415.3333" y="158.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="418.6667" y="160.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="418.6667" y="160.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="402" y="148" width="80" height="60">
-			</bounds>
+			<bounds x="402" y="148" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="736" y="582" width="92" height="42">
-			</bounds>
+			<bounds x="736" y="582" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="738" y="584" width="88" height="38">
-			</bounds>
+			<bounds x="738" y="584" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="521" y="232" width="82" height="32">
-			</bounds>
+			<bounds x="521" y="232" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="523" y="234" width="78" height="28">
-			</bounds>
+			<bounds x="523" y="234" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="182" y="173" width="42" height="37">
-			</bounds>
+			<bounds x="182" y="173" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="184" y="175" width="38" height="33">
-			</bounds>
+			<bounds x="184" y="175" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="187" y="138" width="42" height="37">
-			</bounds>
+			<bounds x="187" y="138" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="189" y="140" width="38" height="33">
-			</bounds>
+			<bounds x="189" y="140" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="202" y="33" width="42" height="37">
-			</bounds>
+			<bounds x="202" y="33" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="204" y="35" width="38" height="33">
-			</bounds>
+			<bounds x="204" y="35" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="197" y="68" width="42" height="37">
-			</bounds>
+			<bounds x="197" y="68" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="199" y="70" width="38" height="33">
-			</bounds>
+			<bounds x="199" y="70" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="192" y="103" width="42" height="37">
-			</bounds>
+			<bounds x="192" y="103" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="194" y="105" width="38" height="33">
-			</bounds>
+			<bounds x="194" y="105" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="177" y="208" width="42" height="37">
-			</bounds>
+			<bounds x="177" y="208" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="179" y="210" width="38" height="33">
-			</bounds>
+			<bounds x="179" y="210" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="169" y="280" width="42" height="37">
-			</bounds>
+			<bounds x="169" y="280" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="171" y="282" width="38" height="33">
-			</bounds>
+			<bounds x="171" y="282" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="166" y="316" width="42" height="37">
-			</bounds>
+			<bounds x="166" y="316" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="168" y="318" width="38" height="33">
-			</bounds>
+			<bounds x="168" y="318" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="174" y="244" width="42" height="37">
-			</bounds>
+			<bounds x="174" y="244" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="176" y="246" width="38" height="33">
-			</bounds>
+			<bounds x="176" y="246" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="151" y="422" width="32" height="37">
-			</bounds>
+			<bounds x="151" y="422" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="153" y="424" width="28" height="33">
-			</bounds>
+			<bounds x="153" y="424" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="160" y="352" width="42" height="37">
-			</bounds>
+			<bounds x="160" y="352" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="162" y="354" width="38" height="33">
-			</bounds>
+			<bounds x="162" y="354" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="155" y="387" width="32" height="37">
-			</bounds>
+			<bounds x="155" y="387" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="157" y="389" width="28" height="33">
-			</bounds>
+			<bounds x="157" y="389" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="143" y="492" width="32" height="37">
-			</bounds>
+			<bounds x="143" y="492" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="145" y="494" width="28" height="33">
-			</bounds>
+			<bounds x="145" y="494" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="147" y="457" width="32" height="37">
-			</bounds>
+			<bounds x="147" y="457" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="149" y="459" width="28" height="33">
-			</bounds>
+			<bounds x="149" y="459" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="715" y="98" width="62" height="42">
-			</bounds>
+			<bounds x="715" y="98" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="717" y="100" width="58" height="38">
-			</bounds>
+			<bounds x="717" y="100" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="773" y="98" width="58" height="42">
-			</bounds>
+			<bounds x="773" y="98" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="775" y="100" width="54" height="38">
-			</bounds>
+			<bounds x="775" y="100" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="819" y="268" width="82" height="42">
-			</bounds>
+			<bounds x="819" y="268" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="821" y="270" width="78" height="38">
-			</bounds>
+			<bounds x="821" y="270" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="728" y="269" width="82" height="42">
-			</bounds>
+			<bounds x="728" y="269" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="730" y="271" width="78" height="38">
-			</bounds>
+			<bounds x="730" y="271" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="636" y="269" width="82" height="42">
-			</bounds>
+			<bounds x="636" y="269" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="638" y="271" width="78" height="38">
-			</bounds>
+			<bounds x="638" y="271" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="636" y="183" width="82" height="42">
-			</bounds>
+			<bounds x="636" y="183" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="638" y="185" width="78" height="38">
-			</bounds>
+			<bounds x="638" y="185" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="728" y="183" width="82" height="42">
-			</bounds>
+			<bounds x="728" y="183" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="730" y="185" width="78" height="38">
-			</bounds>
+			<bounds x="730" y="185" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="819" y="183" width="82" height="42">
-			</bounds>
+			<bounds x="819" y="183" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="821" y="185" width="78" height="38">
-			</bounds>
+			<bounds x="821" y="185" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="699" y="135" width="74" height="42">
-			</bounds>
+			<bounds x="699" y="135" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="701" y="137" width="70" height="38">
-			</bounds>
+			<bounds x="701" y="137" width="70" height="38"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="770" y="135" width="74" height="42">
-			</bounds>
+			<bounds x="770" y="135" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="772" y="137" width="70" height="38">
-			</bounds>
+			<bounds x="772" y="137" width="70" height="38"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="637" y="336" width="82" height="42">
-			</bounds>
+			<bounds x="637" y="336" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="639" y="338" width="78" height="38">
-			</bounds>
+			<bounds x="639" y="338" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="728" y="336" width="82" height="42">
-			</bounds>
+			<bounds x="728" y="336" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="730" y="338" width="78" height="38">
-			</bounds>
+			<bounds x="730" y="338" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="819" y="420" width="82" height="42">
-			</bounds>
+			<bounds x="819" y="420" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="821" y="422" width="78" height="38">
-			</bounds>
+			<bounds x="821" y="422" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="728" y="420" width="82" height="42">
-			</bounds>
+			<bounds x="728" y="420" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="730" y="422" width="78" height="38">
-			</bounds>
+			<bounds x="730" y="422" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="638" y="420" width="82" height="42">
-			</bounds>
+			<bounds x="638" y="420" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="640" y="422" width="78" height="38">
-			</bounds>
+			<bounds x="640" y="422" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="818" y="336" width="82" height="42">
-			</bounds>
+			<bounds x="818" y="336" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="820" y="338" width="78" height="38">
-			</bounds>
+			<bounds x="820" y="338" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="638" y="526" width="92" height="42">
-			</bounds>
+			<bounds x="638" y="526" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="640" y="528" width="88" height="38">
-			</bounds>
+			<bounds x="640" y="528" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="814" y="556" width="92" height="42">
-			</bounds>
+			<bounds x="814" y="556" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="816" y="558" width="88" height="38">
-			</bounds>
+			<bounds x="816" y="558" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="807" y="515" width="92" height="42">
-			</bounds>
+			<bounds x="807" y="515" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="809" y="517" width="88" height="38">
-			</bounds>
+			<bounds x="809" y="517" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="646" y="567" width="92" height="42">
-			</bounds>
+			<bounds x="646" y="567" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="648" y="569" width="88" height="38">
-			</bounds>
+			<bounds x="648" y="569" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="739" y="466" width="52" height="32">
-			</bounds>
+			<bounds x="739" y="466" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="741" y="468" width="48" height="28">
-			</bounds>
+			<bounds x="741" y="468" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="716" y="500" width="92" height="42">
-			</bounds>
+			<bounds x="716" y="500" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="718" y="502" width="88" height="38">
-			</bounds>
+			<bounds x="718" y="502" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="725" y="541" width="92" height="42">
-			</bounds>
+			<bounds x="725" y="541" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="727" y="543" width="88" height="38">
-			</bounds>
+			<bounds x="727" y="543" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="522" y="8" width="42" height="42">
-			</bounds>
+			<bounds x="522" y="8" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="524" y="10" width="38" height="38">
-			</bounds>
+			<bounds x="524" y="10" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="498" y="50" width="92" height="32">
-			</bounds>
+			<bounds x="498" y="50" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="500" y="52" width="88" height="28">
-			</bounds>
+			<bounds x="500" y="52" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="504" y="87" width="82" height="32">
-			</bounds>
+			<bounds x="504" y="87" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="506" y="89" width="78" height="28">
-			</bounds>
+			<bounds x="506" y="89" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="507" y="123" width="82" height="32">
-			</bounds>
+			<bounds x="507" y="123" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="509" y="125" width="78" height="28">
-			</bounds>
+			<bounds x="509" y="125" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="511" y="159" width="82" height="32">
-			</bounds>
+			<bounds x="511" y="159" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="513" y="161" width="78" height="28">
-			</bounds>
+			<bounds x="513" y="161" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="516" y="196" width="82" height="32">
-			</bounds>
+			<bounds x="516" y="196" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="518" y="198" width="78" height="28">
-			</bounds>
+			<bounds x="518" y="198" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="526" y="580" width="62" height="32">
-			</bounds>
+			<bounds x="526" y="580" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="528" y="582" width="58" height="28">
-			</bounds>
+			<bounds x="528" y="582" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="574" y="472" width="32" height="32">
-			</bounds>
+			<bounds x="574" y="472" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="576" y="474" width="28" height="28">
-			</bounds>
+			<bounds x="576" y="474" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="598" y="490" width="32" height="32">
-			</bounds>
+			<bounds x="598" y="490" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="600" y="492" width="28" height="28">
-			</bounds>
+			<bounds x="600" y="492" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="582" y="516" width="32" height="32">
-			</bounds>
+			<bounds x="582" y="516" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="584" y="518" width="28" height="28">
-			</bounds>
+			<bounds x="584" y="518" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="603" y="537" width="32" height="32">
-			</bounds>
+			<bounds x="603" y="537" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="605" y="539" width="28" height="28">
-			</bounds>
+			<bounds x="605" y="539" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="589" y="564" width="32" height="32">
-			</bounds>
+			<bounds x="589" y="564" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="591" y="566" width="28" height="28">
-			</bounds>
+			<bounds x="591" y="566" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="610" y="586" width="32" height="32">
-			</bounds>
+			<bounds x="610" y="586" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="612" y="588" width="28" height="28">
-			</bounds>
+			<bounds x="612" y="588" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="592" y="448" width="32" height="32">
-			</bounds>
+			<bounds x="592" y="448" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="594" y="450" width="28" height="28">
-			</bounds>
+			<bounds x="594" y="450" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="545" y="415" width="82" height="32">
-			</bounds>
+			<bounds x="545" y="415" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="547" y="417" width="78" height="28">
-			</bounds>
+			<bounds x="547" y="417" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="540" y="379" width="82" height="32">
-			</bounds>
+			<bounds x="540" y="379" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="542" y="381" width="78" height="28">
-			</bounds>
+			<bounds x="542" y="381" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="526" y="269" width="82" height="32">
-			</bounds>
+			<bounds x="526" y="269" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="528" y="271" width="78" height="28">
-			</bounds>
+			<bounds x="528" y="271" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="531" y="305" width="82" height="32">
-			</bounds>
+			<bounds x="531" y="305" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="533" y="307" width="78" height="28">
-			</bounds>
+			<bounds x="533" y="307" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="535" y="342" width="82" height="32">
-			</bounds>
+			<bounds x="535" y="342" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="537" y="344" width="78" height="28">
-			</bounds>
+			<bounds x="537" y="344" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_2_border" state="0">
-			<bounds x="301" y="282" width="42" height="19">
-			</bounds>
+			<bounds x="301" y="282" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_2" state="0">
-			<bounds x="303" y="284" width="38" height="15">
-			</bounds>
+			<bounds x="303" y="284" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="235" y="318" width="42" height="19">
-			</bounds>
+			<bounds x="235" y="318" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="237" y="320" width="38" height="15">
-			</bounds>
+			<bounds x="237" y="320" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="440" y="270" width="62" height="42">
-			</bounds>
+			<bounds x="440" y="270" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="442" y="272" width="58" height="38">
-			</bounds>
+			<bounds x="442" y="272" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="401" y="281" width="42" height="19">
-			</bounds>
+			<bounds x="401" y="281" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="403" y="283" width="38" height="15">
-			</bounds>
+			<bounds x="403" y="283" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="242" y="271" width="62" height="42">
-			</bounds>
+			<bounds x="242" y="271" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="244" y="273" width="58" height="38">
-			</bounds>
+			<bounds x="244" y="273" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="467" y="319" width="42" height="19">
-			</bounds>
+			<bounds x="467" y="319" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="469" y="321" width="38" height="15">
-			</bounds>
+			<bounds x="469" y="321" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="282" y="346" width="62" height="32">
-			</bounds>
+			<bounds x="282" y="346" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="284" y="348" width="58" height="28">
-			</bounds>
+			<bounds x="284" y="348" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="282" y="376" width="62" height="32">
-			</bounds>
+			<bounds x="282" y="376" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="284" y="378" width="58" height="28">
-			</bounds>
+			<bounds x="284" y="378" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="402" y="346" width="62" height="32">
-			</bounds>
+			<bounds x="402" y="346" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="404" y="348" width="58" height="28">
-			</bounds>
+			<bounds x="404" y="348" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="402" y="376" width="62" height="32">
-			</bounds>
+			<bounds x="402" y="376" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="404" y="378" width="58" height="28">
-			</bounds>
+			<bounds x="404" y="378" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="342" y="376" width="62" height="32">
-			</bounds>
+			<bounds x="342" y="376" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="344" y="378" width="58" height="28">
-			</bounds>
+			<bounds x="344" y="378" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="342" y="346" width="62" height="32">
-			</bounds>
+			<bounds x="342" y="346" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="344" y="348" width="58" height="28">
-			</bounds>
+			<bounds x="344" y="348" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="378" y="329" width="22" height="19">
-			</bounds>
+			<bounds x="378" y="329" width="22" height="19"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="380" y="331" width="18" height="15">
-			</bounds>
+			<bounds x="380" y="331" width="18" height="15"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="367" y="329" width="14" height="19">
-			</bounds>
+			<bounds x="367" y="329" width="14" height="19"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="369" y="331" width="10" height="15">
-			</bounds>
+			<bounds x="369" y="331" width="10" height="15"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="348" y="329" width="22" height="19">
-			</bounds>
+			<bounds x="348" y="329" width="22" height="19"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="350" y="331" width="18" height="15">
-			</bounds>
+			<bounds x="350" y="331" width="18" height="15"/>
 		</backdrop>
 		<backdrop name="lamp197" element="colour_button_110_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="418" y="215" width="52" height="52">
-			</bounds>
+			<bounds x="418" y="215" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp197" element="colour_button_110" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="420" y="217" width="48" height="48">
-			</bounds>
+			<bounds x="420" y="217" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp196" element="colour_button_111_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="282" y="215" width="52" height="52">
-			</bounds>
+			<bounds x="282" y="215" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp196" element="colour_button_111" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="284" y="217" width="48" height="48">
-			</bounds>
+			<bounds x="284" y="217" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp195" element="colour_button_112_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="418" y="93" width="52" height="52">
-			</bounds>
+			<bounds x="418" y="93" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp195" element="colour_button_112" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="420" y="95" width="48" height="48">
-			</bounds>
+			<bounds x="420" y="95" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp194" element="colour_button_113_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="282" y="93" width="52" height="52">
-			</bounds>
+			<bounds x="282" y="93" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp194" element="colour_button_113" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="284" y="95" width="48" height="48">
-			</bounds>
+			<bounds x="284" y="95" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_115_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="439" y="629" width="92" height="42">
-			</bounds>
+			<bounds x="439" y="629" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_115" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="441" y="631" width="88" height="38">
-			</bounds>
+			<bounds x="441" y="631" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_116_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="326" y="629" width="92" height="42">
-			</bounds>
+			<bounds x="326" y="629" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_116" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="328" y="631" width="88" height="38">
-			</bounds>
+			<bounds x="328" y="631" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_117_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="212" y="629" width="92" height="42">
-			</bounds>
+			<bounds x="212" y="629" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_117" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="214" y="631" width="88" height="38">
-			</bounds>
+			<bounds x="214" y="631" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_118_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="71" y="629" width="92" height="42">
-			</bounds>
+			<bounds x="71" y="629" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_118" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="73" y="631" width="88" height="38">
-			</bounds>
+			<bounds x="73" y="631" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_119_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="591" y="630" width="92" height="42">
-			</bounds>
+			<bounds x="591" y="630" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_119" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="593" y="632" width="88" height="38">
-			</bounds>
+			<bounds x="593" y="632" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_120_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="695" y="630" width="92" height="42">
-			</bounds>
+			<bounds x="695" y="630" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_120" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="697" y="632" width="88" height="38">
-			</bounds>
+			<bounds x="697" y="632" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_121_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="796" y="630" width="92" height="42">
-			</bounds>
+			<bounds x="796" y="630" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_121" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="798" y="632" width="88" height="38">
-			</bounds>
+			<bounds x="798" y="632" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp199" element="colour_button_126_border" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="342" y="260" width="62" height="62">
-			</bounds>
+			<bounds x="342" y="260" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp199" element="colour_button_126" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="344" y="262" width="58" height="58">
-			</bounds>
+			<bounds x="344" y="262" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_127_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="869" y="11" width="32" height="42">
-			</bounds>
+			<bounds x="869" y="11" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_127" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="871" y="13" width="28" height="38">
-			</bounds>
+			<bounds x="871" y="13" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_128_border" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="836" y="11" width="32" height="42">
-			</bounds>
+			<bounds x="836" y="11" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_128" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="838" y="13" width="28" height="38">
-			</bounds>
+			<bounds x="838" y="13" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_129_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="836" y="53" width="32" height="42">
-			</bounds>
+			<bounds x="836" y="53" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_129" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="838" y="55" width="28" height="38">
-			</bounds>
+			<bounds x="838" y="55" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_130_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="869" y="53" width="32" height="42">
-			</bounds>
+			<bounds x="869" y="53" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_130" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="871" y="55" width="28" height="38">
-			</bounds>
+			<bounds x="871" y="55" width="28" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="229" y="582" width="272" height="30">
-			</bounds>
+			<bounds x="229" y="582" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="229" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="229" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="246" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="246" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="263" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="263" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="280" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="280" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="297" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="297" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="314" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="314" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="331" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="331" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="348" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="348" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="365" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="365" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="382" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="382" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="399" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="399" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="416" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="416" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="433" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="433" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="450" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="450" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="467" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="467" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="484" y="582" width="17" height="30">
-			</bounds>
+			<bounds x="484" y="582" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label108" element="label_108">
-			<bounds x="255" y="565" width="34" height="13">
-			</bounds>
+			<bounds x="255" y="565" width="34" height="13"/>
 		</backdrop>
 		<backdrop name="label109" element="label_109">
-			<bounds x="438" y="564" width="47" height="13">
-			</bounds>
+			<bounds x="438" y="564" width="47" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_reel" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_button" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_button" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_button" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_button" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_button" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1bigdel.lay
+++ b/src/mame/layout/m1bigdel.lay
@@ -8,11800 +8,7174 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="mix n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="mix n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="steppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="steppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="a win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="a win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="choose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="choose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED or">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED or">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" dead">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string=" dead">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="dash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="dash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="CARD ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="CARD ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="hi lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="hi lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="OR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="OR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Q">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Q">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="black">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="black">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="blackjack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="blackjack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="pays first line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="when lit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="pays first line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="when lit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="double">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLACKJACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="double">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLACKJACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="PAYS first two lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WHEN LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="PAYS first two lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WHEN LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="super blackjack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="super blackjack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="pays 12-13-14-15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OR LINE 1 +3 WHEN L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="pays 12-13-14-15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OR LINE 1 +3 WHEN L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="30P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="30P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="30P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="30P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="30P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="30P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_241_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_241">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_242_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_242">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_243_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_243">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_244_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_244">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_280_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_280">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_281_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_281">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_282_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_282">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_283_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_283">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_284_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_284">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="twist">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_285_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_285">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_289_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_289">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_143">
 		<text string="nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_156">
 		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_157">
 		<text string="line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="835" height="792">
-			</bounds>
+			<bounds x="0" y="0" width="835" height="792"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="201" y="558" width="80" height="140">
-			</bounds>
+			<bounds x="201" y="558" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="201.0000" y="558.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="201.0000" y="558.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="204.3333" y="559.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="204.3333" y="559.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="207.6667" y="561.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="207.6667" y="561.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="211.0000" y="563.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="211.0000" y="563.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="214.3333" y="565.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="214.3333" y="565.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="217.6667" y="567.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="217.6667" y="567.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="201.0000" y="604.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="201.0000" y="604.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="204.3333" y="606.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="204.3333" y="606.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="207.6667" y="608.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="207.6667" y="608.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="211.0000" y="610.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="211.0000" y="610.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="214.3333" y="612.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="214.3333" y="612.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="217.6667" y="614.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="217.6667" y="614.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="201.0000" y="651.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="201.0000" y="651.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="204.3333" y="653.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="204.3333" y="653.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="207.6667" y="655.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="207.6667" y="655.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="211.0000" y="657.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="211.0000" y="657.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="214.3333" y="659.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="214.3333" y="659.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="217.6667" y="661.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="217.6667" y="661.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="201" y="558" width="80" height="140">
-			</bounds>
+			<bounds x="201" y="558" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="285" y="558" width="80" height="140">
-			</bounds>
+			<bounds x="285" y="558" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="285.0000" y="558.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="285.0000" y="558.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="288.3333" y="559.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="288.3333" y="559.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="291.6667" y="561.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="291.6667" y="561.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="295.0000" y="563.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="295.0000" y="563.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="298.3333" y="565.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="298.3333" y="565.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="301.6667" y="567.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="301.6667" y="567.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="285.0000" y="604.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="285.0000" y="604.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="288.3333" y="606.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="288.3333" y="606.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="291.6667" y="608.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="291.6667" y="608.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="295.0000" y="610.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="295.0000" y="610.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="298.3333" y="612.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="298.3333" y="612.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="301.6667" y="614.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="301.6667" y="614.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="285.0000" y="651.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="285.0000" y="651.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="288.3333" y="653.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="288.3333" y="653.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="291.6667" y="655.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="291.6667" y="655.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="295.0000" y="657.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="295.0000" y="657.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="298.3333" y="659.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="298.3333" y="659.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="301.6667" y="661.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="301.6667" y="661.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="285" y="558" width="80" height="140">
-			</bounds>
+			<bounds x="285" y="558" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="369" y="558" width="80" height="140">
-			</bounds>
+			<bounds x="369" y="558" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="369.0000" y="558.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="369.0000" y="558.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="372.3333" y="559.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="372.3333" y="559.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="375.6667" y="561.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="375.6667" y="561.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="379.0000" y="563.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="379.0000" y="563.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="382.3333" y="565.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="382.3333" y="565.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="385.6667" y="567.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="385.6667" y="567.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="369.0000" y="604.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="369.0000" y="604.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="372.3333" y="606.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="372.3333" y="606.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="375.6667" y="608.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="375.6667" y="608.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="379.0000" y="610.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="379.0000" y="610.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="382.3333" y="612.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="382.3333" y="612.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="385.6667" y="614.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="385.6667" y="614.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="369.0000" y="651.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="369.0000" y="651.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="372.3333" y="653.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="372.3333" y="653.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="375.6667" y="655.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="375.6667" y="655.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="379.0000" y="657.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="379.0000" y="657.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="382.3333" y="659.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="382.3333" y="659.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="385.6667" y="661.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="385.6667" y="661.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="369" y="558" width="80" height="140">
-			</bounds>
+			<bounds x="369" y="558" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="594" y="383" width="58" height="26">
-			</bounds>
+			<bounds x="594" y="383" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="596" y="385" width="54" height="22">
-			</bounds>
+			<bounds x="596" y="385" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="594" y="408" width="58" height="26">
-			</bounds>
+			<bounds x="594" y="408" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="596" y="410" width="54" height="22">
-			</bounds>
+			<bounds x="596" y="410" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="768" y="408" width="58" height="26">
-			</bounds>
+			<bounds x="768" y="408" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="770" y="410" width="54" height="22">
-			</bounds>
+			<bounds x="770" y="410" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="768" y="383" width="58" height="26">
-			</bounds>
+			<bounds x="768" y="383" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="770" y="385" width="54" height="22">
-			</bounds>
+			<bounds x="770" y="385" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="710" y="408" width="58" height="26">
-			</bounds>
+			<bounds x="710" y="408" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="712" y="410" width="54" height="22">
-			</bounds>
+			<bounds x="712" y="410" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="710" y="383" width="58" height="26">
-			</bounds>
+			<bounds x="710" y="383" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="712" y="385" width="54" height="22">
-			</bounds>
+			<bounds x="712" y="385" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="652" y="408" width="58" height="26">
-			</bounds>
+			<bounds x="652" y="408" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="654" y="410" width="54" height="22">
-			</bounds>
+			<bounds x="654" y="410" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="652" y="383" width="58" height="26">
-			</bounds>
+			<bounds x="652" y="383" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="654" y="385" width="54" height="22">
-			</bounds>
+			<bounds x="654" y="385" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="710" y="269" width="58" height="26">
-			</bounds>
+			<bounds x="710" y="269" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="712" y="271" width="54" height="22">
-			</bounds>
+			<bounds x="712" y="271" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="710" y="295" width="58" height="26">
-			</bounds>
+			<bounds x="710" y="295" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="712" y="297" width="54" height="22">
-			</bounds>
+			<bounds x="712" y="297" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="768" y="269" width="58" height="26">
-			</bounds>
+			<bounds x="768" y="269" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="770" y="271" width="54" height="22">
-			</bounds>
+			<bounds x="770" y="271" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="768" y="295" width="58" height="26">
-			</bounds>
+			<bounds x="768" y="295" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="770" y="297" width="54" height="22">
-			</bounds>
+			<bounds x="770" y="297" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="652" y="295" width="58" height="26">
-			</bounds>
+			<bounds x="652" y="295" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="654" y="297" width="54" height="22">
-			</bounds>
+			<bounds x="654" y="297" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="652" y="269" width="58" height="26">
-			</bounds>
+			<bounds x="652" y="269" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="654" y="271" width="54" height="22">
-			</bounds>
+			<bounds x="654" y="271" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="594" y="269" width="58" height="26">
-			</bounds>
+			<bounds x="594" y="269" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="596" y="271" width="54" height="22">
-			</bounds>
+			<bounds x="596" y="271" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="594" y="295" width="58" height="26">
-			</bounds>
+			<bounds x="594" y="295" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="596" y="297" width="54" height="22">
-			</bounds>
+			<bounds x="596" y="297" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_2_border" state="0">
-			<bounds x="227" y="702" width="34" height="34">
-			</bounds>
+			<bounds x="227" y="702" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_2" state="0">
-			<bounds x="229" y="704" width="30" height="30">
-			</bounds>
+			<bounds x="229" y="704" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_2_border" state="0">
-			<bounds x="365" y="702" width="34" height="34">
-			</bounds>
+			<bounds x="365" y="702" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_2" state="0">
-			<bounds x="367" y="704" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="704" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_2_border" state="0">
-			<bounds x="499" y="702" width="34" height="34">
-			</bounds>
+			<bounds x="499" y="702" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_2" state="0">
-			<bounds x="501" y="704" width="30" height="30">
-			</bounds>
+			<bounds x="501" y="704" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="636" y="701" width="34" height="34">
-			</bounds>
+			<bounds x="636" y="701" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="638" y="703" width="30" height="30">
-			</bounds>
+			<bounds x="638" y="703" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="636" y="565" width="34" height="34">
-			</bounds>
+			<bounds x="636" y="565" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="638" y="567" width="30" height="30">
-			</bounds>
+			<bounds x="638" y="567" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="636" y="667" width="34" height="34">
-			</bounds>
+			<bounds x="636" y="667" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="638" y="669" width="30" height="30">
-			</bounds>
+			<bounds x="638" y="669" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="636" y="633" width="34" height="34">
-			</bounds>
+			<bounds x="636" y="633" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="638" y="635" width="30" height="30">
-			</bounds>
+			<bounds x="638" y="635" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="636" y="599" width="34" height="34">
-			</bounds>
+			<bounds x="636" y="599" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="638" y="601" width="30" height="30">
-			</bounds>
+			<bounds x="638" y="601" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="636" y="531" width="34" height="34">
-			</bounds>
+			<bounds x="636" y="531" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="638" y="533" width="30" height="30">
-			</bounds>
+			<bounds x="638" y="533" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="296" y="497" width="80" height="28">
-			</bounds>
+			<bounds x="296" y="497" width="80" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="298" y="499" width="76" height="24">
-			</bounds>
+			<bounds x="298" y="499" width="76" height="24"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="316" y="469" width="34" height="28">
-			</bounds>
+			<bounds x="316" y="469" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="318" y="471" width="30" height="24">
-			</bounds>
+			<bounds x="318" y="471" width="30" height="24"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="105" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="105" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="107" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="107" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="141" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="141" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="143" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="143" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="177" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="177" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="179" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="179" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="213" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="213" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="215" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="215" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="249" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="249" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="251" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="251" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="285" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="285" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="287" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="287" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="321" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="321" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="323" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="323" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="357" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="357" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="359" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="359" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="393" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="393" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="395" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="395" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="429" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="429" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="431" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="431" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="465" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="465" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="467" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="467" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="501" y="429" width="36" height="36">
-			</bounds>
+			<bounds x="501" y="429" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="503" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="503" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="251" y="469" width="60" height="28">
-			</bounds>
+			<bounds x="251" y="469" width="60" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="253" y="471" width="56" height="24">
-			</bounds>
+			<bounds x="253" y="471" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="353" y="468" width="60" height="28">
-			</bounds>
+			<bounds x="353" y="468" width="60" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="355" y="470" width="56" height="24">
-			</bounds>
+			<bounds x="355" y="470" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="63" y="605" width="34" height="26">
-			</bounds>
+			<bounds x="63" y="605" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="65" y="607" width="30" height="22">
-			</bounds>
+			<bounds x="65" y="607" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="63" y="579" width="34" height="26">
-			</bounds>
+			<bounds x="63" y="579" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="65" y="581" width="30" height="22">
-			</bounds>
+			<bounds x="65" y="581" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="63" y="553" width="34" height="26">
-			</bounds>
+			<bounds x="63" y="553" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="65" y="555" width="30" height="22">
-			</bounds>
+			<bounds x="65" y="555" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="63" y="631" width="34" height="26">
-			</bounds>
+			<bounds x="63" y="631" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="65" y="633" width="30" height="22">
-			</bounds>
+			<bounds x="65" y="633" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="396" y="324" width="90" height="36">
-			</bounds>
+			<bounds x="396" y="324" width="90" height="36"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="398" y="326" width="86" height="32">
-			</bounds>
+			<bounds x="398" y="326" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="396" y="360" width="90" height="48">
-			</bounds>
+			<bounds x="396" y="360" width="90" height="48"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="398" y="362" width="86" height="44">
-			</bounds>
+			<bounds x="398" y="362" width="86" height="44"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="396" y="215" width="90" height="36">
-			</bounds>
+			<bounds x="396" y="215" width="90" height="36"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="398" y="217" width="86" height="32">
-			</bounds>
+			<bounds x="398" y="217" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="396" y="250" width="90" height="48">
-			</bounds>
+			<bounds x="396" y="250" width="90" height="48"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="398" y="252" width="86" height="44">
-			</bounds>
+			<bounds x="398" y="252" width="86" height="44"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="396" y="102" width="90" height="36">
-			</bounds>
+			<bounds x="396" y="102" width="90" height="36"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="398" y="104" width="86" height="32">
-			</bounds>
+			<bounds x="398" y="104" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="396" y="137" width="90" height="68">
-			</bounds>
+			<bounds x="396" y="137" width="90" height="68"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="398" y="139" width="86" height="64">
-			</bounds>
+			<bounds x="398" y="139" width="86" height="64"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="448" y="35" width="36" height="36">
-			</bounds>
+			<bounds x="448" y="35" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="450" y="37" width="32" height="32">
-			</bounds>
+			<bounds x="450" y="37" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="412" y="35" width="36" height="36">
-			</bounds>
+			<bounds x="412" y="35" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="414" y="37" width="32" height="32">
-			</bounds>
+			<bounds x="414" y="37" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="376" y="35" width="36" height="36">
-			</bounds>
+			<bounds x="376" y="35" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="378" y="37" width="32" height="32">
-			</bounds>
+			<bounds x="378" y="37" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="330" y="24" width="46" height="56">
-			</bounds>
+			<bounds x="330" y="24" width="46" height="56"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="332" y="26" width="42" height="52">
-			</bounds>
+			<bounds x="332" y="26" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="287" y="35" width="36" height="36">
-			</bounds>
+			<bounds x="287" y="35" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="289" y="37" width="32" height="32">
-			</bounds>
+			<bounds x="289" y="37" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="251" y="35" width="36" height="36">
-			</bounds>
+			<bounds x="251" y="35" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="253" y="37" width="32" height="32">
-			</bounds>
+			<bounds x="253" y="37" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="206" y="24" width="46" height="56">
-			</bounds>
+			<bounds x="206" y="24" width="46" height="56"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="208" y="26" width="42" height="52">
-			</bounds>
+			<bounds x="208" y="26" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="340" y="289" width="34" height="34">
-			</bounds>
+			<bounds x="340" y="289" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="342" y="291" width="30" height="30">
-			</bounds>
+			<bounds x="342" y="291" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="264" y="289" width="34" height="34">
-			</bounds>
+			<bounds x="264" y="289" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="266" y="291" width="30" height="30">
-			</bounds>
+			<bounds x="266" y="291" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="226" y="290" width="34" height="34">
-			</bounds>
+			<bounds x="226" y="290" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="228" y="292" width="30" height="30">
-			</bounds>
+			<bounds x="228" y="292" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="226" y="187" width="34" height="34">
-			</bounds>
+			<bounds x="226" y="187" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="228" y="189" width="30" height="30">
-			</bounds>
+			<bounds x="228" y="189" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="226" y="221" width="34" height="34">
-			</bounds>
+			<bounds x="226" y="221" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="228" y="223" width="30" height="30">
-			</bounds>
+			<bounds x="228" y="223" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="226" y="255" width="34" height="34">
-			</bounds>
+			<bounds x="226" y="255" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="228" y="257" width="30" height="30">
-			</bounds>
+			<bounds x="228" y="257" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="226" y="119" width="34" height="34">
-			</bounds>
+			<bounds x="226" y="119" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="228" y="121" width="30" height="30">
-			</bounds>
+			<bounds x="228" y="121" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="226" y="153" width="34" height="34">
-			</bounds>
+			<bounds x="226" y="153" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="228" y="155" width="30" height="30">
-			</bounds>
+			<bounds x="228" y="155" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="264" y="119" width="34" height="34">
-			</bounds>
+			<bounds x="264" y="119" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="266" y="121" width="30" height="30">
-			</bounds>
+			<bounds x="266" y="121" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="264" y="153" width="34" height="34">
-			</bounds>
+			<bounds x="264" y="153" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="266" y="155" width="30" height="30">
-			</bounds>
+			<bounds x="266" y="155" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="264" y="187" width="34" height="34">
-			</bounds>
+			<bounds x="264" y="187" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="266" y="189" width="30" height="30">
-			</bounds>
+			<bounds x="266" y="189" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="264" y="221" width="34" height="34">
-			</bounds>
+			<bounds x="264" y="221" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="266" y="223" width="30" height="30">
-			</bounds>
+			<bounds x="266" y="223" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="264" y="255" width="34" height="34">
-			</bounds>
+			<bounds x="264" y="255" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="266" y="257" width="30" height="30">
-			</bounds>
+			<bounds x="266" y="257" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="301" y="119" width="34" height="34">
-			</bounds>
+			<bounds x="301" y="119" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="303" y="121" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="121" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="301" y="255" width="34" height="34">
-			</bounds>
+			<bounds x="301" y="255" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="303" y="257" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="257" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="301" y="221" width="34" height="34">
-			</bounds>
+			<bounds x="301" y="221" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="303" y="223" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="223" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="301" y="187" width="34" height="34">
-			</bounds>
+			<bounds x="301" y="187" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="303" y="189" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="189" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="301" y="153" width="34" height="34">
-			</bounds>
+			<bounds x="301" y="153" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="303" y="155" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="155" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="340" y="119" width="34" height="34">
-			</bounds>
+			<bounds x="340" y="119" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="342" y="121" width="30" height="30">
-			</bounds>
+			<bounds x="342" y="121" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="340" y="153" width="34" height="34">
-			</bounds>
+			<bounds x="340" y="153" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="342" y="155" width="30" height="30">
-			</bounds>
+			<bounds x="342" y="155" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="340" y="187" width="34" height="34">
-			</bounds>
+			<bounds x="340" y="187" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="342" y="189" width="30" height="30">
-			</bounds>
+			<bounds x="342" y="189" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="340" y="221" width="34" height="34">
-			</bounds>
+			<bounds x="340" y="221" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="342" y="223" width="30" height="30">
-			</bounds>
+			<bounds x="342" y="223" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="340" y="255" width="34" height="34">
-			</bounds>
+			<bounds x="340" y="255" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="342" y="257" width="30" height="30">
-			</bounds>
+			<bounds x="342" y="257" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="301" y="289" width="34" height="34">
-			</bounds>
+			<bounds x="301" y="289" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="303" y="291" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="291" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="340" y="356" width="34" height="34">
-			</bounds>
+			<bounds x="340" y="356" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="342" y="358" width="30" height="30">
-			</bounds>
+			<bounds x="342" y="358" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="340" y="323" width="34" height="34">
-			</bounds>
+			<bounds x="340" y="323" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="342" y="325" width="30" height="30">
-			</bounds>
+			<bounds x="342" y="325" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="264" y="356" width="34" height="34">
-			</bounds>
+			<bounds x="264" y="356" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="266" y="358" width="30" height="30">
-			</bounds>
+			<bounds x="266" y="358" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="264" y="323" width="34" height="34">
-			</bounds>
+			<bounds x="264" y="323" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="266" y="325" width="30" height="30">
-			</bounds>
+			<bounds x="266" y="325" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="301" y="323" width="34" height="34">
-			</bounds>
+			<bounds x="301" y="323" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="303" y="325" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="325" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="301" y="356" width="34" height="34">
-			</bounds>
+			<bounds x="301" y="356" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="303" y="358" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="358" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_241_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="643" y="1" width="45" height="27">
-			</bounds>
+			<bounds x="643" y="1" width="45" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_241" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="645" y="3" width="41" height="23">
-			</bounds>
+			<bounds x="645" y="3" width="41" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_242_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="740" y="1" width="46" height="27">
-			</bounds>
+			<bounds x="740" y="1" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_242" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="742" y="3" width="42" height="23">
-			</bounds>
+			<bounds x="742" y="3" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_243_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="691" y="1" width="46" height="27">
-			</bounds>
+			<bounds x="691" y="1" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_243" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="693" y="3" width="42" height="23">
-			</bounds>
+			<bounds x="693" y="3" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_244_border" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="789" y="1" width="46" height="27">
-			</bounds>
+			<bounds x="789" y="1" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_244" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="791" y="3" width="42" height="23">
-			</bounds>
+			<bounds x="791" y="3" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_280_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="194" y="765" width="75" height="27">
-			</bounds>
+			<bounds x="194" y="765" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_280" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="196" y="767" width="71" height="23">
-			</bounds>
+			<bounds x="196" y="767" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_281_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="102" y="765" width="75" height="27">
-			</bounds>
+			<bounds x="102" y="765" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_281" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="104" y="767" width="71" height="23">
-			</bounds>
+			<bounds x="104" y="767" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_282_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="291" y="765" width="75" height="27">
-			</bounds>
+			<bounds x="291" y="765" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_282" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="293" y="767" width="71" height="23">
-			</bounds>
+			<bounds x="293" y="767" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_283_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="377" y="765" width="75" height="27">
-			</bounds>
+			<bounds x="377" y="765" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_283" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="379" y="767" width="71" height="23">
-			</bounds>
+			<bounds x="379" y="767" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_284_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="464" y="765" width="75" height="27">
-			</bounds>
+			<bounds x="464" y="765" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_284" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="466" y="767" width="71" height="23">
-			</bounds>
+			<bounds x="466" y="767" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_285_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="622" y="755" width="75" height="37">
-			</bounds>
+			<bounds x="622" y="755" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_285" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="624" y="757" width="71" height="33">
-			</bounds>
+			<bounds x="624" y="757" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_289_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="542" y="765" width="75" height="27">
-			</bounds>
+			<bounds x="542" y="765" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_289" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="544" y="767" width="71" height="23">
-			</bounds>
+			<bounds x="544" y="767" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="190" y="526" width="272" height="30">
-			</bounds>
+			<bounds x="190" y="526" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="190" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="190" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="207" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="207" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="224" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="224" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="241" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="241" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="258" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="258" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="275" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="275" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="292" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="292" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="309" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="309" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="326" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="326" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="343" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="343" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="360" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="360" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="377" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="377" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="394" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="394" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="411" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="411" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="428" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="428" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="445" y="526" width="17" height="30">
-			</bounds>
+			<bounds x="445" y="526" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label143" element="label_143">
-			<bounds x="25" y="667" width="86" height="29">
-			</bounds>
+			<bounds x="25" y="667" width="86" height="29"/>
 		</backdrop>
 		<backdrop name="label156" element="label_156">
-			<bounds x="167" y="620" width="23" height="16">
-			</bounds>
+			<bounds x="167" y="620" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label157" element="label_157">
-			<bounds x="452" y="620" width="24" height="16">
-			</bounds>
+			<bounds x="452" y="620" width="24" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1calypsa.lay
+++ b/src/mame/layout/m1calypsa.lay
@@ -8,14136 +8,8276 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5 + Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5 + Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mystery Win ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mystery Win ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Numbers">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="In View">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Numbers">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="In View">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Hi-Lo Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Hi-Lo Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Super Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Super Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="0.17" blue="0.04">
-			</color>
+			<color red="0.24" green="0.17" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.04" blue="0.01">
-			</color>
+			<color red="0.06" green="0.04" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.35" blue="0.09">
-			</color>
+			<color red="0.48" green="0.35" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.02">
-			</color>
+			<color red="0.12" green="0.09" blue="0.02"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="0.17" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.04" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.35" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.02">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Number Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Number Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bonus Add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus Add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Add Again">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Add Again">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Reel Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Reel Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bounty Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bounty Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Honky Bonky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Honky Bonky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Paradise Alley">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Paradise Alley">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="Super ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="Super ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Reggae Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Reggae Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jamaica Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jamaica Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Limbo Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Limbo Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Calypso Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Calypso Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Money Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Money Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Money Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Money Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Winspin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Winspin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Calypso">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Calypso">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudge Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="n Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="n Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="C A L Y P S O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="C A L Y P S O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudge Up n Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Up n Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Palm Tree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Palm Tree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Palm Tree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Palm Tree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Palm Tree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Palm Tree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Award MegaMoney">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Award MegaMoney">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Palm Tree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Palm Tree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1 Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2 Bonus Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2 Bonus Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+2 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1 Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1 Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Party">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Party">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1 Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1 Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2 Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2 Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C&#x26;ash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_149_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_149">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Calypso">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_4">
 		<text string="Triplebar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_5">
 		<text string="Doublebar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_6">
 		<text string="Singlebar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_7">
 		<text string="Red 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_8">
 		<text string="Blue 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_9">
 		<text string="Pineapples">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_10">
 		<text string="Mixed 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_11">
 		<text string="Bananas">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_34">
 		<text string="Thanks to Dangerous Dave and Gary for roms.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="www.fruit-emu.com">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_100">
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_102">
 		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_103">
 		<text string="Plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_115">
 		<text string="Thanks to Dialtone and Wizard.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_116">
 		<text string="By spa with help from Bugs!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_136">
 		<text string="Jackpots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_137">
 		<text string="Thanks to Shiny for Reel Symbols.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_138">
 		<text string="MAYGAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_139">
 		<text string="WWW.MFME.CO.UK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="695" height="707">
-			</bounds>
+			<bounds x="0" y="0" width="695" height="707"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="78" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="78" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="78.0000" y="444.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="78.0000" y="444.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="81.3333" y="445.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="81.3333" y="445.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="84.6667" y="447.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="84.6667" y="447.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="88.0000" y="449.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="88.0000" y="449.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="91.3333" y="451.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="91.3333" y="451.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="94.6667" y="453.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="94.6667" y="453.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="78.0000" y="490.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="78.0000" y="490.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="81.3333" y="492.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="81.3333" y="492.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="84.6667" y="494.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="84.6667" y="494.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="88.0000" y="496.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="88.0000" y="496.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="91.3333" y="498.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="91.3333" y="498.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="94.6667" y="500.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="94.6667" y="500.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="78.0000" y="537.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="78.0000" y="537.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="81.3333" y="539.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="81.3333" y="539.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="84.6667" y="541.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="84.6667" y="541.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="88.0000" y="543.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="88.0000" y="543.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="91.3333" y="545.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="91.3333" y="545.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="94.6667" y="547.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="94.6667" y="547.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="78" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="78" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="198" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="198" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="444.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="198.0000" y="444.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="201.3333" y="445.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="201.3333" y="445.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="204.6667" y="447.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="204.6667" y="447.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="208.0000" y="449.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="208.0000" y="449.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="211.3333" y="451.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="211.3333" y="451.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="214.6667" y="453.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="214.6667" y="453.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="490.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="198.0000" y="490.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="201.3333" y="492.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="201.3333" y="492.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="204.6667" y="494.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="204.6667" y="494.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="208.0000" y="496.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="208.0000" y="496.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="211.3333" y="498.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="211.3333" y="498.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="214.6667" y="500.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="214.6667" y="500.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="537.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="198.0000" y="537.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="201.3333" y="539.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="201.3333" y="539.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="204.6667" y="541.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="204.6667" y="541.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="208.0000" y="543.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="208.0000" y="543.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="211.3333" y="545.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="211.3333" y="545.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="214.6667" y="547.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="214.6667" y="547.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="198" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="198" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="318" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="318" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="444.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="318.0000" y="444.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="445.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="321.3333" y="445.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="447.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="324.6667" y="447.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="449.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="328.0000" y="449.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="451.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="331.3333" y="451.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="453.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="334.6667" y="453.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="490.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="318.0000" y="490.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="492.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="321.3333" y="492.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="494.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="324.6667" y="494.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="496.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="328.0000" y="496.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="498.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="331.3333" y="498.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="500.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="334.6667" y="500.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="537.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="318.0000" y="537.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="539.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="321.3333" y="539.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="541.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="324.6667" y="541.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="543.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="328.0000" y="543.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="545.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="331.3333" y="545.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="547.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="334.6667" y="547.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="318" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="318" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="102" y="256" width="60" height="50">
-			</bounds>
+			<bounds x="102" y="256" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="256.0000" width="60.0000" height="50.0000">
-			</bounds>
+			<bounds x="102.0000" y="256.0000" width="60.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.5000" y="258.0833" width="55.0000" height="45.8333">
-			</bounds>
+			<bounds x="104.5000" y="258.0833" width="55.0000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="107.0000" y="260.1667" width="50.0000" height="41.6667">
-			</bounds>
+			<bounds x="107.0000" y="260.1667" width="50.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="109.5000" y="262.2500" width="45.0000" height="37.5000">
-			</bounds>
+			<bounds x="109.5000" y="262.2500" width="45.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="112.0000" y="264.3333" width="40.0000" height="33.3333">
-			</bounds>
+			<bounds x="112.0000" y="264.3333" width="40.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="114.5000" y="266.4167" width="35.0000" height="29.1667">
-			</bounds>
+			<bounds x="114.5000" y="266.4167" width="35.0000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="102" y="256" width="60" height="50">
-			</bounds>
+			<bounds x="102" y="256" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="624" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="624" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="626" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="626" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="547" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="547" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="549" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="549" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="470" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="470" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="472" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="472" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="393" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="393" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="395" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="395" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="316" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="316" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="318" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="318" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="239" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="239" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="241" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="241" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="85" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="85" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="87" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="87" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="8" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="8" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="10" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="10" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="162" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="162" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="164" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="164" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="5" y="555" width="52" height="30">
-			</bounds>
+			<bounds x="5" y="555" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="7" y="557" width="48" height="26">
-			</bounds>
+			<bounds x="7" y="557" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="5" y="527" width="52" height="30">
-			</bounds>
+			<bounds x="5" y="527" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="7" y="529" width="48" height="26">
-			</bounds>
+			<bounds x="7" y="529" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="5" y="499" width="52" height="30">
-			</bounds>
+			<bounds x="5" y="499" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="7" y="501" width="48" height="26">
-			</bounds>
+			<bounds x="7" y="501" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="5" y="471" width="52" height="30">
-			</bounds>
+			<bounds x="5" y="471" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="7" y="473" width="48" height="26">
-			</bounds>
+			<bounds x="7" y="473" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="5" y="443" width="52" height="30">
-			</bounds>
+			<bounds x="5" y="443" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="7" y="445" width="48" height="26">
-			</bounds>
+			<bounds x="7" y="445" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="445" y="543" width="57" height="32">
-			</bounds>
+			<bounds x="445" y="543" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="447" y="545" width="53" height="28">
-			</bounds>
+			<bounds x="447" y="545" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="500" y="543" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="543" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="502" y="545" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="545" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="500" y="483" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="483" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="502" y="485" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="485" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="500" y="453" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="453" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="502" y="455" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="455" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="445" y="513" width="57" height="32">
-			</bounds>
+			<bounds x="445" y="513" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="447" y="515" width="53" height="28">
-			</bounds>
+			<bounds x="447" y="515" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="500" y="513" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="513" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="502" y="515" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="515" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="445" y="483" width="57" height="32">
-			</bounds>
+			<bounds x="445" y="483" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="447" y="485" width="53" height="28">
-			</bounds>
+			<bounds x="447" y="485" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="445" y="453" width="57" height="32">
-			</bounds>
+			<bounds x="445" y="453" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="447" y="455" width="53" height="28">
-			</bounds>
+			<bounds x="447" y="455" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="452" y="53" width="52" height="32">
-			</bounds>
+			<bounds x="452" y="53" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="454" y="55" width="48" height="28">
-			</bounds>
+			<bounds x="454" y="55" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="402" y="53" width="52" height="32">
-			</bounds>
+			<bounds x="402" y="53" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="404" y="55" width="48" height="28">
-			</bounds>
+			<bounds x="404" y="55" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="352" y="53" width="52" height="32">
-			</bounds>
+			<bounds x="352" y="53" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="354" y="55" width="48" height="28">
-			</bounds>
+			<bounds x="354" y="55" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="302" y="53" width="52" height="32">
-			</bounds>
+			<bounds x="302" y="53" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="304" y="55" width="48" height="28">
-			</bounds>
+			<bounds x="304" y="55" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="252" y="53" width="52" height="32">
-			</bounds>
+			<bounds x="252" y="53" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="254" y="55" width="48" height="28">
-			</bounds>
+			<bounds x="254" y="55" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="202" y="53" width="52" height="32">
-			</bounds>
+			<bounds x="202" y="53" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="204" y="55" width="48" height="28">
-			</bounds>
+			<bounds x="204" y="55" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="496" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="496" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="498" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="498" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="496" y="121" width="57" height="32">
-			</bounds>
+			<bounds x="496" y="121" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="498" y="123" width="53" height="28">
-			</bounds>
+			<bounds x="498" y="123" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="441" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="441" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="443" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="443" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="451" y="143" width="67" height="67">
-			</bounds>
+			<bounds x="451" y="143" width="67" height="67"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="453" y="145" width="63" height="63">
-			</bounds>
+			<bounds x="453" y="145" width="63" height="63"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="386" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="386" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="388" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="388" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="331" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="331" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="333" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="333" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="276" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="276" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="278" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="278" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="221" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="221" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="223" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="223" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="166" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="166" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="168" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="168" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="111" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="111" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="113" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="113" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="56" y="91" width="57" height="32">
-			</bounds>
+			<bounds x="56" y="91" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="58" y="93" width="53" height="28">
-			</bounds>
+			<bounds x="58" y="93" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="56" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="56" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="58" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="58" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="96" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="96" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="98" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="98" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="136" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="136" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="138" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="138" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="176" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="176" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="178" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="178" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="216" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="216" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="218" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="218" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="256" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="256" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="258" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="258" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="296" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="296" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="298" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="298" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="336" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="336" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="338" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="338" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="376" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="376" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="378" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="378" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="416" y="162" width="42" height="29">
-			</bounds>
+			<bounds x="416" y="162" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="418" y="164" width="38" height="25">
-			</bounds>
+			<bounds x="418" y="164" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="436" y="408" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="408" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="438" y="410" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="410" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="436" y="293" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="293" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="438" y="295" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="295" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="436" y="316" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="316" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="438" y="318" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="318" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="436" y="339" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="339" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="438" y="341" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="341" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="436" y="385" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="385" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="438" y="387" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="387" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="436" y="362" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="362" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="438" y="364" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="364" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="436" y="270" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="270" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="438" y="272" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="272" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="436" y="247" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="247" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="438" y="249" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="249" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="436" y="224" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="224" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="438" y="226" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="226" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="436" y="201" width="42" height="25">
-			</bounds>
+			<bounds x="436" y="201" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="438" y="203" width="38" height="21">
-			</bounds>
+			<bounds x="438" y="203" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="511" y="161" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="161" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="513" y="163" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="163" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="511" y="215" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="215" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="513" y="217" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="217" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="511" y="188" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="188" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="513" y="190" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="190" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="511" y="377" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="377" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="513" y="379" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="379" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="511" y="350" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="350" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="513" y="352" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="352" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="511" y="242" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="242" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="513" y="244" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="244" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="511" y="269" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="269" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="513" y="271" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="271" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="511" y="404" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="404" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="513" y="406" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="406" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="511" y="323" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="323" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="513" y="325" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="325" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="511" y="296" width="42" height="29">
-			</bounds>
+			<bounds x="511" y="296" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="513" y="298" width="38" height="25">
-			</bounds>
+			<bounds x="513" y="298" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="623" y="343" width="52" height="32">
-			</bounds>
+			<bounds x="623" y="343" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="625" y="345" width="48" height="28">
-			</bounds>
+			<bounds x="625" y="345" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="623" y="373" width="52" height="32">
-			</bounds>
+			<bounds x="623" y="373" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="625" y="375" width="48" height="28">
-			</bounds>
+			<bounds x="625" y="375" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="623" y="403" width="52" height="32">
-			</bounds>
+			<bounds x="623" y="403" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="625" y="405" width="48" height="28">
-			</bounds>
+			<bounds x="625" y="405" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="623" y="523" width="52" height="32">
-			</bounds>
+			<bounds x="623" y="523" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="625" y="525" width="48" height="28">
-			</bounds>
+			<bounds x="625" y="525" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="623" y="493" width="52" height="32">
-			</bounds>
+			<bounds x="623" y="493" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="625" y="495" width="48" height="28">
-			</bounds>
+			<bounds x="625" y="495" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="623" y="463" width="52" height="32">
-			</bounds>
+			<bounds x="623" y="463" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="625" y="465" width="48" height="28">
-			</bounds>
+			<bounds x="625" y="465" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="623" y="433" width="52" height="32">
-			</bounds>
+			<bounds x="623" y="433" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="625" y="435" width="48" height="28">
-			</bounds>
+			<bounds x="625" y="435" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="607" y="313" width="82" height="32">
-			</bounds>
+			<bounds x="607" y="313" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="609" y="315" width="78" height="28">
-			</bounds>
+			<bounds x="609" y="315" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="607" y="283" width="82" height="32">
-			</bounds>
+			<bounds x="607" y="283" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="609" y="285" width="78" height="28">
-			</bounds>
+			<bounds x="609" y="285" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="607" y="253" width="82" height="32">
-			</bounds>
+			<bounds x="607" y="253" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="609" y="255" width="78" height="28">
-			</bounds>
+			<bounds x="609" y="255" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="607" y="223" width="82" height="32">
-			</bounds>
+			<bounds x="607" y="223" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="609" y="225" width="78" height="28">
-			</bounds>
+			<bounds x="609" y="225" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="607" y="193" width="82" height="32">
-			</bounds>
+			<bounds x="607" y="193" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="609" y="195" width="78" height="28">
-			</bounds>
+			<bounds x="609" y="195" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="607" y="163" width="82" height="32">
-			</bounds>
+			<bounds x="607" y="163" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="609" y="165" width="78" height="28">
-			</bounds>
+			<bounds x="609" y="165" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="607" y="133" width="82" height="32">
-			</bounds>
+			<bounds x="607" y="133" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="609" y="135" width="78" height="28">
-			</bounds>
+			<bounds x="609" y="135" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="581" y="538" width="42" height="22">
-			</bounds>
+			<bounds x="581" y="538" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="583" y="540" width="38" height="18">
-			</bounds>
+			<bounds x="583" y="540" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="623" y="553" width="52" height="32">
-			</bounds>
+			<bounds x="623" y="553" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="625" y="555" width="48" height="28">
-			</bounds>
+			<bounds x="625" y="555" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="115" y="6" width="302" height="32">
-			</bounds>
+			<bounds x="115" y="6" width="302" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="117" y="8" width="298" height="28">
-			</bounds>
+			<bounds x="117" y="8" width="298" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="100" y="308" width="64" height="32">
-			</bounds>
+			<bounds x="100" y="308" width="64" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="102" y="310" width="60" height="28">
-			</bounds>
+			<bounds x="102" y="310" width="60" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="275" y="259" width="42" height="42">
-			</bounds>
+			<bounds x="275" y="259" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="277" y="261" width="38" height="38">
-			</bounds>
+			<bounds x="277" y="261" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="235" y="259" width="42" height="42">
-			</bounds>
+			<bounds x="235" y="259" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="237" y="261" width="38" height="38">
-			</bounds>
+			<bounds x="237" y="261" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="195" y="259" width="42" height="42">
-			</bounds>
+			<bounds x="195" y="259" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="197" y="261" width="38" height="38">
-			</bounds>
+			<bounds x="197" y="261" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="195" y="300" width="122" height="22">
-			</bounds>
+			<bounds x="195" y="300" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="197" y="302" width="118" height="18">
-			</bounds>
+			<bounds x="197" y="302" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="31" y="191" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="191" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="33" y="193" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="193" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="331" y="191" width="52" height="32">
-			</bounds>
+			<bounds x="331" y="191" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="333" y="193" width="48" height="28">
-			</bounds>
+			<bounds x="333" y="193" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="281" y="191" width="52" height="32">
-			</bounds>
+			<bounds x="281" y="191" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="283" y="193" width="48" height="28">
-			</bounds>
+			<bounds x="283" y="193" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="231" y="191" width="52" height="32">
-			</bounds>
+			<bounds x="231" y="191" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="233" y="193" width="48" height="28">
-			</bounds>
+			<bounds x="233" y="193" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="181" y="191" width="52" height="32">
-			</bounds>
+			<bounds x="181" y="191" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="183" y="193" width="48" height="28">
-			</bounds>
+			<bounds x="183" y="193" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="131" y="191" width="52" height="32">
-			</bounds>
+			<bounds x="131" y="191" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="133" y="193" width="48" height="28">
-			</bounds>
+			<bounds x="133" y="193" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="81" y="191" width="52" height="32">
-			</bounds>
+			<bounds x="81" y="191" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="83" y="193" width="48" height="28">
-			</bounds>
+			<bounds x="83" y="193" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="331" y="221" width="52" height="32">
-			</bounds>
+			<bounds x="331" y="221" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="333" y="223" width="48" height="28">
-			</bounds>
+			<bounds x="333" y="223" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="331" y="251" width="52" height="32">
-			</bounds>
+			<bounds x="331" y="251" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="333" y="253" width="48" height="28">
-			</bounds>
+			<bounds x="333" y="253" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="331" y="341" width="52" height="32">
-			</bounds>
+			<bounds x="331" y="341" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="333" y="343" width="48" height="28">
-			</bounds>
+			<bounds x="333" y="343" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="331" y="371" width="52" height="32">
-			</bounds>
+			<bounds x="331" y="371" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="333" y="373" width="48" height="28">
-			</bounds>
+			<bounds x="333" y="373" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="331" y="311" width="52" height="32">
-			</bounds>
+			<bounds x="331" y="311" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="333" y="313" width="48" height="28">
-			</bounds>
+			<bounds x="333" y="313" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="331" y="281" width="52" height="32">
-			</bounds>
+			<bounds x="331" y="281" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="333" y="283" width="48" height="28">
-			</bounds>
+			<bounds x="333" y="283" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="31" y="221" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="221" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="33" y="223" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="223" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="31" y="251" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="251" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="33" y="253" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="253" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="31" y="281" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="281" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="33" y="283" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="283" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="31" y="311" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="311" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="33" y="313" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="313" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="31" y="341" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="341" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="33" y="343" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="343" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="31" y="371" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="371" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="33" y="373" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="373" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="31" y="401" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="401" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="33" y="403" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="403" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="81" y="401" width="52" height="32">
-			</bounds>
+			<bounds x="81" y="401" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="83" y="403" width="48" height="28">
-			</bounds>
+			<bounds x="83" y="403" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="131" y="401" width="52" height="32">
-			</bounds>
+			<bounds x="131" y="401" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="133" y="403" width="48" height="28">
-			</bounds>
+			<bounds x="133" y="403" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="181" y="401" width="52" height="32">
-			</bounds>
+			<bounds x="181" y="401" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="183" y="403" width="48" height="28">
-			</bounds>
+			<bounds x="183" y="403" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="231" y="401" width="52" height="32">
-			</bounds>
+			<bounds x="231" y="401" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="233" y="403" width="48" height="28">
-			</bounds>
+			<bounds x="233" y="403" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="281" y="401" width="52" height="32">
-			</bounds>
+			<bounds x="281" y="401" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="283" y="403" width="48" height="28">
-			</bounds>
+			<bounds x="283" y="403" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="331" y="401" width="52" height="32">
-			</bounds>
+			<bounds x="331" y="401" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="333" y="403" width="48" height="28">
-			</bounds>
+			<bounds x="333" y="403" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="colour_button_147_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="552" y="382" width="52" height="52">
-			</bounds>
+			<bounds x="552" y="382" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp171" element="colour_button_147" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="554" y="384" width="48" height="48">
-			</bounds>
+			<bounds x="554" y="384" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp205" element="colour_button_148_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="4" y="141" width="54" height="52">
-			</bounds>
+			<bounds x="4" y="141" width="54" height="52"/>
 		</backdrop>
 		<backdrop name="lamp205" element="colour_button_148" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="6" y="143" width="50" height="48">
-			</bounds>
+			<bounds x="6" y="143" width="50" height="48"/>
 		</backdrop>
 		<backdrop name="lamp216" element="colour_button_149_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="5" y="76" width="54" height="52">
-			</bounds>
+			<bounds x="5" y="76" width="54" height="52"/>
 		</backdrop>
 		<backdrop name="lamp216" element="colour_button_149" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="7" y="78" width="50" height="48">
-			</bounds>
+			<bounds x="7" y="78" width="50" height="48"/>
 		</backdrop>
 		<backdrop name="lamp227" element="colour_button_150_border" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="502" y="40" width="52" height="52">
-			</bounds>
+			<bounds x="502" y="40" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp227" element="colour_button_150" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="504" y="42" width="48" height="48">
-			</bounds>
+			<bounds x="504" y="42" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp160" element="colour_button_151_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="386" y="382" width="52" height="52">
-			</bounds>
+			<bounds x="386" y="382" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp160" element="colour_button_151" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="388" y="384" width="48" height="48">
-			</bounds>
+			<bounds x="388" y="384" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_153_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="9" y="635" width="66" height="37">
-			</bounds>
+			<bounds x="9" y="635" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_153" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="11" y="637" width="62" height="33">
-			</bounds>
+			<bounds x="11" y="637" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_154_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="85" y="635" width="66" height="37">
-			</bounds>
+			<bounds x="85" y="635" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_154" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="87" y="637" width="62" height="33">
-			</bounds>
+			<bounds x="87" y="637" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_155_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="205" y="635" width="66" height="37">
-			</bounds>
+			<bounds x="205" y="635" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_155" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="207" y="637" width="62" height="33">
-			</bounds>
+			<bounds x="207" y="637" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_156_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="325" y="635" width="66" height="37">
-			</bounds>
+			<bounds x="325" y="635" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_156" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="327" y="637" width="62" height="33">
-			</bounds>
+			<bounds x="327" y="637" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_157_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="431" y="635" width="66" height="37">
-			</bounds>
+			<bounds x="431" y="635" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_157" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="433" y="637" width="62" height="33">
-			</bounds>
+			<bounds x="433" y="637" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_158_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="525" y="635" width="66" height="37">
-			</bounds>
+			<bounds x="525" y="635" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_158" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="527" y="637" width="62" height="33">
-			</bounds>
+			<bounds x="527" y="637" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_159_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="619" y="636" width="66" height="37">
-			</bounds>
+			<bounds x="619" y="636" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_159" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="621" y="638" width="62" height="33">
-			</bounds>
+			<bounds x="621" y="638" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp248" element="colour_button_160_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="625" y="47" width="42" height="62">
-			</bounds>
+			<bounds x="625" y="47" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp248" element="colour_button_160" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="627" y="49" width="38" height="58">
-			</bounds>
+			<bounds x="627" y="49" width="38" height="58"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="93" y="360" width="224" height="26">
-			</bounds>
+			<bounds x="93" y="360" width="224" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="93" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="93" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="107" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="107" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="121" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="121" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="135" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="135" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="149" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="149" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="163" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="163" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="177" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="177" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="191" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="191" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="205" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="205" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="219" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="219" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="233" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="233" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="247" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="247" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="261" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="261" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="275" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="275" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="289" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="289" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="303" y="360" width="14" height="26">
-			</bounds>
+			<bounds x="303" y="360" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="label4" element="label_4">
-			<bounds x="399" y="589" width="51" height="13">
-			</bounds>
+			<bounds x="399" y="589" width="51" height="13"/>
 		</backdrop>
 		<backdrop name="label5" element="label_5">
-			<bounds x="318" y="589" width="59" height="13">
-			</bounds>
+			<bounds x="318" y="589" width="59" height="13"/>
 		</backdrop>
 		<backdrop name="label6" element="label_6">
-			<bounds x="244" y="589" width="54" height="13">
-			</bounds>
+			<bounds x="244" y="589" width="54" height="13"/>
 		</backdrop>
 		<backdrop name="label7" element="label_7">
-			<bounds x="558" y="589" width="41" height="13">
-			</bounds>
+			<bounds x="558" y="589" width="41" height="13"/>
 		</backdrop>
 		<backdrop name="label8" element="label_8">
-			<bounds x="478" y="589" width="43" height="13">
-			</bounds>
+			<bounds x="478" y="589" width="43" height="13"/>
 		</backdrop>
 		<backdrop name="label9" element="label_9">
-			<bounds x="163" y="589" width="63" height="13">
-			</bounds>
+			<bounds x="163" y="589" width="63" height="13"/>
 		</backdrop>
 		<backdrop name="label10" element="label_10">
-			<bounds x="90" y="589" width="54" height="13">
-			</bounds>
+			<bounds x="90" y="589" width="54" height="13"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="17" y="589" width="50" height="13">
-			</bounds>
+			<bounds x="17" y="589" width="50" height="13"/>
 		</backdrop>
 		<backdrop name="label34" element="label_34">
-			<bounds x="39" y="14" width="66" height="65">
-			</bounds>
+			<bounds x="39" y="14" width="66" height="65"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="522" y="8" width="108" height="13">
-			</bounds>
+			<bounds x="522" y="8" width="108" height="13"/>
 		</backdrop>
 		<backdrop name="label100" element="label_100">
-			<bounds x="337" y="431" width="42" height="13">
-			</bounds>
+			<bounds x="337" y="431" width="42" height="13"/>
 		</backdrop>
 		<backdrop name="label102" element="label_102">
-			<bounds x="96" y="385" width="30" height="13">
-			</bounds>
+			<bounds x="96" y="385" width="30" height="13"/>
 		</backdrop>
 		<backdrop name="label103" element="label_103">
-			<bounds x="285" y="385" width="31" height="13">
-			</bounds>
+			<bounds x="285" y="385" width="31" height="13"/>
 		</backdrop>
 		<backdrop name="label115" element="label_115">
-			<bounds x="110" y="347" width="181" height="13">
-			</bounds>
+			<bounds x="110" y="347" width="181" height="13"/>
 		</backdrop>
 		<backdrop name="label116" element="label_116">
-			<bounds x="201" y="230" width="98" height="26">
-			</bounds>
+			<bounds x="201" y="230" width="98" height="26"/>
 		</backdrop>
 		<backdrop name="label136" element="label_136">
-			<bounds x="629" y="589" width="52" height="13">
-			</bounds>
+			<bounds x="629" y="589" width="52" height="13"/>
 		</backdrop>
 		<backdrop name="label137" element="label_137">
-			<bounds x="186" y="136" width="196" height="13">
-			</bounds>
+			<bounds x="186" y="136" width="196" height="13"/>
 		</backdrop>
 		<backdrop name="label138" element="label_138">
-			<bounds x="621" y="34" width="52" height="13">
-			</bounds>
+			<bounds x="621" y="34" width="52" height="13"/>
 		</backdrop>
 		<backdrop name="label139" element="label_139">
-			<bounds x="442" y="437" width="118" height="13">
-			</bounds>
+			<bounds x="442" y="437" width="118" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_button" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_button" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_button" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_button" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_button" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_button" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1casclb.lay
+++ b/src/mame/layout/m1casclb.lay
@@ -8,8744 +8,6019 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Insufficient Funds To Pay Major Prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Insufficient Funds To Pay Major Prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.12" blue="0.02">
-			</color>
+			<color red="0.48" green="0.12" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.97" green="0.24" blue="0.04">
-			</color>
+			<color red="0.97" green="0.24" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.01">
-			</color>
+			<color red="0.24" green="0.06" blue="0.01"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.12" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.97" green="0.24" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.01">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.12" blue="0.02">
-			</color>
+			<color red="0.48" green="0.12" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_2" defstate="0">
 		<rect state="1">
-			<color red="0.97" green="0.24" blue="0.04">
-			</color>
+			<color red="0.97" green="0.24" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.01">
-			</color>
+			<color red="0.24" green="0.06" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.12" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.97" green="0.24" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_73_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_73">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_74_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_74">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_75_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_75">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_76_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_76">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_77_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_77">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_78_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_78">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Save">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Part Wi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_79_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_79">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_80_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_80">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_81_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_81">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_13">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_17">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_28">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_29">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_33">
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_34">
 		<text string="RESERVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_35">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_36">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_59">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_68">
 		<text string="War Paint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_69">
 		<text string="V1.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="614" height="663">
-			</bounds>
+			<bounds x="0" y="0" width="614" height="663"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="12" y="275" width="100" height="180">
-			</bounds>
+			<bounds x="12" y="275" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="12" y="275" width="100" height="180">
-			</bounds>
+			<bounds x="12" y="275" width="100" height="180"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="129" y="275" width="100" height="180">
-			</bounds>
+			<bounds x="129" y="275" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="129" y="275" width="100" height="180">
-			</bounds>
+			<bounds x="129" y="275" width="100" height="180"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="246" y="275" width="100" height="180">
-			</bounds>
+			<bounds x="246" y="275" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="246" y="275" width="100" height="180">
-			</bounds>
+			<bounds x="246" y="275" width="100" height="180"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="363" y="275" width="100" height="180">
-			</bounds>
+			<bounds x="363" y="275" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="363" y="275" width="100" height="180">
-			</bounds>
+			<bounds x="363" y="275" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="346" y="370" width="12" height="12">
-			</bounds>
+			<bounds x="346" y="370" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="348" y="372" width="8" height="8">
-			</bounds>
+			<bounds x="348" y="372" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="346" y="360" width="12" height="12">
-			</bounds>
+			<bounds x="346" y="360" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="348" y="362" width="8" height="8">
-			</bounds>
+			<bounds x="348" y="362" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="346" y="350" width="12" height="12">
-			</bounds>
+			<bounds x="346" y="350" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="348" y="352" width="8" height="8">
-			</bounds>
+			<bounds x="348" y="352" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="229" y="370" width="12" height="12">
-			</bounds>
+			<bounds x="229" y="370" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="231" y="372" width="8" height="8">
-			</bounds>
+			<bounds x="231" y="372" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="229" y="360" width="12" height="12">
-			</bounds>
+			<bounds x="229" y="360" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="231" y="362" width="8" height="8">
-			</bounds>
+			<bounds x="231" y="362" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="229" y="350" width="12" height="12">
-			</bounds>
+			<bounds x="229" y="350" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="231" y="352" width="8" height="8">
-			</bounds>
+			<bounds x="231" y="352" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="112" y="350" width="12" height="12">
-			</bounds>
+			<bounds x="112" y="350" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="114" y="352" width="8" height="8">
-			</bounds>
+			<bounds x="114" y="352" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="112" y="360" width="12" height="12">
-			</bounds>
+			<bounds x="112" y="360" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="114" y="362" width="8" height="8">
-			</bounds>
+			<bounds x="114" y="362" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="112" y="370" width="12" height="12">
-			</bounds>
+			<bounds x="112" y="370" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="114" y="372" width="8" height="8">
-			</bounds>
+			<bounds x="114" y="372" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="463" y="347" width="12" height="12">
-			</bounds>
+			<bounds x="463" y="347" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="465" y="349" width="8" height="8">
-			</bounds>
+			<bounds x="465" y="349" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="463" y="357" width="12" height="12">
-			</bounds>
+			<bounds x="463" y="357" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="465" y="359" width="8" height="8">
-			</bounds>
+			<bounds x="465" y="359" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="463" y="367" width="12" height="12">
-			</bounds>
+			<bounds x="463" y="367" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="465" y="369" width="8" height="8">
-			</bounds>
+			<bounds x="465" y="369" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="61" y="495" width="52" height="19">
-			</bounds>
+			<bounds x="61" y="495" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="63" y="497" width="48" height="15">
-			</bounds>
+			<bounds x="63" y="497" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="111" y="488" width="52" height="19">
-			</bounds>
+			<bounds x="111" y="488" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="113" y="490" width="48" height="15">
-			</bounds>
+			<bounds x="113" y="490" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="161" y="481" width="52" height="19">
-			</bounds>
+			<bounds x="161" y="481" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="163" y="483" width="48" height="15">
-			</bounds>
+			<bounds x="163" y="483" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="211" y="478" width="52" height="19">
-			</bounds>
+			<bounds x="211" y="478" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="213" y="480" width="48" height="15">
-			</bounds>
+			<bounds x="213" y="480" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="261" y="481" width="52" height="19">
-			</bounds>
+			<bounds x="261" y="481" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="263" y="483" width="48" height="15">
-			</bounds>
+			<bounds x="263" y="483" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="311" y="488" width="52" height="19">
-			</bounds>
+			<bounds x="311" y="488" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="313" y="490" width="48" height="15">
-			</bounds>
+			<bounds x="313" y="490" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="361" y="495" width="52" height="19">
-			</bounds>
+			<bounds x="361" y="495" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="363" y="497" width="48" height="15">
-			</bounds>
+			<bounds x="363" y="497" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="555" y="290" width="52" height="62">
-			</bounds>
+			<bounds x="555" y="290" width="52" height="62"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="557" y="292" width="48" height="58">
-			</bounds>
+			<bounds x="557" y="292" width="48" height="58"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="525" y="359" width="52" height="62">
-			</bounds>
+			<bounds x="525" y="359" width="52" height="62"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="527" y="361" width="48" height="58">
-			</bounds>
+			<bounds x="527" y="361" width="48" height="58"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="495" y="429" width="52" height="62">
-			</bounds>
+			<bounds x="495" y="429" width="52" height="62"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="497" y="431" width="48" height="58">
-			</bounds>
+			<bounds x="497" y="431" width="48" height="58"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="465" y="499" width="52" height="62">
-			</bounds>
+			<bounds x="465" y="499" width="52" height="62"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="467" y="501" width="48" height="58">
-			</bounds>
+			<bounds x="467" y="501" width="48" height="58"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="479" y="290" width="62" height="42">
-			</bounds>
+			<bounds x="479" y="290" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="481" y="292" width="58" height="38">
-			</bounds>
+			<bounds x="481" y="292" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="489" y="119" width="114" height="28">
-			</bounds>
+			<bounds x="489" y="119" width="114" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="491" y="121" width="110" height="24">
-			</bounds>
+			<bounds x="491" y="121" width="110" height="24"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="503" y="205" width="88" height="22">
-			</bounds>
+			<bounds x="503" y="205" width="88" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="505" y="207" width="84" height="18">
-			</bounds>
+			<bounds x="505" y="207" width="84" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2_border" state="0">
-			<bounds x="503" y="171" width="88" height="37">
-			</bounds>
+			<bounds x="503" y="171" width="88" height="37"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2" state="0">
-			<bounds x="505" y="173" width="84" height="33">
-			</bounds>
+			<bounds x="505" y="173" width="84" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_73_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="27" y="592" width="70" height="42">
-			</bounds>
+			<bounds x="27" y="592" width="70" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_73" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="29" y="594" width="66" height="38">
-			</bounds>
+			<bounds x="29" y="594" width="66" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_74_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="144" y="592" width="70" height="42">
-			</bounds>
+			<bounds x="144" y="592" width="70" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_74" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="146" y="594" width="66" height="38">
-			</bounds>
+			<bounds x="146" y="594" width="66" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_75_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="261" y="592" width="70" height="42">
-			</bounds>
+			<bounds x="261" y="592" width="70" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_75" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="263" y="594" width="66" height="38">
-			</bounds>
+			<bounds x="263" y="594" width="66" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_76_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="378" y="592" width="70" height="42">
-			</bounds>
+			<bounds x="378" y="592" width="70" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_76" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="380" y="594" width="66" height="38">
-			</bounds>
+			<bounds x="380" y="594" width="66" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_77_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="61" y="519" width="68" height="42">
-			</bounds>
+			<bounds x="61" y="519" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_77" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="63" y="521" width="64" height="38">
-			</bounds>
+			<bounds x="63" y="521" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_78_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="345" y="519" width="68" height="42">
-			</bounds>
+			<bounds x="345" y="519" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_78" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="347" y="521" width="64" height="38">
-			</bounds>
+			<bounds x="347" y="521" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_79_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="539" y="592" width="70" height="42">
-			</bounds>
+			<bounds x="539" y="592" width="70" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_79" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="541" y="594" width="66" height="38">
-			</bounds>
+			<bounds x="541" y="594" width="66" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_80_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="464" y="592" width="70" height="42">
-			</bounds>
+			<bounds x="464" y="592" width="70" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_80" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="466" y="594" width="66" height="38">
-			</bounds>
+			<bounds x="466" y="594" width="66" height="38"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_81_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="522" y="57" width="46" height="62">
-			</bounds>
+			<bounds x="522" y="57" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_81" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="524" y="59" width="42" height="58">
-			</bounds>
+			<bounds x="524" y="59" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="202" y="192" width="24" height="32">
-			</bounds>
+			<bounds x="202" y="192" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off184" element="led_off">
-			<bounds x="205" y="194" width="17" height="2">
-			</bounds>
+			<bounds x="205" y="194" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off185" element="led_off">
-			<bounds x="219" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="219" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off186" element="led_off">
-			<bounds x="219" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="219" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off187" element="led_off">
-			<bounds x="205" y="218" width="17" height="2">
-			</bounds>
+			<bounds x="205" y="218" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off188" element="led_off">
-			<bounds x="205" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="205" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off189" element="led_off">
-			<bounds x="205" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="205" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off190" element="led_off">
-			<bounds x="205" y="206" width="17" height="2">
-			</bounds>
+			<bounds x="205" y="206" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off191" element="led_dot_off">
-			<bounds x="222" y="218" width="3" height="2">
-			</bounds>
+			<bounds x="222" y="218" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp184" element="led_on">
-			<bounds x="205" y="194" width="17" height="2">
-			</bounds>
+			<bounds x="205" y="194" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp185" element="led_on">
-			<bounds x="219" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="219" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp186" element="led_on">
-			<bounds x="219" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="219" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp187" element="led_on">
-			<bounds x="205" y="218" width="17" height="2">
-			</bounds>
+			<bounds x="205" y="218" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp188" element="led_on">
-			<bounds x="205" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="205" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp189" element="led_on">
-			<bounds x="205" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="205" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp190" element="led_on">
-			<bounds x="205" y="206" width="17" height="2">
-			</bounds>
+			<bounds x="205" y="206" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp191" element="led_dot_on">
-			<bounds x="222" y="218" width="3" height="2">
-			</bounds>
+			<bounds x="222" y="218" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="211" y="141" width="18" height="24">
-			</bounds>
+			<bounds x="211" y="141" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="led_off208" element="led_off">
-			<bounds x="213" y="143" width="12" height="2">
-			</bounds>
+			<bounds x="213" y="143" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off209" element="led_off">
-			<bounds x="223" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="223" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off210" element="led_off">
-			<bounds x="223" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="223" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off211" element="led_off">
-			<bounds x="213" y="160" width="12" height="2">
-			</bounds>
+			<bounds x="213" y="160" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off212" element="led_off">
-			<bounds x="213" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="213" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off213" element="led_off">
-			<bounds x="213" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="213" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off214" element="led_off">
-			<bounds x="213" y="151" width="12" height="2">
-			</bounds>
+			<bounds x="213" y="151" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off215" element="led_dot_off">
-			<bounds x="226" y="160" width="2" height="2">
-			</bounds>
+			<bounds x="226" y="160" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp208" element="led_on">
-			<bounds x="213" y="143" width="12" height="2">
-			</bounds>
+			<bounds x="213" y="143" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp209" element="led_on">
-			<bounds x="223" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="223" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp210" element="led_on">
-			<bounds x="223" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="223" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp211" element="led_on">
-			<bounds x="213" y="160" width="12" height="2">
-			</bounds>
+			<bounds x="213" y="160" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp212" element="led_on">
-			<bounds x="213" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="213" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp213" element="led_on">
-			<bounds x="213" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="213" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp214" element="led_on">
-			<bounds x="213" y="151" width="12" height="2">
-			</bounds>
+			<bounds x="213" y="151" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp215" element="led_dot_on">
-			<bounds x="226" y="160" width="2" height="2">
-			</bounds>
+			<bounds x="226" y="160" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="158" y="61" width="40" height="50">
-			</bounds>
+			<bounds x="158" y="61" width="40" height="50"/>
 		</backdrop>
 		<backdrop name="led_off152" element="led_off">
-			<bounds x="163" y="65" width="28" height="4">
-			</bounds>
+			<bounds x="163" y="65" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off153" element="led_off">
-			<bounds x="186" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="186" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off154" element="led_off">
-			<bounds x="186" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="186" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off155" element="led_off">
-			<bounds x="163" y="101" width="28" height="4">
-			</bounds>
+			<bounds x="163" y="101" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off156" element="led_off">
-			<bounds x="163" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="163" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off157" element="led_off">
-			<bounds x="163" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="163" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off158" element="led_off">
-			<bounds x="163" y="83" width="28" height="4">
-			</bounds>
+			<bounds x="163" y="83" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off159" element="led_dot_off">
-			<bounds x="192" y="101" width="5" height="4">
-			</bounds>
+			<bounds x="192" y="101" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="lamp152" element="led_on">
-			<bounds x="163" y="65" width="28" height="4">
-			</bounds>
+			<bounds x="163" y="65" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp153" element="led_on">
-			<bounds x="186" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="186" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp154" element="led_on">
-			<bounds x="186" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="186" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp155" element="led_on">
-			<bounds x="163" y="101" width="28" height="4">
-			</bounds>
+			<bounds x="163" y="101" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp156" element="led_on">
-			<bounds x="163" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="163" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp157" element="led_on">
-			<bounds x="163" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="163" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp158" element="led_on">
-			<bounds x="163" y="83" width="28" height="4">
-			</bounds>
+			<bounds x="163" y="83" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp159" element="led_dot_on">
-			<bounds x="192" y="101" width="5" height="4">
-			</bounds>
+			<bounds x="192" y="101" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="278" y="61" width="40" height="50">
-			</bounds>
+			<bounds x="278" y="61" width="40" height="50"/>
 		</backdrop>
 		<backdrop name="led_off176" element="led_off">
-			<bounds x="283" y="65" width="28" height="4">
-			</bounds>
+			<bounds x="283" y="65" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off177" element="led_off">
-			<bounds x="306" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="306" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off178" element="led_off">
-			<bounds x="306" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="306" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off179" element="led_off">
-			<bounds x="283" y="101" width="28" height="4">
-			</bounds>
+			<bounds x="283" y="101" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off180" element="led_off">
-			<bounds x="283" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="283" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off181" element="led_off">
-			<bounds x="283" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="283" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off182" element="led_off">
-			<bounds x="283" y="83" width="28" height="4">
-			</bounds>
+			<bounds x="283" y="83" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off183" element="led_dot_off">
-			<bounds x="312" y="101" width="5" height="4">
-			</bounds>
+			<bounds x="312" y="101" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="lamp176" element="led_on">
-			<bounds x="283" y="65" width="28" height="4">
-			</bounds>
+			<bounds x="283" y="65" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp177" element="led_on">
-			<bounds x="306" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="306" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp178" element="led_on">
-			<bounds x="306" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="306" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp179" element="led_on">
-			<bounds x="283" y="101" width="28" height="4">
-			</bounds>
+			<bounds x="283" y="101" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp180" element="led_on">
-			<bounds x="283" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="283" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp181" element="led_on">
-			<bounds x="283" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="283" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp182" element="led_on">
-			<bounds x="283" y="83" width="28" height="4">
-			</bounds>
+			<bounds x="283" y="83" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp183" element="led_dot_on">
-			<bounds x="312" y="101" width="5" height="4">
-			</bounds>
+			<bounds x="312" y="101" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="238" y="61" width="40" height="50">
-			</bounds>
+			<bounds x="238" y="61" width="40" height="50"/>
 		</backdrop>
 		<backdrop name="led_off168" element="led_off">
-			<bounds x="243" y="65" width="28" height="4">
-			</bounds>
+			<bounds x="243" y="65" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off169" element="led_off">
-			<bounds x="266" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="266" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off170" element="led_off">
-			<bounds x="266" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="266" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off171" element="led_off">
-			<bounds x="243" y="101" width="28" height="4">
-			</bounds>
+			<bounds x="243" y="101" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off172" element="led_off">
-			<bounds x="243" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="243" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off173" element="led_off">
-			<bounds x="243" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="243" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off174" element="led_off">
-			<bounds x="243" y="83" width="28" height="4">
-			</bounds>
+			<bounds x="243" y="83" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off175" element="led_dot_off">
-			<bounds x="272" y="101" width="5" height="4">
-			</bounds>
+			<bounds x="272" y="101" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="lamp168" element="led_on">
-			<bounds x="243" y="65" width="28" height="4">
-			</bounds>
+			<bounds x="243" y="65" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp169" element="led_on">
-			<bounds x="266" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="266" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="led_on">
-			<bounds x="266" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="266" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="led_on">
-			<bounds x="243" y="101" width="28" height="4">
-			</bounds>
+			<bounds x="243" y="101" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp172" element="led_on">
-			<bounds x="243" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="243" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp173" element="led_on">
-			<bounds x="243" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="243" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp174" element="led_on">
-			<bounds x="243" y="83" width="28" height="4">
-			</bounds>
+			<bounds x="243" y="83" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp175" element="led_dot_on">
-			<bounds x="272" y="101" width="5" height="4">
-			</bounds>
+			<bounds x="272" y="101" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="198" y="61" width="40" height="50">
-			</bounds>
+			<bounds x="198" y="61" width="40" height="50"/>
 		</backdrop>
 		<backdrop name="led_off160" element="led_off">
-			<bounds x="203" y="65" width="28" height="4">
-			</bounds>
+			<bounds x="203" y="65" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off161" element="led_off">
-			<bounds x="226" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="226" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off162" element="led_off">
-			<bounds x="226" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="226" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off163" element="led_off">
-			<bounds x="203" y="101" width="28" height="4">
-			</bounds>
+			<bounds x="203" y="101" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off164" element="led_off">
-			<bounds x="203" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="203" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off165" element="led_off">
-			<bounds x="203" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="203" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="led_off166" element="led_off">
-			<bounds x="203" y="83" width="28" height="4">
-			</bounds>
+			<bounds x="203" y="83" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="led_off167" element="led_dot_off">
-			<bounds x="232" y="101" width="5" height="4">
-			</bounds>
+			<bounds x="232" y="101" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="lamp160" element="led_on">
-			<bounds x="203" y="65" width="28" height="4">
-			</bounds>
+			<bounds x="203" y="65" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp161" element="led_on">
-			<bounds x="226" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="226" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp162" element="led_on">
-			<bounds x="226" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="226" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp163" element="led_on">
-			<bounds x="203" y="101" width="28" height="4">
-			</bounds>
+			<bounds x="203" y="101" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp164" element="led_on">
-			<bounds x="203" y="83" width="5" height="22">
-			</bounds>
+			<bounds x="203" y="83" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp165" element="led_on">
-			<bounds x="203" y="65" width="5" height="22">
-			</bounds>
+			<bounds x="203" y="65" width="5" height="22"/>
 		</backdrop>
 		<backdrop name="lamp166" element="led_on">
-			<bounds x="203" y="83" width="28" height="4">
-			</bounds>
+			<bounds x="203" y="83" width="28" height="4"/>
 		</backdrop>
 		<backdrop name="lamp167" element="led_dot_on">
-			<bounds x="232" y="101" width="5" height="4">
-			</bounds>
+			<bounds x="232" y="101" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="189" y="528" width="24" height="32">
-			</bounds>
+			<bounds x="189" y="528" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="192" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="192" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="206" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="206" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="206" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="206" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="192" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="192" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="192" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="192" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="192" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="192" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="192" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="192" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_dot_off">
-			<bounds x="209" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="209" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="192" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="192" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="206" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="206" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="206" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="206" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="192" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="192" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="192" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="192" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="192" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="192" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="192" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="192" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_dot_on">
-			<bounds x="209" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="209" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="213" y="528" width="24" height="32">
-			</bounds>
+			<bounds x="213" y="528" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="216" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="216" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="230" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="230" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="230" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="230" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="216" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="216" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="216" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="216" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="216" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="216" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="216" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="216" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="233" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="233" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="216" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="216" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="230" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="230" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="230" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="230" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="216" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="216" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="216" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="216" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="216" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="216" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="216" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="216" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="233" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="233" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="237" y="528" width="24" height="32">
-			</bounds>
+			<bounds x="237" y="528" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="240" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="240" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="254" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="254" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="254" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="254" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="240" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="240" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="240" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="240" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="240" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="240" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="240" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="240" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="257" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="257" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="240" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="240" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="254" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="254" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="254" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="254" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="240" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="240" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="240" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="240" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="240" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="240" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="240" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="240" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="257" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="257" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="261" y="528" width="24" height="32">
-			</bounds>
+			<bounds x="261" y="528" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="264" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="264" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="278" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="278" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="278" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="278" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="264" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="264" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="264" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="264" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="264" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="264" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="264" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="264" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="281" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="281" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="264" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="264" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="278" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="278" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="278" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="278" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="264" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="264" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="264" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="264" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="264" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="264" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="264" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="264" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="281" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="281" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="576" y="528" width="24" height="32">
-			</bounds>
+			<bounds x="576" y="528" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="579" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="593" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="593" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="593" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="593" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="579" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="579" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="579" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="579" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="579" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="579" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="596" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="596" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="579" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="593" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="593" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="593" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="593" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="579" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="579" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="579" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="579" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="579" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="579" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="596" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="596" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="552" y="528" width="24" height="32">
-			</bounds>
+			<bounds x="552" y="528" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="555" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="555" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="569" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="569" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="569" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="569" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="555" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="555" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="555" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="555" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="555" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="555" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="555" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="555" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="572" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="572" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="555" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="555" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="569" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="569" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="569" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="569" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="555" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="555" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="555" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="555" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="555" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="555" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="555" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="555" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="572" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="572" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="226" y="192" width="24" height="32">
-			</bounds>
+			<bounds x="226" y="192" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off192" element="led_off">
-			<bounds x="229" y="194" width="17" height="2">
-			</bounds>
+			<bounds x="229" y="194" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off193" element="led_off">
-			<bounds x="243" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="243" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off194" element="led_off">
-			<bounds x="243" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="243" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off195" element="led_off">
-			<bounds x="229" y="218" width="17" height="2">
-			</bounds>
+			<bounds x="229" y="218" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off196" element="led_off">
-			<bounds x="229" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="229" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off197" element="led_off">
-			<bounds x="229" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="229" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off198" element="led_off">
-			<bounds x="229" y="206" width="17" height="2">
-			</bounds>
+			<bounds x="229" y="206" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off199" element="led_dot_off">
-			<bounds x="246" y="218" width="3" height="2">
-			</bounds>
+			<bounds x="246" y="218" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp192" element="led_on">
-			<bounds x="229" y="194" width="17" height="2">
-			</bounds>
+			<bounds x="229" y="194" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp193" element="led_on">
-			<bounds x="243" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="243" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp194" element="led_on">
-			<bounds x="243" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="243" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp195" element="led_on">
-			<bounds x="229" y="218" width="17" height="2">
-			</bounds>
+			<bounds x="229" y="218" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp196" element="led_on">
-			<bounds x="229" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="229" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp197" element="led_on">
-			<bounds x="229" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="229" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp198" element="led_on">
-			<bounds x="229" y="206" width="17" height="2">
-			</bounds>
+			<bounds x="229" y="206" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp199" element="led_dot_on">
-			<bounds x="246" y="218" width="3" height="2">
-			</bounds>
+			<bounds x="246" y="218" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="250" y="192" width="24" height="32">
-			</bounds>
+			<bounds x="250" y="192" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="253" y="194" width="17" height="2">
-			</bounds>
+			<bounds x="253" y="194" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="267" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="267" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="267" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="267" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="253" y="218" width="17" height="2">
-			</bounds>
+			<bounds x="253" y="218" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="253" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="253" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="253" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="253" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="253" y="206" width="17" height="2">
-			</bounds>
+			<bounds x="253" y="206" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="270" y="218" width="3" height="2">
-			</bounds>
+			<bounds x="270" y="218" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="253" y="194" width="17" height="2">
-			</bounds>
+			<bounds x="253" y="194" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="267" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="267" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="267" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="267" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="253" y="218" width="17" height="2">
-			</bounds>
+			<bounds x="253" y="218" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="253" y="206" width="3" height="14">
-			</bounds>
+			<bounds x="253" y="206" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="253" y="194" width="3" height="14">
-			</bounds>
+			<bounds x="253" y="194" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="253" y="206" width="17" height="2">
-			</bounds>
+			<bounds x="253" y="206" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="270" y="218" width="3" height="2">
-			</bounds>
+			<bounds x="270" y="218" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="229" y="141" width="18" height="24">
-			</bounds>
+			<bounds x="229" y="141" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="led_off216" element="led_off">
-			<bounds x="231" y="143" width="12" height="2">
-			</bounds>
+			<bounds x="231" y="143" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off217" element="led_off">
-			<bounds x="241" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="241" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off218" element="led_off">
-			<bounds x="241" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="241" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off219" element="led_off">
-			<bounds x="231" y="160" width="12" height="2">
-			</bounds>
+			<bounds x="231" y="160" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off220" element="led_off">
-			<bounds x="231" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="231" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off221" element="led_off">
-			<bounds x="231" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="231" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off222" element="led_off">
-			<bounds x="231" y="151" width="12" height="2">
-			</bounds>
+			<bounds x="231" y="151" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off223" element="led_dot_off">
-			<bounds x="244" y="160" width="2" height="2">
-			</bounds>
+			<bounds x="244" y="160" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp216" element="led_on">
-			<bounds x="231" y="143" width="12" height="2">
-			</bounds>
+			<bounds x="231" y="143" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp217" element="led_on">
-			<bounds x="241" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="241" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp218" element="led_on">
-			<bounds x="241" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="241" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp219" element="led_on">
-			<bounds x="231" y="160" width="12" height="2">
-			</bounds>
+			<bounds x="231" y="160" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp220" element="led_on">
-			<bounds x="231" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="231" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp221" element="led_on">
-			<bounds x="231" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="231" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp222" element="led_on">
-			<bounds x="231" y="151" width="12" height="2">
-			</bounds>
+			<bounds x="231" y="151" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp223" element="led_dot_on">
-			<bounds x="244" y="160" width="2" height="2">
-			</bounds>
+			<bounds x="244" y="160" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="247" y="141" width="18" height="24">
-			</bounds>
+			<bounds x="247" y="141" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="249" y="143" width="12" height="2">
-			</bounds>
+			<bounds x="249" y="143" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="259" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="259" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="259" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="259" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="249" y="160" width="12" height="2">
-			</bounds>
+			<bounds x="249" y="160" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="249" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="249" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="249" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="249" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="249" y="151" width="12" height="2">
-			</bounds>
+			<bounds x="249" y="151" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="262" y="160" width="2" height="2">
-			</bounds>
+			<bounds x="262" y="160" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="249" y="143" width="12" height="2">
-			</bounds>
+			<bounds x="249" y="143" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="259" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="259" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="259" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="259" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="249" y="160" width="12" height="2">
-			</bounds>
+			<bounds x="249" y="160" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="249" y="151" width="2" height="10">
-			</bounds>
+			<bounds x="249" y="151" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="249" y="143" width="2" height="10">
-			</bounds>
+			<bounds x="249" y="143" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="249" y="151" width="12" height="2">
-			</bounds>
+			<bounds x="249" y="151" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="262" y="160" width="2" height="2">
-			</bounds>
+			<bounds x="262" y="160" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="label13" element="label_13">
-			<bounds x="170" y="4" width="133" height="67">
-			</bounds>
+			<bounds x="170" y="4" width="133" height="67"/>
 		</backdrop>
 		<backdrop name="label17" element="label_17">
-			<bounds x="109" y="35" width="51" height="90">
-			</bounds>
+			<bounds x="109" y="35" width="51" height="90"/>
 		</backdrop>
 		<backdrop name="label28" element="label_28">
-			<bounds x="189" y="134" width="21" height="38">
-			</bounds>
+			<bounds x="189" y="134" width="21" height="38"/>
 		</backdrop>
 		<backdrop name="label29" element="label_29">
-			<bounds x="175" y="182" width="28" height="49">
-			</bounds>
+			<bounds x="175" y="182" width="28" height="49"/>
 		</backdrop>
 		<backdrop name="label33" element="label_33">
-			<bounds x="201" y="174" width="72" height="21">
-			</bounds>
+			<bounds x="201" y="174" width="72" height="21"/>
 		</backdrop>
 		<backdrop name="label34" element="label_34">
-			<bounds x="213" y="127" width="50" height="16">
-			</bounds>
+			<bounds x="213" y="127" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="label35" element="label_35">
-			<bounds x="191" y="509" width="96" height="23">
-			</bounds>
+			<bounds x="191" y="509" width="96" height="23"/>
 		</backdrop>
 		<backdrop name="label36" element="label_36">
-			<bounds x="153" y="503" width="38" height="67">
-			</bounds>
+			<bounds x="153" y="503" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label59" element="label_59">
-			<bounds x="551" y="514" width="51" height="16">
-			</bounds>
+			<bounds x="551" y="514" width="51" height="16"/>
 		</backdrop>
 		<backdrop name="label68" element="label_68">
-			<bounds x="2" y="634" width="58" height="16">
-			</bounds>
+			<bounds x="2" y="634" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="label69" element="label_69">
-			<bounds x="581" y="639" width="27" height="16">
-			</bounds>
+			<bounds x="581" y="639" width="27" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_button" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1casroy1.lay
+++ b/src/mame/layout/m1casroy1.lay
@@ -8,9816 +8,6424 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.15" blue="0.00">
-			</color>
+			<color red="0.45" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.04" blue="0.00">
-			</color>
+			<color red="0.11" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.90" green="0.29" blue="0.00">
-			</color>
+			<color red="0.90" green="0.29" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.07" blue="0.00">
-			</color>
+			<color red="0.22" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="- O O O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.90" green="0.29" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="- O O O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="AK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
 		<text string="ES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
 		<text string="NU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.15" blue="0.00">
-			</color>
+			<color red="0.45" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.04" blue="0.00">
-			</color>
+			<color red="0.11" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.90" green="0.29" blue="0.00">
-			</color>
+			<color red="0.90" green="0.29" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.07" blue="0.00">
-			</color>
+			<color red="0.22" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="O O O -">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.90" green="0.29" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="O O O -">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</disk>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</disk>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</disk>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</disk>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</disk>
 		<text string="x4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</disk>
-		<text string="x4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</disk>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</disk>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="INO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="INO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="CAS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="CAS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.35" green="0.17" blue="0.00">
-			</color>
+			<color red="0.35" green="0.17" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.04" blue="0.00">
-			</color>
+			<color red="0.09" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.69" green="0.35" blue="0.00">
-			</color>
+			<color red="0.69" green="0.35" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.09" blue="0.00">
-			</color>
+			<color red="0.17" green="0.09" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.35" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.69" green="0.35" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.09" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.35" green="0.17" blue="0.00">
-			</color>
+			<color red="0.35" green="0.17" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.04" blue="0.00">
-			</color>
+			<color red="0.09" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.69" green="0.35" blue="0.00">
-			</color>
+			<color red="0.69" green="0.35" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.09" blue="0.00">
-			</color>
+			<color red="0.17" green="0.09" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.35" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.69" green="0.35" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.09" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.35" green="0.17" blue="0.00">
-			</color>
+			<color red="0.35" green="0.17" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.04" blue="0.00">
-			</color>
+			<color red="0.09" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.69" green="0.35" blue="0.00">
-			</color>
+			<color red="0.69" green="0.35" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.09" blue="0.00">
-			</color>
+			<color red="0.17" green="0.09" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.35" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.69" green="0.35" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.09" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.35" green="0.17" blue="0.00">
-			</color>
+			<color red="0.35" green="0.17" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.04" blue="0.00">
-			</color>
+			<color red="0.09" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.69" green="0.35" blue="0.00">
-			</color>
+			<color red="0.69" green="0.35" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.09" blue="0.00">
-			</color>
+			<color red="0.17" green="0.09" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.35" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.69" green="0.35" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.09" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_110_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_110">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_126_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_126">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_127_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_127">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_128_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_128">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_129_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_129">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SAVE IT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_130_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_130">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_141_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_141">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_6">
 		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_7">
 		<text string="FOUR CHIPS TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SELECT FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_10">
 		<text string="7 7 7 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_11">
 		<text string="Reserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_36">
 		<text string="PRESENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_37">
 		<text string="CASINO ROYALE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_45">
 		<text string=" Win                  Bank              Credit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_46">
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_55">
 		<text string="Drag window edge for">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="additional information ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_56">
 		<text string="Drag window edge to hide">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="additional information &#x3C;---">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_57">
 		<text string="+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_59">
 		<text string="x3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_60">
 		<text string="x4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_61">
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_62">
 		<text string="Jack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_63">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_64">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_65">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_66">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_67">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_68">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_69">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_70">
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_71">
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_72">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="Layout version 1.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="See M1Adness Website ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="Save It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_79">
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_80">
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_81">
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_82">
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_83">
 		<text string="Space">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_84">
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_85">
 		<text string="` or X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_86">
 		<text string="Reel 4 H/N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_87">
 		<text string="Reel 3 H/N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_88">
 		<text string="Reel 2 H/N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_89">
 		<text string="Reel 1 H/N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_90">
 		<text string="&#xA3;1 in">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_91">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_92">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_93">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_94">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_95">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_96">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="790" height="493">
-			</bounds>
+			<bounds x="0" y="0" width="790" height="493"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="19" y="277" width="80" height="134">
-			</bounds>
+			<bounds x="19" y="277" width="80" height="134"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="19" y="277" width="80" height="134">
-			</bounds>
+			<bounds x="19" y="277" width="80" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="103" y="277" width="80" height="134">
-			</bounds>
+			<bounds x="103" y="277" width="80" height="134"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="103" y="277" width="80" height="134">
-			</bounds>
+			<bounds x="103" y="277" width="80" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="187" y="277" width="80" height="134">
-			</bounds>
+			<bounds x="187" y="277" width="80" height="134"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="187" y="277" width="80" height="134">
-			</bounds>
+			<bounds x="187" y="277" width="80" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="271" y="277" width="80" height="134">
-			</bounds>
+			<bounds x="271" y="277" width="80" height="134"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="271" y="277" width="80" height="134">
-			</bounds>
+			<bounds x="271" y="277" width="80" height="134"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="268" y="154" width="62" height="19">
-			</bounds>
+			<bounds x="268" y="154" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="270" y="156" width="58" height="15">
-			</bounds>
+			<bounds x="270" y="156" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="498" y="373" width="77" height="27">
-			</bounds>
+			<bounds x="498" y="373" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="500" y="375" width="73" height="23">
-			</bounds>
+			<bounds x="500" y="375" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="368" y="307" width="77" height="27">
-			</bounds>
+			<bounds x="368" y="307" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="370" y="309" width="73" height="23">
-			</bounds>
+			<bounds x="370" y="309" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="372" y="367" width="42" height="42">
-			</bounds>
+			<bounds x="372" y="367" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="374" y="369" width="38" height="38">
-			</bounds>
+			<bounds x="374" y="369" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="426" y="344" width="42" height="42">
-			</bounds>
+			<bounds x="426" y="344" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="428" y="346" width="38" height="38">
-			</bounds>
+			<bounds x="428" y="346" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="479" y="320" width="42" height="42">
-			</bounds>
+			<bounds x="479" y="320" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="481" y="322" width="38" height="38">
-			</bounds>
+			<bounds x="481" y="322" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="530" y="294" width="42" height="42">
-			</bounds>
+			<bounds x="530" y="294" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="532" y="296" width="38" height="38">
-			</bounds>
+			<bounds x="532" y="296" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="24" y="256" width="10" height="10">
-			</bounds>
+			<bounds x="24" y="256" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="26" y="258" width="6" height="6">
-			</bounds>
+			<bounds x="26" y="258" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="34" y="256" width="10" height="10">
-			</bounds>
+			<bounds x="34" y="256" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="36" y="258" width="6" height="6">
-			</bounds>
+			<bounds x="36" y="258" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="44" y="256" width="10" height="10">
-			</bounds>
+			<bounds x="44" y="256" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="46" y="258" width="6" height="6">
-			</bounds>
+			<bounds x="46" y="258" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="54" y="256" width="10" height="10">
-			</bounds>
+			<bounds x="54" y="256" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="56" y="258" width="6" height="6">
-			</bounds>
+			<bounds x="56" y="258" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="24" y="246" width="10" height="10">
-			</bounds>
+			<bounds x="24" y="246" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="26" y="248" width="6" height="6">
-			</bounds>
+			<bounds x="26" y="248" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="34" y="246" width="10" height="10">
-			</bounds>
+			<bounds x="34" y="246" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="36" y="248" width="6" height="6">
-			</bounds>
+			<bounds x="36" y="248" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="44" y="246" width="10" height="10">
-			</bounds>
+			<bounds x="44" y="246" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="46" y="248" width="6" height="6">
-			</bounds>
+			<bounds x="46" y="248" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="54" y="246" width="10" height="10">
-			</bounds>
+			<bounds x="54" y="246" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="56" y="248" width="6" height="6">
-			</bounds>
+			<bounds x="56" y="248" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="54" y="236" width="10" height="10">
-			</bounds>
+			<bounds x="54" y="236" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="56" y="238" width="6" height="6">
-			</bounds>
+			<bounds x="56" y="238" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="44" y="236" width="10" height="10">
-			</bounds>
+			<bounds x="44" y="236" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="46" y="238" width="6" height="6">
-			</bounds>
+			<bounds x="46" y="238" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="34" y="236" width="10" height="10">
-			</bounds>
+			<bounds x="34" y="236" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="36" y="238" width="6" height="6">
-			</bounds>
+			<bounds x="36" y="238" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="24" y="236" width="10" height="10">
-			</bounds>
+			<bounds x="24" y="236" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="26" y="238" width="6" height="6">
-			</bounds>
+			<bounds x="26" y="238" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="68" y="78" width="27" height="42">
-			</bounds>
+			<bounds x="68" y="78" width="27" height="42"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="70" y="80" width="23" height="38">
-			</bounds>
+			<bounds x="70" y="80" width="23" height="38"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="45" y="78" width="27" height="42">
-			</bounds>
+			<bounds x="45" y="78" width="27" height="42"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="47" y="80" width="23" height="38">
-			</bounds>
+			<bounds x="47" y="80" width="23" height="38"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="22" y="78" width="27" height="42">
-			</bounds>
+			<bounds x="22" y="78" width="27" height="42"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="24" y="80" width="23" height="38">
-			</bounds>
+			<bounds x="24" y="80" width="23" height="38"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="322" y="78" width="27" height="42">
-			</bounds>
+			<bounds x="322" y="78" width="27" height="42"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="324" y="80" width="23" height="38">
-			</bounds>
+			<bounds x="324" y="80" width="23" height="38"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="298" y="78" width="27" height="42">
-			</bounds>
+			<bounds x="298" y="78" width="27" height="42"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="300" y="80" width="23" height="38">
-			</bounds>
+			<bounds x="300" y="80" width="23" height="38"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="274" y="78" width="27" height="42">
-			</bounds>
+			<bounds x="274" y="78" width="27" height="42"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="276" y="80" width="23" height="38">
-			</bounds>
+			<bounds x="276" y="80" width="23" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="40" y="154" width="62" height="19">
-			</bounds>
+			<bounds x="40" y="154" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="42" y="156" width="58" height="15">
-			</bounds>
+			<bounds x="42" y="156" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="461" y="245" width="32" height="32">
-			</bounds>
+			<bounds x="461" y="245" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="463" y="247" width="28" height="28">
-			</bounds>
+			<bounds x="463" y="247" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="499" y="235" width="42" height="19">
-			</bounds>
+			<bounds x="499" y="235" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="501" y="237" width="38" height="15">
-			</bounds>
+			<bounds x="501" y="237" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="542" y="199" width="32" height="32">
-			</bounds>
+			<bounds x="542" y="199" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="544" y="201" width="28" height="28">
-			</bounds>
+			<bounds x="544" y="201" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="499" y="176" width="42" height="19">
-			</bounds>
+			<bounds x="499" y="176" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="501" y="178" width="38" height="15">
-			</bounds>
+			<bounds x="501" y="178" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="460" y="157" width="32" height="32">
-			</bounds>
+			<bounds x="460" y="157" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="462" y="159" width="28" height="28">
-			</bounds>
+			<bounds x="462" y="159" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="412" y="176" width="42" height="19">
-			</bounds>
+			<bounds x="412" y="176" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="414" y="178" width="38" height="15">
-			</bounds>
+			<bounds x="414" y="178" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="379" y="199" width="32" height="32">
-			</bounds>
+			<bounds x="379" y="199" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="381" y="201" width="28" height="28">
-			</bounds>
+			<bounds x="381" y="201" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="412" y="234" width="42" height="19">
-			</bounds>
+			<bounds x="412" y="234" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="414" y="236" width="38" height="15">
-			</bounds>
+			<bounds x="414" y="236" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="285" y="462" width="32" height="27">
-			</bounds>
+			<bounds x="285" y="462" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="287" y="464" width="28" height="23">
-			</bounds>
+			<bounds x="287" y="464" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="256" y="462" width="32" height="27">
-			</bounds>
+			<bounds x="256" y="462" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="258" y="464" width="28" height="23">
-			</bounds>
+			<bounds x="258" y="464" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="227" y="462" width="32" height="27">
-			</bounds>
+			<bounds x="227" y="462" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="229" y="464" width="28" height="23">
-			</bounds>
+			<bounds x="229" y="464" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="198" y="462" width="32" height="27">
-			</bounds>
+			<bounds x="198" y="462" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="200" y="464" width="28" height="23">
-			</bounds>
+			<bounds x="200" y="464" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="169" y="462" width="32" height="27">
-			</bounds>
+			<bounds x="169" y="462" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="171" y="464" width="28" height="23">
-			</bounds>
+			<bounds x="171" y="464" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="140" y="462" width="32" height="27">
-			</bounds>
+			<bounds x="140" y="462" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="142" y="464" width="28" height="23">
-			</bounds>
+			<bounds x="142" y="464" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="103" y="462" width="28" height="27">
-			</bounds>
+			<bounds x="103" y="462" width="28" height="27"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="105" y="464" width="24" height="23">
-			</bounds>
+			<bounds x="105" y="464" width="24" height="23"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="74" y="462" width="33" height="27">
-			</bounds>
+			<bounds x="74" y="462" width="33" height="27"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="76" y="464" width="29" height="23">
-			</bounds>
+			<bounds x="76" y="464" width="29" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="214" y="179" width="27" height="27">
-			</bounds>
+			<bounds x="214" y="179" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="216" y="181" width="23" height="23">
-			</bounds>
+			<bounds x="216" y="181" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="187" y="179" width="27" height="27">
-			</bounds>
+			<bounds x="187" y="179" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="189" y="181" width="23" height="23">
-			</bounds>
+			<bounds x="189" y="181" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="160" y="179" width="27" height="27">
-			</bounds>
+			<bounds x="160" y="179" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="162" y="181" width="23" height="23">
-			</bounds>
+			<bounds x="162" y="181" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="133" y="179" width="27" height="27">
-			</bounds>
+			<bounds x="133" y="179" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="135" y="181" width="23" height="23">
-			</bounds>
+			<bounds x="135" y="181" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_110_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="382" y="419" width="75" height="40">
-			</bounds>
+			<bounds x="382" y="419" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_110" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="384" y="421" width="71" height="36">
-			</bounds>
+			<bounds x="384" y="421" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_126_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="475" y="7" width="37" height="37">
-			</bounds>
+			<bounds x="475" y="7" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_126" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="477" y="9" width="33" height="33">
-			</bounds>
+			<bounds x="477" y="9" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_127_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="500" y="419" width="75" height="40">
-			</bounds>
+			<bounds x="500" y="419" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_127" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="502" y="421" width="71" height="36">
-			</bounds>
+			<bounds x="502" y="421" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_128_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="382" y="419" width="75" height="40">
-			</bounds>
+			<bounds x="382" y="419" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_128" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="384" y="421" width="71" height="36">
-			</bounds>
+			<bounds x="384" y="421" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_129_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="501" y="99" width="75" height="40">
-			</bounds>
+			<bounds x="501" y="99" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_129" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="503" y="101" width="71" height="36">
-			</bounds>
+			<bounds x="503" y="101" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_130_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="383" y="99" width="75" height="40">
-			</bounds>
+			<bounds x="383" y="99" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_130" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="385" y="101" width="71" height="36">
-			</bounds>
+			<bounds x="385" y="101" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_140_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="274" y="419" width="75" height="40">
-			</bounds>
+			<bounds x="274" y="419" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_140" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="276" y="421" width="71" height="36">
-			</bounds>
+			<bounds x="276" y="421" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_141_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="190" y="419" width="75" height="40">
-			</bounds>
+			<bounds x="190" y="419" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_141" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="192" y="421" width="71" height="36">
-			</bounds>
+			<bounds x="192" y="421" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_142_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="106" y="419" width="75" height="40">
-			</bounds>
+			<bounds x="106" y="419" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_142" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="108" y="421" width="71" height="36">
-			</bounds>
+			<bounds x="108" y="421" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_143_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="22" y="419" width="75" height="40">
-			</bounds>
+			<bounds x="22" y="419" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_143" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="24" y="421" width="71" height="36">
-			</bounds>
+			<bounds x="24" y="421" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="197" y="26" width="24" height="32">
-			</bounds>
+			<bounds x="197" y="26" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off184" element="led_off">
-			<bounds x="200" y="28" width="17" height="2">
-			</bounds>
+			<bounds x="200" y="28" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off185" element="led_off">
-			<bounds x="214" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="214" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off186" element="led_off">
-			<bounds x="214" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="214" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off187" element="led_off">
-			<bounds x="200" y="52" width="17" height="2">
-			</bounds>
+			<bounds x="200" y="52" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off188" element="led_off">
-			<bounds x="200" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="200" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off189" element="led_off">
-			<bounds x="200" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="200" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off190" element="led_off">
-			<bounds x="200" y="40" width="17" height="2">
-			</bounds>
+			<bounds x="200" y="40" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off191" element="led_dot_off">
-			<bounds x="217" y="52" width="3" height="2">
-			</bounds>
+			<bounds x="217" y="52" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp184" element="led_on">
-			<bounds x="200" y="28" width="17" height="2">
-			</bounds>
+			<bounds x="200" y="28" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp185" element="led_on">
-			<bounds x="214" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="214" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp186" element="led_on">
-			<bounds x="214" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="214" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp187" element="led_on">
-			<bounds x="200" y="52" width="17" height="2">
-			</bounds>
+			<bounds x="200" y="52" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp188" element="led_on">
-			<bounds x="200" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="200" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp189" element="led_on">
-			<bounds x="200" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="200" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp190" element="led_on">
-			<bounds x="200" y="40" width="17" height="2">
-			</bounds>
+			<bounds x="200" y="40" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp191" element="led_dot_on">
-			<bounds x="217" y="52" width="3" height="2">
-			</bounds>
+			<bounds x="217" y="52" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="173" y="26" width="24" height="32">
-			</bounds>
+			<bounds x="173" y="26" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off176" element="led_off">
-			<bounds x="176" y="28" width="17" height="2">
-			</bounds>
+			<bounds x="176" y="28" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off177" element="led_off">
-			<bounds x="190" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="190" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off178" element="led_off">
-			<bounds x="190" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="190" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off179" element="led_off">
-			<bounds x="176" y="52" width="17" height="2">
-			</bounds>
+			<bounds x="176" y="52" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off180" element="led_off">
-			<bounds x="176" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="176" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off181" element="led_off">
-			<bounds x="176" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="176" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off182" element="led_off">
-			<bounds x="176" y="40" width="17" height="2">
-			</bounds>
+			<bounds x="176" y="40" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off183" element="led_dot_off">
-			<bounds x="193" y="52" width="3" height="2">
-			</bounds>
+			<bounds x="193" y="52" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp176" element="led_on">
-			<bounds x="176" y="28" width="17" height="2">
-			</bounds>
+			<bounds x="176" y="28" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp177" element="led_on">
-			<bounds x="190" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="190" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp178" element="led_on">
-			<bounds x="190" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="190" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp179" element="led_on">
-			<bounds x="176" y="52" width="17" height="2">
-			</bounds>
+			<bounds x="176" y="52" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp180" element="led_on">
-			<bounds x="176" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="176" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp181" element="led_on">
-			<bounds x="176" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="176" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp182" element="led_on">
-			<bounds x="176" y="40" width="17" height="2">
-			</bounds>
+			<bounds x="176" y="40" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp183" element="led_dot_on">
-			<bounds x="193" y="52" width="3" height="2">
-			</bounds>
+			<bounds x="193" y="52" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="149" y="26" width="24" height="32">
-			</bounds>
+			<bounds x="149" y="26" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off168" element="led_off">
-			<bounds x="152" y="28" width="17" height="2">
-			</bounds>
+			<bounds x="152" y="28" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off169" element="led_off">
-			<bounds x="166" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="166" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off170" element="led_off">
-			<bounds x="166" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="166" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off171" element="led_off">
-			<bounds x="152" y="52" width="17" height="2">
-			</bounds>
+			<bounds x="152" y="52" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off172" element="led_off">
-			<bounds x="152" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="152" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off173" element="led_off">
-			<bounds x="152" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="152" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off174" element="led_off">
-			<bounds x="152" y="40" width="17" height="2">
-			</bounds>
+			<bounds x="152" y="40" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off175" element="led_dot_off">
-			<bounds x="169" y="52" width="3" height="2">
-			</bounds>
+			<bounds x="169" y="52" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp168" element="led_on">
-			<bounds x="152" y="28" width="17" height="2">
-			</bounds>
+			<bounds x="152" y="28" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp169" element="led_on">
-			<bounds x="166" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="166" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp170" element="led_on">
-			<bounds x="166" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="166" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp171" element="led_on">
-			<bounds x="152" y="52" width="17" height="2">
-			</bounds>
+			<bounds x="152" y="52" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp172" element="led_on">
-			<bounds x="152" y="40" width="3" height="14">
-			</bounds>
+			<bounds x="152" y="40" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp173" element="led_on">
-			<bounds x="152" y="28" width="3" height="14">
-			</bounds>
+			<bounds x="152" y="28" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp174" element="led_on">
-			<bounds x="152" y="40" width="17" height="2">
-			</bounds>
+			<bounds x="152" y="40" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp175" element="led_dot_on">
-			<bounds x="169" y="52" width="3" height="2">
-			</bounds>
+			<bounds x="169" y="52" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="137" y="124" width="32" height="40">
-			</bounds>
+			<bounds x="137" y="124" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off144" element="led_off">
-			<bounds x="141" y="127" width="22" height="3">
-			</bounds>
+			<bounds x="141" y="127" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off145" element="led_off">
-			<bounds x="159" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="159" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off146" element="led_off">
-			<bounds x="159" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="159" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off147" element="led_off">
-			<bounds x="141" y="156" width="22" height="3">
-			</bounds>
+			<bounds x="141" y="156" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off148" element="led_off">
-			<bounds x="141" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="141" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off149" element="led_off">
-			<bounds x="141" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="141" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off150" element="led_off">
-			<bounds x="141" y="142" width="22" height="3">
-			</bounds>
+			<bounds x="141" y="142" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off151" element="led_dot_off">
-			<bounds x="164" y="156" width="4" height="3">
-			</bounds>
+			<bounds x="164" y="156" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp144" element="led_on">
-			<bounds x="141" y="127" width="22" height="3">
-			</bounds>
+			<bounds x="141" y="127" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp145" element="led_on">
-			<bounds x="159" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="159" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="led_on">
-			<bounds x="159" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="159" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="led_on">
-			<bounds x="141" y="156" width="22" height="3">
-			</bounds>
+			<bounds x="141" y="156" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp148" element="led_on">
-			<bounds x="141" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="141" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp149" element="led_on">
-			<bounds x="141" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="141" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp150" element="led_on">
-			<bounds x="141" y="142" width="22" height="3">
-			</bounds>
+			<bounds x="141" y="142" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp151" element="led_dot_on">
-			<bounds x="164" y="156" width="4" height="3">
-			</bounds>
+			<bounds x="164" y="156" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="169" y="124" width="32" height="40">
-			</bounds>
+			<bounds x="169" y="124" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off152" element="led_off">
-			<bounds x="173" y="127" width="22" height="3">
-			</bounds>
+			<bounds x="173" y="127" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off153" element="led_off">
-			<bounds x="191" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="191" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off154" element="led_off">
-			<bounds x="191" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="191" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off155" element="led_off">
-			<bounds x="173" y="156" width="22" height="3">
-			</bounds>
+			<bounds x="173" y="156" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off156" element="led_off">
-			<bounds x="173" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="173" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off157" element="led_off">
-			<bounds x="173" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="173" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off158" element="led_off">
-			<bounds x="173" y="142" width="22" height="3">
-			</bounds>
+			<bounds x="173" y="142" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off159" element="led_dot_off">
-			<bounds x="196" y="156" width="4" height="3">
-			</bounds>
+			<bounds x="196" y="156" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp152" element="led_on">
-			<bounds x="173" y="127" width="22" height="3">
-			</bounds>
+			<bounds x="173" y="127" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp153" element="led_on">
-			<bounds x="191" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="191" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp154" element="led_on">
-			<bounds x="191" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="191" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="led_on">
-			<bounds x="173" y="156" width="22" height="3">
-			</bounds>
+			<bounds x="173" y="156" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp156" element="led_on">
-			<bounds x="173" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="173" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp157" element="led_on">
-			<bounds x="173" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="173" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp158" element="led_on">
-			<bounds x="173" y="142" width="22" height="3">
-			</bounds>
+			<bounds x="173" y="142" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp159" element="led_dot_on">
-			<bounds x="196" y="156" width="4" height="3">
-			</bounds>
+			<bounds x="196" y="156" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="201" y="124" width="32" height="40">
-			</bounds>
+			<bounds x="201" y="124" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off160" element="led_off">
-			<bounds x="205" y="127" width="22" height="3">
-			</bounds>
+			<bounds x="205" y="127" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off161" element="led_off">
-			<bounds x="223" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="223" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off162" element="led_off">
-			<bounds x="223" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="223" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off163" element="led_off">
-			<bounds x="205" y="156" width="22" height="3">
-			</bounds>
+			<bounds x="205" y="156" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off164" element="led_off">
-			<bounds x="205" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="205" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off165" element="led_off">
-			<bounds x="205" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="205" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off166" element="led_off">
-			<bounds x="205" y="142" width="22" height="3">
-			</bounds>
+			<bounds x="205" y="142" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off167" element="led_dot_off">
-			<bounds x="228" y="156" width="4" height="3">
-			</bounds>
+			<bounds x="228" y="156" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp160" element="led_on">
-			<bounds x="205" y="127" width="22" height="3">
-			</bounds>
+			<bounds x="205" y="127" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp161" element="led_on">
-			<bounds x="223" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="223" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp162" element="led_on">
-			<bounds x="223" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="223" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp163" element="led_on">
-			<bounds x="205" y="156" width="22" height="3">
-			</bounds>
+			<bounds x="205" y="156" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp164" element="led_on">
-			<bounds x="205" y="142" width="4" height="18">
-			</bounds>
+			<bounds x="205" y="142" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp165" element="led_on">
-			<bounds x="205" y="127" width="4" height="18">
-			</bounds>
+			<bounds x="205" y="127" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp166" element="led_on">
-			<bounds x="205" y="142" width="22" height="3">
-			</bounds>
+			<bounds x="205" y="142" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp167" element="led_dot_on">
-			<bounds x="228" y="156" width="4" height="3">
-			</bounds>
+			<bounds x="228" y="156" width="4" height="3"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="383" y="69" width="192" height="17">
-			</bounds>
+			<bounds x="383" y="69" width="192" height="17"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="383" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="383" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="395" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="395" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="407" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="407" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="419" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="419" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="431" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="431" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="443" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="443" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="455" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="455" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="467" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="467" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="479" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="479" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="491" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="491" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="503" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="503" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="515" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="515" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="527" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="527" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="539" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="539" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="551" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="551" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="563" y="69" width="12" height="17">
-			</bounds>
+			<bounds x="563" y="69" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="label6" element="label_6">
-			<bounds x="146" y="72" width="78" height="24">
-			</bounds>
+			<bounds x="146" y="72" width="78" height="24"/>
 		</backdrop>
 		<backdrop name="label7" element="label_7">
-			<bounds x="147" y="210" width="80" height="24">
-			</bounds>
+			<bounds x="147" y="210" width="80" height="24"/>
 		</backdrop>
 		<backdrop name="label10" element="label_10">
-			<bounds x="143" y="94" width="84" height="32">
-			</bounds>
+			<bounds x="143" y="94" width="84" height="32"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="157" y="4" width="58" height="18">
-			</bounds>
+			<bounds x="157" y="4" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="label36" element="label_36">
-			<bounds x="674" y="88" width="45" height="14">
-			</bounds>
+			<bounds x="674" y="88" width="45" height="14"/>
 		</backdrop>
 		<backdrop name="label37" element="label_37">
-			<bounds x="630" y="103" width="126" height="18">
-			</bounds>
+			<bounds x="630" y="103" width="126" height="18"/>
 		</backdrop>
 		<backdrop name="label45" element="label_45">
-			<bounds x="402" y="47" width="169" height="14">
-			</bounds>
+			<bounds x="402" y="47" width="169" height="14"/>
 		</backdrop>
 		<backdrop name="label46" element="label_46">
-			<bounds x="447" y="206" width="58" height="19">
-			</bounds>
+			<bounds x="447" y="206" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="label55" element="label_55">
-			<bounds x="477" y="466" width="100" height="24">
-			</bounds>
+			<bounds x="477" y="466" width="100" height="24"/>
 		</backdrop>
 		<backdrop name="label56" element="label_56">
-			<bounds x="667" y="466" width="106" height="24">
-			</bounds>
+			<bounds x="667" y="466" width="106" height="24"/>
 		</backdrop>
 		<backdrop name="label57" element="label_57">
-			<bounds x="697" y="40" width="6" height="14">
-			</bounds>
+			<bounds x="697" y="40" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label59" element="label_59">
-			<bounds x="705" y="131" width="12" height="14">
-			</bounds>
+			<bounds x="705" y="131" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label60" element="label_60">
-			<bounds x="768" y="131" width="12" height="14">
-			</bounds>
+			<bounds x="768" y="131" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label61" element="label_61">
-			<bounds x="763" y="188" width="22" height="24">
-			</bounds>
+			<bounds x="763" y="188" width="22" height="24"/>
 		</backdrop>
 		<backdrop name="label62" element="label_62">
-			<bounds x="764" y="154" width="20" height="24">
-			</bounds>
+			<bounds x="764" y="154" width="20" height="24"/>
 		</backdrop>
 		<backdrop name="label63" element="label_63">
-			<bounds x="766" y="227" width="18" height="14">
-			</bounds>
+			<bounds x="766" y="227" width="18" height="14"/>
 		</backdrop>
 		<backdrop name="label64" element="label_64">
-			<bounds x="766" y="259" width="18" height="14">
-			</bounds>
+			<bounds x="766" y="259" width="18" height="14"/>
 		</backdrop>
 		<backdrop name="label65" element="label_65">
-			<bounds x="768" y="327" width="12" height="14">
-			</bounds>
+			<bounds x="768" y="327" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label66" element="label_66">
-			<bounds x="702" y="160" width="18" height="14">
-			</bounds>
+			<bounds x="702" y="160" width="18" height="14"/>
 		</backdrop>
 		<backdrop name="label67" element="label_67">
-			<bounds x="705" y="193" width="12" height="14">
-			</bounds>
+			<bounds x="705" y="193" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label68" element="label_68">
-			<bounds x="705" y="227" width="12" height="14">
-			</bounds>
+			<bounds x="705" y="227" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label69" element="label_69">
-			<bounds x="705" y="259" width="12" height="14">
-			</bounds>
+			<bounds x="705" y="259" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label70" element="label_70">
-			<bounds x="703" y="327" width="18" height="14">
-			</bounds>
+			<bounds x="703" y="327" width="18" height="14"/>
 		</backdrop>
 		<backdrop name="label71" element="label_71">
-			<bounds x="703" y="294" width="18" height="14">
-			</bounds>
+			<bounds x="703" y="294" width="18" height="14"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="768" y="294" width="12" height="14">
-			</bounds>
+			<bounds x="768" y="294" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="602" y="434" width="178" height="24">
-			</bounds>
+			<bounds x="602" y="434" width="178" height="24"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="743" y="415" width="31" height="12">
-			</bounds>
+			<bounds x="743" y="415" width="31" height="12"/>
 		</backdrop>
 		<backdrop name="label79" element="label_79">
-			<bounds x="743" y="401" width="20" height="12">
-			</bounds>
+			<bounds x="743" y="401" width="20" height="12"/>
 		</backdrop>
 		<backdrop name="label80" element="label_80">
-			<bounds x="743" y="387" width="29" height="12">
-			</bounds>
+			<bounds x="743" y="387" width="29" height="12"/>
 		</backdrop>
 		<backdrop name="label81" element="label_81">
-			<bounds x="743" y="373" width="29" height="12">
-			</bounds>
+			<bounds x="743" y="373" width="29" height="12"/>
 		</backdrop>
 		<backdrop name="label82" element="label_82">
-			<bounds x="707" y="415" width="6" height="12">
-			</bounds>
+			<bounds x="707" y="415" width="6" height="12"/>
 		</backdrop>
 		<backdrop name="label83" element="label_83">
-			<bounds x="707" y="401" width="26" height="12">
-			</bounds>
+			<bounds x="707" y="401" width="26" height="12"/>
 		</backdrop>
 		<backdrop name="label84" element="label_84">
-			<bounds x="707" y="387" width="7" height="12">
-			</bounds>
+			<bounds x="707" y="387" width="7" height="12"/>
 		</backdrop>
 		<backdrop name="label85" element="label_85">
-			<bounds x="707" y="373" width="22" height="12">
-			</bounds>
+			<bounds x="707" y="373" width="22" height="12"/>
 		</backdrop>
 		<backdrop name="label86" element="label_86">
-			<bounds x="637" y="416" width="47" height="12">
-			</bounds>
+			<bounds x="637" y="416" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="label87" element="label_87">
-			<bounds x="637" y="402" width="47" height="12">
-			</bounds>
+			<bounds x="637" y="402" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="label88" element="label_88">
-			<bounds x="637" y="388" width="47" height="12">
-			</bounds>
+			<bounds x="637" y="388" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="label89" element="label_89">
-			<bounds x="637" y="374" width="47" height="12">
-			</bounds>
+			<bounds x="637" y="374" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="label90" element="label_90">
-			<bounds x="637" y="360" width="20" height="12">
-			</bounds>
+			<bounds x="637" y="360" width="20" height="12"/>
 		</backdrop>
 		<backdrop name="label91" element="label_91">
-			<bounds x="601" y="416" width="5" height="12">
-			</bounds>
+			<bounds x="601" y="416" width="5" height="12"/>
 		</backdrop>
 		<backdrop name="label92" element="label_92">
-			<bounds x="601" y="402" width="5" height="12">
-			</bounds>
+			<bounds x="601" y="402" width="5" height="12"/>
 		</backdrop>
 		<backdrop name="label93" element="label_93">
-			<bounds x="601" y="388" width="5" height="12">
-			</bounds>
+			<bounds x="601" y="388" width="5" height="12"/>
 		</backdrop>
 		<backdrop name="label94" element="label_94">
-			<bounds x="601" y="374" width="5" height="12">
-			</bounds>
+			<bounds x="601" y="374" width="5" height="12"/>
 		</backdrop>
 		<backdrop name="label95" element="label_95">
-			<bounds x="601" y="360" width="5" height="12">
-			</bounds>
+			<bounds x="601" y="360" width="5" height="12"/>
 		</backdrop>
 		<backdrop name="label96" element="label_96">
-			<bounds x="592" y="65" width="102" height="12">
-			</bounds>
+			<bounds x="592" y="65" width="102" height="12"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_button" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1chain.lay
+++ b/src/mame/layout/m1chain.lay
@@ -8,11380 +8,7019 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.03" blue="0.00">
-			</color>
+			<color red="0.29" green="0.03" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.01" blue="0.00">
-			</color>
+			<color red="0.07" green="0.01" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.59" green="0.06" blue="0.00">
-			</color>
+			<color red="0.59" green="0.06" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.02" blue="0.00">
-			</color>
+			<color red="0.15" green="0.02" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.03" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.01" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.59" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.02" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.13">
-			</bounds>
-		</text>
 		<text string="Super 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.23" width="0.80" height="0.13">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.23" width="0.80" height="0.13"/>
 		</text>
 		<text string="&#xA3;5.00 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.13"/>
 		</text>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.13"/>
 		</text>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.77" width="0.80" height="0.13">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.13">
-			</bounds>
-		</text>
-		<text string="Super 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.23" width="0.80" height="0.13">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.13">
-			</bounds>
-		</text>
-		<text string="&#xA3;5.00 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.13">
-			</bounds>
-		</text>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.13">
-			</bounds>
-		</text>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.77" width="0.80" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.77" width="0.80" height="0.13"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.16">
-			</color>
+			<color red="0.50" green="0.15" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.31" blue="0.33">
-			</color>
+			<color red="1.00" green="0.31" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.08">
-			</color>
+			<color red="0.25" green="0.07" blue="0.08"/>
 		</rect>
 		<text string="Chain">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.31" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.08">
-			</color>
-		</rect>
-		<text string="Chain">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Reaction">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Reaction">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Lucky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="For Some">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Lucky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="For Some">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Tutty Fruity">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Tutty Fruity">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.03" blue="0.00">
-			</color>
+			<color red="0.29" green="0.03" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.01" blue="0.00">
-			</color>
+			<color red="0.07" green="0.01" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.59" green="0.06" blue="0.00">
-			</color>
+			<color red="0.59" green="0.06" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.02" blue="0.00">
-			</color>
+			<color red="0.15" green="0.02" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.03" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.01" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.59" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.02" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.03" blue="0.00">
-			</color>
+			<color red="0.29" green="0.03" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.01" blue="0.00">
-			</color>
+			<color red="0.07" green="0.01" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.59" green="0.06" blue="0.00">
-			</color>
+			<color red="0.59" green="0.06" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.02" blue="0.00">
-			</color>
+			<color red="0.15" green="0.02" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.03" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.01" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.59" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.02" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Even Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Even Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Lucky Strike">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Lucky Strike">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.03" blue="0.00">
-			</color>
+			<color red="0.29" green="0.03" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.01" blue="0.00">
-			</color>
+			<color red="0.07" green="0.01" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.59" green="0.06" blue="0.00">
-			</color>
+			<color red="0.59" green="0.06" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.02" blue="0.00">
-			</color>
+			<color red="0.15" green="0.02" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.03" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.01" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.59" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.02" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Splash Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Splash Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Heavens Above">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Heavens Above">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Twister">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Twister">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Big Win Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Big Win Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Squash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Squash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Link">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Link">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Skill Symbol">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Skill Symbol">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Stoppa Symbol">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Stoppa Symbol">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Symbols In View">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Symbols In View">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Extra Symbols">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Extra Symbols">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="Super 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="Super 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="Blue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="Blue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Link 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Link 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Link 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Link 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Link 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Link 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Link 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Link 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Link 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Link 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Mixed 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mixed 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2 bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2 bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3 bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Blue 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Blue 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_96_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_96">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_97_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="colour_button_97">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_98_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_98">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_99_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_99">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_100_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_100">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_101_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_101">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_102_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_102">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_103_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_103">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_7">
 		<text string="Created by spa with help from Bugs. Thanks to Dangerous Dave and Gary for help with roms.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_8">
 		<text string="Visit: www.poundrun.org ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="+ ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="www.fruitemu.co.uk + www.fruitf">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="label_9">
 		<text string="10/08/2004">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_10">
 		<text string="Thanks to Wizard and DialTone for a great emulator.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_11">
 		<text string="3 X DOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_61">
 		<text string="&#xA3;5 Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_62">
 		<text string="10p Play">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_63">
 		<text string="Link All Symbols For Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_79">
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_80">
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_81">
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_82">
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_83">
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_84">
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_85">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_86">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="660" height="680">
-			</bounds>
+			<bounds x="0" y="0" width="660" height="680"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="99" y="421" width="80" height="140">
-			</bounds>
+			<bounds x="99" y="421" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="99.0000" y="421.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="99.0000" y="421.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="102.3333" y="422.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="102.3333" y="422.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="105.6667" y="424.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="105.6667" y="424.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="109.0000" y="426.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="109.0000" y="426.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="112.3333" y="428.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="112.3333" y="428.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="115.6667" y="430.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="115.6667" y="430.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="99.0000" y="467.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="99.0000" y="467.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="102.3333" y="469.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="102.3333" y="469.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="105.6667" y="471.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="105.6667" y="471.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="109.0000" y="473.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="109.0000" y="473.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="112.3333" y="475.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="112.3333" y="475.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="115.6667" y="477.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="115.6667" y="477.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="99.0000" y="514.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="99.0000" y="514.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="102.3333" y="516.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="102.3333" y="516.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="105.6667" y="518.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="105.6667" y="518.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="109.0000" y="520.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="109.0000" y="520.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="112.3333" y="522.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="112.3333" y="522.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="115.6667" y="524.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="115.6667" y="524.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="99" y="421" width="80" height="140">
-			</bounds>
+			<bounds x="99" y="421" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="203" y="421" width="80" height="140">
-			</bounds>
+			<bounds x="203" y="421" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="421.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="421.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="422.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="422.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="424.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="424.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="426.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="426.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="428.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="428.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="430.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="430.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="467.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="467.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="469.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="469.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="471.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="471.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="473.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="473.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="475.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="475.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="477.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="477.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="514.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="514.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="516.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="516.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="518.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="518.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="520.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="520.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="522.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="522.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="524.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="524.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="203" y="421" width="80" height="140">
-			</bounds>
+			<bounds x="203" y="421" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="307" y="421" width="80" height="140">
-			</bounds>
+			<bounds x="307" y="421" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="307.0000" y="421.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="307.0000" y="421.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="310.3333" y="422.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="310.3333" y="422.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="313.6667" y="424.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="313.6667" y="424.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="317.0000" y="426.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="317.0000" y="426.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="320.3333" y="428.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="320.3333" y="428.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="323.6667" y="430.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="323.6667" y="430.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="307.0000" y="467.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="307.0000" y="467.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="310.3333" y="469.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="310.3333" y="469.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="313.6667" y="471.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="313.6667" y="471.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="317.0000" y="473.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="317.0000" y="473.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="320.3333" y="475.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="320.3333" y="475.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="323.6667" y="477.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="323.6667" y="477.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="307.0000" y="514.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="307.0000" y="514.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="310.3333" y="516.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="310.3333" y="516.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="313.6667" y="518.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="313.6667" y="518.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="317.0000" y="520.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="317.0000" y="520.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="320.3333" y="522.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="320.3333" y="522.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="323.6667" y="524.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="323.6667" y="524.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="307" y="421" width="80" height="140">
-			</bounds>
+			<bounds x="307" y="421" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="93" y="251" width="60" height="50">
-			</bounds>
+			<bounds x="93" y="251" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="93.0000" y="251.0000" width="60.0000" height="50.0000">
-			</bounds>
+			<bounds x="93.0000" y="251.0000" width="60.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="95.5000" y="253.0833" width="55.0000" height="45.8333">
-			</bounds>
+			<bounds x="95.5000" y="253.0833" width="55.0000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="98.0000" y="255.1667" width="50.0000" height="41.6667">
-			</bounds>
+			<bounds x="98.0000" y="255.1667" width="50.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="100.5000" y="257.2500" width="45.0000" height="37.5000">
-			</bounds>
+			<bounds x="100.5000" y="257.2500" width="45.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="103.0000" y="259.3333" width="40.0000" height="33.3333">
-			</bounds>
+			<bounds x="103.0000" y="259.3333" width="40.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="105.5000" y="261.4167" width="35.0000" height="29.1667">
-			</bounds>
+			<bounds x="105.5000" y="261.4167" width="35.0000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="93" y="251" width="60" height="50">
-			</bounds>
+			<bounds x="93" y="251" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="308" y="354" width="20" height="57">
-			</bounds>
+			<bounds x="308" y="354" width="20" height="57"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="310" y="356" width="16" height="53">
-			</bounds>
+			<bounds x="310" y="356" width="16" height="53"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="49" y="4" width="302" height="32">
-			</bounds>
+			<bounds x="49" y="4" width="302" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="51" y="6" width="298" height="28">
-			</bounds>
+			<bounds x="51" y="6" width="298" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="460" y="437" width="102" height="102">
-			</bounds>
+			<bounds x="460" y="437" width="102" height="102"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="462" y="439" width="98" height="98">
-			</bounds>
+			<bounds x="462" y="439" width="98" height="98"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="454" y="258" width="82" height="32">
-			</bounds>
+			<bounds x="454" y="258" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="456" y="260" width="78" height="28">
-			</bounds>
+			<bounds x="456" y="260" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="454" y="287" width="82" height="32">
-			</bounds>
+			<bounds x="454" y="287" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="456" y="289" width="78" height="28">
-			</bounds>
+			<bounds x="456" y="289" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="239" y="37" width="62" height="42">
-			</bounds>
+			<bounds x="239" y="37" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="241" y="39" width="58" height="38">
-			</bounds>
+			<bounds x="241" y="39" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="239" y="77" width="62" height="42">
-			</bounds>
+			<bounds x="239" y="77" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="241" y="79" width="58" height="38">
-			</bounds>
+			<bounds x="241" y="79" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="239" y="117" width="62" height="42">
-			</bounds>
+			<bounds x="239" y="117" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="241" y="119" width="58" height="38">
-			</bounds>
+			<bounds x="241" y="119" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="239" y="157" width="62" height="42">
-			</bounds>
+			<bounds x="239" y="157" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="241" y="159" width="58" height="38">
-			</bounds>
+			<bounds x="241" y="159" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="239" y="197" width="62" height="20">
-			</bounds>
+			<bounds x="239" y="197" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="241" y="199" width="58" height="16">
-			</bounds>
+			<bounds x="241" y="199" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="87" y="167" width="22" height="22">
-			</bounds>
+			<bounds x="87" y="167" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="89" y="169" width="18" height="18">
-			</bounds>
+			<bounds x="89" y="169" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="87" y="127" width="22" height="22">
-			</bounds>
+			<bounds x="87" y="127" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="89" y="129" width="18" height="18">
-			</bounds>
+			<bounds x="89" y="129" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="87" y="87" width="22" height="22">
-			</bounds>
+			<bounds x="87" y="87" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="89" y="89" width="18" height="18">
-			</bounds>
+			<bounds x="89" y="89" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="87" y="47" width="22" height="22">
-			</bounds>
+			<bounds x="87" y="47" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="89" y="49" width="18" height="18">
-			</bounds>
+			<bounds x="89" y="49" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="108" y="197" width="62" height="20">
-			</bounds>
+			<bounds x="108" y="197" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="110" y="199" width="58" height="16">
-			</bounds>
+			<bounds x="110" y="199" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="108" y="157" width="62" height="42">
-			</bounds>
+			<bounds x="108" y="157" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="110" y="159" width="58" height="38">
-			</bounds>
+			<bounds x="110" y="159" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="108" y="117" width="62" height="42">
-			</bounds>
+			<bounds x="108" y="117" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="110" y="119" width="58" height="38">
-			</bounds>
+			<bounds x="110" y="119" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="108" y="77" width="62" height="42">
-			</bounds>
+			<bounds x="108" y="77" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="110" y="79" width="58" height="38">
-			</bounds>
+			<bounds x="110" y="79" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="108" y="37" width="62" height="42">
-			</bounds>
+			<bounds x="108" y="37" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="110" y="39" width="58" height="38">
-			</bounds>
+			<bounds x="110" y="39" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="174" y="197" width="62" height="20">
-			</bounds>
+			<bounds x="174" y="197" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="176" y="199" width="58" height="16">
-			</bounds>
+			<bounds x="176" y="199" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="174" y="157" width="62" height="42">
-			</bounds>
+			<bounds x="174" y="157" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="176" y="159" width="58" height="38">
-			</bounds>
+			<bounds x="176" y="159" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="174" y="117" width="62" height="42">
-			</bounds>
+			<bounds x="174" y="117" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="176" y="119" width="58" height="38">
-			</bounds>
+			<bounds x="176" y="119" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="174" y="77" width="62" height="42">
-			</bounds>
+			<bounds x="174" y="77" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="176" y="79" width="58" height="38">
-			</bounds>
+			<bounds x="176" y="79" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="174" y="37" width="62" height="42">
-			</bounds>
+			<bounds x="174" y="37" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="176" y="39" width="58" height="38">
-			</bounds>
+			<bounds x="176" y="39" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="322" y="37" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="37" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="324" y="39" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="39" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="322" y="67" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="67" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="324" y="69" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="69" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="322" y="247" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="247" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="324" y="249" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="249" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="322" y="277" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="277" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="324" y="279" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="279" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="322" y="217" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="217" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="324" y="219" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="219" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="322" y="187" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="187" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="324" y="189" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="189" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="322" y="157" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="157" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="324" y="159" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="159" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="322" y="127" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="127" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="324" y="129" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="129" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="322" y="97" width="52" height="32">
-			</bounds>
+			<bounds x="322" y="97" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="324" y="99" width="48" height="28">
-			</bounds>
+			<bounds x="324" y="99" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="566" y="314" width="56" height="32">
-			</bounds>
+			<bounds x="566" y="314" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="568" y="316" width="52" height="28">
-			</bounds>
+			<bounds x="568" y="316" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="566" y="284" width="56" height="32">
-			</bounds>
+			<bounds x="566" y="284" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="568" y="286" width="52" height="28">
-			</bounds>
+			<bounds x="568" y="286" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="566" y="254" width="56" height="32">
-			</bounds>
+			<bounds x="566" y="254" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="568" y="256" width="52" height="28">
-			</bounds>
+			<bounds x="568" y="256" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="566" y="224" width="56" height="32">
-			</bounds>
+			<bounds x="566" y="224" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="568" y="226" width="52" height="28">
-			</bounds>
+			<bounds x="568" y="226" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="566" y="194" width="56" height="32">
-			</bounds>
+			<bounds x="566" y="194" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="568" y="196" width="52" height="28">
-			</bounds>
+			<bounds x="568" y="196" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="566" y="164" width="56" height="32">
-			</bounds>
+			<bounds x="566" y="164" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="568" y="166" width="52" height="28">
-			</bounds>
+			<bounds x="568" y="166" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="566" y="134" width="56" height="32">
-			</bounds>
+			<bounds x="566" y="134" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="568" y="136" width="52" height="28">
-			</bounds>
+			<bounds x="568" y="136" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="566" y="104" width="56" height="32">
-			</bounds>
+			<bounds x="566" y="104" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="568" y="106" width="52" height="28">
-			</bounds>
+			<bounds x="568" y="106" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="231" y="320" width="32" height="18">
-			</bounds>
+			<bounds x="231" y="320" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="233" y="322" width="28" height="14">
-			</bounds>
+			<bounds x="233" y="322" width="28" height="14"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="226" y="256" width="42" height="42">
-			</bounds>
+			<bounds x="226" y="256" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="228" y="258" width="38" height="38">
-			</bounds>
+			<bounds x="228" y="258" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="266" y="269" width="42" height="42">
-			</bounds>
+			<bounds x="266" y="269" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="268" y="271" width="38" height="38">
-			</bounds>
+			<bounds x="268" y="271" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="264" y="346" width="42" height="42">
-			</bounds>
+			<bounds x="264" y="346" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="266" y="348" width="38" height="38">
-			</bounds>
+			<bounds x="266" y="348" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="226" y="360" width="42" height="42">
-			</bounds>
+			<bounds x="226" y="360" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="228" y="362" width="38" height="38">
-			</bounds>
+			<bounds x="228" y="362" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="188" y="346" width="42" height="42">
-			</bounds>
+			<bounds x="188" y="346" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="190" y="348" width="38" height="38">
-			</bounds>
+			<bounds x="190" y="348" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="174" y="308" width="42" height="42">
-			</bounds>
+			<bounds x="174" y="308" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="176" y="310" width="38" height="38">
-			</bounds>
+			<bounds x="176" y="310" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="187" y="269" width="42" height="42">
-			</bounds>
+			<bounds x="187" y="269" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="189" y="271" width="38" height="38">
-			</bounds>
+			<bounds x="189" y="271" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="279" y="308" width="42" height="42">
-			</bounds>
+			<bounds x="279" y="308" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="281" y="310" width="38" height="38">
-			</bounds>
+			<bounds x="281" y="310" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="155" y="250" width="24" height="24">
-			</bounds>
+			<bounds x="155" y="250" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="157" y="252" width="20" height="20">
-			</bounds>
+			<bounds x="157" y="252" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="155" y="278" width="24" height="24">
-			</bounds>
+			<bounds x="155" y="278" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="157" y="280" width="20" height="20">
-			</bounds>
+			<bounds x="157" y="280" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="373" y="254" width="42" height="18">
-			</bounds>
+			<bounds x="373" y="254" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="375" y="256" width="38" height="14">
-			</bounds>
+			<bounds x="375" y="256" width="38" height="14"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="373" y="194" width="42" height="18">
-			</bounds>
+			<bounds x="373" y="194" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="375" y="196" width="38" height="14">
-			</bounds>
+			<bounds x="375" y="196" width="38" height="14"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="373" y="134" width="42" height="18">
-			</bounds>
+			<bounds x="373" y="134" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="375" y="136" width="38" height="14">
-			</bounds>
+			<bounds x="375" y="136" width="38" height="14"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="373" y="74" width="42" height="18">
-			</bounds>
+			<bounds x="373" y="74" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="375" y="76" width="38" height="14">
-			</bounds>
+			<bounds x="375" y="76" width="38" height="14"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="374" y="44" width="42" height="18">
-			</bounds>
+			<bounds x="374" y="44" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="376" y="46" width="38" height="14">
-			</bounds>
+			<bounds x="376" y="46" width="38" height="14"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="574" y="576" width="82" height="27">
-			</bounds>
+			<bounds x="574" y="576" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="576" y="578" width="78" height="23">
-			</bounds>
+			<bounds x="576" y="578" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="7" y="576" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="576" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="9" y="578" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="578" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="88" y="576" width="82" height="27">
-			</bounds>
+			<bounds x="88" y="576" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="90" y="578" width="78" height="23">
-			</bounds>
+			<bounds x="90" y="578" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="169" y="576" width="82" height="27">
-			</bounds>
+			<bounds x="169" y="576" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="171" y="578" width="78" height="23">
-			</bounds>
+			<bounds x="171" y="578" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="250" y="576" width="82" height="27">
-			</bounds>
+			<bounds x="250" y="576" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="252" y="578" width="78" height="23">
-			</bounds>
+			<bounds x="252" y="578" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="331" y="576" width="82" height="27">
-			</bounds>
+			<bounds x="331" y="576" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="333" y="578" width="78" height="23">
-			</bounds>
+			<bounds x="333" y="578" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="412" y="576" width="82" height="27">
-			</bounds>
+			<bounds x="412" y="576" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="414" y="578" width="78" height="23">
-			</bounds>
+			<bounds x="414" y="578" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="493" y="576" width="82" height="27">
-			</bounds>
+			<bounds x="493" y="576" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="495" y="578" width="78" height="23">
-			</bounds>
+			<bounds x="495" y="578" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="27" y="37" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="37" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="29" y="39" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="39" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="27" y="67" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="67" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="29" y="69" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="69" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="27" y="97" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="97" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="29" y="99" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="99" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="27" y="127" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="127" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="29" y="129" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="129" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="27" y="157" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="157" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="29" y="159" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="159" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="27" y="187" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="187" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="29" y="189" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="189" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="27" y="217" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="217" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="29" y="219" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="219" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="27" y="247" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="247" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="29" y="249" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="249" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="27" y="277" width="52" height="32">
-			</bounds>
+			<bounds x="27" y="277" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="29" y="279" width="48" height="28">
-			</bounds>
+			<bounds x="29" y="279" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_96_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="402" y="605" width="66" height="42">
-			</bounds>
+			<bounds x="402" y="605" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_96" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="404" y="607" width="62" height="38">
-			</bounds>
+			<bounds x="404" y="607" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_97_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="492" y="605" width="66" height="42">
-			</bounds>
+			<bounds x="492" y="605" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_97" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="494" y="607" width="62" height="38">
-			</bounds>
+			<bounds x="494" y="607" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_98_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="314" y="605" width="66" height="42">
-			</bounds>
+			<bounds x="314" y="605" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_98" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="316" y="607" width="62" height="38">
-			</bounds>
+			<bounds x="316" y="607" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_99_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="210" y="605" width="66" height="42">
-			</bounds>
+			<bounds x="210" y="605" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_99" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="212" y="607" width="62" height="38">
-			</bounds>
+			<bounds x="212" y="607" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_100_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="106" y="605" width="66" height="42">
-			</bounds>
+			<bounds x="106" y="605" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_100" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="108" y="607" width="62" height="38">
-			</bounds>
+			<bounds x="108" y="607" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_101_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="8" y="605" width="66" height="42">
-			</bounds>
+			<bounds x="8" y="605" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_101" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="10" y="607" width="62" height="38">
-			</bounds>
+			<bounds x="10" y="607" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_102_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="475" y="21" width="46" height="62">
-			</bounds>
+			<bounds x="475" y="21" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_102" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="477" y="23" width="42" height="58">
-			</bounds>
+			<bounds x="477" y="23" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_103_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="584" y="605" width="66" height="42">
-			</bounds>
+			<bounds x="584" y="605" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_103" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="586" y="607" width="62" height="38">
-			</bounds>
+			<bounds x="586" y="607" width="62" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="411" y="379" width="224" height="26">
-			</bounds>
+			<bounds x="411" y="379" width="224" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="411" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="411" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="425" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="425" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="439" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="439" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="453" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="453" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="467" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="467" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="481" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="481" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="495" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="495" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="509" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="509" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="523" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="523" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="537" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="537" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="551" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="551" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="565" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="565" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="579" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="579" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="593" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="593" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="607" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="607" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="621" y="379" width="14" height="26">
-			</bounds>
+			<bounds x="621" y="379" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="label7" element="label_7">
-			<bounds x="18" y="368" width="62" height="130">
-			</bounds>
+			<bounds x="18" y="368" width="62" height="130"/>
 		</backdrop>
 		<backdrop name="label8" element="label_8">
-			<bounds x="436" y="124" width="118" height="104">
-			</bounds>
+			<bounds x="436" y="124" width="118" height="104"/>
 		</backdrop>
 		<backdrop name="label9" element="label_9">
-			<bounds x="462" y="8" width="69" height="13">
-			</bounds>
+			<bounds x="462" y="8" width="69" height="13"/>
 		</backdrop>
 		<backdrop name="label10" element="label_10">
-			<bounds x="574" y="449" width="53" height="104">
-			</bounds>
+			<bounds x="574" y="449" width="53" height="104"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="575" y="80" width="35" height="26">
-			</bounds>
+			<bounds x="575" y="80" width="35" height="26"/>
 		</backdrop>
 		<backdrop name="label61" element="label_61">
-			<bounds x="523" y="36" width="46" height="26">
-			</bounds>
+			<bounds x="523" y="36" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="label62" element="label_62">
-			<bounds x="449" y="36" width="25" height="26">
-			</bounds>
+			<bounds x="449" y="36" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label63" element="label_63">
-			<bounds x="124" y="330" width="47" height="65">
-			</bounds>
+			<bounds x="124" y="330" width="47" height="65"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="595" y="565" width="33" height="13">
-			</bounds>
+			<bounds x="595" y="565" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="516" y="565" width="33" height="13">
-			</bounds>
+			<bounds x="516" y="565" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label79" element="label_79">
-			<bounds x="435" y="565" width="33" height="13">
-			</bounds>
+			<bounds x="435" y="565" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label80" element="label_80">
-			<bounds x="355" y="565" width="33" height="13">
-			</bounds>
+			<bounds x="355" y="565" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label81" element="label_81">
-			<bounds x="274" y="565" width="33" height="13">
-			</bounds>
+			<bounds x="274" y="565" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label82" element="label_82">
-			<bounds x="200" y="565" width="23" height="13">
-			</bounds>
+			<bounds x="200" y="565" width="23" height="13"/>
 		</backdrop>
 		<backdrop name="label83" element="label_83">
-			<bounds x="117" y="565" width="23" height="13">
-			</bounds>
+			<bounds x="117" y="565" width="23" height="13"/>
 		</backdrop>
 		<backdrop name="label84" element="label_84">
-			<bounds x="37" y="565" width="23" height="13">
-			</bounds>
+			<bounds x="37" y="565" width="23" height="13"/>
 		</backdrop>
 		<backdrop name="label85" element="label_85">
-			<bounds x="594" y="404" width="40" height="13">
-			</bounds>
+			<bounds x="594" y="404" width="40" height="13"/>
 		</backdrop>
 		<backdrop name="label86" element="label_86">
-			<bounds x="412" y="404" width="34" height="13">
-			</bounds>
+			<bounds x="412" y="404" width="34" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1cik51o.lay
+++ b/src/mame/layout/m1cik51o.lay
@@ -8,13294 +8,8264 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="KEYHOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="KEYHOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BANKRUPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BANKRUPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STOCK ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MARKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOCK ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MARKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GO TO ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CORNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO TO ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CORNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="INSURANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="INSURANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_255_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_255_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1   SUPERHOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1   SUPERHOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="6 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 SUPERHOLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CASH IS KING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH IS KING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="STOP AND ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="STOP AND ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MONEY GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MONEY GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CASH SHOOTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH SHOOTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="STEP TO NEAREST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="STEP TO NEAREST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REGISTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REGISTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="SUPER SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="SUPER SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="superhold+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="superhold+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="feature+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="feature+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="rupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOLD +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOLD +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YELLOW KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YELLOW KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K O ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="K O ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="k">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="k">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="rupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="GREEN KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="GREEN KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOLD+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOLD+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="PURPLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="PURPLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K 0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="K 0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="rupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOLD +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOLD +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="KNOCKOUTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="KNOCKOUTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="all  keys lit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="pays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string=" CASH RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="all  keys lit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="pays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string=" CASH RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BLUE KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BLUE KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YELLOW KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YELLOW KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="GREEN KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="GREEN KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="PURPLE KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="PURPLE KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="cash+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="cash+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string=" K O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string=" K O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BLUE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BLUE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOLD+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOLD+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="   HOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string=" CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="   HOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string=" CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOT CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HOT CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI-LO-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI-LO-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_244_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_244">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SWAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_245_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_245">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SWAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_252_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_252">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SWAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_253_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_253">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SWAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_254_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_254">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_255_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_255">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_256_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_256">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_257_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_257">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_258_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_258">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_259_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_259">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_260_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_260">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_261_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_261">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_48">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_49">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_205">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_206">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1059" height="731">
-			</bounds>
+			<bounds x="0" y="0" width="1059" height="731"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="361" y="477" width="80" height="140">
-			</bounds>
+			<bounds x="361" y="477" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="361.0000" y="477.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="361.0000" y="477.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="364.3333" y="478.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="364.3333" y="478.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="367.6667" y="480.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="367.6667" y="480.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="371.0000" y="482.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="371.0000" y="482.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="374.3333" y="484.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="374.3333" y="484.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="377.6667" y="486.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="377.6667" y="486.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="361.0000" y="523.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="361.0000" y="523.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="364.3333" y="525.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="364.3333" y="525.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="367.6667" y="527.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="367.6667" y="527.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="371.0000" y="529.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="371.0000" y="529.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="374.3333" y="531.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="374.3333" y="531.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="377.6667" y="533.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="377.6667" y="533.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="361.0000" y="570.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="361.0000" y="570.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="364.3333" y="572.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="364.3333" y="572.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="367.6667" y="574.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="367.6667" y="574.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="371.0000" y="576.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="371.0000" y="576.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="374.3333" y="578.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="374.3333" y="578.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="377.6667" y="580.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="377.6667" y="580.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="361" y="477" width="80" height="140">
-			</bounds>
+			<bounds x="361" y="477" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="444" y="477" width="80" height="140">
-			</bounds>
+			<bounds x="444" y="477" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="444.0000" y="477.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="444.0000" y="477.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="447.3333" y="478.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="447.3333" y="478.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="450.6667" y="480.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="450.6667" y="480.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="454.0000" y="482.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="454.0000" y="482.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="457.3333" y="484.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="457.3333" y="484.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="460.6667" y="486.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="460.6667" y="486.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="444.0000" y="523.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="444.0000" y="523.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="447.3333" y="525.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="447.3333" y="525.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="450.6667" y="527.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="450.6667" y="527.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="454.0000" y="529.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="454.0000" y="529.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="457.3333" y="531.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="457.3333" y="531.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="460.6667" y="533.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="460.6667" y="533.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="444.0000" y="570.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="444.0000" y="570.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="447.3333" y="572.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="447.3333" y="572.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="450.6667" y="574.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="450.6667" y="574.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="454.0000" y="576.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="454.0000" y="576.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="457.3333" y="578.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="457.3333" y="578.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="460.6667" y="580.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="460.6667" y="580.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="444" y="477" width="80" height="140">
-			</bounds>
+			<bounds x="444" y="477" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="527" y="477" width="80" height="140">
-			</bounds>
+			<bounds x="527" y="477" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="527.0000" y="477.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="527.0000" y="477.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="530.3333" y="478.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="530.3333" y="478.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="533.6667" y="480.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="533.6667" y="480.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="537.0000" y="482.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="537.0000" y="482.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="540.3333" y="484.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="540.3333" y="484.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="543.6667" y="486.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="543.6667" y="486.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="527.0000" y="523.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="527.0000" y="523.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="530.3333" y="525.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="530.3333" y="525.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="533.6667" y="527.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="533.6667" y="527.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="537.0000" y="529.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="537.0000" y="529.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="540.3333" y="531.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="540.3333" y="531.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="543.6667" y="533.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="543.6667" y="533.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="527.0000" y="570.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="527.0000" y="570.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="530.3333" y="572.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="530.3333" y="572.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="533.6667" y="574.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="533.6667" y="574.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="537.0000" y="576.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="537.0000" y="576.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="540.3333" y="578.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="540.3333" y="578.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="543.6667" y="580.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="543.6667" y="580.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="527" y="477" width="80" height="140">
-			</bounds>
+			<bounds x="527" y="477" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="359" y="181" width="80" height="80">
-			</bounds>
+			<bounds x="359" y="181" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="359.0000" y="181.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="359.0000" y="181.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="362.3333" y="184.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="362.3333" y="184.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="365.6667" y="187.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="365.6667" y="187.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="369.0000" y="191.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="369.0000" y="191.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="372.3333" y="194.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="372.3333" y="194.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="375.6667" y="197.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="375.6667" y="197.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="359" y="181" width="80" height="80">
-			</bounds>
+			<bounds x="359" y="181" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="263" y="1" width="75" height="30">
-			</bounds>
+			<bounds x="263" y="1" width="75" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="265" y="3" width="71" height="26">
-			</bounds>
+			<bounds x="265" y="3" width="71" height="26"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="338" y="1" width="75" height="30">
-			</bounds>
+			<bounds x="338" y="1" width="75" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="340" y="3" width="71" height="26">
-			</bounds>
+			<bounds x="340" y="3" width="71" height="26"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="413" y="1" width="75" height="30">
-			</bounds>
+			<bounds x="413" y="1" width="75" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="415" y="3" width="71" height="26">
-			</bounds>
+			<bounds x="415" y="3" width="71" height="26"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="488" y="1" width="74" height="30">
-			</bounds>
+			<bounds x="488" y="1" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="490" y="3" width="70" height="26">
-			</bounds>
+			<bounds x="490" y="3" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="562" y="1" width="74" height="30">
-			</bounds>
+			<bounds x="562" y="1" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="564" y="3" width="70" height="26">
-			</bounds>
+			<bounds x="564" y="3" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="636" y="1" width="74" height="30">
-			</bounds>
+			<bounds x="636" y="1" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="638" y="3" width="70" height="26">
-			</bounds>
+			<bounds x="638" y="3" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="710" y="1" width="75" height="30">
-			</bounds>
+			<bounds x="710" y="1" width="75" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="712" y="3" width="71" height="26">
-			</bounds>
+			<bounds x="712" y="3" width="71" height="26"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1_border" state="0">
-			<bounds x="133" y="502" width="82" height="35">
-			</bounds>
+			<bounds x="133" y="502" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1" state="0">
-			<bounds x="135" y="504" width="78" height="31">
-			</bounds>
+			<bounds x="135" y="504" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="133" y="432" width="82" height="35">
-			</bounds>
+			<bounds x="133" y="432" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="135" y="434" width="78" height="31">
-			</bounds>
+			<bounds x="135" y="434" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="133" y="467" width="82" height="35">
-			</bounds>
+			<bounds x="133" y="467" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="135" y="469" width="78" height="31">
-			</bounds>
+			<bounds x="135" y="469" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="133" y="537" width="82" height="35">
-			</bounds>
+			<bounds x="133" y="537" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="135" y="539" width="78" height="31">
-			</bounds>
+			<bounds x="135" y="539" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="133" y="324" width="82" height="36">
-			</bounds>
+			<bounds x="133" y="324" width="82" height="36"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="135" y="326" width="78" height="32">
-			</bounds>
+			<bounds x="135" y="326" width="78" height="32"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="133" y="362" width="82" height="35">
-			</bounds>
+			<bounds x="133" y="362" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="135" y="364" width="78" height="31">
-			</bounds>
+			<bounds x="135" y="364" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="133" y="397" width="82" height="35">
-			</bounds>
+			<bounds x="133" y="397" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="135" y="399" width="78" height="31">
-			</bounds>
+			<bounds x="135" y="399" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="406" y="39" width="182" height="36">
-			</bounds>
+			<bounds x="406" y="39" width="182" height="36"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="408" y="41" width="178" height="32">
-			</bounds>
+			<bounds x="408" y="41" width="178" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="291" y="601" width="58" height="27">
-			</bounds>
+			<bounds x="291" y="601" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="293" y="603" width="54" height="23">
-			</bounds>
+			<bounds x="293" y="603" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="132" y="162" width="78" height="40">
-			</bounds>
+			<bounds x="132" y="162" width="78" height="40"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="134" y="164" width="74" height="36">
-			</bounds>
+			<bounds x="134" y="164" width="74" height="36"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="132" y="82" width="78" height="40">
-			</bounds>
+			<bounds x="132" y="82" width="78" height="40"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="134" y="84" width="74" height="36">
-			</bounds>
+			<bounds x="134" y="84" width="74" height="36"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="132" y="122" width="78" height="40">
-			</bounds>
+			<bounds x="132" y="122" width="78" height="40"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="134" y="124" width="74" height="36">
-			</bounds>
+			<bounds x="134" y="124" width="74" height="36"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="132" y="42" width="78" height="40">
-			</bounds>
+			<bounds x="132" y="42" width="78" height="40"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="134" y="44" width="74" height="36">
-			</bounds>
+			<bounds x="134" y="44" width="74" height="36"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="132" y="242" width="78" height="40">
-			</bounds>
+			<bounds x="132" y="242" width="78" height="40"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="134" y="244" width="74" height="36">
-			</bounds>
+			<bounds x="134" y="244" width="74" height="36"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="132" y="202" width="78" height="40">
-			</bounds>
+			<bounds x="132" y="202" width="78" height="40"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="134" y="204" width="74" height="36">
-			</bounds>
+			<bounds x="134" y="204" width="74" height="36"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="133" y="4" width="78" height="36">
-			</bounds>
+			<bounds x="133" y="4" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="135" y="6" width="74" height="32">
-			</bounds>
+			<bounds x="135" y="6" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="558" y="384" width="78" height="28">
-			</bounds>
+			<bounds x="558" y="384" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="560" y="386" width="74" height="24">
-			</bounds>
+			<bounds x="560" y="386" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="339" y="141" width="78" height="28">
-			</bounds>
+			<bounds x="339" y="141" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="341" y="143" width="74" height="24">
-			</bounds>
+			<bounds x="341" y="143" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="558" y="141" width="78" height="28">
-			</bounds>
+			<bounds x="558" y="141" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="560" y="143" width="74" height="24">
-			</bounds>
+			<bounds x="560" y="143" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="670" y="141" width="78" height="28">
-			</bounds>
+			<bounds x="670" y="141" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="672" y="143" width="74" height="24">
-			</bounds>
+			<bounds x="672" y="143" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="246" y="406" width="87" height="67">
-			</bounds>
+			<bounds x="246" y="406" width="87" height="67"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="248" y="408" width="83" height="63">
-			</bounds>
+			<bounds x="248" y="408" width="83" height="63"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="246" y="68" width="87" height="67">
-			</bounds>
+			<bounds x="246" y="68" width="87" height="67"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="248" y="70" width="83" height="63">
-			</bounds>
+			<bounds x="248" y="70" width="83" height="63"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="336" y="82" width="61" height="34">
-			</bounds>
+			<bounds x="336" y="82" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="338" y="84" width="57" height="30">
-			</bounds>
+			<bounds x="338" y="84" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="397" y="82" width="58" height="34">
-			</bounds>
+			<bounds x="397" y="82" width="58" height="34"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="399" y="84" width="54" height="30">
-			</bounds>
+			<bounds x="399" y="84" width="54" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="455" y="82" width="61" height="34">
-			</bounds>
+			<bounds x="455" y="82" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="457" y="84" width="57" height="30">
-			</bounds>
+			<bounds x="457" y="84" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="516" y="82" width="61" height="34">
-			</bounds>
+			<bounds x="516" y="82" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="518" y="84" width="57" height="30">
-			</bounds>
+			<bounds x="518" y="84" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="577" y="82" width="61" height="34">
-			</bounds>
+			<bounds x="577" y="82" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="579" y="84" width="57" height="30">
-			</bounds>
+			<bounds x="579" y="84" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="638" y="82" width="61" height="34">
-			</bounds>
+			<bounds x="638" y="82" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="640" y="84" width="57" height="30">
-			</bounds>
+			<bounds x="640" y="84" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="699" y="82" width="61" height="34">
-			</bounds>
+			<bounds x="699" y="82" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="701" y="84" width="57" height="30">
-			</bounds>
+			<bounds x="701" y="84" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="763" y="68" width="87" height="67">
-			</bounds>
+			<bounds x="763" y="68" width="87" height="67"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="765" y="70" width="83" height="63">
-			</bounds>
+			<bounds x="765" y="70" width="83" height="63"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="776" y="135" width="61" height="34">
-			</bounds>
+			<bounds x="776" y="135" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="778" y="137" width="57" height="30">
-			</bounds>
+			<bounds x="778" y="137" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="776" y="169" width="61" height="34">
-			</bounds>
+			<bounds x="776" y="169" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="778" y="171" width="57" height="30">
-			</bounds>
+			<bounds x="778" y="171" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="776" y="203" width="61" height="34">
-			</bounds>
+			<bounds x="776" y="203" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="778" y="205" width="57" height="30">
-			</bounds>
+			<bounds x="778" y="205" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="776" y="237" width="61" height="34">
-			</bounds>
+			<bounds x="776" y="237" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="778" y="239" width="57" height="30">
-			</bounds>
+			<bounds x="778" y="239" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="776" y="271" width="61" height="34">
-			</bounds>
+			<bounds x="776" y="271" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="778" y="273" width="57" height="30">
-			</bounds>
+			<bounds x="778" y="273" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="776" y="305" width="61" height="34">
-			</bounds>
+			<bounds x="776" y="305" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="778" y="307" width="57" height="30">
-			</bounds>
+			<bounds x="778" y="307" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="776" y="339" width="61" height="34">
-			</bounds>
+			<bounds x="776" y="339" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="778" y="341" width="57" height="30">
-			</bounds>
+			<bounds x="778" y="341" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="776" y="373" width="61" height="34">
-			</bounds>
+			<bounds x="776" y="373" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="778" y="375" width="57" height="30">
-			</bounds>
+			<bounds x="778" y="375" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="336" y="420" width="61" height="34">
-			</bounds>
+			<bounds x="336" y="420" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="338" y="422" width="57" height="30">
-			</bounds>
+			<bounds x="338" y="422" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="397" y="420" width="61" height="34">
-			</bounds>
+			<bounds x="397" y="420" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="399" y="422" width="57" height="30">
-			</bounds>
+			<bounds x="399" y="422" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="458" y="420" width="61" height="34">
-			</bounds>
+			<bounds x="458" y="420" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="460" y="422" width="57" height="30">
-			</bounds>
+			<bounds x="460" y="422" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="519" y="420" width="61" height="34">
-			</bounds>
+			<bounds x="519" y="420" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="521" y="422" width="57" height="30">
-			</bounds>
+			<bounds x="521" y="422" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="580" y="420" width="61" height="34">
-			</bounds>
+			<bounds x="580" y="420" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="582" y="422" width="57" height="30">
-			</bounds>
+			<bounds x="582" y="422" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="641" y="420" width="61" height="34">
-			</bounds>
+			<bounds x="641" y="420" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="643" y="422" width="57" height="30">
-			</bounds>
+			<bounds x="643" y="422" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="702" y="420" width="61" height="34">
-			</bounds>
+			<bounds x="702" y="420" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="704" y="422" width="57" height="30">
-			</bounds>
+			<bounds x="704" y="422" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="931" y="242" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="242" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="933" y="244" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="244" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="931" y="242" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="242" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="933" y="244" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="244" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="931" y="272" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="272" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="933" y="274" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="274" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="931" y="272" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="272" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="933" y="274" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="274" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="931" y="302" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="302" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="933" y="304" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="304" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="931" y="302" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="302" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="933" y="304" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="304" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="931" y="422" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="422" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="933" y="424" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="424" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="931" y="422" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="422" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="933" y="424" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="424" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="931" y="392" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="392" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="933" y="394" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="394" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="931" y="392" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="392" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="933" y="394" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="394" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="931" y="362" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="362" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="933" y="364" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="364" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="931" y="362" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="362" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="933" y="364" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="364" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="931" y="332" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="332" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="933" y="334" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="334" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="931" y="332" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="332" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="933" y="334" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="334" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="931" y="212" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="212" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="933" y="214" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="214" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="931" y="212" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="212" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="933" y="214" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="214" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="931" y="182" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="182" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="933" y="184" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="184" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="931" y="182" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="182" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="933" y="184" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="184" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="931" y="152" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="152" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="933" y="154" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="154" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="931" y="152" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="152" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="933" y="154" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="154" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="931" y="122" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="122" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="933" y="124" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="124" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="931" y="122" width="38" height="28">
-			</bounds>
+			<bounds x="931" y="122" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="933" y="124" width="34" height="24">
-			</bounds>
+			<bounds x="933" y="124" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="665" y="180" width="82" height="25">
-			</bounds>
+			<bounds x="665" y="180" width="82" height="25"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="667" y="182" width="78" height="21">
-			</bounds>
+			<bounds x="667" y="182" width="78" height="21"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="665" y="180" width="82" height="25">
-			</bounds>
+			<bounds x="665" y="180" width="82" height="25"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="667" y="182" width="78" height="21">
-			</bounds>
+			<bounds x="667" y="182" width="78" height="21"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="442" y="210" width="25" height="25">
-			</bounds>
+			<bounds x="442" y="210" width="25" height="25"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="444" y="212" width="21" height="21">
-			</bounds>
+			<bounds x="444" y="212" width="21" height="21"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="330" y="210" width="25" height="25">
-			</bounds>
+			<bounds x="330" y="210" width="25" height="25"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="332" y="212" width="21" height="21">
-			</bounds>
+			<bounds x="332" y="212" width="21" height="21"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="25" y="6" width="78" height="36">
-			</bounds>
+			<bounds x="25" y="6" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="27" y="8" width="74" height="32">
-			</bounds>
+			<bounds x="27" y="8" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="25" y="6" width="78" height="36">
-			</bounds>
+			<bounds x="25" y="6" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="27" y="8" width="74" height="32">
-			</bounds>
+			<bounds x="27" y="8" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_2_border" state="0">
-			<bounds x="453" y="270" width="128" height="42">
-			</bounds>
+			<bounds x="453" y="270" width="128" height="42"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_2" state="0">
-			<bounds x="455" y="272" width="124" height="38">
-			</bounds>
+			<bounds x="455" y="272" width="124" height="38"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="482" y="238" width="70" height="30">
-			</bounds>
+			<bounds x="482" y="238" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="484" y="240" width="66" height="26">
-			</bounds>
+			<bounds x="484" y="240" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="482" y="208" width="70" height="30">
-			</bounds>
+			<bounds x="482" y="208" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="484" y="210" width="66" height="26">
-			</bounds>
+			<bounds x="484" y="210" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="482" y="178" width="70" height="30">
-			</bounds>
+			<bounds x="482" y="178" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="484" y="180" width="66" height="26">
-			</bounds>
+			<bounds x="484" y="180" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="482" y="148" width="70" height="30">
-			</bounds>
+			<bounds x="482" y="148" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="484" y="150" width="66" height="26">
-			</bounds>
+			<bounds x="484" y="150" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="482" y="118" width="70" height="30">
-			</bounds>
+			<bounds x="482" y="118" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="484" y="120" width="66" height="26">
-			</bounds>
+			<bounds x="484" y="120" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2_border" state="0">
-			<bounds x="920" y="62" width="58" height="24">
-			</bounds>
+			<bounds x="920" y="62" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2" state="0">
-			<bounds x="922" y="64" width="54" height="20">
-			</bounds>
+			<bounds x="922" y="64" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="920" y="62" width="58" height="24">
-			</bounds>
+			<bounds x="920" y="62" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="922" y="64" width="54" height="20">
-			</bounds>
+			<bounds x="922" y="64" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="920" y="86" width="58" height="36">
-			</bounds>
+			<bounds x="920" y="86" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="922" y="88" width="54" height="32">
-			</bounds>
+			<bounds x="922" y="88" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="920" y="86" width="58" height="36">
-			</bounds>
+			<bounds x="920" y="86" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="922" y="88" width="54" height="32">
-			</bounds>
+			<bounds x="922" y="88" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="763" y="406" width="87" height="67">
-			</bounds>
+			<bounds x="763" y="406" width="87" height="67"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="765" y="408" width="83" height="63">
-			</bounds>
+			<bounds x="765" y="408" width="83" height="63"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="256" y="146" width="61" height="34">
-			</bounds>
+			<bounds x="256" y="146" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="258" y="148" width="57" height="30">
-			</bounds>
+			<bounds x="258" y="148" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="256" y="182" width="61" height="34">
-			</bounds>
+			<bounds x="256" y="182" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="258" y="184" width="57" height="30">
-			</bounds>
+			<bounds x="258" y="184" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="256" y="218" width="61" height="34">
-			</bounds>
+			<bounds x="256" y="218" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="258" y="220" width="57" height="30">
-			</bounds>
+			<bounds x="258" y="220" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="256" y="254" width="61" height="34">
-			</bounds>
+			<bounds x="256" y="254" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="258" y="256" width="57" height="30">
-			</bounds>
+			<bounds x="258" y="256" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="256" y="290" width="61" height="34">
-			</bounds>
+			<bounds x="256" y="290" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="258" y="292" width="57" height="30">
-			</bounds>
+			<bounds x="258" y="292" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="256" y="326" width="61" height="34">
-			</bounds>
+			<bounds x="256" y="326" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="258" y="328" width="57" height="30">
-			</bounds>
+			<bounds x="258" y="328" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="256" y="362" width="61" height="34">
-			</bounds>
+			<bounds x="256" y="362" width="61" height="34"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="258" y="364" width="57" height="30">
-			</bounds>
+			<bounds x="258" y="364" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="770" y="489" width="56" height="134">
-			</bounds>
+			<bounds x="770" y="489" width="56" height="134"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="772" y="491" width="52" height="130">
-			</bounds>
+			<bounds x="772" y="491" width="52" height="130"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="770" y="489" width="56" height="134">
-			</bounds>
+			<bounds x="770" y="489" width="56" height="134"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="772" y="491" width="52" height="130">
-			</bounds>
+			<bounds x="772" y="491" width="52" height="130"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="955" y="490" width="42" height="33">
-			</bounds>
+			<bounds x="955" y="490" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="957" y="492" width="38" height="29">
-			</bounds>
+			<bounds x="957" y="492" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="955" y="524" width="42" height="33">
-			</bounds>
+			<bounds x="955" y="524" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="957" y="526" width="38" height="29">
-			</bounds>
+			<bounds x="957" y="526" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="997" y="489" width="56" height="134">
-			</bounds>
+			<bounds x="997" y="489" width="56" height="134"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="999" y="491" width="52" height="130">
-			</bounds>
+			<bounds x="999" y="491" width="52" height="130"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="997" y="489" width="56" height="134">
-			</bounds>
+			<bounds x="997" y="489" width="56" height="134"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="999" y="491" width="52" height="130">
-			</bounds>
+			<bounds x="999" y="491" width="52" height="130"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="826" y="490" width="42" height="33">
-			</bounds>
+			<bounds x="826" y="490" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="828" y="492" width="38" height="29">
-			</bounds>
+			<bounds x="828" y="492" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="826" y="524" width="42" height="33">
-			</bounds>
+			<bounds x="826" y="524" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="828" y="526" width="38" height="29">
-			</bounds>
+			<bounds x="828" y="526" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="826" y="558" width="42" height="33">
-			</bounds>
+			<bounds x="826" y="558" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="828" y="560" width="38" height="29">
-			</bounds>
+			<bounds x="828" y="560" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="955" y="558" width="42" height="33">
-			</bounds>
+			<bounds x="955" y="558" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="957" y="560" width="38" height="29">
-			</bounds>
+			<bounds x="957" y="560" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="826" y="590" width="42" height="33">
-			</bounds>
+			<bounds x="826" y="590" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="828" y="592" width="38" height="29">
-			</bounds>
+			<bounds x="828" y="592" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="955" y="590" width="42" height="33">
-			</bounds>
+			<bounds x="955" y="590" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="957" y="592" width="38" height="29">
-			</bounds>
+			<bounds x="957" y="592" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="244" y="596" width="34" height="34">
-			</bounds>
+			<bounds x="244" y="596" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="246" y="598" width="30" height="30">
-			</bounds>
+			<bounds x="246" y="598" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="275" y="561" width="34" height="34">
-			</bounds>
+			<bounds x="275" y="561" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="277" y="563" width="30" height="30">
-			</bounds>
+			<bounds x="277" y="563" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="244" y="528" width="34" height="34">
-			</bounds>
+			<bounds x="244" y="528" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="246" y="530" width="30" height="30">
-			</bounds>
+			<bounds x="246" y="530" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="272" y="492" width="34" height="34">
-			</bounds>
+			<bounds x="272" y="492" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="274" y="494" width="30" height="30">
-			</bounds>
+			<bounds x="274" y="494" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="347" y="384" width="78" height="28">
-			</bounds>
+			<bounds x="347" y="384" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="349" y="386" width="74" height="24">
-			</bounds>
+			<bounds x="349" y="386" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="683" y="384" width="78" height="28">
-			</bounds>
+			<bounds x="683" y="384" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="685" y="386" width="74" height="24">
-			</bounds>
+			<bounds x="685" y="386" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp147" element="colour_button_244_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="281" y="108" width="47" height="26">
-			</bounds>
+			<bounds x="281" y="108" width="47" height="26"/>
 		</backdrop>
 		<backdrop name="lamp147" element="colour_button_244" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="283" y="110" width="43" height="22">
-			</bounds>
+			<bounds x="283" y="110" width="43" height="22"/>
 		</backdrop>
 		<backdrop name="lamp157" element="colour_button_245_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="764" y="108" width="47" height="26">
-			</bounds>
+			<bounds x="764" y="108" width="47" height="26"/>
 		</backdrop>
 		<backdrop name="lamp157" element="colour_button_245" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="766" y="110" width="43" height="22">
-			</bounds>
+			<bounds x="766" y="110" width="43" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="colour_button_252_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="281" y="445" width="47" height="26">
-			</bounds>
+			<bounds x="281" y="445" width="47" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="colour_button_252" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="283" y="447" width="43" height="22">
-			</bounds>
+			<bounds x="283" y="447" width="43" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="colour_button_253_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="764" y="445" width="47" height="26">
-			</bounds>
+			<bounds x="764" y="445" width="47" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="colour_button_253" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="766" y="447" width="43" height="22">
-			</bounds>
+			<bounds x="766" y="447" width="43" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_254_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="788" y="682" width="75" height="37">
-			</bounds>
+			<bounds x="788" y="682" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_254" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="790" y="684" width="71" height="33">
-			</bounds>
+			<bounds x="790" y="684" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_255_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="701" y="682" width="75" height="37">
-			</bounds>
+			<bounds x="701" y="682" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_255" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="703" y="684" width="71" height="33">
-			</bounds>
+			<bounds x="703" y="684" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_256_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="618" y="682" width="75" height="37">
-			</bounds>
+			<bounds x="618" y="682" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_256" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="620" y="684" width="71" height="33">
-			</bounds>
+			<bounds x="620" y="684" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_257_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="533" y="682" width="75" height="37">
-			</bounds>
+			<bounds x="533" y="682" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_257" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="535" y="684" width="71" height="33">
-			</bounds>
+			<bounds x="535" y="684" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_258_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="446" y="682" width="75" height="37">
-			</bounds>
+			<bounds x="446" y="682" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_258" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="448" y="684" width="71" height="33">
-			</bounds>
+			<bounds x="448" y="684" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_259_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="366" y="682" width="75" height="37">
-			</bounds>
+			<bounds x="366" y="682" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_259" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="368" y="684" width="71" height="33">
-			</bounds>
+			<bounds x="368" y="684" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_260_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="282" y="682" width="75" height="37">
-			</bounds>
+			<bounds x="282" y="682" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_260" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="284" y="684" width="71" height="33">
-			</bounds>
+			<bounds x="284" y="684" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_261_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="840" y="1" width="45" height="37">
-			</bounds>
+			<bounds x="840" y="1" width="45" height="37"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_261" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="842" y="3" width="41" height="33">
-			</bounds>
+			<bounds x="842" y="3" width="41" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="710" y="209" width="24" height="32">
-			</bounds>
+			<bounds x="710" y="209" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="713" y="211" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="211" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="727" y="211" width="3" height="14">
-			</bounds>
+			<bounds x="727" y="211" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="727" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="727" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="713" y="235" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="235" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="713" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="713" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="713" y="211" width="3" height="14">
-			</bounds>
+			<bounds x="713" y="211" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="713" y="223" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="223" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="730" y="235" width="3" height="2">
-			</bounds>
+			<bounds x="730" y="235" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="713" y="211" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="211" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="727" y="211" width="3" height="14">
-			</bounds>
+			<bounds x="727" y="211" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="727" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="727" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="713" y="235" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="235" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="713" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="713" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="713" y="211" width="3" height="14">
-			</bounds>
+			<bounds x="713" y="211" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="713" y="223" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="223" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="730" y="235" width="3" height="2">
-			</bounds>
+			<bounds x="730" y="235" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="686" y="209" width="24" height="32">
-			</bounds>
+			<bounds x="686" y="209" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="689" y="211" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="211" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="703" y="211" width="3" height="14">
-			</bounds>
+			<bounds x="703" y="211" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="703" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="703" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="689" y="235" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="235" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="689" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="689" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="689" y="211" width="3" height="14">
-			</bounds>
+			<bounds x="689" y="211" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="689" y="223" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="223" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="706" y="235" width="3" height="2">
-			</bounds>
+			<bounds x="706" y="235" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="689" y="211" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="211" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="703" y="211" width="3" height="14">
-			</bounds>
+			<bounds x="703" y="211" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="703" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="703" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="689" y="235" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="235" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="689" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="689" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="689" y="211" width="3" height="14">
-			</bounds>
+			<bounds x="689" y="211" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="689" y="223" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="223" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="706" y="235" width="3" height="2">
-			</bounds>
+			<bounds x="706" y="235" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="352" y="333" width="272" height="30">
-			</bounds>
+			<bounds x="352" y="333" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="352" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="352" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="369" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="369" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="386" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="386" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="403" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="403" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="420" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="420" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="437" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="437" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="454" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="454" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="471" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="471" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="488" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="488" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="505" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="505" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="522" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="522" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="539" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="539" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="556" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="556" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="573" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="573" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="590" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="590" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="607" y="333" width="17" height="30">
-			</bounds>
+			<bounds x="607" y="333" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label48" element="label_48">
-			<bounds x="558" y="314" width="52" height="19">
-			</bounds>
+			<bounds x="558" y="314" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="label49" element="label_49">
-			<bounds x="364" y="314" width="47" height="19">
-			</bounds>
+			<bounds x="364" y="314" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="674" y="284" width="49" height="70">
-			</bounds>
+			<bounds x="674" y="284" width="49" height="70"/>
 		</backdrop>
 		<backdrop name="label205" element="label_205">
-			<bounds x="611" y="541" width="29" height="16">
-			</bounds>
+			<bounds x="611" y="541" width="29" height="16"/>
 		</backdrop>
 		<backdrop name="label206" element="label_206">
-			<bounds x="326" y="541" width="26" height="16">
-			</bounds>
+			<bounds x="326" y="541" width="26" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_button" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_button" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_button" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_button" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1clbfvr.lay
+++ b/src/mame/layout/m1clbfvr.lay
@@ -8,17178 +8,9262 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Insufficient Coins to pay Major Prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Insufficient Coins to pay Major Prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="LOSE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="LOSE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="HI-LO TO GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="HI-LO TO GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="GAME OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="GAME OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="COL.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="COL.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="FREE TICKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="FREE TICKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TICKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TICKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="K.O.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="K.O.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="K.O.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="K.O.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="K.O.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="K.O.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TICKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TICKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TICKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TICKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Press STOP for Winning Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Press STOP for Winning Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 ORANGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 ORANGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 SEVENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 SEVENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 JACKPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 JACKPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 ORANGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 ORANGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 SEVENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 SEVENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Exc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 JACKPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 JACKPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="4 KNOCKOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="4 KNOCKOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="5 KNOCKOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="5 KNOCKOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNOC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="9 KNOCKOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="9 KNOCKOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FOLLOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FOLLOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LYNX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LYNX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROULETT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROULETT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUNNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RUNNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LUCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LUCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HIT OR MISS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="HIT OR MISS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HI-LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI-LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MEGA MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="MEGA MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Take">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_194_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_194">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Take">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_195_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_195">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_197_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_197">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_198_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_198">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_199_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_199">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_200_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_200">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_201_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_201">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_202_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_202">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_203_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_203">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Take">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_204_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_204">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Take">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_205_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_205">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_109">
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_110">
 		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_111">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_112">
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_113">
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_114">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_115">
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_116">
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_117">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_118">
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_120">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_121">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_122">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_123">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_124">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_135">
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_190">
 		<text string="CLUB FEVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_191">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1024" height="697">
-			</bounds>
+			<bounds x="0" y="0" width="1024" height="697"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="202" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="202" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="202" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="202" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="286" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="286" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="286" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="286" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="370" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="370" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="370" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="370" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="454" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="454" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="454" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="454" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="356" y="261" width="80" height="80">
-			</bounds>
+			<bounds x="356" y="261" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="356" y="261" width="80" height="80">
-			</bounds>
+			<bounds x="356" y="261" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="949" y="2" width="62" height="62">
-			</bounds>
+			<bounds x="949" y="2" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="951" y="4" width="58" height="58">
-			</bounds>
+			<bounds x="951" y="4" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="476" y="305" width="42" height="42">
-			</bounds>
+			<bounds x="476" y="305" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="478" y="307" width="38" height="38">
-			</bounds>
+			<bounds x="478" y="307" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="225" y="255" width="42" height="42">
-			</bounds>
+			<bounds x="225" y="255" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="227" y="257" width="38" height="38">
-			</bounds>
+			<bounds x="227" y="257" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="269" y="255" width="42" height="42">
-			</bounds>
+			<bounds x="269" y="255" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="271" y="257" width="38" height="38">
-			</bounds>
+			<bounds x="271" y="257" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="225" y="299" width="42" height="42">
-			</bounds>
+			<bounds x="225" y="299" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="227" y="301" width="38" height="38">
-			</bounds>
+			<bounds x="227" y="301" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="269" y="299" width="42" height="42">
-			</bounds>
+			<bounds x="269" y="299" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="271" y="301" width="38" height="38">
-			</bounds>
+			<bounds x="271" y="301" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="520" y="261" width="42" height="42">
-			</bounds>
+			<bounds x="520" y="261" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="522" y="263" width="38" height="38">
-			</bounds>
+			<bounds x="522" y="263" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="476" y="261" width="42" height="42">
-			</bounds>
+			<bounds x="476" y="261" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="478" y="263" width="38" height="38">
-			</bounds>
+			<bounds x="478" y="263" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="520" y="305" width="42" height="42">
-			</bounds>
+			<bounds x="520" y="305" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="522" y="307" width="38" height="38">
-			</bounds>
+			<bounds x="522" y="307" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="376" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="376" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="378" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="378" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="216" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="216" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="218" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="218" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="535" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="535" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="537" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="537" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="496" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="496" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="498" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="498" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="456" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="456" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="458" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="458" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="416" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="416" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="418" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="418" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="336" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="336" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="338" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="338" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="296" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="296" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="298" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="298" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="256" y="179" width="42" height="42">
-			</bounds>
+			<bounds x="256" y="179" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="258" y="181" width="38" height="38">
-			</bounds>
+			<bounds x="258" y="181" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="574" y="352" width="42" height="42">
-			</bounds>
+			<bounds x="574" y="352" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="576" y="354" width="38" height="38">
-			</bounds>
+			<bounds x="576" y="354" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="574" y="193" width="42" height="42">
-			</bounds>
+			<bounds x="574" y="193" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="576" y="195" width="38" height="38">
-			</bounds>
+			<bounds x="576" y="195" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="591" y="233" width="42" height="42">
-			</bounds>
+			<bounds x="591" y="233" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="593" y="235" width="38" height="38">
-			</bounds>
+			<bounds x="593" y="235" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="591" y="273" width="42" height="42">
-			</bounds>
+			<bounds x="591" y="273" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="593" y="275" width="38" height="38">
-			</bounds>
+			<bounds x="593" y="275" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="591" y="313" width="42" height="42">
-			</bounds>
+			<bounds x="591" y="313" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="593" y="315" width="38" height="38">
-			</bounds>
+			<bounds x="593" y="315" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="455" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="455" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="457" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="457" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="495" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="495" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="497" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="497" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="534" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="534" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="536" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="536" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="415" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="415" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="417" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="417" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="375" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="375" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="377" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="377" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="336" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="336" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="338" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="338" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="296" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="296" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="298" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="298" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="216" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="216" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="218" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="218" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="256" y="376" width="42" height="42">
-			</bounds>
+			<bounds x="256" y="376" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="258" y="378" width="38" height="38">
-			</bounds>
+			<bounds x="258" y="378" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="177" y="358" width="42" height="42">
-			</bounds>
+			<bounds x="177" y="358" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="179" y="360" width="38" height="38">
-			</bounds>
+			<bounds x="179" y="360" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="159" y="318" width="42" height="42">
-			</bounds>
+			<bounds x="159" y="318" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="161" y="320" width="38" height="38">
-			</bounds>
+			<bounds x="161" y="320" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="159" y="278" width="42" height="42">
-			</bounds>
+			<bounds x="159" y="278" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="161" y="280" width="38" height="38">
-			</bounds>
+			<bounds x="161" y="280" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="159" y="238" width="42" height="42">
-			</bounds>
+			<bounds x="159" y="238" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="161" y="240" width="38" height="38">
-			</bounds>
+			<bounds x="161" y="240" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="176" y="199" width="42" height="42">
-			</bounds>
+			<bounds x="176" y="199" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="178" y="201" width="38" height="38">
-			</bounds>
+			<bounds x="178" y="201" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="399" y="6" width="37" height="37">
-			</bounds>
+			<bounds x="399" y="6" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="401" y="8" width="33" height="33">
-			</bounds>
+			<bounds x="401" y="8" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="365" y="6" width="37" height="37">
-			</bounds>
+			<bounds x="365" y="6" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="367" y="8" width="33" height="33">
-			</bounds>
+			<bounds x="367" y="8" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="432" y="121" width="37" height="37">
-			</bounds>
+			<bounds x="432" y="121" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="434" y="123" width="33" height="33">
-			</bounds>
+			<bounds x="434" y="123" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="398" y="138" width="37" height="37">
-			</bounds>
+			<bounds x="398" y="138" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="400" y="140" width="33" height="33">
-			</bounds>
+			<bounds x="400" y="140" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="364" y="138" width="37" height="37">
-			</bounds>
+			<bounds x="364" y="138" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="366" y="140" width="33" height="33">
-			</bounds>
+			<bounds x="366" y="140" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="330" y="123" width="37" height="37">
-			</bounds>
+			<bounds x="330" y="123" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="332" y="125" width="33" height="33">
-			</bounds>
+			<bounds x="332" y="125" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="320" y="89" width="37" height="37">
-			</bounds>
+			<bounds x="320" y="89" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="322" y="91" width="33" height="33">
-			</bounds>
+			<bounds x="322" y="91" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="320" y="55" width="37" height="37">
-			</bounds>
+			<bounds x="320" y="55" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="322" y="57" width="33" height="33">
-			</bounds>
+			<bounds x="322" y="57" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="445" y="87" width="37" height="37">
-			</bounds>
+			<bounds x="445" y="87" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="447" y="89" width="33" height="33">
-			</bounds>
+			<bounds x="447" y="89" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="330" y="20" width="37" height="37">
-			</bounds>
+			<bounds x="330" y="20" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="332" y="22" width="33" height="33">
-			</bounds>
+			<bounds x="332" y="22" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="434" y="18" width="37" height="37">
-			</bounds>
+			<bounds x="434" y="18" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="436" y="20" width="33" height="33">
-			</bounds>
+			<bounds x="436" y="20" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="445" y="53" width="37" height="37">
-			</bounds>
+			<bounds x="445" y="53" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="447" y="55" width="33" height="33">
-			</bounds>
+			<bounds x="447" y="55" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="614" y="509" width="52" height="52">
-			</bounds>
+			<bounds x="614" y="509" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="616" y="511" width="48" height="48">
-			</bounds>
+			<bounds x="616" y="511" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="914" y="628" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="628" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="916" y="630" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="630" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="703" y="605" width="19" height="19">
-			</bounds>
+			<bounds x="703" y="605" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="705" y="607" width="15" height="15">
-			</bounds>
+			<bounds x="705" y="607" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="914" y="596" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="596" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="916" y="598" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="598" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="914" y="567" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="567" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="916" y="569" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="569" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="914" y="538" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="538" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="916" y="540" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="540" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="914" y="509" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="509" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="916" y="511" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="511" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="914" y="480" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="480" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="916" y="482" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="482" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="914" y="451" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="451" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="916" y="453" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="453" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="914" y="422" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="422" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="916" y="424" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="424" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="914" y="393" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="393" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="916" y="395" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="395" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="914" y="364" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="364" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="916" y="366" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="366" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="914" y="335" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="335" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="916" y="337" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="337" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="914" y="306" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="306" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="916" y="308" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="308" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="914" y="277" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="277" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="916" y="279" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="279" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="914" y="248" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="248" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="916" y="250" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="250" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="914" y="219" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="219" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="916" y="221" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="221" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="914" y="190" width="77" height="27">
-			</bounds>
+			<bounds x="914" y="190" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="916" y="192" width="73" height="23">
-			</bounds>
+			<bounds x="916" y="192" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="854" y="597" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="597" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="856" y="599" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="599" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="854" y="568" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="568" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="856" y="570" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="570" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="854" y="539" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="539" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="856" y="541" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="541" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="854" y="510" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="510" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="856" y="512" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="512" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="854" y="481" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="481" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="856" y="483" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="483" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="854" y="452" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="452" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="856" y="454" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="454" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="854" y="423" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="423" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="856" y="425" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="425" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="854" y="394" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="394" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="856" y="396" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="396" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="854" y="365" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="365" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="856" y="367" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="367" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="854" y="336" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="336" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="856" y="338" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="338" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="854" y="307" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="307" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="856" y="309" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="309" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="854" y="278" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="278" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="856" y="280" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="280" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="854" y="249" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="249" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="856" y="251" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="251" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="854" y="220" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="220" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="856" y="222" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="222" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="854" y="191" width="27" height="27">
-			</bounds>
+			<bounds x="854" y="191" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="856" y="193" width="23" height="23">
-			</bounds>
+			<bounds x="856" y="193" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="958" y="124" width="17" height="12">
-			</bounds>
+			<bounds x="958" y="124" width="17" height="12"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="960" y="126" width="13" height="8">
-			</bounds>
+			<bounds x="960" y="126" width="13" height="8"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="948" y="111" width="12" height="21">
-			</bounds>
+			<bounds x="948" y="111" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="950" y="113" width="8" height="17">
-			</bounds>
+			<bounds x="950" y="113" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="948" y="130" width="12" height="21">
-			</bounds>
+			<bounds x="948" y="130" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="950" y="132" width="8" height="17">
-			</bounds>
+			<bounds x="950" y="132" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="948" y="149" width="36" height="12">
-			</bounds>
+			<bounds x="948" y="149" width="36" height="12"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="950" y="151" width="32" height="8">
-			</bounds>
+			<bounds x="950" y="151" width="32" height="8"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="972" y="130" width="12" height="21">
-			</bounds>
+			<bounds x="972" y="130" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="974" y="132" width="8" height="17">
-			</bounds>
+			<bounds x="974" y="132" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="972" y="112" width="12" height="21">
-			</bounds>
+			<bounds x="972" y="112" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="974" y="114" width="8" height="17">
-			</bounds>
+			<bounds x="974" y="114" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="948" y="102" width="36" height="12">
-			</bounds>
+			<bounds x="948" y="102" width="36" height="12"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="950" y="104" width="32" height="8">
-			</bounds>
+			<bounds x="950" y="104" width="32" height="8"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="929" y="111" width="12" height="21">
-			</bounds>
+			<bounds x="929" y="111" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="931" y="113" width="8" height="17">
-			</bounds>
+			<bounds x="931" y="113" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="929" y="130" width="12" height="21">
-			</bounds>
+			<bounds x="929" y="130" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="931" y="132" width="8" height="17">
-			</bounds>
+			<bounds x="931" y="132" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="905" y="149" width="36" height="12">
-			</bounds>
+			<bounds x="905" y="149" width="36" height="12"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="907" y="151" width="32" height="8">
-			</bounds>
+			<bounds x="907" y="151" width="32" height="8"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="905" y="130" width="12" height="21">
-			</bounds>
+			<bounds x="905" y="130" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="907" y="132" width="8" height="17">
-			</bounds>
+			<bounds x="907" y="132" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="905" y="111" width="12" height="21">
-			</bounds>
+			<bounds x="905" y="111" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="907" y="113" width="8" height="17">
-			</bounds>
+			<bounds x="907" y="113" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="914" y="124" width="17" height="12">
-			</bounds>
+			<bounds x="914" y="124" width="17" height="12"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="916" y="126" width="13" height="8">
-			</bounds>
+			<bounds x="916" y="126" width="13" height="8"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="887" y="111" width="12" height="21">
-			</bounds>
+			<bounds x="887" y="111" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="889" y="113" width="8" height="17">
-			</bounds>
+			<bounds x="889" y="113" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="887" y="130" width="12" height="21">
-			</bounds>
+			<bounds x="887" y="130" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="889" y="132" width="8" height="17">
-			</bounds>
+			<bounds x="889" y="132" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="863" y="149" width="36" height="12">
-			</bounds>
+			<bounds x="863" y="149" width="36" height="12"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="865" y="151" width="32" height="8">
-			</bounds>
+			<bounds x="865" y="151" width="32" height="8"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="863" y="130" width="12" height="21">
-			</bounds>
+			<bounds x="863" y="130" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="865" y="132" width="8" height="17">
-			</bounds>
+			<bounds x="865" y="132" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="863" y="111" width="12" height="21">
-			</bounds>
+			<bounds x="863" y="111" width="12" height="21"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="865" y="113" width="8" height="17">
-			</bounds>
+			<bounds x="865" y="113" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="873" y="124" width="17" height="12">
-			</bounds>
+			<bounds x="873" y="124" width="17" height="12"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="875" y="126" width="13" height="8">
-			</bounds>
+			<bounds x="875" y="126" width="13" height="8"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="863" y="102" width="36" height="12">
-			</bounds>
+			<bounds x="863" y="102" width="36" height="12"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="865" y="104" width="32" height="8">
-			</bounds>
+			<bounds x="865" y="104" width="32" height="8"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="905" y="102" width="36" height="12">
-			</bounds>
+			<bounds x="905" y="102" width="36" height="12"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="907" y="104" width="32" height="8">
-			</bounds>
+			<bounds x="907" y="104" width="32" height="8"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="863" y="75" width="121" height="27">
-			</bounds>
+			<bounds x="863" y="75" width="121" height="27"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="865" y="77" width="117" height="23">
-			</bounds>
+			<bounds x="865" y="77" width="117" height="23"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="836" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="836" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="838" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="838" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="855" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="855" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="857" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="857" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="874" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="874" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="876" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="876" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="703" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="703" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="705" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="705" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="722" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="722" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="724" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="724" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="741" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="741" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="743" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="743" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="760" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="760" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="762" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="762" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="779" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="779" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="781" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="781" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="798" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="798" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="800" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="800" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="817" y="633" width="19" height="19">
-			</bounds>
+			<bounds x="817" y="633" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="819" y="635" width="15" height="15">
-			</bounds>
+			<bounds x="819" y="635" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="801" y="508" width="19" height="19">
-			</bounds>
+			<bounds x="801" y="508" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="803" y="510" width="15" height="15">
-			</bounds>
+			<bounds x="803" y="510" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="778" y="507" width="19" height="19">
-			</bounds>
+			<bounds x="778" y="507" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="780" y="509" width="15" height="15">
-			</bounds>
+			<bounds x="780" y="509" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="17" y="401" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="401" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="19" y="403" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="403" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="17" y="360" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="360" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="19" y="362" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="362" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="17" y="321" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="321" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="19" y="323" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="323" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="17" y="282" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="282" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="19" y="284" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="284" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="17" y="244" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="244" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="19" y="246" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="246" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="17" y="204" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="204" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="19" y="206" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="206" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="17" y="165" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="165" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="19" y="167" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="167" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="17" y="126" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="126" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="19" y="128" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="128" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="17" y="87" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="87" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="19" y="89" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="89" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="17" y="48" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="48" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="19" y="50" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="50" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="17" y="9" width="62" height="37">
-			</bounds>
+			<bounds x="17" y="9" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="19" y="11" width="58" height="33">
-			</bounds>
+			<bounds x="19" y="11" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="685" y="324" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="324" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="687" y="326" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="326" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="685" y="363" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="363" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="687" y="365" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="365" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="684" y="402" width="62" height="37">
-			</bounds>
+			<bounds x="684" y="402" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="686" y="404" width="58" height="33">
-			</bounds>
+			<bounds x="686" y="404" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="685" y="285" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="285" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="687" y="287" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="287" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="685" y="246" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="246" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="687" y="248" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="248" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="685" y="208" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="208" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="687" y="210" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="210" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="685" y="168" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="168" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="687" y="170" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="170" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="685" y="129" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="129" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="687" y="131" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="131" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="685" y="90" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="90" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="687" y="92" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="92" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="685" y="51" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="51" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="687" y="53" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="53" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="685" y="12" width="62" height="37">
-			</bounds>
+			<bounds x="685" y="12" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="687" y="14" width="58" height="33">
-			</bounds>
+			<bounds x="687" y="14" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="756" y="12" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="12" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="758" y="14" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="14" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="756" y="402" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="402" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="758" y="404" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="404" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="756" y="363" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="363" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="758" y="365" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="365" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="756" y="324" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="324" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="758" y="326" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="326" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="756" y="285" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="285" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="758" y="287" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="287" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="756" y="246" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="246" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="758" y="248" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="248" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="756" y="207" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="207" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="758" y="209" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="209" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="756" y="168" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="168" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="758" y="170" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="170" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="756" y="129" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="129" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="758" y="131" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="131" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="756" y="90" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="90" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="758" y="92" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="92" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="756" y="51" width="62" height="37">
-			</bounds>
+			<bounds x="756" y="51" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="758" y="53" width="58" height="33">
-			</bounds>
+			<bounds x="758" y="53" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="85" y="399" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="399" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="87" y="401" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="401" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="85" y="360" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="360" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="87" y="362" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="362" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="85" y="321" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="321" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="87" y="323" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="323" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="85" y="282" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="282" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="87" y="284" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="284" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="85" y="243" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="243" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="87" y="245" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="245" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="85" y="204" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="204" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="87" y="206" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="206" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="85" y="165" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="165" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="87" y="167" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="167" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="85" y="126" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="126" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="87" y="128" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="128" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="85" y="87" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="87" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="87" y="89" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="89" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="85" y="48" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="48" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="87" y="50" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="50" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="85" y="9" width="62" height="37">
-			</bounds>
+			<bounds x="85" y="9" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="87" y="11" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="11" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="363" y="81" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="81" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="365" y="83" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="83" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="382" y="81" width="19" height="19">
-			</bounds>
+			<bounds x="382" y="81" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="384" y="83" width="15" height="15">
-			</bounds>
+			<bounds x="384" y="83" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="401" y="81" width="19" height="19">
-			</bounds>
+			<bounds x="401" y="81" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="403" y="83" width="15" height="15">
-			</bounds>
+			<bounds x="403" y="83" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="420" y="81" width="19" height="19">
-			</bounds>
+			<bounds x="420" y="81" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="422" y="83" width="15" height="15">
-			</bounds>
+			<bounds x="422" y="83" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="560" y="442" width="42" height="42">
-			</bounds>
+			<bounds x="560" y="442" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="562" y="444" width="38" height="38">
-			</bounds>
+			<bounds x="562" y="444" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="560" y="486" width="42" height="42">
-			</bounds>
+			<bounds x="560" y="486" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="562" y="488" width="38" height="38">
-			</bounds>
+			<bounds x="562" y="488" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="560" y="530" width="42" height="42">
-			</bounds>
+			<bounds x="560" y="530" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="562" y="532" width="38" height="38">
-			</bounds>
+			<bounds x="562" y="532" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="560" y="574" width="42" height="42">
-			</bounds>
+			<bounds x="560" y="574" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="562" y="576" width="38" height="38">
-			</bounds>
+			<bounds x="562" y="576" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp215" element="colour_button_193_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="677" y="440" width="75" height="52">
-			</bounds>
+			<bounds x="677" y="440" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp215" element="colour_button_193" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="679" y="442" width="71" height="48">
-			</bounds>
+			<bounds x="679" y="442" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp87" element="colour_button_194_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="749" y="440" width="75" height="52">
-			</bounds>
+			<bounds x="749" y="440" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp87" element="colour_button_194" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="751" y="442" width="71" height="48">
-			</bounds>
+			<bounds x="751" y="442" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_195_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="456" y="624" width="75" height="52">
-			</bounds>
+			<bounds x="456" y="624" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_195" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="458" y="626" width="71" height="48">
-			</bounds>
+			<bounds x="458" y="626" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_196_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="533" y="624" width="75" height="52">
-			</bounds>
+			<bounds x="533" y="624" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_196" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="535" y="626" width="71" height="48">
-			</bounds>
+			<bounds x="535" y="626" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_197_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="610" y="624" width="75" height="52">
-			</bounds>
+			<bounds x="610" y="624" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_197" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="612" y="626" width="71" height="48">
-			</bounds>
+			<bounds x="612" y="626" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_198_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="379" y="624" width="75" height="52">
-			</bounds>
+			<bounds x="379" y="624" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_198" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="381" y="626" width="71" height="48">
-			</bounds>
+			<bounds x="381" y="626" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_199_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="302" y="624" width="75" height="52">
-			</bounds>
+			<bounds x="302" y="624" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_199" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="304" y="626" width="71" height="48">
-			</bounds>
+			<bounds x="304" y="626" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_200_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="225" y="624" width="75" height="52">
-			</bounds>
+			<bounds x="225" y="624" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_200" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="227" y="626" width="71" height="48">
-			</bounds>
+			<bounds x="227" y="626" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_201_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="148" y="624" width="75" height="52">
-			</bounds>
+			<bounds x="148" y="624" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_201" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="150" y="626" width="71" height="48">
-			</bounds>
+			<bounds x="150" y="626" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_202_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="71" y="624" width="75" height="52">
-			</bounds>
+			<bounds x="71" y="624" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_202" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="73" y="626" width="71" height="48">
-			</bounds>
+			<bounds x="73" y="626" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp95" element="colour_button_203_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="8" y="438" width="75" height="52">
-			</bounds>
+			<bounds x="8" y="438" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp95" element="colour_button_203" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="10" y="440" width="71" height="48">
-			</bounds>
+			<bounds x="10" y="440" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp214" element="colour_button_204_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="80" y="438" width="75" height="52">
-			</bounds>
+			<bounds x="80" y="438" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp214" element="colour_button_204" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="82" y="440" width="71" height="48">
-			</bounds>
+			<bounds x="82" y="440" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp98" element="colour_button_205_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="873" y="4" width="75" height="27">
-			</bounds>
+			<bounds x="873" y="4" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="colour_button_205" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="875" y="6" width="71" height="23">
-			</bounds>
+			<bounds x="875" y="6" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="245" y="429" width="272" height="30">
-			</bounds>
+			<bounds x="245" y="429" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="245" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="245" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="262" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="262" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="279" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="279" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="296" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="296" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="313" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="313" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="330" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="330" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="347" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="347" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="364" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="364" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="381" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="381" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="398" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="398" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="415" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="415" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="432" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="432" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="449" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="449" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="466" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="466" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="483" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="483" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="500" y="429" width="17" height="30">
-			</bounds>
+			<bounds x="500" y="429" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label109" element="label_109">
-			<bounds x="878" y="160" width="86" height="24">
-			</bounds>
+			<bounds x="878" y="160" width="86" height="24"/>
 		</backdrop>
 		<backdrop name="label110" element="label_110">
-			<bounds x="892" y="197" width="18" height="13">
-			</bounds>
+			<bounds x="892" y="197" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label111" element="label_111">
-			<bounds x="892" y="225" width="18" height="13">
-			</bounds>
+			<bounds x="892" y="225" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label112" element="label_112">
-			<bounds x="892" y="254" width="18" height="13">
-			</bounds>
+			<bounds x="892" y="254" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="894" y="284" width="18" height="13">
-			</bounds>
+			<bounds x="894" y="284" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="894" y="344" width="18" height="13">
-			</bounds>
+			<bounds x="894" y="344" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label115" element="label_115">
-			<bounds x="893" y="315" width="18" height="13">
-			</bounds>
+			<bounds x="893" y="315" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label116" element="label_116">
-			<bounds x="893" y="371" width="18" height="13">
-			</bounds>
+			<bounds x="893" y="371" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label117" element="label_117">
-			<bounds x="892" y="399" width="18" height="13">
-			</bounds>
+			<bounds x="892" y="399" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label118" element="label_118">
-			<bounds x="896" y="429" width="12" height="13">
-			</bounds>
+			<bounds x="896" y="429" width="12" height="13"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="896" y="457" width="12" height="13">
-			</bounds>
+			<bounds x="896" y="457" width="12" height="13"/>
 		</backdrop>
 		<backdrop name="label120" element="label_120">
-			<bounds x="896" y="486" width="12" height="13">
-			</bounds>
+			<bounds x="896" y="486" width="12" height="13"/>
 		</backdrop>
 		<backdrop name="label121" element="label_121">
-			<bounds x="897" y="516" width="12" height="13">
-			</bounds>
+			<bounds x="897" y="516" width="12" height="13"/>
 		</backdrop>
 		<backdrop name="label122" element="label_122">
-			<bounds x="897" y="544" width="12" height="13">
-			</bounds>
+			<bounds x="897" y="544" width="12" height="13"/>
 		</backdrop>
 		<backdrop name="label123" element="label_123">
-			<bounds x="898" y="573" width="12" height="13">
-			</bounds>
+			<bounds x="898" y="573" width="12" height="13"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="898" y="602" width="12" height="13">
-			</bounds>
+			<bounds x="898" y="602" width="12" height="13"/>
 		</backdrop>
 		<backdrop name="label135" element="label_135">
-			<bounds x="724" y="601" width="23" height="26">
-			</bounds>
+			<bounds x="724" y="601" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="label190" element="label_190">
-			<bounds x="168" y="43" width="135" height="96">
-			</bounds>
+			<bounds x="168" y="43" width="135" height="96"/>
 		</backdrop>
 		<backdrop name="label191" element="label_191">
-			<bounds x="834" y="108" width="21" height="48">
-			</bounds>
+			<bounds x="834" y="108" width="21" height="48"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_button" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_button" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_button" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_button" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_button" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1cluecb1.lay
+++ b/src/mame/layout/m1cluecb1.lay
@@ -8,13992 +8,8563 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3; 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3; 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3; 10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3; 10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3; 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3; 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3; 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3; 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3; 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3; 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="OPEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="OPEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3; 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3; 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MURDERED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="MURDERED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENTER MANSION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENTER MANSION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WEAPON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MURDERED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MURDERED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUIT OF ARMOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUIT OF ARMOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FIND A WILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FIND A WILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SHOT AT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOT AT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SECRET PASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SECRET PASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MISS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MISS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUIT OF ARMOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUIT OF ARMOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3; 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3; 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 WINLINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 WINLINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 WINLINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 WINLINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 WINLINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 WINLINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SHOT IN THE DARK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOT IN THE DARK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FINGER PRINTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FINGER PRINTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="IDENTITY PARADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="IDENTITY PARADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CASH CLUE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH CLUE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.03">
-			</color>
+			<color red="0.06" green="0.00" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.06">
-			</color>
+			<color red="0.13" green="0.00" blue="0.06"/>
 		</rect>
 		<text string="PROF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.06">
-			</color>
-		</rect>
-		<text string="PROF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MISS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MISS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MRS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MRS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLONEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="COLONEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MRS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MRS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ALL CLUED UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ALL CLUED UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.03">
-			</color>
+			<color red="0.06" green="0.00" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.06">
-			</color>
+			<color red="0.13" green="0.00" blue="0.06"/>
 		</rect>
 		<text string="PLUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.06">
-			</color>
-		</rect>
-		<text string="PLUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SCARLET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SCARLET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WHITE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WHITE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MUSTARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MUSTARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PEACOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="PEACOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GREEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GREEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_212_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_212">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_213_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_213">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="10p START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_214_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_214">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_215_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_215">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_216_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_216">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_217_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_217">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_218_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_218">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_219_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_219">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_225_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_225">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_167">
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_168">
 		<text string="CASH METER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_169">
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_170">
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_171">
 		<text string="MAGNIFYING GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_172">
 		<text string="FINGER PRINTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_173">
 		<text string="SHOT IN THE DARK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_174">
 		<text string="IDENTITY PARADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_175">
 		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_176">
 		<text string="6 ELIMINATED &#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_177">
 		<text string="5 ELIMINATED &#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_178">
 		<text string="4 ELEMINATED &#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_179">
 		<text string="3 ELIMINATED &#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_180">
 		<text string="2 ELIMINATED &#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_181">
 		<text string="1 ELIMINATED &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_182">
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_183">
 		<text string="RESERVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_184">
 		<text string="MILLIONAIRES MANSION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_185">
 		<text string="SHOT AT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_194">
 		<text string="X4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_195">
 		<text string="X3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_196">
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_197">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_198">
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_199">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_200">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_201">
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_202">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_203">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_204">
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_205">
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_206">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_207">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_208">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_209">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_210">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_211">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1007" height="873">
-			</bounds>
+			<bounds x="0" y="0" width="1007" height="873"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="87" y="659" width="80" height="150">
-			</bounds>
+			<bounds x="87" y="659" width="80" height="150"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="87.0000" y="659.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="87.0000" y="659.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="90.3333" y="661.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="90.3333" y="661.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="93.6667" y="663.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="93.6667" y="663.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="97.0000" y="665.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="97.0000" y="665.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="100.3333" y="667.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="100.3333" y="667.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="103.6667" y="669.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="103.6667" y="669.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="87.0000" y="709.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="87.0000" y="709.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="90.3333" y="711.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="90.3333" y="711.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="93.6667" y="713.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="93.6667" y="713.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="97.0000" y="715.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="97.0000" y="715.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="100.3333" y="717.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="100.3333" y="717.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="103.6667" y="719.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="103.6667" y="719.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="87.0000" y="759.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="87.0000" y="759.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="90.3333" y="761.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="90.3333" y="761.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="93.6667" y="763.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="93.6667" y="763.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="97.0000" y="765.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="97.0000" y="765.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="100.3333" y="767.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="100.3333" y="767.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="103.6667" y="769.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="103.6667" y="769.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="87" y="659" width="80" height="150">
-			</bounds>
+			<bounds x="87" y="659" width="80" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="181" y="659" width="80" height="150">
-			</bounds>
+			<bounds x="181" y="659" width="80" height="150"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="181.0000" y="659.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="181.0000" y="659.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="184.3333" y="661.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="184.3333" y="661.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="187.6667" y="663.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="187.6667" y="663.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="191.0000" y="665.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="191.0000" y="665.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="194.3333" y="667.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="194.3333" y="667.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="197.6667" y="669.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="197.6667" y="669.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="181.0000" y="709.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="181.0000" y="709.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="184.3333" y="711.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="184.3333" y="711.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="187.6667" y="713.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="187.6667" y="713.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="191.0000" y="715.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="191.0000" y="715.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="194.3333" y="717.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="194.3333" y="717.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="197.6667" y="719.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="197.6667" y="719.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="181.0000" y="759.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="181.0000" y="759.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="184.3333" y="761.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="184.3333" y="761.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="187.6667" y="763.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="187.6667" y="763.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="191.0000" y="765.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="191.0000" y="765.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="194.3333" y="767.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="194.3333" y="767.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="197.6667" y="769.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="197.6667" y="769.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="181" y="659" width="80" height="150">
-			</bounds>
+			<bounds x="181" y="659" width="80" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="274" y="659" width="80" height="150">
-			</bounds>
+			<bounds x="274" y="659" width="80" height="150"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="659.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="274.0000" y="659.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="277.3333" y="661.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="277.3333" y="661.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="280.6667" y="663.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="280.6667" y="663.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.0000" y="665.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="284.0000" y="665.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="287.3333" y="667.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="287.3333" y="667.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="290.6667" y="669.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="290.6667" y="669.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="709.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="274.0000" y="709.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="277.3333" y="711.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="277.3333" y="711.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="280.6667" y="713.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="280.6667" y="713.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.0000" y="715.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="284.0000" y="715.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="287.3333" y="717.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="287.3333" y="717.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="290.6667" y="719.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="290.6667" y="719.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="759.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="274.0000" y="759.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="277.3333" y="761.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="277.3333" y="761.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="280.6667" y="763.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="280.6667" y="763.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.0000" y="765.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="284.0000" y="765.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="287.3333" y="767.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="287.3333" y="767.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="290.6667" y="769.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="290.6667" y="769.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="274" y="659" width="80" height="150">
-			</bounds>
+			<bounds x="274" y="659" width="80" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="367" y="659" width="80" height="150">
-			</bounds>
+			<bounds x="367" y="659" width="80" height="150"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="367.0000" y="659.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="367.0000" y="659.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="370.3333" y="661.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="370.3333" y="661.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="373.6667" y="663.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="373.6667" y="663.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="377.0000" y="665.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="377.0000" y="665.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="380.3333" y="667.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="380.3333" y="667.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="383.6667" y="669.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="383.6667" y="669.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="367.0000" y="709.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="367.0000" y="709.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="370.3333" y="711.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="370.3333" y="711.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="373.6667" y="713.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="373.6667" y="713.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="377.0000" y="715.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="377.0000" y="715.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="380.3333" y="717.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="380.3333" y="717.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="383.6667" y="719.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="383.6667" y="719.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="367.0000" y="759.0000" width="80.0000" height="50.0000">
-			</bounds>
+			<bounds x="367.0000" y="759.0000" width="80.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="370.3333" y="761.0833" width="73.3333" height="45.8333">
-			</bounds>
+			<bounds x="370.3333" y="761.0833" width="73.3333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="373.6667" y="763.1667" width="66.6667" height="41.6667">
-			</bounds>
+			<bounds x="373.6667" y="763.1667" width="66.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="377.0000" y="765.2500" width="60.0000" height="37.5000">
-			</bounds>
+			<bounds x="377.0000" y="765.2500" width="60.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="380.3333" y="767.3333" width="53.3333" height="33.3333">
-			</bounds>
+			<bounds x="380.3333" y="767.3333" width="53.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="383.6667" y="769.4167" width="46.6667" height="29.1667">
-			</bounds>
+			<bounds x="383.6667" y="769.4167" width="46.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="367" y="659" width="80" height="150">
-			</bounds>
+			<bounds x="367" y="659" width="80" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="122" y="537" width="65" height="65">
-			</bounds>
+			<bounds x="122" y="537" width="65" height="65"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="122.0000" y="537.0000" width="65.0000" height="65.0000">
-			</bounds>
+			<bounds x="122.0000" y="537.0000" width="65.0000" height="65.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="124.7083" y="539.7083" width="59.5833" height="59.5833">
-			</bounds>
+			<bounds x="124.7083" y="539.7083" width="59.5833" height="59.5833"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="127.4167" y="542.4167" width="54.1667" height="54.1667">
-			</bounds>
+			<bounds x="127.4167" y="542.4167" width="54.1667" height="54.1667"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="130.1250" y="545.1250" width="48.7500" height="48.7500">
-			</bounds>
+			<bounds x="130.1250" y="545.1250" width="48.7500" height="48.7500"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="132.8333" y="547.8333" width="43.3333" height="43.3333">
-			</bounds>
+			<bounds x="132.8333" y="547.8333" width="43.3333" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="135.5417" y="550.5417" width="37.9167" height="37.9167">
-			</bounds>
+			<bounds x="135.5417" y="550.5417" width="37.9167" height="37.9167"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="122" y="537" width="65" height="65">
-			</bounds>
+			<bounds x="122" y="537" width="65" height="65"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="260" y="330" width="57" height="19">
-			</bounds>
+			<bounds x="260" y="330" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="262" y="332" width="53" height="15">
-			</bounds>
+			<bounds x="262" y="332" width="53" height="15"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="316" y="330" width="57" height="19">
-			</bounds>
+			<bounds x="316" y="330" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="318" y="332" width="53" height="15">
-			</bounds>
+			<bounds x="318" y="332" width="53" height="15"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="372" y="330" width="57" height="19">
-			</bounds>
+			<bounds x="372" y="330" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="374" y="332" width="53" height="15">
-			</bounds>
+			<bounds x="374" y="332" width="53" height="15"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="427" y="292" width="102" height="52">
-			</bounds>
+			<bounds x="427" y="292" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="429" y="294" width="98" height="48">
-			</bounds>
+			<bounds x="429" y="294" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="427" y="233" width="102" height="52">
-			</bounds>
+			<bounds x="427" y="233" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="429" y="235" width="98" height="48">
-			</bounds>
+			<bounds x="429" y="235" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="427" y="142" width="102" height="82">
-			</bounds>
+			<bounds x="427" y="142" width="102" height="82"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="429" y="144" width="98" height="78">
-			</bounds>
+			<bounds x="429" y="144" width="98" height="78"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="307" y="142" width="102" height="82">
-			</bounds>
+			<bounds x="307" y="142" width="102" height="82"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="309" y="144" width="98" height="78">
-			</bounds>
+			<bounds x="309" y="144" width="98" height="78"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="187" y="142" width="102" height="82">
-			</bounds>
+			<bounds x="187" y="142" width="102" height="82"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="189" y="144" width="98" height="78">
-			</bounds>
+			<bounds x="189" y="144" width="98" height="78"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="187" y="248" width="102" height="82">
-			</bounds>
+			<bounds x="187" y="248" width="102" height="82"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="189" y="250" width="98" height="78">
-			</bounds>
+			<bounds x="189" y="250" width="98" height="78"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="187" y="350" width="102" height="82">
-			</bounds>
+			<bounds x="187" y="350" width="102" height="82"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="189" y="352" width="98" height="78">
-			</bounds>
+			<bounds x="189" y="352" width="98" height="78"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="307" y="349" width="102" height="82">
-			</bounds>
+			<bounds x="307" y="349" width="102" height="82"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="309" y="351" width="98" height="78">
-			</bounds>
+			<bounds x="309" y="351" width="98" height="78"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="338" y="497" width="42" height="19">
-			</bounds>
+			<bounds x="338" y="497" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="340" y="499" width="38" height="15">
-			</bounds>
+			<bounds x="340" y="499" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="427" y="350" width="102" height="82">
-			</bounds>
+			<bounds x="427" y="350" width="102" height="82"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="429" y="352" width="98" height="78">
-			</bounds>
+			<bounds x="429" y="352" width="98" height="78"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="529" y="374" width="72" height="62">
-			</bounds>
+			<bounds x="529" y="374" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="531" y="376" width="68" height="58">
-			</bounds>
+			<bounds x="531" y="376" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="529" y="315" width="72" height="62">
-			</bounds>
+			<bounds x="529" y="315" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="531" y="317" width="68" height="58">
-			</bounds>
+			<bounds x="531" y="317" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="529" y="256" width="72" height="62">
-			</bounds>
+			<bounds x="529" y="256" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="531" y="258" width="68" height="58">
-			</bounds>
+			<bounds x="531" y="258" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="529" y="197" width="72" height="62">
-			</bounds>
+			<bounds x="529" y="197" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="531" y="199" width="68" height="58">
-			</bounds>
+			<bounds x="531" y="199" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="529" y="138" width="72" height="62">
-			</bounds>
+			<bounds x="529" y="138" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="531" y="140" width="68" height="58">
-			</bounds>
+			<bounds x="531" y="140" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="529" y="79" width="72" height="62">
-			</bounds>
+			<bounds x="529" y="79" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="531" y="81" width="68" height="58">
-			</bounds>
+			<bounds x="531" y="81" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="460" y="79" width="72" height="62">
-			</bounds>
+			<bounds x="460" y="79" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="462" y="81" width="68" height="58">
-			</bounds>
+			<bounds x="462" y="81" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="391" y="79" width="72" height="62">
-			</bounds>
+			<bounds x="391" y="79" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="393" y="81" width="68" height="58">
-			</bounds>
+			<bounds x="393" y="81" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="322" y="79" width="72" height="62">
-			</bounds>
+			<bounds x="322" y="79" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="324" y="81" width="68" height="58">
-			</bounds>
+			<bounds x="324" y="81" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="253" y="79" width="72" height="62">
-			</bounds>
+			<bounds x="253" y="79" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="255" y="81" width="68" height="58">
-			</bounds>
+			<bounds x="255" y="81" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="184" y="79" width="72" height="62">
-			</bounds>
+			<bounds x="184" y="79" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="186" y="81" width="68" height="58">
-			</bounds>
+			<bounds x="186" y="81" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="115" y="79" width="72" height="62">
-			</bounds>
+			<bounds x="115" y="79" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="117" y="81" width="68" height="58">
-			</bounds>
+			<bounds x="117" y="81" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="115" y="138" width="72" height="62">
-			</bounds>
+			<bounds x="115" y="138" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="117" y="140" width="68" height="58">
-			</bounds>
+			<bounds x="117" y="140" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="115" y="197" width="72" height="62">
-			</bounds>
+			<bounds x="115" y="197" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="117" y="199" width="68" height="58">
-			</bounds>
+			<bounds x="117" y="199" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="115" y="256" width="72" height="62">
-			</bounds>
+			<bounds x="115" y="256" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="117" y="258" width="68" height="58">
-			</bounds>
+			<bounds x="117" y="258" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="115" y="315" width="72" height="62">
-			</bounds>
+			<bounds x="115" y="315" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="117" y="317" width="68" height="58">
-			</bounds>
+			<bounds x="117" y="317" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="115" y="374" width="72" height="62">
-			</bounds>
+			<bounds x="115" y="374" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="117" y="376" width="68" height="58">
-			</bounds>
+			<bounds x="117" y="376" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="115" y="433" width="72" height="62">
-			</bounds>
+			<bounds x="115" y="433" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="117" y="435" width="68" height="58">
-			</bounds>
+			<bounds x="117" y="435" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="184" y="433" width="72" height="62">
-			</bounds>
+			<bounds x="184" y="433" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="186" y="435" width="68" height="58">
-			</bounds>
+			<bounds x="186" y="435" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="253" y="433" width="72" height="62">
-			</bounds>
+			<bounds x="253" y="433" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="255" y="435" width="68" height="58">
-			</bounds>
+			<bounds x="255" y="435" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="322" y="433" width="72" height="62">
-			</bounds>
+			<bounds x="322" y="433" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="324" y="435" width="68" height="58">
-			</bounds>
+			<bounds x="324" y="435" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="391" y="433" width="72" height="62">
-			</bounds>
+			<bounds x="391" y="433" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="393" y="435" width="68" height="58">
-			</bounds>
+			<bounds x="393" y="435" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="460" y="433" width="72" height="62">
-			</bounds>
+			<bounds x="460" y="433" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="462" y="435" width="68" height="58">
-			</bounds>
+			<bounds x="462" y="435" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="529" y="433" width="72" height="62">
-			</bounds>
+			<bounds x="529" y="433" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="531" y="435" width="68" height="58">
-			</bounds>
+			<bounds x="531" y="435" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="3" y="223" width="77" height="19">
-			</bounds>
+			<bounds x="3" y="223" width="77" height="19"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="5" y="225" width="73" height="15">
-			</bounds>
+			<bounds x="5" y="225" width="73" height="15"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="2" y="171" width="72" height="42">
-			</bounds>
+			<bounds x="2" y="171" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="4" y="173" width="68" height="38">
-			</bounds>
+			<bounds x="4" y="173" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="75" y="144" width="36" height="52">
-			</bounds>
+			<bounds x="75" y="144" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="77" y="146" width="32" height="48">
-			</bounds>
+			<bounds x="77" y="146" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="765" y="578" width="42" height="42">
-			</bounds>
+			<bounds x="765" y="578" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="767" y="580" width="38" height="38">
-			</bounds>
+			<bounds x="767" y="580" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="42" y="247" width="62" height="27">
-			</bounds>
+			<bounds x="42" y="247" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="44" y="249" width="58" height="23">
-			</bounds>
+			<bounds x="44" y="249" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="75" y="202" width="36" height="19">
-			</bounds>
+			<bounds x="75" y="202" width="36" height="19"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="77" y="204" width="32" height="15">
-			</bounds>
+			<bounds x="77" y="204" width="32" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="12" y="136" width="55" height="32">
-			</bounds>
+			<bounds x="12" y="136" width="55" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="14" y="138" width="51" height="28">
-			</bounds>
+			<bounds x="14" y="138" width="51" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="765" y="620" width="42" height="42">
-			</bounds>
+			<bounds x="765" y="620" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="767" y="622" width="38" height="38">
-			</bounds>
+			<bounds x="767" y="622" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="765" y="662" width="42" height="42">
-			</bounds>
+			<bounds x="765" y="662" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="767" y="664" width="38" height="38">
-			</bounds>
+			<bounds x="767" y="664" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="765" y="704" width="42" height="42">
-			</bounds>
+			<bounds x="765" y="704" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="767" y="706" width="38" height="38">
-			</bounds>
+			<bounds x="767" y="706" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="744" y="747" width="82" height="52">
-			</bounds>
+			<bounds x="744" y="747" width="82" height="52"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="746" y="749" width="78" height="48">
-			</bounds>
+			<bounds x="746" y="749" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="704" y="720" width="37" height="22">
-			</bounds>
+			<bounds x="704" y="720" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="706" y="722" width="33" height="18">
-			</bounds>
+			<bounds x="706" y="722" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="556" y="528" width="52" height="32">
-			</bounds>
+			<bounds x="556" y="528" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="558" y="530" width="48" height="28">
-			</bounds>
+			<bounds x="558" y="530" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="643" y="528" width="52" height="32">
-			</bounds>
+			<bounds x="643" y="528" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="645" y="530" width="48" height="28">
-			</bounds>
+			<bounds x="645" y="530" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="643" y="561" width="52" height="32">
-			</bounds>
+			<bounds x="643" y="561" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="645" y="563" width="48" height="28">
-			</bounds>
+			<bounds x="645" y="563" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="56" y="518" width="37" height="19">
-			</bounds>
+			<bounds x="56" y="518" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="58" y="520" width="33" height="15">
-			</bounds>
+			<bounds x="58" y="520" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="556" y="561" width="52" height="32">
-			</bounds>
+			<bounds x="556" y="561" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="558" y="563" width="48" height="28">
-			</bounds>
+			<bounds x="558" y="563" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="556" y="594" width="52" height="32">
-			</bounds>
+			<bounds x="556" y="594" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="558" y="596" width="48" height="28">
-			</bounds>
+			<bounds x="558" y="596" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="643" y="594" width="52" height="32">
-			</bounds>
+			<bounds x="643" y="594" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="645" y="596" width="48" height="28">
-			</bounds>
+			<bounds x="645" y="596" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="643" y="627" width="52" height="32">
-			</bounds>
+			<bounds x="643" y="627" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="645" y="629" width="48" height="28">
-			</bounds>
+			<bounds x="645" y="629" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="556" y="627" width="52" height="32">
-			</bounds>
+			<bounds x="556" y="627" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="558" y="629" width="48" height="28">
-			</bounds>
+			<bounds x="558" y="629" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="556" y="660" width="52" height="32">
-			</bounds>
+			<bounds x="556" y="660" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="558" y="662" width="48" height="28">
-			</bounds>
+			<bounds x="558" y="662" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="643" y="660" width="52" height="32">
-			</bounds>
+			<bounds x="643" y="660" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="645" y="662" width="48" height="28">
-			</bounds>
+			<bounds x="645" y="662" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="643" y="693" width="52" height="32">
-			</bounds>
+			<bounds x="643" y="693" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="645" y="695" width="48" height="28">
-			</bounds>
+			<bounds x="645" y="695" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="605" y="311" width="62" height="62">
-			</bounds>
+			<bounds x="605" y="311" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="607" y="313" width="58" height="58">
-			</bounds>
+			<bounds x="607" y="313" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="607" y="126" width="52" height="52">
-			</bounds>
+			<bounds x="607" y="126" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="609" y="128" width="48" height="48">
-			</bounds>
+			<bounds x="609" y="128" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="607" y="183" width="52" height="52">
-			</bounds>
+			<bounds x="607" y="183" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="609" y="185" width="48" height="48">
-			</bounds>
+			<bounds x="609" y="185" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="607" y="240" width="52" height="52">
-			</bounds>
+			<bounds x="607" y="240" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="609" y="242" width="48" height="48">
-			</bounds>
+			<bounds x="609" y="242" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="725" y="209" width="27" height="27">
-			</bounds>
+			<bounds x="725" y="209" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="727" y="211" width="23" height="23">
-			</bounds>
+			<bounds x="727" y="211" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="753" y="237" width="27" height="27">
-			</bounds>
+			<bounds x="753" y="237" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="755" y="239" width="23" height="23">
-			</bounds>
+			<bounds x="755" y="239" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="754" y="180" width="27" height="27">
-			</bounds>
+			<bounds x="754" y="180" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="756" y="182" width="23" height="23">
-			</bounds>
+			<bounds x="756" y="182" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="556" y="693" width="52" height="32">
-			</bounds>
+			<bounds x="556" y="693" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="558" y="695" width="48" height="28">
-			</bounds>
+			<bounds x="558" y="695" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="556" y="726" width="52" height="32">
-			</bounds>
+			<bounds x="556" y="726" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="558" y="728" width="48" height="28">
-			</bounds>
+			<bounds x="558" y="728" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="643" y="726" width="52" height="32">
-			</bounds>
+			<bounds x="643" y="726" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="645" y="728" width="48" height="28">
-			</bounds>
+			<bounds x="645" y="728" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="643" y="759" width="52" height="32">
-			</bounds>
+			<bounds x="643" y="759" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="645" y="761" width="48" height="28">
-			</bounds>
+			<bounds x="645" y="761" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="556" y="759" width="52" height="32">
-			</bounds>
+			<bounds x="556" y="759" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="558" y="761" width="48" height="28">
-			</bounds>
+			<bounds x="558" y="761" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="13" y="676" width="72" height="32">
-			</bounds>
+			<bounds x="13" y="676" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="15" y="678" width="68" height="28">
-			</bounds>
+			<bounds x="15" y="678" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="13" y="714" width="72" height="32">
-			</bounds>
+			<bounds x="13" y="714" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="15" y="716" width="68" height="28">
-			</bounds>
+			<bounds x="15" y="716" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="13" y="752" width="72" height="32">
-			</bounds>
+			<bounds x="13" y="752" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="15" y="754" width="68" height="28">
-			</bounds>
+			<bounds x="15" y="754" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="695" y="180" width="27" height="27">
-			</bounds>
+			<bounds x="695" y="180" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="697" y="182" width="23" height="23">
-			</bounds>
+			<bounds x="697" y="182" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="695" y="237" width="27" height="27">
-			</bounds>
+			<bounds x="695" y="237" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="697" y="239" width="23" height="23">
-			</bounds>
+			<bounds x="697" y="239" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="777" y="146" width="27" height="27">
-			</bounds>
+			<bounds x="777" y="146" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="779" y="148" width="23" height="23">
-			</bounds>
+			<bounds x="779" y="148" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="785" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="785" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="787" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="787" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="777" y="273" width="27" height="27">
-			</bounds>
+			<bounds x="777" y="273" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="779" y="275" width="23" height="23">
-			</bounds>
+			<bounds x="779" y="275" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="677" y="273" width="27" height="27">
-			</bounds>
+			<bounds x="677" y="273" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="679" y="275" width="23" height="23">
-			</bounds>
+			<bounds x="679" y="275" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="664" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="664" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="666" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="666" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="677" y="146" width="27" height="27">
-			</bounds>
+			<bounds x="677" y="146" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="679" y="148" width="23" height="23">
-			</bounds>
+			<bounds x="679" y="148" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="839" y="126" width="122" height="32">
-			</bounds>
+			<bounds x="839" y="126" width="122" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="841" y="128" width="118" height="28">
-			</bounds>
+			<bounds x="841" y="128" width="118" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="839" y="158" width="122" height="32">
-			</bounds>
+			<bounds x="839" y="158" width="122" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="841" y="160" width="118" height="28">
-			</bounds>
+			<bounds x="841" y="160" width="118" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="839" y="190" width="122" height="32">
-			</bounds>
+			<bounds x="839" y="190" width="122" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="841" y="192" width="118" height="28">
-			</bounds>
+			<bounds x="841" y="192" width="118" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="839" y="222" width="122" height="32">
-			</bounds>
+			<bounds x="839" y="222" width="122" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="841" y="224" width="118" height="28">
-			</bounds>
+			<bounds x="841" y="224" width="118" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="839" y="254" width="122" height="32">
-			</bounds>
+			<bounds x="839" y="254" width="122" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="841" y="256" width="118" height="28">
-			</bounds>
+			<bounds x="841" y="256" width="118" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="928" y="383" width="62" height="62">
-			</bounds>
+			<bounds x="928" y="383" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="930" y="385" width="58" height="58">
-			</bounds>
+			<bounds x="930" y="385" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="869" y="383" width="62" height="62">
-			</bounds>
+			<bounds x="869" y="383" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="871" y="385" width="58" height="58">
-			</bounds>
+			<bounds x="871" y="385" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="810" y="383" width="62" height="62">
-			</bounds>
+			<bounds x="810" y="383" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="812" y="385" width="58" height="58">
-			</bounds>
+			<bounds x="812" y="385" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="751" y="383" width="62" height="62">
-			</bounds>
+			<bounds x="751" y="383" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="753" y="385" width="58" height="58">
-			</bounds>
+			<bounds x="753" y="385" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="692" y="383" width="62" height="62">
-			</bounds>
+			<bounds x="692" y="383" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="694" y="385" width="58" height="58">
-			</bounds>
+			<bounds x="694" y="385" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="633" y="383" width="62" height="62">
-			</bounds>
+			<bounds x="633" y="383" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="635" y="385" width="58" height="58">
-			</bounds>
+			<bounds x="635" y="385" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="839" y="286" width="122" height="32">
-			</bounds>
+			<bounds x="839" y="286" width="122" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="841" y="288" width="118" height="28">
-			</bounds>
+			<bounds x="841" y="288" width="118" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="928" y="442" width="62" height="62">
-			</bounds>
+			<bounds x="928" y="442" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="930" y="444" width="58" height="58">
-			</bounds>
+			<bounds x="930" y="444" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="869" y="442" width="62" height="62">
-			</bounds>
+			<bounds x="869" y="442" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="871" y="444" width="58" height="58">
-			</bounds>
+			<bounds x="871" y="444" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="810" y="442" width="62" height="62">
-			</bounds>
+			<bounds x="810" y="442" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="812" y="444" width="58" height="58">
-			</bounds>
+			<bounds x="812" y="444" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="751" y="442" width="62" height="62">
-			</bounds>
+			<bounds x="751" y="442" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="753" y="444" width="58" height="58">
-			</bounds>
+			<bounds x="753" y="444" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="692" y="442" width="62" height="62">
-			</bounds>
+			<bounds x="692" y="442" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="694" y="444" width="58" height="58">
-			</bounds>
+			<bounds x="694" y="444" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="633" y="442" width="62" height="62">
-			</bounds>
+			<bounds x="633" y="442" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="635" y="444" width="58" height="58">
-			</bounds>
+			<bounds x="635" y="444" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="9" y="518" width="37" height="19">
-			</bounds>
+			<bounds x="9" y="518" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="11" y="520" width="33" height="15">
-			</bounds>
+			<bounds x="11" y="520" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_212_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="748" y="817" width="79" height="42">
-			</bounds>
+			<bounds x="748" y="817" width="79" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_212" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="750" y="819" width="75" height="38">
-			</bounds>
+			<bounds x="750" y="819" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_213_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="659" y="817" width="79" height="42">
-			</bounds>
+			<bounds x="659" y="817" width="79" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_213" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="661" y="819" width="75" height="38">
-			</bounds>
+			<bounds x="661" y="819" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_214_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="569" y="817" width="79" height="42">
-			</bounds>
+			<bounds x="569" y="817" width="79" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_214" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="571" y="819" width="75" height="38">
-			</bounds>
+			<bounds x="571" y="819" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_215_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="481" y="817" width="79" height="42">
-			</bounds>
+			<bounds x="481" y="817" width="79" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_215" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="483" y="819" width="75" height="38">
-			</bounds>
+			<bounds x="483" y="819" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_216_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="370" y="817" width="75" height="42">
-			</bounds>
+			<bounds x="370" y="817" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_216" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="372" y="819" width="71" height="38">
-			</bounds>
+			<bounds x="372" y="819" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_217_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="278" y="817" width="75" height="42">
-			</bounds>
+			<bounds x="278" y="817" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_217" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="280" y="819" width="71" height="38">
-			</bounds>
+			<bounds x="280" y="819" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_218_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="183" y="817" width="75" height="42">
-			</bounds>
+			<bounds x="183" y="817" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_218" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="185" y="819" width="71" height="38">
-			</bounds>
+			<bounds x="185" y="819" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_219_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="89" y="817" width="75" height="42">
-			</bounds>
+			<bounds x="89" y="817" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_219" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="91" y="819" width="71" height="38">
-			</bounds>
+			<bounds x="91" y="819" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_225_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="894" y="3" width="75" height="27">
-			</bounds>
+			<bounds x="894" y="3" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_225" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="896" y="5" width="71" height="23">
-			</bounds>
+			<bounds x="896" y="5" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="282" y="506" width="24" height="32">
-			</bounds>
+			<bounds x="282" y="506" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off248" element="led_off">
-			<bounds x="285" y="508" width="17" height="2">
-			</bounds>
+			<bounds x="285" y="508" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off249" element="led_off">
-			<bounds x="299" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="299" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off250" element="led_off">
-			<bounds x="299" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="299" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off251" element="led_off">
-			<bounds x="285" y="532" width="17" height="2">
-			</bounds>
+			<bounds x="285" y="532" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off252" element="led_off">
-			<bounds x="285" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="285" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off253" element="led_off">
-			<bounds x="285" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="285" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off254" element="led_off">
-			<bounds x="285" y="520" width="17" height="2">
-			</bounds>
+			<bounds x="285" y="520" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off255" element="led_dot_off">
-			<bounds x="302" y="532" width="3" height="2">
-			</bounds>
+			<bounds x="302" y="532" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp248" element="led_on">
-			<bounds x="285" y="508" width="17" height="2">
-			</bounds>
+			<bounds x="285" y="508" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp249" element="led_on">
-			<bounds x="299" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="299" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp250" element="led_on">
-			<bounds x="299" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="299" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp251" element="led_on">
-			<bounds x="285" y="532" width="17" height="2">
-			</bounds>
+			<bounds x="285" y="532" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp252" element="led_on">
-			<bounds x="285" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="285" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp253" element="led_on">
-			<bounds x="285" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="285" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp254" element="led_on">
-			<bounds x="285" y="520" width="17" height="2">
-			</bounds>
+			<bounds x="285" y="520" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp255" element="led_dot_on">
-			<bounds x="302" y="532" width="3" height="2">
-			</bounds>
+			<bounds x="302" y="532" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="258" y="506" width="24" height="32">
-			</bounds>
+			<bounds x="258" y="506" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="261" y="508" width="17" height="2">
-			</bounds>
+			<bounds x="261" y="508" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="275" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="275" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="275" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="275" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="261" y="532" width="17" height="2">
-			</bounds>
+			<bounds x="261" y="532" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="261" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="261" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="261" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="261" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="261" y="520" width="17" height="2">
-			</bounds>
+			<bounds x="261" y="520" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="278" y="532" width="3" height="2">
-			</bounds>
+			<bounds x="278" y="532" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="261" y="508" width="17" height="2">
-			</bounds>
+			<bounds x="261" y="508" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="275" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="275" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="275" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="275" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="261" y="532" width="17" height="2">
-			</bounds>
+			<bounds x="261" y="532" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="261" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="261" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="261" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="261" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="261" y="520" width="17" height="2">
-			</bounds>
+			<bounds x="261" y="520" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="278" y="532" width="3" height="2">
-			</bounds>
+			<bounds x="278" y="532" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="234" y="506" width="24" height="32">
-			</bounds>
+			<bounds x="234" y="506" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="237" y="508" width="17" height="2">
-			</bounds>
+			<bounds x="237" y="508" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="251" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="251" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="251" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="251" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="237" y="532" width="17" height="2">
-			</bounds>
+			<bounds x="237" y="532" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="237" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="237" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="237" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="237" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="237" y="520" width="17" height="2">
-			</bounds>
+			<bounds x="237" y="520" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="254" y="532" width="3" height="2">
-			</bounds>
+			<bounds x="254" y="532" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="237" y="508" width="17" height="2">
-			</bounds>
+			<bounds x="237" y="508" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="251" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="251" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="251" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="251" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="237" y="532" width="17" height="2">
-			</bounds>
+			<bounds x="237" y="532" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="237" y="520" width="3" height="14">
-			</bounds>
+			<bounds x="237" y="520" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="237" y="508" width="3" height="14">
-			</bounds>
+			<bounds x="237" y="508" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="237" y="520" width="17" height="2">
-			</bounds>
+			<bounds x="237" y="520" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="254" y="532" width="3" height="2">
-			</bounds>
+			<bounds x="254" y="532" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="241" y="34" width="24" height="32">
-			</bounds>
+			<bounds x="241" y="34" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off112" element="led_off">
-			<bounds x="244" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="244" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off113" element="led_off">
-			<bounds x="258" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="258" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off114" element="led_off">
-			<bounds x="258" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="258" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off115" element="led_off">
-			<bounds x="244" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="244" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off116" element="led_off">
-			<bounds x="244" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="244" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off117" element="led_off">
-			<bounds x="244" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="244" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off118" element="led_off">
-			<bounds x="244" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="244" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="261" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="261" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp112" element="led_on">
-			<bounds x="244" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="244" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp113" element="led_on">
-			<bounds x="258" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="258" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp114" element="led_on">
-			<bounds x="258" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="258" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp115" element="led_on">
-			<bounds x="244" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="244" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp116" element="led_on">
-			<bounds x="244" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="244" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp117" element="led_on">
-			<bounds x="244" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="244" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp118" element="led_on">
-			<bounds x="244" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="244" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="261" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="261" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="217" y="34" width="24" height="32">
-			</bounds>
+			<bounds x="217" y="34" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="220" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="220" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="234" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="234" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="234" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="234" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="220" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="220" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="220" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="220" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="220" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="220" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="220" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="220" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="237" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="237" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="220" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="220" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="234" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="234" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="234" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="234" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="220" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="220" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="220" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="220" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="220" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="220" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="220" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="220" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="237" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="237" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="154" y="34" width="24" height="32">
-			</bounds>
+			<bounds x="154" y="34" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="157" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="171" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="171" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="171" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="171" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="157" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="157" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="157" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="157" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="157" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="157" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="174" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="174" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="157" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="171" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="171" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="171" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="171" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="157" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="157" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="157" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="157" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="157" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="157" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="174" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="174" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="130" y="34" width="24" height="32">
-			</bounds>
+			<bounds x="130" y="34" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="133" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="147" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="147" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="147" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="147" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="133" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="133" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="133" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="133" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="133" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="133" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="150" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="150" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="133" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="147" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="147" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="147" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="147" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="133" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="133" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="133" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="133" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="133" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="133" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="150" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="150" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="107" y="34" width="24" height="32">
-			</bounds>
+			<bounds x="107" y="34" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="110" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="110" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="124" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="124" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="124" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="124" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="110" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="110" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="110" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="110" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="110" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="110" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="110" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="110" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="127" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="127" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="110" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="110" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="124" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="124" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="124" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="124" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="110" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="110" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="110" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="110" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="110" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="110" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="110" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="110" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="127" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="127" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="359" y="283" width="24" height="32">
-			</bounds>
+			<bounds x="359" y="283" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="362" y="285" width="17" height="2">
-			</bounds>
+			<bounds x="362" y="285" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="376" y="285" width="3" height="14">
-			</bounds>
+			<bounds x="376" y="285" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="376" y="297" width="3" height="14">
-			</bounds>
+			<bounds x="376" y="297" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="362" y="309" width="17" height="2">
-			</bounds>
+			<bounds x="362" y="309" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="362" y="297" width="3" height="14">
-			</bounds>
+			<bounds x="362" y="297" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="362" y="285" width="3" height="14">
-			</bounds>
+			<bounds x="362" y="285" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="362" y="297" width="17" height="2">
-			</bounds>
+			<bounds x="362" y="297" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="379" y="309" width="3" height="2">
-			</bounds>
+			<bounds x="379" y="309" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="362" y="285" width="17" height="2">
-			</bounds>
+			<bounds x="362" y="285" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="376" y="285" width="3" height="14">
-			</bounds>
+			<bounds x="376" y="285" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="376" y="297" width="3" height="14">
-			</bounds>
+			<bounds x="376" y="297" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="362" y="309" width="17" height="2">
-			</bounds>
+			<bounds x="362" y="309" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="362" y="297" width="3" height="14">
-			</bounds>
+			<bounds x="362" y="297" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="362" y="285" width="3" height="14">
-			</bounds>
+			<bounds x="362" y="285" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="362" y="297" width="17" height="2">
-			</bounds>
+			<bounds x="362" y="297" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="379" y="309" width="3" height="2">
-			</bounds>
+			<bounds x="379" y="309" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="335" y="283" width="24" height="32">
-			</bounds>
+			<bounds x="335" y="283" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="338" y="285" width="17" height="2">
-			</bounds>
+			<bounds x="338" y="285" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="352" y="285" width="3" height="14">
-			</bounds>
+			<bounds x="352" y="285" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="352" y="297" width="3" height="14">
-			</bounds>
+			<bounds x="352" y="297" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="338" y="309" width="17" height="2">
-			</bounds>
+			<bounds x="338" y="309" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="338" y="297" width="3" height="14">
-			</bounds>
+			<bounds x="338" y="297" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="338" y="285" width="3" height="14">
-			</bounds>
+			<bounds x="338" y="285" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="338" y="297" width="17" height="2">
-			</bounds>
+			<bounds x="338" y="297" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="355" y="309" width="3" height="2">
-			</bounds>
+			<bounds x="355" y="309" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="338" y="285" width="17" height="2">
-			</bounds>
+			<bounds x="338" y="285" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="352" y="285" width="3" height="14">
-			</bounds>
+			<bounds x="352" y="285" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="352" y="297" width="3" height="14">
-			</bounds>
+			<bounds x="352" y="297" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="338" y="309" width="17" height="2">
-			</bounds>
+			<bounds x="338" y="309" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="338" y="297" width="3" height="14">
-			</bounds>
+			<bounds x="338" y="297" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="338" y="285" width="3" height="14">
-			</bounds>
+			<bounds x="338" y="285" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="338" y="297" width="17" height="2">
-			</bounds>
+			<bounds x="338" y="297" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="355" y="309" width="3" height="2">
-			</bounds>
+			<bounds x="355" y="309" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="264" y="34" width="24" height="32">
-			</bounds>
+			<bounds x="264" y="34" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off120" element="led_off">
-			<bounds x="267" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="267" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="281" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="281" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="281" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="281" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="267" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="267" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="267" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="267" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="267" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="267" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="267" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="267" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="284" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="284" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp120" element="led_on">
-			<bounds x="267" y="36" width="17" height="2">
-			</bounds>
+			<bounds x="267" y="36" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="281" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="281" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="281" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="281" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="267" y="60" width="17" height="2">
-			</bounds>
+			<bounds x="267" y="60" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="267" y="48" width="3" height="14">
-			</bounds>
+			<bounds x="267" y="48" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="267" y="36" width="3" height="14">
-			</bounds>
+			<bounds x="267" y="36" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="267" y="48" width="17" height="2">
-			</bounds>
+			<bounds x="267" y="48" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="284" y="60" width="3" height="2">
-			</bounds>
+			<bounds x="284" y="60" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="132" y="622" width="272" height="30">
-			</bounds>
+			<bounds x="132" y="622" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="132" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="132" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="149" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="149" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="166" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="166" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="183" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="183" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="200" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="200" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="217" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="217" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="234" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="234" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="251" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="251" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="268" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="268" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="285" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="285" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="302" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="302" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="319" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="319" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="336" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="336" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="353" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="353" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="370" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="370" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="387" y="622" width="17" height="30">
-			</bounds>
+			<bounds x="387" y="622" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label167" element="label_167">
-			<bounds x="315" y="256" width="86" height="24">
-			</bounds>
+			<bounds x="315" y="256" width="86" height="24"/>
 		</backdrop>
 		<backdrop name="label168" element="label_168">
-			<bounds x="195" y="540" width="135" height="24">
-			</bounds>
+			<bounds x="195" y="540" width="135" height="24"/>
 		</backdrop>
 		<backdrop name="label169" element="label_169">
-			<bounds x="123" y="504" width="21" height="24">
-			</bounds>
+			<bounds x="123" y="504" width="21" height="24"/>
 		</backdrop>
 		<backdrop name="label170" element="label_170">
-			<bounds x="160" y="504" width="28" height="24">
-			</bounds>
+			<bounds x="160" y="504" width="28" height="24"/>
 		</backdrop>
 		<backdrop name="label171" element="label_171">
-			<bounds x="18" y="96" width="78" height="26">
-			</bounds>
+			<bounds x="18" y="96" width="78" height="26"/>
 		</backdrop>
 		<backdrop name="label172" element="label_172">
-			<bounds x="608" y="93" width="51" height="26">
-			</bounds>
+			<bounds x="608" y="93" width="51" height="26"/>
 		</backdrop>
 		<backdrop name="label173" element="label_173">
-			<bounds x="712" y="129" width="56" height="39">
-			</bounds>
+			<bounds x="712" y="129" width="56" height="39"/>
 		</backdrop>
 		<backdrop name="label174" element="label_174">
-			<bounds x="709" y="345" width="182" height="24">
-			</bounds>
+			<bounds x="709" y="345" width="182" height="24"/>
 		</backdrop>
 		<backdrop name="label175" element="label_175">
-			<bounds x="430" y="501" width="125" height="24">
-			</bounds>
+			<bounds x="430" y="501" width="125" height="24"/>
 		</backdrop>
 		<backdrop name="label176" element="label_176">
-			<bounds x="453" y="522" width="76" height="39">
-			</bounds>
+			<bounds x="453" y="522" width="76" height="39"/>
 		</backdrop>
 		<backdrop name="label177" element="label_177">
-			<bounds x="453" y="560" width="76" height="39">
-			</bounds>
+			<bounds x="453" y="560" width="76" height="39"/>
 		</backdrop>
 		<backdrop name="label178" element="label_178">
-			<bounds x="452" y="600" width="80" height="39">
-			</bounds>
+			<bounds x="452" y="600" width="80" height="39"/>
 		</backdrop>
 		<backdrop name="label179" element="label_179">
-			<bounds x="453" y="639" width="76" height="39">
-			</bounds>
+			<bounds x="453" y="639" width="76" height="39"/>
 		</backdrop>
 		<backdrop name="label180" element="label_180">
-			<bounds x="452" y="678" width="80" height="39">
-			</bounds>
+			<bounds x="452" y="678" width="80" height="39"/>
 		</backdrop>
 		<backdrop name="label181" element="label_181">
-			<bounds x="455" y="718" width="76" height="39">
-			</bounds>
+			<bounds x="455" y="718" width="76" height="39"/>
 		</backdrop>
 		<backdrop name="label182" element="label_182">
-			<bounds x="89" y="5" width="99" height="24">
-			</bounds>
+			<bounds x="89" y="5" width="99" height="24"/>
 		</backdrop>
 		<backdrop name="label183" element="label_183">
-			<bounds x="201" y="5" width="98" height="24">
-			</bounds>
+			<bounds x="201" y="5" width="98" height="24"/>
 		</backdrop>
 		<backdrop name="label184" element="label_184">
-			<bounds x="186" y="223" width="242" height="24">
-			</bounds>
+			<bounds x="186" y="223" width="242" height="24"/>
 		</backdrop>
 		<backdrop name="label185" element="label_185">
-			<bounds x="7" y="491" width="91" height="24">
-			</bounds>
+			<bounds x="7" y="491" width="91" height="24"/>
 		</backdrop>
 		<backdrop name="label194" element="label_194">
-			<bounds x="926" y="561" width="16" height="13">
-			</bounds>
+			<bounds x="926" y="561" width="16" height="13"/>
 		</backdrop>
 		<backdrop name="label195" element="label_195">
-			<bounds x="885" y="561" width="16" height="13">
-			</bounds>
+			<bounds x="885" y="561" width="16" height="13"/>
 		</backdrop>
 		<backdrop name="label196" element="label_196">
-			<bounds x="920" y="617" width="26" height="13">
-			</bounds>
+			<bounds x="920" y="617" width="26" height="13"/>
 		</backdrop>
 		<backdrop name="label197" element="label_197">
-			<bounds x="922" y="645" width="22" height="13">
-			</bounds>
+			<bounds x="922" y="645" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label198" element="label_198">
-			<bounds x="922" y="674" width="22" height="13">
-			</bounds>
+			<bounds x="922" y="674" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label199" element="label_199">
-			<bounds x="922" y="702" width="22" height="13">
-			</bounds>
+			<bounds x="922" y="702" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label200" element="label_200">
-			<bounds x="922" y="757" width="22" height="13">
-			</bounds>
+			<bounds x="922" y="757" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label201" element="label_201">
-			<bounds x="922" y="729" width="22" height="13">
-			</bounds>
+			<bounds x="922" y="729" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label202" element="label_202">
-			<bounds x="885" y="785" width="15" height="13">
-			</bounds>
+			<bounds x="885" y="785" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label203" element="label_203">
-			<bounds x="926" y="785" width="15" height="13">
-			</bounds>
+			<bounds x="926" y="785" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label204" element="label_204">
-			<bounds x="918" y="591" width="29" height="13">
-			</bounds>
+			<bounds x="918" y="591" width="29" height="13"/>
 		</backdrop>
 		<backdrop name="label205" element="label_205">
-			<bounds x="885" y="645" width="15" height="13">
-			</bounds>
+			<bounds x="885" y="645" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label206" element="label_206">
-			<bounds x="885" y="674" width="15" height="13">
-			</bounds>
+			<bounds x="885" y="674" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label207" element="label_207">
-			<bounds x="885" y="729" width="15" height="13">
-			</bounds>
+			<bounds x="885" y="729" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label208" element="label_208">
-			<bounds x="874" y="757" width="33" height="13">
-			</bounds>
+			<bounds x="874" y="757" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label209" element="label_209">
-			<bounds x="881" y="591" width="22" height="13">
-			</bounds>
+			<bounds x="881" y="591" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label210" element="label_210">
-			<bounds x="881" y="617" width="22" height="13">
-			</bounds>
+			<bounds x="881" y="617" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label211" element="label_211">
-			<bounds x="885" y="702" width="15" height="13">
-			</bounds>
+			<bounds x="885" y="702" width="15" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_reel" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1cluedo4.lay
+++ b/src/mame/layout/m1cluedo4.lay
@@ -8,13300 +8,8037 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="  Target">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Practice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="  Target">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Practice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
+			<color red="0.03" green="0.47" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
+			<color red="0.06" green="0.94" blue="0.70"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
+			<color red="0.01" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Select A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Select A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Stop 'n Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop 'n Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
+			<color red="0.03" green="0.47" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
+			<color red="0.06" green="0.94" blue="0.70"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
+			<color red="0.01" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" Nud">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" Nud">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
+			<color red="0.03" green="0.47" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
+			<color red="0.06" green="0.94" blue="0.70"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
+			<color red="0.01" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Select A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Select A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="All Clued Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="All Clued Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
+			<color red="0.03" green="0.47" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
+			<color red="0.06" green="0.94" blue="0.70"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
+			<color red="0.01" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Murdered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Murdered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
+			<color red="0.03" green="0.47" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
+			<color red="0.06" green="0.94" blue="0.70"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
+			<color red="0.01" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Stop A Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop A Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Select A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Select A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
+			<color red="0.03" green="0.47" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
+			<color red="0.06" green="0.94" blue="0.70"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
+			<color red="0.01" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" Nud">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" Nud">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Kitchen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Kitchen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Billiard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Billiard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Acquitted">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Acquitted">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Arrested">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Arrested">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Lounge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lounge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Find The Murderer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Find The Murderer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Eliminator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Eliminator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Conservatory">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Conservatory">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Library">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Library">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Study">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Study">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Fingerprints">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fingerprints">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repea">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repea">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Murdered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Murdered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
+			<color red="0.03" green="0.47" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
+			<color red="0.06" green="0.94" blue="0.70"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
+			<color red="0.01" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.47" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.94" blue="0.70">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Select A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Select A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Myst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bars Or Sevens">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bars Or Sevens">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_207_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_3" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.35" blue="0.17">
-			</color>
+			<color red="0.45" green="0.35" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.04">
-			</color>
+			<color red="0.11" green="0.09" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.91" green="0.71" blue="0.35">
-			</color>
+			<color red="0.91" green="0.71" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.09">
-			</color>
+			<color red="0.22" green="0.18" blue="0.09"/>
 		</rect>
 		<text string="Clu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.35" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.91" green="0.71" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.09">
-			</color>
-		</rect>
-		<text string="Clu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.35" blue="0.17">
-			</color>
+			<color red="0.45" green="0.35" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.04">
-			</color>
+			<color red="0.11" green="0.09" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.91" green="0.71" blue="0.35">
-			</color>
+			<color red="0.91" green="0.71" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.09">
-			</color>
+			<color red="0.22" green="0.18" blue="0.09"/>
 		</rect>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.35" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.91" green="0.71" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.09">
-			</color>
-		</rect>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.35" blue="0.17">
-			</color>
+			<color red="0.45" green="0.35" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.04">
-			</color>
+			<color red="0.11" green="0.09" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.91" green="0.71" blue="0.35">
-			</color>
+			<color red="0.91" green="0.71" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.09">
-			</color>
+			<color red="0.22" green="0.18" blue="0.09"/>
 		</rect>
 		<text string="d">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.35" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.91" green="0.71" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.09">
-			</color>
-		</rect>
-		<text string="d">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.35" blue="0.17">
-			</color>
+			<color red="0.45" green="0.35" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.04">
-			</color>
+			<color red="0.11" green="0.09" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.91" green="0.71" blue="0.35">
-			</color>
+			<color red="0.91" green="0.71" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.09">
-			</color>
+			<color red="0.22" green="0.18" blue="0.09"/>
 		</rect>
 		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.35" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.91" green="0.71" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.09">
-			</color>
-		</rect>
-		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.38" blue="0.43">
-			</color>
+			<color red="0.32" green="0.38" blue="0.43"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.11">
-			</color>
+			<color red="0.08" green="0.09" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.76" blue="0.87">
-			</color>
+			<color red="0.64" green="0.76" blue="0.87"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.19" blue="0.22">
-			</color>
+			<color red="0.16" green="0.19" blue="0.22"/>
 		</rect>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.32" green="0.38" blue="0.43">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.11">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.64" green="0.76" blue="0.87">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.19" blue="0.22">
-			</color>
-		</rect>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.38" blue="0.43">
-			</color>
+			<color red="0.32" green="0.38" blue="0.43"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.11">
-			</color>
+			<color red="0.08" green="0.09" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.76" blue="0.87">
-			</color>
+			<color red="0.64" green="0.76" blue="0.87"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.19" blue="0.22">
-			</color>
+			<color red="0.16" green="0.19" blue="0.22"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.32" green="0.38" blue="0.43">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.11">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.64" green="0.76" blue="0.87">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.19" blue="0.22">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</disk>
 		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</disk>
 		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</disk>
 		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</disk>
 		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</disk>
 		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</disk>
 		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_133_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_133_2" defstate="0">
 		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_132_2" defstate="0">
 		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_131_2" defstate="0">
 		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_130_2" defstate="0">
 		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_129_2" defstate="0">
 		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
+			<color red="0.45" green="0.42" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_128_2" defstate="0">
 		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
+			<color red="0.89" green="0.84" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
+			<color red="0.22" green="0.21" blue="0.02"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.42" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.89" green="0.84" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.21" blue="0.02">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_202_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_194_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_199_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Super Sleuth  x60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Sleuth  x60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Detective  x40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Detective  x40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Amateur  x20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Amateur  x20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.27" green="0.15" blue="0.24">
-			</color>
+			<color red="0.27" green="0.15" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.04" blue="0.06">
-			</color>
+			<color red="0.07" green="0.04" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.55" green="0.29" blue="0.49">
-			</color>
+			<color red="0.55" green="0.29" blue="0.49"/>
 		</rect>
 		<rect state="0">
-			<color red="0.14" green="0.07" blue="0.12">
-			</color>
+			<color red="0.14" green="0.07" blue="0.12"/>
 		</rect>
 		<text string="Prof.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Plum">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.27" green="0.15" blue="0.24">
-			</color>
+			<color red="0.27" green="0.15" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.04" blue="0.06">
-			</color>
+			<color red="0.07" green="0.04" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.55" green="0.29" blue="0.49">
-			</color>
+			<color red="0.55" green="0.29" blue="0.49"/>
 		</rect>
 		<rect state="0">
-			<color red="0.14" green="0.07" blue="0.12">
-			</color>
+			<color red="0.14" green="0.07" blue="0.12"/>
 		</rect>
 		<text string="Prof.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Plum">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Mrs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Peacoc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Mrs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Peacoc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.88" blue="0.05">
-			</color>
+			<color red="0.95" green="0.88" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="Colonel ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Mustard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.88" blue="0.05">
-			</color>
+			<color red="0.95" green="0.88" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="Colonel ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Mustard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Mrs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="White">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Mrs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="White">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Miss Scarlet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Miss Scarlet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.30" blue="0.15">
-			</color>
+			<color red="0.00" green="0.30" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.04">
-			</color>
+			<color red="0.00" green="0.07" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.61" blue="0.31">
-			</color>
+			<color red="0.00" green="0.61" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.15" blue="0.07">
-			</color>
+			<color red="0.00" green="0.15" blue="0.07"/>
 		</rect>
 		<text string="Rev.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Green">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.30" blue="0.15">
-			</color>
+			<color red="0.00" green="0.30" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.04">
-			</color>
+			<color red="0.00" green="0.07" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.61" blue="0.31">
-			</color>
+			<color red="0.00" green="0.61" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.15" blue="0.07">
-			</color>
+			<color red="0.00" green="0.15" blue="0.07"/>
 		</rect>
 		<text string="Rev.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Green">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Ballroom">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Ballroom">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Suit Of Armour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Suit Of Armour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Murdered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Murdered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Go Back 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Go Back 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Advance To Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Advance To Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Go Forward 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Go Forward 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Prime Suspect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Prime Suspect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Dininig">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Dininig">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Token">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist=",,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_72">
 		<text string="Eliminator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_73">
 		<text string="1 Eliminated=60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_74">
 		<text string="2 Eliminated=&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_75">
 		<text string="3 Eliminated=&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_76">
 		<text string="4 Eliminated=&#xA3;3+ Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="5 Eliminated=&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_84">
 		<text string="Suspect List">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_85">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_86">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_111">
 		<text string="Outer=20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_122">
 		<text string="Bull=&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_123">
 		<text string="Inner=60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_124">
 		<text string="Outer=20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="Inner=60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="Practice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="Target">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_135">
 		<text string="Fingerprints">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_145">
 		<text string="Starts Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_149">
 		<text string="? Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_160">
 		<text string="1 2 3 4 5 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="654">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="654"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="203" y="394" width="80" height="140">
-			</bounds>
+			<bounds x="203" y="394" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="394.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="394.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="395.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="395.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="397.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="397.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="399.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="399.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="401.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="401.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="403.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="403.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="440.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="440.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="442.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="442.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="444.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="444.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="446.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="446.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="448.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="448.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="450.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="450.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="487.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="487.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="489.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="489.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="491.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="491.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="493.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="493.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="495.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="495.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="497.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="497.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="203" y="394" width="80" height="140">
-			</bounds>
+			<bounds x="203" y="394" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="311" y="394" width="80" height="140">
-			</bounds>
+			<bounds x="311" y="394" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="311.0000" y="394.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="311.0000" y="394.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="314.3333" y="395.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="314.3333" y="395.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="317.6667" y="397.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="317.6667" y="397.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="321.0000" y="399.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="321.0000" y="399.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="324.3333" y="401.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="324.3333" y="401.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="327.6667" y="403.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="327.6667" y="403.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="311.0000" y="440.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="311.0000" y="440.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="314.3333" y="442.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="314.3333" y="442.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="317.6667" y="444.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="317.6667" y="444.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="321.0000" y="446.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="321.0000" y="446.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="324.3333" y="448.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="324.3333" y="448.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="327.6667" y="450.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="327.6667" y="450.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="311.0000" y="487.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="311.0000" y="487.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="314.3333" y="489.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="314.3333" y="489.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="317.6667" y="491.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="317.6667" y="491.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="321.0000" y="493.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="321.0000" y="493.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="324.3333" y="495.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="324.3333" y="495.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="327.6667" y="497.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="327.6667" y="497.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="311" y="394" width="80" height="140">
-			</bounds>
+			<bounds x="311" y="394" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="419" y="394" width="80" height="140">
-			</bounds>
+			<bounds x="419" y="394" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="419.0000" y="394.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="419.0000" y="394.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="422.3333" y="395.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="422.3333" y="395.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="425.6667" y="397.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="425.6667" y="397.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="429.0000" y="399.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="429.0000" y="399.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="432.3333" y="401.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="432.3333" y="401.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="435.6667" y="403.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="435.6667" y="403.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="419.0000" y="440.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="419.0000" y="440.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="422.3333" y="442.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="422.3333" y="442.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="425.6667" y="444.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="425.6667" y="444.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="429.0000" y="446.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="429.0000" y="446.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="432.3333" y="448.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="432.3333" y="448.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="435.6667" y="450.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="435.6667" y="450.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="419.0000" y="487.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="419.0000" y="487.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="422.3333" y="489.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="422.3333" y="489.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="425.6667" y="491.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="425.6667" y="491.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="429.0000" y="493.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="429.0000" y="493.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="432.3333" y="495.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="432.3333" y="495.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="435.6667" y="497.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="435.6667" y="497.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="419" y="394" width="80" height="140">
-			</bounds>
+			<bounds x="419" y="394" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="72" y="317" width="60" height="60">
-			</bounds>
+			<bounds x="72" y="317" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="72.0000" y="317.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="72.0000" y="317.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="74.5000" y="319.5000" width="55.0000" height="55.0000">
-			</bounds>
+			<bounds x="74.5000" y="319.5000" width="55.0000" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="77.0000" y="322.0000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="77.0000" y="322.0000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="79.5000" y="324.5000" width="45.0000" height="45.0000">
-			</bounds>
+			<bounds x="79.5000" y="324.5000" width="45.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="82.0000" y="327.0000" width="40.0000" height="40.0000">
-			</bounds>
+			<bounds x="82.0000" y="327.0000" width="40.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="84.5000" y="329.5000" width="35.0000" height="35.0000">
-			</bounds>
+			<bounds x="84.5000" y="329.5000" width="35.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="72" y="317" width="60" height="60">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="72" y="317" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="61" y="34" width="91" height="32">
-			</bounds>
+			<bounds x="61" y="34" width="91" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="63" y="36" width="87" height="28">
-			</bounds>
+			<bounds x="63" y="36" width="87" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="597" y="20" width="19" height="19">
-			</bounds>
+			<bounds x="597" y="20" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="599" y="22" width="15" height="15">
-			</bounds>
+			<bounds x="599" y="22" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="5" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="7" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="60" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="60" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="62" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="62" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="115" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="115" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="117" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="117" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="170" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="170" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="172" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="172" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="225" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="225" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="227" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="227" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="280" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="280" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="282" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="282" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="335" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="335" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="337" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="337" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="390" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="390" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="392" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="392" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="445" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="445" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="447" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="447" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="500" y="3" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="3" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="502" y="5" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="5" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="445" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="445" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="447" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="447" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="390" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="390" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="392" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="392" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="335" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="335" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="337" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="337" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="280" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="280" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="282" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="282" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="225" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="225" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="227" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="227" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="170" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="170" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="172" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="172" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="115" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="115" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="117" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="117" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="60" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="60" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="62" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="62" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="5" y="33" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="33" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="7" y="35" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="35" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="5" y="63" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="63" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="7" y="65" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="65" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="5" y="93" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="93" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="7" y="95" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="95" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="5" y="123" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="123" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="7" y="125" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="125" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="5" y="153" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="153" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="7" y="155" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="155" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="5" y="183" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="183" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="7" y="185" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="185" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="5" y="213" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="213" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="7" y="215" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="215" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="5" y="243" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="243" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="7" y="245" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="245" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="5" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="5" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="7" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="7" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="71" y="63" width="81" height="22">
-			</bounds>
+			<bounds x="71" y="63" width="81" height="22"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="73" y="65" width="77" height="18">
-			</bounds>
+			<bounds x="73" y="65" width="77" height="18"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="410" y="95" width="32" height="52">
-			</bounds>
+			<bounds x="410" y="95" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="412" y="97" width="28" height="48">
-			</bounds>
+			<bounds x="412" y="97" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="439" y="95" width="62" height="52">
-			</bounds>
+			<bounds x="439" y="95" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="441" y="97" width="58" height="48">
-			</bounds>
+			<bounds x="441" y="97" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="149" y="99" width="57" height="20">
-			</bounds>
+			<bounds x="149" y="99" width="57" height="20"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="151" y="101" width="53" height="16">
-			</bounds>
+			<bounds x="151" y="101" width="53" height="16"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="149" y="189" width="57" height="20">
-			</bounds>
+			<bounds x="149" y="189" width="57" height="20"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="151" y="191" width="53" height="16">
-			</bounds>
+			<bounds x="151" y="191" width="53" height="16"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="61" y="222" width="91" height="23">
-			</bounds>
+			<bounds x="61" y="222" width="91" height="23"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="63" y="224" width="87" height="19">
-			</bounds>
+			<bounds x="63" y="224" width="87" height="19"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="61" y="242" width="81" height="32">
-			</bounds>
+			<bounds x="61" y="242" width="81" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="63" y="244" width="77" height="28">
-			</bounds>
+			<bounds x="63" y="244" width="77" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="250" y="250" width="62" height="24">
-			</bounds>
+			<bounds x="250" y="250" width="62" height="24"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="252" y="252" width="58" height="20">
-			</bounds>
+			<bounds x="252" y="252" width="58" height="20"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="250" y="222" width="62" height="31">
-			</bounds>
+			<bounds x="250" y="222" width="62" height="31"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="252" y="224" width="58" height="27">
-			</bounds>
+			<bounds x="252" y="224" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="410" y="34" width="91" height="32">
-			</bounds>
+			<bounds x="410" y="34" width="91" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="412" y="36" width="87" height="28">
-			</bounds>
+			<bounds x="412" y="36" width="87" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="420" y="63" width="81" height="22">
-			</bounds>
+			<bounds x="420" y="63" width="81" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="422" y="65" width="77" height="18">
-			</bounds>
+			<bounds x="422" y="65" width="77" height="18"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="459" y="157" width="42" height="52">
-			</bounds>
+			<bounds x="459" y="157" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="461" y="159" width="38" height="48">
-			</bounds>
+			<bounds x="461" y="159" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="410" y="167" width="52" height="32">
-			</bounds>
+			<bounds x="410" y="167" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="412" y="169" width="48" height="28">
-			</bounds>
+			<bounds x="412" y="169" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="410" y="223" width="91" height="22">
-			</bounds>
+			<bounds x="410" y="223" width="91" height="22"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="412" y="225" width="87" height="18">
-			</bounds>
+			<bounds x="412" y="225" width="87" height="18"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="420" y="242" width="81" height="32">
-			</bounds>
+			<bounds x="420" y="242" width="81" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="422" y="244" width="77" height="28">
-			</bounds>
+			<bounds x="422" y="244" width="77" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="500" y="243" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="243" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="502" y="245" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="245" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="500" y="213" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="213" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="502" y="215" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="215" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="500" y="183" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="183" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="502" y="185" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="185" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="500" y="153" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="153" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="502" y="155" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="155" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="500" y="123" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="123" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="502" y="125" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="125" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="500" y="93" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="93" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="502" y="95" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="95" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="500" y="63" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="63" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="502" y="65" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="65" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="500" y="33" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="33" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="502" y="35" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="35" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="500" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="500" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="502" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="502" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_2_border" state="0">
-			<bounds x="420" y="157" width="42" height="13">
-			</bounds>
+			<bounds x="420" y="157" width="42" height="13"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_2" state="0">
-			<bounds x="422" y="159" width="38" height="9">
-			</bounds>
+			<bounds x="422" y="159" width="38" height="9"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_3_border" state="0">
-			<bounds x="420" y="196" width="42" height="13">
-			</bounds>
+			<bounds x="420" y="196" width="42" height="13"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_3" state="0">
-			<bounds x="422" y="198" width="38" height="9">
-			</bounds>
+			<bounds x="422" y="198" width="38" height="9"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="209" y="544" width="52" height="52">
-			</bounds>
+			<bounds x="209" y="544" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="211" y="546" width="48" height="48">
-			</bounds>
+			<bounds x="211" y="546" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="258" y="544" width="24" height="52">
-			</bounds>
+			<bounds x="258" y="544" width="24" height="52"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="260" y="546" width="20" height="48">
-			</bounds>
+			<bounds x="260" y="546" width="20" height="48"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="279" y="544" width="24" height="52">
-			</bounds>
+			<bounds x="279" y="544" width="24" height="52"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="281" y="546" width="20" height="48">
-			</bounds>
+			<bounds x="281" y="546" width="20" height="48"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="300" y="544" width="24" height="52">
-			</bounds>
+			<bounds x="300" y="544" width="24" height="52"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="302" y="546" width="20" height="48">
-			</bounds>
+			<bounds x="302" y="546" width="20" height="48"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="134" y="571" width="36" height="22">
-			</bounds>
+			<bounds x="134" y="571" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="136" y="573" width="32" height="18">
-			</bounds>
+			<bounds x="136" y="573" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="95" y="571" width="42" height="22">
-			</bounds>
+			<bounds x="95" y="571" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="97" y="573" width="38" height="18">
-			</bounds>
+			<bounds x="97" y="573" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="116" y="401" width="32" height="40">
-			</bounds>
+			<bounds x="116" y="401" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="118" y="403" width="28" height="36">
-			</bounds>
+			<bounds x="118" y="403" width="28" height="36"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="116" y="518" width="32" height="40">
-			</bounds>
+			<bounds x="116" y="518" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="118" y="520" width="28" height="36">
-			</bounds>
+			<bounds x="118" y="520" width="28" height="36"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="116" y="479" width="32" height="40">
-			</bounds>
+			<bounds x="116" y="479" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="118" y="481" width="28" height="36">
-			</bounds>
+			<bounds x="118" y="481" width="28" height="36"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="116" y="440" width="32" height="40">
-			</bounds>
+			<bounds x="116" y="440" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="118" y="442" width="28" height="36">
-			</bounds>
+			<bounds x="118" y="442" width="28" height="36"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="497" y="344" width="22" height="14">
-			</bounds>
+			<bounds x="497" y="344" width="22" height="14"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="499" y="346" width="18" height="10">
-			</bounds>
+			<bounds x="499" y="346" width="18" height="10"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="542" y="344" width="22" height="14">
-			</bounds>
+			<bounds x="542" y="344" width="22" height="14"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="544" y="346" width="18" height="10">
-			</bounds>
+			<bounds x="544" y="346" width="18" height="10"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="585" y="344" width="22" height="14">
-			</bounds>
+			<bounds x="585" y="344" width="22" height="14"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="587" y="346" width="18" height="10">
-			</bounds>
+			<bounds x="587" y="346" width="18" height="10"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="629" y="344" width="22" height="14">
-			</bounds>
+			<bounds x="629" y="344" width="22" height="14"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="631" y="346" width="18" height="10">
-			</bounds>
+			<bounds x="631" y="346" width="18" height="10"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="673" y="344" width="22" height="14">
-			</bounds>
+			<bounds x="673" y="344" width="22" height="14"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="675" y="346" width="18" height="10">
-			</bounds>
+			<bounds x="675" y="346" width="18" height="10"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="719" y="344" width="22" height="14">
-			</bounds>
+			<bounds x="719" y="344" width="22" height="14"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="721" y="346" width="18" height="10">
-			</bounds>
+			<bounds x="721" y="346" width="18" height="10"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_2_border" state="0">
-			<bounds x="724" y="355" width="12" height="17">
-			</bounds>
+			<bounds x="724" y="355" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_2" state="0">
-			<bounds x="726" y="357" width="8" height="13">
-			</bounds>
+			<bounds x="726" y="357" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_2_border" state="0">
-			<bounds x="678" y="355" width="12" height="17">
-			</bounds>
+			<bounds x="678" y="355" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_2" state="0">
-			<bounds x="680" y="357" width="8" height="13">
-			</bounds>
+			<bounds x="680" y="357" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_2_border" state="0">
-			<bounds x="634" y="355" width="12" height="17">
-			</bounds>
+			<bounds x="634" y="355" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_2" state="0">
-			<bounds x="636" y="357" width="8" height="13">
-			</bounds>
+			<bounds x="636" y="357" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_2_border" state="0">
-			<bounds x="590" y="355" width="12" height="17">
-			</bounds>
+			<bounds x="590" y="355" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_2" state="0">
-			<bounds x="592" y="357" width="8" height="13">
-			</bounds>
+			<bounds x="592" y="357" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_2_border" state="0">
-			<bounds x="547" y="355" width="12" height="17">
-			</bounds>
+			<bounds x="547" y="355" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_2" state="0">
-			<bounds x="549" y="357" width="8" height="13">
-			</bounds>
+			<bounds x="549" y="357" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_2_border" state="0">
-			<bounds x="502" y="355" width="12" height="17">
-			</bounds>
+			<bounds x="502" y="355" width="12" height="17"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_2" state="0">
-			<bounds x="504" y="357" width="8" height="13">
-			</bounds>
+			<bounds x="504" y="357" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_2_border" state="0">
-			<bounds x="410" y="242" width="13" height="22">
-			</bounds>
+			<bounds x="410" y="242" width="13" height="22"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_2" state="0">
-			<bounds x="412" y="244" width="9" height="18">
-			</bounds>
+			<bounds x="412" y="244" width="9" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_2_border" state="0">
-			<bounds x="410" y="63" width="13" height="12">
-			</bounds>
+			<bounds x="410" y="63" width="13" height="12"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_2" state="0">
-			<bounds x="412" y="65" width="9" height="8">
-			</bounds>
+			<bounds x="412" y="65" width="9" height="8"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2_border" state="0">
-			<bounds x="139" y="242" width="13" height="22">
-			</bounds>
+			<bounds x="139" y="242" width="13" height="22"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2" state="0">
-			<bounds x="141" y="244" width="9" height="18">
-			</bounds>
+			<bounds x="141" y="244" width="9" height="18"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2_border" state="0">
-			<bounds x="61" y="63" width="13" height="12">
-			</bounds>
+			<bounds x="61" y="63" width="13" height="12"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2" state="0">
-			<bounds x="63" y="65" width="9" height="8">
-			</bounds>
+			<bounds x="63" y="65" width="9" height="8"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="677" y="280" width="102" height="22">
-			</bounds>
+			<bounds x="677" y="280" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="679" y="282" width="98" height="18">
-			</bounds>
+			<bounds x="679" y="282" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="677" y="260" width="102" height="22">
-			</bounds>
+			<bounds x="677" y="260" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="679" y="262" width="98" height="18">
-			</bounds>
+			<bounds x="679" y="262" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="677" y="240" width="102" height="22">
-			</bounds>
+			<bounds x="677" y="240" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="679" y="242" width="98" height="18">
-			</bounds>
+			<bounds x="679" y="242" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="483" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="483" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="485" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="485" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="483" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="483" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="485" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="485" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="527" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="527" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="529" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="529" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="527" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="527" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="529" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="529" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="571" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="571" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="573" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="573" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="571" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="571" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="573" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="573" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="615" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="615" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="617" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="617" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="615" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="615" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="617" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="617" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="659" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="659" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="661" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="661" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="659" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="659" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="661" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="661" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="703" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="703" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="705" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="705" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="703" y="306" width="46" height="32">
-			</bounds>
+			<bounds x="703" y="306" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="705" y="308" width="42" height="28">
-			</bounds>
+			<bounds x="705" y="308" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="250" y="63" width="62" height="22">
-			</bounds>
+			<bounds x="250" y="63" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="252" y="65" width="58" height="18">
-			</bounds>
+			<bounds x="252" y="65" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="250" y="49" width="62" height="17">
-			</bounds>
+			<bounds x="250" y="49" width="62" height="17"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="252" y="51" width="58" height="13">
-			</bounds>
+			<bounds x="252" y="51" width="58" height="13"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_2_border" state="0">
-			<bounds x="255" y="34" width="52" height="18">
-			</bounds>
+			<bounds x="255" y="34" width="52" height="18"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_2" state="0">
-			<bounds x="257" y="36" width="48" height="14">
-			</bounds>
+			<bounds x="257" y="36" width="48" height="14"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="280" y="177" width="57" height="37">
-			</bounds>
+			<bounds x="280" y="177" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="282" y="179" width="53" height="33">
-			</bounds>
+			<bounds x="282" y="179" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="280" y="142" width="57" height="37">
-			</bounds>
+			<bounds x="280" y="142" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="282" y="144" width="53" height="33">
-			</bounds>
+			<bounds x="282" y="144" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="225" y="177" width="57" height="37">
-			</bounds>
+			<bounds x="225" y="177" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="227" y="179" width="53" height="33">
-			</bounds>
+			<bounds x="227" y="179" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="225" y="142" width="57" height="37">
-			</bounds>
+			<bounds x="225" y="142" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="227" y="144" width="53" height="33">
-			</bounds>
+			<bounds x="227" y="144" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="280" y="107" width="57" height="37">
-			</bounds>
+			<bounds x="280" y="107" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="282" y="109" width="53" height="33">
-			</bounds>
+			<bounds x="282" y="109" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="225" y="107" width="57" height="37">
-			</bounds>
+			<bounds x="225" y="107" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="227" y="109" width="53" height="33">
-			</bounds>
+			<bounds x="227" y="109" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="110" y="137" width="42" height="42">
-			</bounds>
+			<bounds x="110" y="137" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="112" y="139" width="38" height="38">
-			</bounds>
+			<bounds x="112" y="139" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="61" y="127" width="52" height="52">
-			</bounds>
+			<bounds x="61" y="127" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="63" y="129" width="48" height="48">
-			</bounds>
+			<bounds x="63" y="129" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_161_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="713" y="1" width="75" height="27">
-			</bounds>
+			<bounds x="713" y="1" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_161" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="715" y="3" width="71" height="23">
-			</bounds>
+			<bounds x="715" y="3" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_162_border" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="713" y="25" width="75" height="27">
-			</bounds>
+			<bounds x="713" y="25" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_162" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="715" y="27" width="71" height="23">
-			</bounds>
+			<bounds x="715" y="27" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_163_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="99" y="602" width="62" height="42">
-			</bounds>
+			<bounds x="99" y="602" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_163" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="101" y="604" width="58" height="38">
-			</bounds>
+			<bounds x="101" y="604" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_164_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="212" y="602" width="62" height="42">
-			</bounds>
+			<bounds x="212" y="602" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_164" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="214" y="604" width="58" height="38">
-			</bounds>
+			<bounds x="214" y="604" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_165_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="320" y="602" width="62" height="42">
-			</bounds>
+			<bounds x="320" y="602" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_165" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="322" y="604" width="58" height="38">
-			</bounds>
+			<bounds x="322" y="604" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_166_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="428" y="602" width="62" height="42">
-			</bounds>
+			<bounds x="428" y="602" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_166" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="430" y="604" width="58" height="38">
-			</bounds>
+			<bounds x="430" y="604" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_167_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="515" y="602" width="62" height="42">
-			</bounds>
+			<bounds x="515" y="602" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_167" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="517" y="604" width="58" height="38">
-			</bounds>
+			<bounds x="517" y="604" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_168_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="612" y="602" width="62" height="42">
-			</bounds>
+			<bounds x="612" y="602" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_168" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="614" y="604" width="58" height="38">
-			</bounds>
+			<bounds x="614" y="604" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_169_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="709" y="602" width="62" height="42">
-			</bounds>
+			<bounds x="709" y="602" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_169" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="711" y="604" width="58" height="38">
-			</bounds>
+			<bounds x="711" y="604" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="590" y="99" width="18" height="24">
-			</bounds>
+			<bounds x="590" y="99" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="592" y="101" width="12" height="2">
-			</bounds>
+			<bounds x="592" y="101" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="602" y="101" width="2" height="10">
-			</bounds>
+			<bounds x="602" y="101" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="602" y="109" width="2" height="10">
-			</bounds>
+			<bounds x="602" y="109" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="592" y="118" width="12" height="2">
-			</bounds>
+			<bounds x="592" y="118" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="592" y="109" width="2" height="10">
-			</bounds>
+			<bounds x="592" y="109" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="592" y="101" width="2" height="10">
-			</bounds>
+			<bounds x="592" y="101" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="592" y="109" width="12" height="2">
-			</bounds>
+			<bounds x="592" y="109" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="605" y="118" width="2" height="2">
-			</bounds>
+			<bounds x="605" y="118" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="592" y="101" width="12" height="2">
-			</bounds>
+			<bounds x="592" y="101" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="602" y="101" width="2" height="10">
-			</bounds>
+			<bounds x="602" y="101" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="602" y="109" width="2" height="10">
-			</bounds>
+			<bounds x="602" y="109" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="592" y="118" width="12" height="2">
-			</bounds>
+			<bounds x="592" y="118" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="592" y="109" width="2" height="10">
-			</bounds>
+			<bounds x="592" y="109" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="592" y="101" width="2" height="10">
-			</bounds>
+			<bounds x="592" y="101" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="592" y="109" width="12" height="2">
-			</bounds>
+			<bounds x="592" y="109" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="605" y="118" width="2" height="2">
-			</bounds>
+			<bounds x="605" y="118" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="572" y="99" width="18" height="24">
-			</bounds>
+			<bounds x="572" y="99" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="574" y="101" width="12" height="2">
-			</bounds>
+			<bounds x="574" y="101" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="584" y="101" width="2" height="10">
-			</bounds>
+			<bounds x="584" y="101" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="584" y="109" width="2" height="10">
-			</bounds>
+			<bounds x="584" y="109" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="574" y="118" width="12" height="2">
-			</bounds>
+			<bounds x="574" y="118" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="574" y="109" width="2" height="10">
-			</bounds>
+			<bounds x="574" y="109" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="574" y="101" width="2" height="10">
-			</bounds>
+			<bounds x="574" y="101" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="574" y="109" width="12" height="2">
-			</bounds>
+			<bounds x="574" y="109" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="587" y="118" width="2" height="2">
-			</bounds>
+			<bounds x="587" y="118" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="574" y="101" width="12" height="2">
-			</bounds>
+			<bounds x="574" y="101" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="584" y="101" width="2" height="10">
-			</bounds>
+			<bounds x="584" y="101" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="584" y="109" width="2" height="10">
-			</bounds>
+			<bounds x="584" y="109" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="574" y="118" width="12" height="2">
-			</bounds>
+			<bounds x="574" y="118" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="574" y="109" width="2" height="10">
-			</bounds>
+			<bounds x="574" y="109" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="574" y="101" width="2" height="10">
-			</bounds>
+			<bounds x="574" y="101" width="2" height="10"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="574" y="109" width="12" height="2">
-			</bounds>
+			<bounds x="574" y="109" width="12" height="2"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="587" y="118" width="2" height="2">
-			</bounds>
+			<bounds x="587" y="118" width="2" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="565" y="181" width="220" height="26">
-			</bounds>
+			<bounds x="565" y="181" width="220" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="565" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="565" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="579" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="579" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="593" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="593" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="607" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="607" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="621" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="621" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="635" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="635" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="649" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="649" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="663" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="663" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="677" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="677" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="691" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="691" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="705" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="705" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="719" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="719" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="733" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="733" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="747" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="747" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="761" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="761" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="775" y="181" width="14" height="26">
-			</bounds>
+			<bounds x="775" y="181" width="14" height="26"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="580" y="211" width="70" height="16">
-			</bounds>
+			<bounds x="580" y="211" width="70" height="16"/>
 		</backdrop>
 		<backdrop name="label73" element="label_73">
-			<bounds x="572" y="227" width="85" height="11">
-			</bounds>
+			<bounds x="572" y="227" width="85" height="11"/>
 		</backdrop>
 		<backdrop name="label74" element="label_74">
-			<bounds x="572" y="240" width="79" height="11">
-			</bounds>
+			<bounds x="572" y="240" width="79" height="11"/>
 		</backdrop>
 		<backdrop name="label75" element="label_75">
-			<bounds x="572" y="253" width="81" height="11">
-			</bounds>
+			<bounds x="572" y="253" width="81" height="11"/>
 		</backdrop>
 		<backdrop name="label76" element="label_76">
-			<bounds x="572" y="266" width="89" height="22">
-			</bounds>
+			<bounds x="572" y="266" width="89" height="22"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="572" y="290" width="81" height="11">
-			</bounds>
+			<bounds x="572" y="290" width="81" height="11"/>
 		</backdrop>
 		<backdrop name="label84" element="label_84">
-			<bounds x="586" y="336" width="64" height="11">
-			</bounds>
+			<bounds x="586" y="336" width="64" height="11"/>
 		</backdrop>
 		<backdrop name="label85" element="label_85">
-			<bounds x="394" y="454" width="22" height="22">
-			</bounds>
+			<bounds x="394" y="454" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label86" element="label_86">
-			<bounds x="286" y="454" width="22" height="22">
-			</bounds>
+			<bounds x="286" y="454" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label111" element="label_111">
-			<bounds x="567" y="53" width="0" height="0">
-			</bounds>
+			<bounds x="567" y="53" width="0" height="0"/>
 		</backdrop>
 		<backdrop name="label122" element="label_122">
-			<bounds x="749" y="92" width="37" height="11">
-			</bounds>
+			<bounds x="749" y="92" width="37" height="11"/>
 		</backdrop>
 		<backdrop name="label123" element="label_123">
-			<bounds x="738" y="77" width="50" height="11">
-			</bounds>
+			<bounds x="738" y="77" width="50" height="11"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="733" y="64" width="53" height="11">
-			</bounds>
+			<bounds x="733" y="64" width="53" height="11"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="742" y="94" width="0" height="0">
-			</bounds>
+			<bounds x="742" y="94" width="0" height="0"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="652" y="40" width="58" height="16">
-			</bounds>
+			<bounds x="652" y="40" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="656" y="29" width="47" height="16">
-			</bounds>
+			<bounds x="656" y="29" width="47" height="16"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="570" y="165" width="46" height="19">
-			</bounds>
+			<bounds x="570" y="165" width="46" height="19"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="731" y="165" width="48" height="19">
-			</bounds>
+			<bounds x="731" y="165" width="48" height="19"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="569" y="116" width="44" height="19">
-			</bounds>
+			<bounds x="569" y="116" width="44" height="19"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="579" y="128" width="22" height="19">
-			</bounds>
+			<bounds x="579" y="128" width="22" height="19"/>
 		</backdrop>
 		<backdrop name="label135" element="label_135">
-			<bounds x="686" y="224" width="83" height="16">
-			</bounds>
+			<bounds x="686" y="224" width="83" height="16"/>
 		</backdrop>
 		<backdrop name="label145" element="label_145">
-			<bounds x="311" y="362" width="81" height="13">
-			</bounds>
+			<bounds x="311" y="362" width="81" height="13"/>
 		</backdrop>
 		<backdrop name="label149" element="label_149">
-			<bounds x="252" y="94" width="55" height="13">
-			</bounds>
+			<bounds x="252" y="94" width="55" height="13"/>
 		</backdrop>
 		<backdrop name="label160" element="label_160">
-			<bounds x="78" y="377" width="50" height="11">
-			</bounds>
+			<bounds x="78" y="377" width="50" height="11"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1cluessf.lay
+++ b/src/mame/layout/m1cluessf.lay
@@ -8,18462 +8,10272 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Murdered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Murdered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 Symbols Start Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 Symbols Start Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Dagger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Dagger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Winsp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Winsp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Ball">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Ball">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.45" blue="0.21">
-			</color>
+			<color red="0.32" green="0.45" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.11" blue="0.05">
-			</color>
+			<color red="0.08" green="0.11" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.65" green="0.90" blue="0.42">
-			</color>
+			<color red="0.65" green="0.90" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.22" blue="0.10">
-			</color>
+			<color red="0.16" green="0.22" blue="0.10"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.32" green="0.45" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.11" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.65" green="0.90" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.22" blue="0.10">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Magnify">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ing Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Magnify">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ing Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.27" blue="0.11">
-			</color>
+			<color red="0.39" green="0.27" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.07" blue="0.02">
-			</color>
+			<color red="0.10" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.54" blue="0.21">
-			</color>
+			<color red="0.79" green="0.54" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.13" blue="0.05">
-			</color>
+			<color red="0.20" green="0.13" blue="0.05"/>
 		</rect>
 		<text string="Murd">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.27" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.54" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.13" blue="0.05">
-			</color>
-		</rect>
-		<text string="Murd">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.27" blue="0.11">
-			</color>
+			<color red="0.39" green="0.27" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.07" blue="0.02">
-			</color>
+			<color red="0.10" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.54" blue="0.21">
-			</color>
+			<color red="0.79" green="0.54" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.13" blue="0.05">
-			</color>
+			<color red="0.20" green="0.13" blue="0.05"/>
 		</rect>
 		<text string="Murd">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.27" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.54" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.13" blue="0.05">
-			</color>
-		</rect>
-		<text string="Murd">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Spanner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Spanner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Billiard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Billiard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Magnify">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ing Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Magnify">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ing Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Library">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Library">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Candle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="stick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Candle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="stick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Winsp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Winsp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Conser">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="vatory">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Conser">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="vatory">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Study">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Study">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_133_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_170_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_170_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.27" blue="0.11">
-			</color>
+			<color red="0.39" green="0.27" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.07" blue="0.02">
-			</color>
+			<color red="0.10" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.54" blue="0.21">
-			</color>
+			<color red="0.79" green="0.54" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.13" blue="0.05">
-			</color>
+			<color red="0.20" green="0.13" blue="0.05"/>
 		</rect>
 		<text string="Murd">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.27" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.54" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.13" blue="0.05">
-			</color>
-		</rect>
-		<text string="Murd">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ered">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Revo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Revo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="lver">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="lver">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Magnify">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ing Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Magnify">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ing Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Winsp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Winsp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Dining">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Dining">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Rope">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Rope">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Kitchen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Kitchen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Magnify">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ing Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Magnify">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ing Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Lounge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Lounge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Winspins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Big Win Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big Win Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4+Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4+Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Dagger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Dagger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Spanner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Spanner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Candlestick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Candlestick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Revolver">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Revolver">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Rope">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Rope">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Pick A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Pick A Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Goto Kitchen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Goto Kitchen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Suit of Armour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Suit of Armour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Prime Suspect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Prime Suspect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Staircase">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Staircase">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_131_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_132_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_132_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_154_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_154_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_155_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_155_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_150_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_149_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_137_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_137_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_138_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_138_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_246_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_246_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_245_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_245_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_174_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_174_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_173_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_173_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="All">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="All">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_226_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_161_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_161_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Clu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Clu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="edo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="edo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Sleuth">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Sleuth">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_191_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_191_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_191_3_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_191_3" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_184_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_184_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_184_3_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_184_3" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_177_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_177_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_177_3_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_177_3" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_178_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_178_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_178_3_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_178_3" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_179_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_179_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_179_3_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_179_3" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_181_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_181_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_181_3_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_181_3" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_223_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Parade">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Parade">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Parade">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Parade">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Rev Green">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Rev Green">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Colonel Mustard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Colonel Mustard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Miss Peacock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Miss Peacock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Miss Scarlet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Miss Scarlet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Rev Green">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Rev Green">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Colonel Mustard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Colonel Mustard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Miss Peacock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Miss Peacock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Miss Scarlet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Miss Scarlet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Rev Green">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Rev Green">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Colonel Mustard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Colonel Mustard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Miss Peacock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Miss Peacock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Miss Scarlet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Miss Scarlet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Step To Nearest Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Step To Nearest Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lineup">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lineup">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Stop 'n' Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop 'n' Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Revolver">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Revolver">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cash climber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash climber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_210_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_210">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_211_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_211">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_212_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_212">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_213_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_213">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_214_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_214">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_215_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_215">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_216_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_216">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_217_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_217">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_224_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_224">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_225_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_225">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_226_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_226">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_227_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_227">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_14">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.07"/>
 		</text>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.13" width="0.90" height="0.07"/>
 		</text>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.07"/>
 		</text>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.27" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.27" width="0.90" height="0.07"/>
 		</text>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.07"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.42" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.42" width="0.90" height="0.07"/>
 		</text>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.07"/>
 		</text>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.57" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.57" width="0.90" height="0.07"/>
 		</text>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.07"/>
 		</text>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.07"/>
 		</text>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.07"/>
 		</text>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.87" width="0.90" height="0.07"/>
 		</text>
 	</element>
 	<element name="label_65">
 		<text string="Nudge Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_101">
 		<text string="Magnifying Glass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_153">
 		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_205">
 		<text string="Super Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_206">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_207">
 		<text string="Hi-Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_208">
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_209">
 		<text string="ID Parade">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="648">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="648"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="165" y="411" width="80" height="140">
-			</bounds>
+			<bounds x="165" y="411" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="165.0000" y="411.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="165.0000" y="411.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="168.3333" y="412.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="168.3333" y="412.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="171.6667" y="414.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="171.6667" y="414.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="175.0000" y="416.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="175.0000" y="416.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="178.3333" y="418.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="178.3333" y="418.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="181.6667" y="420.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="181.6667" y="420.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="165.0000" y="457.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="165.0000" y="457.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="168.3333" y="459.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="168.3333" y="459.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="171.6667" y="461.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="171.6667" y="461.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="175.0000" y="463.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="175.0000" y="463.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="178.3333" y="465.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="178.3333" y="465.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="181.6667" y="467.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="181.6667" y="467.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="165.0000" y="504.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="165.0000" y="504.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="168.3333" y="506.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="168.3333" y="506.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="171.6667" y="508.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="171.6667" y="508.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="175.0000" y="510.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="175.0000" y="510.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="178.3333" y="512.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="178.3333" y="512.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="181.6667" y="514.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="181.6667" y="514.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="165" y="411" width="80" height="140">
-			</bounds>
+			<bounds x="165" y="411" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="255" y="411" width="80" height="140">
-			</bounds>
+			<bounds x="255" y="411" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="255.0000" y="411.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="255.0000" y="411.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.3333" y="412.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="258.3333" y="412.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.6667" y="414.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="261.6667" y="414.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.0000" y="416.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="265.0000" y="416.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="268.3333" y="418.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="268.3333" y="418.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="271.6667" y="420.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="271.6667" y="420.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="255.0000" y="457.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="255.0000" y="457.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.3333" y="459.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="258.3333" y="459.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.6667" y="461.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="261.6667" y="461.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.0000" y="463.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="265.0000" y="463.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="268.3333" y="465.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="268.3333" y="465.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="271.6667" y="467.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="271.6667" y="467.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="255.0000" y="504.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="255.0000" y="504.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.3333" y="506.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="258.3333" y="506.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.6667" y="508.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="261.6667" y="508.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.0000" y="510.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="265.0000" y="510.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="268.3333" y="512.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="268.3333" y="512.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="271.6667" y="514.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="271.6667" y="514.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="255" y="411" width="80" height="140">
-			</bounds>
+			<bounds x="255" y="411" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="345" y="411" width="80" height="140">
-			</bounds>
+			<bounds x="345" y="411" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="345.0000" y="411.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="345.0000" y="411.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="348.3333" y="412.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="348.3333" y="412.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="351.6667" y="414.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="351.6667" y="414.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="355.0000" y="416.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="355.0000" y="416.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="358.3333" y="418.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="358.3333" y="418.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="361.6667" y="420.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="361.6667" y="420.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="345.0000" y="457.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="345.0000" y="457.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="348.3333" y="459.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="348.3333" y="459.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="351.6667" y="461.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="351.6667" y="461.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="355.0000" y="463.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="355.0000" y="463.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="358.3333" y="465.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="358.3333" y="465.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="361.6667" y="467.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="361.6667" y="467.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="345.0000" y="504.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="345.0000" y="504.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="348.3333" y="506.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="348.3333" y="506.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="351.6667" y="508.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="351.6667" y="508.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="355.0000" y="510.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="355.0000" y="510.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="358.3333" y="512.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="358.3333" y="512.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="361.6667" y="514.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="361.6667" y="514.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="345" y="411" width="80" height="140">
-			</bounds>
+			<bounds x="345" y="411" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="266" y="206" width="50" height="50">
-			</bounds>
+			<bounds x="266" y="206" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="266.0000" y="206.0000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="266.0000" y="206.0000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="268.0833" y="208.0833" width="45.8333" height="45.8333">
-			</bounds>
+			<bounds x="268.0833" y="208.0833" width="45.8333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="270.1667" y="210.1667" width="41.6667" height="41.6667">
-			</bounds>
+			<bounds x="270.1667" y="210.1667" width="41.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="272.2500" y="212.2500" width="37.5000" height="37.5000">
-			</bounds>
+			<bounds x="272.2500" y="212.2500" width="37.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="274.3333" y="214.3333" width="33.3333" height="33.3333">
-			</bounds>
+			<bounds x="274.3333" y="214.3333" width="33.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="276.4167" y="216.4167" width="29.1667" height="29.1667">
-			</bounds>
+			<bounds x="276.4167" y="216.4167" width="29.1667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="266" y="206" width="50" height="50">
-			</bounds>
+			<bounds x="266" y="206" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="7" y="272" width="54" height="27">
-			</bounds>
+			<bounds x="7" y="272" width="54" height="27"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="9" y="274" width="50" height="23">
-			</bounds>
+			<bounds x="9" y="274" width="50" height="23"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="521" y="337" width="62" height="37">
-			</bounds>
+			<bounds x="521" y="337" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="523" y="339" width="58" height="33">
-			</bounds>
+			<bounds x="523" y="339" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="384" y="95" width="97" height="27">
-			</bounds>
+			<bounds x="384" y="95" width="97" height="27"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="386" y="97" width="93" height="23">
-			</bounds>
+			<bounds x="386" y="97" width="93" height="23"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="575" y="68" width="50" height="30">
-			</bounds>
+			<bounds x="575" y="68" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="577" y="70" width="46" height="26">
-			</bounds>
+			<bounds x="577" y="70" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="527" y="68" width="50" height="30">
-			</bounds>
+			<bounds x="527" y="68" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="529" y="70" width="46" height="26">
-			</bounds>
+			<bounds x="529" y="70" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="479" y="68" width="50" height="30">
-			</bounds>
+			<bounds x="479" y="68" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="481" y="70" width="46" height="26">
-			</bounds>
+			<bounds x="481" y="70" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="431" y="68" width="31" height="30">
-			</bounds>
+			<bounds x="431" y="68" width="31" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="433" y="70" width="27" height="26">
-			</bounds>
+			<bounds x="433" y="70" width="27" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="410" y="68" width="24" height="30">
-			</bounds>
+			<bounds x="410" y="68" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="412" y="70" width="20" height="26">
-			</bounds>
+			<bounds x="412" y="70" width="20" height="26"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="192" y="68" width="44" height="30">
-			</bounds>
+			<bounds x="192" y="68" width="44" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="194" y="70" width="40" height="26">
-			</bounds>
+			<bounds x="194" y="70" width="40" height="26"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="163" y="68" width="32" height="30">
-			</bounds>
+			<bounds x="163" y="68" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="165" y="70" width="28" height="26">
-			</bounds>
+			<bounds x="165" y="70" width="28" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="384" y="350" width="97" height="27">
-			</bounds>
+			<bounds x="384" y="350" width="97" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="386" y="352" width="93" height="23">
-			</bounds>
+			<bounds x="386" y="352" width="93" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="575" y="374" width="50" height="30">
-			</bounds>
+			<bounds x="575" y="374" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="577" y="376" width="46" height="26">
-			</bounds>
+			<bounds x="577" y="376" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="527" y="374" width="50" height="30">
-			</bounds>
+			<bounds x="527" y="374" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="529" y="376" width="46" height="26">
-			</bounds>
+			<bounds x="529" y="376" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="479" y="374" width="50" height="30">
-			</bounds>
+			<bounds x="479" y="374" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="481" y="376" width="46" height="26">
-			</bounds>
+			<bounds x="481" y="376" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="288" y="68" width="50" height="30">
-			</bounds>
+			<bounds x="288" y="68" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="290" y="70" width="46" height="26">
-			</bounds>
+			<bounds x="290" y="70" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="336" y="68" width="50" height="30">
-			</bounds>
+			<bounds x="336" y="68" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="338" y="70" width="46" height="26">
-			</bounds>
+			<bounds x="338" y="70" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="240" y="68" width="50" height="30">
-			</bounds>
+			<bounds x="240" y="68" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="242" y="70" width="46" height="26">
-			</bounds>
+			<bounds x="242" y="70" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="670" y="123" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="123" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="672" y="125" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="125" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="670" y="151" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="151" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="672" y="153" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="153" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="670" y="179" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="179" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="672" y="181" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="181" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="623" y="179" width="50" height="30">
-			</bounds>
+			<bounds x="623" y="179" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="625" y="181" width="46" height="26">
-			</bounds>
+			<bounds x="625" y="181" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="670" y="207" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="207" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="672" y="209" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="209" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="670" y="235" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="235" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="672" y="237" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="237" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="670" y="263" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="263" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="672" y="265" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="265" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="623" y="263" width="50" height="30">
-			</bounds>
+			<bounds x="623" y="263" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="625" y="265" width="46" height="26">
-			</bounds>
+			<bounds x="625" y="265" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="670" y="291" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="291" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="672" y="293" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="293" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="670" y="319" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="319" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="672" y="321" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="321" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="670" y="95" width="50" height="30">
-			</bounds>
+			<bounds x="670" y="95" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="672" y="97" width="46" height="26">
-			</bounds>
+			<bounds x="672" y="97" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="670" y="68" width="32" height="30">
-			</bounds>
+			<bounds x="670" y="68" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="672" y="70" width="28" height="26">
-			</bounds>
+			<bounds x="672" y="70" width="28" height="26"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="623" y="68" width="50" height="30">
-			</bounds>
+			<bounds x="623" y="68" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="625" y="70" width="46" height="26">
-			</bounds>
+			<bounds x="625" y="70" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="670" y="347" width="37" height="30">
-			</bounds>
+			<bounds x="670" y="347" width="37" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="672" y="349" width="33" height="26">
-			</bounds>
+			<bounds x="672" y="349" width="33" height="26"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="641" y="374" width="32" height="30">
-			</bounds>
+			<bounds x="641" y="374" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="643" y="376" width="28" height="26">
-			</bounds>
+			<bounds x="643" y="376" width="28" height="26"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="670" y="374" width="32" height="30">
-			</bounds>
+			<bounds x="670" y="374" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="672" y="376" width="28" height="26">
-			</bounds>
+			<bounds x="672" y="376" width="28" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_2_border" state="0">
-			<bounds x="417" y="339" width="32" height="14">
-			</bounds>
+			<bounds x="417" y="339" width="32" height="14"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_2" state="0">
-			<bounds x="419" y="341" width="28" height="10">
-			</bounds>
+			<bounds x="419" y="341" width="28" height="10"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_2_border" state="0">
-			<bounds x="607" y="263" width="19" height="14">
-			</bounds>
+			<bounds x="607" y="263" width="19" height="14"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_2" state="0">
-			<bounds x="609" y="265" width="15" height="10">
-			</bounds>
+			<bounds x="609" y="265" width="15" height="10"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="240" y="374" width="50" height="30">
-			</bounds>
+			<bounds x="240" y="374" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="242" y="376" width="46" height="26">
-			</bounds>
+			<bounds x="242" y="376" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="163" y="374" width="32" height="30">
-			</bounds>
+			<bounds x="163" y="374" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="165" y="376" width="28" height="26">
-			</bounds>
+			<bounds x="165" y="376" width="28" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="404" y="374" width="30" height="30">
-			</bounds>
+			<bounds x="404" y="374" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="406" y="376" width="26" height="26">
-			</bounds>
+			<bounds x="406" y="376" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="431" y="374" width="25" height="30">
-			</bounds>
+			<bounds x="431" y="374" width="25" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="433" y="376" width="21" height="26">
-			</bounds>
+			<bounds x="433" y="376" width="21" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="336" y="374" width="50" height="30">
-			</bounds>
+			<bounds x="336" y="374" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="338" y="376" width="46" height="26">
-			</bounds>
+			<bounds x="338" y="376" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="288" y="374" width="50" height="30">
-			</bounds>
+			<bounds x="288" y="374" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="290" y="376" width="46" height="26">
-			</bounds>
+			<bounds x="290" y="376" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="192" y="374" width="42" height="30">
-			</bounds>
+			<bounds x="192" y="374" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="194" y="376" width="38" height="26">
-			</bounds>
+			<bounds x="194" y="376" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="192" y="220" width="16" height="32">
-			</bounds>
+			<bounds x="192" y="220" width="16" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="194" y="222" width="12" height="28">
-			</bounds>
+			<bounds x="194" y="222" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="145" y="123" width="50" height="30">
-			</bounds>
+			<bounds x="145" y="123" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="147" y="125" width="46" height="26">
-			</bounds>
+			<bounds x="147" y="125" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="145" y="151" width="50" height="30">
-			</bounds>
+			<bounds x="145" y="151" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="147" y="153" width="46" height="26">
-			</bounds>
+			<bounds x="147" y="153" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="145" y="179" width="50" height="30">
-			</bounds>
+			<bounds x="145" y="179" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="147" y="181" width="46" height="26">
-			</bounds>
+			<bounds x="147" y="181" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="145" y="207" width="50" height="30">
-			</bounds>
+			<bounds x="145" y="207" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="147" y="209" width="46" height="26">
-			</bounds>
+			<bounds x="147" y="209" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="145" y="234" width="50" height="31">
-			</bounds>
+			<bounds x="145" y="234" width="50" height="31"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="147" y="236" width="46" height="27">
-			</bounds>
+			<bounds x="147" y="236" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="145" y="95" width="50" height="30">
-			</bounds>
+			<bounds x="145" y="95" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="147" y="97" width="46" height="26">
-			</bounds>
+			<bounds x="147" y="97" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="145" y="319" width="50" height="30">
-			</bounds>
+			<bounds x="145" y="319" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="147" y="321" width="46" height="26">
-			</bounds>
+			<bounds x="147" y="321" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="145" y="291" width="50" height="30">
-			</bounds>
+			<bounds x="145" y="291" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="147" y="293" width="46" height="26">
-			</bounds>
+			<bounds x="147" y="293" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="145" y="263" width="50" height="30">
-			</bounds>
+			<bounds x="145" y="263" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="147" y="265" width="46" height="26">
-			</bounds>
+			<bounds x="147" y="265" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="153" y="347" width="42" height="30">
-			</bounds>
+			<bounds x="153" y="347" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="155" y="349" width="38" height="26">
-			</bounds>
+			<bounds x="155" y="349" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="398" y="132" width="68" height="32">
-			</bounds>
+			<bounds x="398" y="132" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="400" y="134" width="64" height="28">
-			</bounds>
+			<bounds x="400" y="134" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="367" y="138" width="32" height="22">
-			</bounds>
+			<bounds x="367" y="138" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="369" y="140" width="28" height="18">
-			</bounds>
+			<bounds x="369" y="140" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="336" y="138" width="32" height="22">
-			</bounds>
+			<bounds x="336" y="138" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="338" y="140" width="28" height="18">
-			</bounds>
+			<bounds x="338" y="140" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="305" y="138" width="32" height="22">
-			</bounds>
+			<bounds x="305" y="138" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="307" y="140" width="28" height="18">
-			</bounds>
+			<bounds x="307" y="140" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="723" y="92" width="55" height="25">
-			</bounds>
+			<bounds x="723" y="92" width="55" height="25"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="725" y="94" width="51" height="21">
-			</bounds>
+			<bounds x="725" y="94" width="51" height="21"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="371" y="244" width="62" height="29">
-			</bounds>
+			<bounds x="371" y="244" width="62" height="29"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="373" y="246" width="58" height="25">
-			</bounds>
+			<bounds x="373" y="246" width="58" height="25"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="371" y="217" width="62" height="29">
-			</bounds>
+			<bounds x="371" y="217" width="62" height="29"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="373" y="219" width="58" height="25">
-			</bounds>
+			<bounds x="373" y="219" width="58" height="25"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="371" y="190" width="62" height="29">
-			</bounds>
+			<bounds x="371" y="190" width="62" height="29"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="373" y="192" width="58" height="25">
-			</bounds>
+			<bounds x="373" y="192" width="58" height="25"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="431" y="244" width="62" height="29">
-			</bounds>
+			<bounds x="431" y="244" width="62" height="29"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="433" y="246" width="58" height="25">
-			</bounds>
+			<bounds x="433" y="246" width="58" height="25"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="431" y="217" width="62" height="29">
-			</bounds>
+			<bounds x="431" y="217" width="62" height="29"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="433" y="219" width="58" height="25">
-			</bounds>
+			<bounds x="433" y="219" width="58" height="25"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="431" y="190" width="62" height="29">
-			</bounds>
+			<bounds x="431" y="190" width="62" height="29"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="433" y="192" width="58" height="25">
-			</bounds>
+			<bounds x="433" y="192" width="58" height="25"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="493" y="180" width="67" height="22">
-			</bounds>
+			<bounds x="493" y="180" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="495" y="182" width="63" height="18">
-			</bounds>
+			<bounds x="495" y="182" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="493" y="200" width="67" height="22">
-			</bounds>
+			<bounds x="493" y="200" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="495" y="202" width="63" height="18">
-			</bounds>
+			<bounds x="495" y="202" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="493" y="220" width="67" height="22">
-			</bounds>
+			<bounds x="493" y="220" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="495" y="222" width="63" height="18">
-			</bounds>
+			<bounds x="495" y="222" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="493" y="240" width="67" height="22">
-			</bounds>
+			<bounds x="493" y="240" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="495" y="242" width="63" height="18">
-			</bounds>
+			<bounds x="495" y="242" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="493" y="260" width="67" height="22">
-			</bounds>
+			<bounds x="493" y="260" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="495" y="262" width="63" height="18">
-			</bounds>
+			<bounds x="495" y="262" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="77" y="560" width="58" height="19">
-			</bounds>
+			<bounds x="77" y="560" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="79" y="562" width="54" height="15">
-			</bounds>
+			<bounds x="79" y="562" width="54" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="149" y="560" width="58" height="19">
-			</bounds>
+			<bounds x="149" y="560" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="151" y="562" width="54" height="15">
-			</bounds>
+			<bounds x="151" y="562" width="54" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="221" y="560" width="58" height="19">
-			</bounds>
+			<bounds x="221" y="560" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="223" y="562" width="54" height="15">
-			</bounds>
+			<bounds x="223" y="562" width="54" height="15"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="365" y="560" width="58" height="19">
-			</bounds>
+			<bounds x="365" y="560" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="367" y="562" width="54" height="15">
-			</bounds>
+			<bounds x="367" y="562" width="54" height="15"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="437" y="560" width="58" height="19">
-			</bounds>
+			<bounds x="437" y="560" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="439" y="562" width="54" height="15">
-			</bounds>
+			<bounds x="439" y="562" width="54" height="15"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="653" y="560" width="77" height="19">
-			</bounds>
+			<bounds x="653" y="560" width="77" height="19"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="655" y="562" width="73" height="15">
-			</bounds>
+			<bounds x="655" y="562" width="73" height="15"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="581" y="560" width="58" height="19">
-			</bounds>
+			<bounds x="581" y="560" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="583" y="562" width="54" height="15">
-			</bounds>
+			<bounds x="583" y="562" width="54" height="15"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="509" y="560" width="58" height="19">
-			</bounds>
+			<bounds x="509" y="560" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="511" y="562" width="54" height="15">
-			</bounds>
+			<bounds x="511" y="562" width="54" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="293" y="560" width="58" height="19">
-			</bounds>
+			<bounds x="293" y="560" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="295" y="562" width="54" height="15">
-			</bounds>
+			<bounds x="295" y="562" width="54" height="15"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="2" y="304" width="54" height="27">
-			</bounds>
+			<bounds x="2" y="304" width="54" height="27"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="4" y="306" width="50" height="23">
-			</bounds>
+			<bounds x="4" y="306" width="50" height="23"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="45" y="290" width="54" height="27">
-			</bounds>
+			<bounds x="45" y="290" width="54" height="27"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="47" y="292" width="50" height="23">
-			</bounds>
+			<bounds x="47" y="292" width="50" height="23"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="89" y="304" width="54" height="27">
-			</bounds>
+			<bounds x="89" y="304" width="54" height="27"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="91" y="306" width="50" height="23">
-			</bounds>
+			<bounds x="91" y="306" width="50" height="23"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="87" y="275" width="54" height="27">
-			</bounds>
+			<bounds x="87" y="275" width="54" height="27"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="89" y="277" width="50" height="23">
-			</bounds>
+			<bounds x="89" y="277" width="50" height="23"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="50" y="257" width="54" height="27">
-			</bounds>
+			<bounds x="50" y="257" width="54" height="27"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="52" y="259" width="50" height="23">
-			</bounds>
+			<bounds x="52" y="259" width="50" height="23"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="46" y="318" width="54" height="27">
-			</bounds>
+			<bounds x="46" y="318" width="54" height="27"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="48" y="320" width="50" height="23">
-			</bounds>
+			<bounds x="48" y="320" width="50" height="23"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="728" y="118" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="118" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="730" y="120" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="120" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="728" y="118" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="118" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="730" y="120" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="120" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="728" y="142" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="142" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="730" y="144" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="144" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="728" y="142" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="142" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="730" y="144" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="144" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="728" y="166" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="166" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="730" y="168" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="168" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="728" y="166" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="166" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="730" y="168" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="168" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="728" y="190" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="190" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="730" y="192" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="192" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="728" y="190" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="190" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="730" y="192" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="192" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="728" y="214" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="214" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="730" y="216" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="216" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="728" y="214" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="214" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="730" y="216" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="216" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="728" y="238" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="238" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="730" y="240" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="240" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="728" y="238" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="238" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="730" y="240" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="240" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="728" y="262" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="262" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="730" y="264" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="264" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="728" y="262" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="262" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="730" y="264" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="264" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="728" y="286" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="286" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="730" y="288" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="288" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="728" y="286" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="286" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="730" y="288" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="288" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="728" y="310" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="310" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="730" y="312" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="312" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="728" y="310" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="310" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="730" y="312" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="312" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="728" y="334" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="334" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="730" y="336" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="336" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="728" y="334" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="334" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="730" y="336" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="336" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="728" y="358" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="358" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="730" y="360" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="360" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="728" y="358" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="358" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="730" y="360" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="360" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="728" y="382" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="382" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="730" y="384" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="384" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="728" y="382" width="47" height="22">
-			</bounds>
+			<bounds x="728" y="382" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="730" y="384" width="43" height="18">
-			</bounds>
+			<bounds x="730" y="384" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_2_border" state="0">
-			<bounds x="453" y="374" width="28" height="30">
-			</bounds>
+			<bounds x="453" y="374" width="28" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_2" state="0">
-			<bounds x="455" y="376" width="24" height="26">
-			</bounds>
+			<bounds x="455" y="376" width="24" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_2_border" state="0">
-			<bounds x="384" y="374" width="24" height="30">
-			</bounds>
+			<bounds x="384" y="374" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_2" state="0">
-			<bounds x="386" y="376" width="20" height="26">
-			</bounds>
+			<bounds x="386" y="376" width="20" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_2_border" state="0">
-			<bounds x="384" y="68" width="29" height="30">
-			</bounds>
+			<bounds x="384" y="68" width="29" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_2" state="0">
-			<bounds x="386" y="70" width="25" height="26">
-			</bounds>
+			<bounds x="386" y="70" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2_border" state="0">
-			<bounds x="459" y="68" width="22" height="30">
-			</bounds>
+			<bounds x="459" y="68" width="22" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2" state="0">
-			<bounds x="461" y="70" width="18" height="26">
-			</bounds>
+			<bounds x="461" y="70" width="18" height="26"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="91" y="415" width="32" height="27">
-			</bounds>
+			<bounds x="91" y="415" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="93" y="417" width="28" height="23">
-			</bounds>
+			<bounds x="93" y="417" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="91" y="443" width="32" height="27">
-			</bounds>
+			<bounds x="91" y="443" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="93" y="445" width="28" height="23">
-			</bounds>
+			<bounds x="93" y="445" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="91" y="471" width="32" height="27">
-			</bounds>
+			<bounds x="91" y="471" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="93" y="473" width="28" height="23">
-			</bounds>
+			<bounds x="93" y="473" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="91" y="499" width="32" height="27">
-			</bounds>
+			<bounds x="91" y="499" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="93" y="501" width="28" height="23">
-			</bounds>
+			<bounds x="93" y="501" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="77" y="528" width="62" height="19">
-			</bounds>
+			<bounds x="77" y="528" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="79" y="530" width="58" height="15">
-			</bounds>
+			<bounds x="79" y="530" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_2_border" state="0">
-			<bounds x="233" y="68" width="9" height="30">
-			</bounds>
+			<bounds x="233" y="68" width="9" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_2" state="0">
-			<bounds x="235" y="70" width="5" height="26">
-			</bounds>
+			<bounds x="235" y="70" width="5" height="26"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_2_border" state="0">
-			<bounds x="145" y="68" width="21" height="30">
-			</bounds>
+			<bounds x="145" y="68" width="21" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_2" state="0">
-			<bounds x="147" y="70" width="17" height="26">
-			</bounds>
+			<bounds x="147" y="70" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_2_border" state="0">
-			<bounds x="231" y="374" width="11" height="30">
-			</bounds>
+			<bounds x="231" y="374" width="11" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_2" state="0">
-			<bounds x="233" y="376" width="7" height="26">
-			</bounds>
+			<bounds x="233" y="376" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_2_border" state="0">
-			<bounds x="145" y="374" width="21" height="30">
-			</bounds>
+			<bounds x="145" y="374" width="21" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_2" state="0">
-			<bounds x="147" y="376" width="17" height="26">
-			</bounds>
+			<bounds x="147" y="376" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_2_border" state="0">
-			<bounds x="623" y="374" width="21" height="30">
-			</bounds>
+			<bounds x="623" y="374" width="21" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_2" state="0">
-			<bounds x="625" y="376" width="17" height="26">
-			</bounds>
+			<bounds x="625" y="376" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_2_border" state="0">
-			<bounds x="145" y="347" width="11" height="30">
-			</bounds>
+			<bounds x="145" y="347" width="11" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_2" state="0">
-			<bounds x="147" y="349" width="7" height="26">
-			</bounds>
+			<bounds x="147" y="349" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_2_border" state="0">
-			<bounds x="699" y="374" width="21" height="30">
-			</bounds>
+			<bounds x="699" y="374" width="21" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_2" state="0">
-			<bounds x="701" y="376" width="17" height="26">
-			</bounds>
+			<bounds x="701" y="376" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_2_border" state="0">
-			<bounds x="704" y="347" width="16" height="30">
-			</bounds>
+			<bounds x="704" y="347" width="16" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_2" state="0">
-			<bounds x="706" y="349" width="12" height="26">
-			</bounds>
+			<bounds x="706" y="349" width="12" height="26"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="25" y="34" width="14" height="27">
-			</bounds>
+			<bounds x="25" y="34" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="27" y="36" width="10" height="23">
-			</bounds>
+			<bounds x="27" y="36" width="10" height="23"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="70" y="34" width="61" height="27">
-			</bounds>
+			<bounds x="70" y="34" width="61" height="27"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="72" y="36" width="57" height="23">
-			</bounds>
+			<bounds x="72" y="36" width="57" height="23"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_2_border" state="0">
-			<bounds x="36" y="34" width="37" height="27">
-			</bounds>
+			<bounds x="36" y="34" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_2" state="0">
-			<bounds x="38" y="36" width="33" height="23">
-			</bounds>
+			<bounds x="38" y="36" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_2_border" state="0">
-			<bounds x="128" y="34" width="16" height="27">
-			</bounds>
+			<bounds x="128" y="34" width="16" height="27"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_2" state="0">
-			<bounds x="130" y="36" width="12" height="23">
-			</bounds>
+			<bounds x="130" y="36" width="12" height="23"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="25" y="10" width="32" height="27">
-			</bounds>
+			<bounds x="25" y="10" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="27" y="12" width="28" height="23">
-			</bounds>
+			<bounds x="27" y="12" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_2_border" state="0">
-			<bounds x="54" y="10" width="22" height="27">
-			</bounds>
+			<bounds x="54" y="10" width="22" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_2" state="0">
-			<bounds x="56" y="12" width="18" height="23">
-			</bounds>
+			<bounds x="56" y="12" width="18" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="92" y="10" width="22" height="27">
-			</bounds>
+			<bounds x="92" y="10" width="22" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="94" y="12" width="18" height="23">
-			</bounds>
+			<bounds x="94" y="12" width="18" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="73" y="10" width="22" height="27">
-			</bounds>
+			<bounds x="73" y="10" width="22" height="27"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="75" y="12" width="18" height="23">
-			</bounds>
+			<bounds x="75" y="12" width="18" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_2_border" state="0">
-			<bounds x="111" y="10" width="33" height="27">
-			</bounds>
+			<bounds x="111" y="10" width="33" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_2" state="0">
-			<bounds x="113" y="12" width="29" height="23">
-			</bounds>
+			<bounds x="113" y="12" width="29" height="23"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_2_border" state="0">
-			<bounds x="699" y="68" width="21" height="30">
-			</bounds>
+			<bounds x="699" y="68" width="21" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_2" state="0">
-			<bounds x="701" y="70" width="17" height="26">
-			</bounds>
+			<bounds x="701" y="70" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="407" y="173" width="32" height="17">
-			</bounds>
+			<bounds x="407" y="173" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="409" y="175" width="28" height="13">
-			</bounds>
+			<bounds x="409" y="175" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="436" y="173" width="22" height="17">
-			</bounds>
+			<bounds x="436" y="173" width="22" height="17"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="438" y="175" width="18" height="13">
-			</bounds>
+			<bounds x="438" y="175" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="393" y="10" width="42" height="24">
-			</bounds>
+			<bounds x="393" y="10" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="395" y="12" width="38" height="20">
-			</bounds>
+			<bounds x="395" y="12" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="353" y="31" width="82" height="32">
-			</bounds>
+			<bounds x="353" y="31" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="355" y="33" width="78" height="28">
-			</bounds>
+			<bounds x="355" y="33" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="432" y="10" width="47" height="24">
-			</bounds>
+			<bounds x="432" y="10" width="47" height="24"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="434" y="12" width="43" height="20">
-			</bounds>
+			<bounds x="434" y="12" width="43" height="20"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="432" y="31" width="82" height="32">
-			</bounds>
+			<bounds x="432" y="31" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="434" y="33" width="78" height="28">
-			</bounds>
+			<bounds x="434" y="33" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="560" y="98" width="19" height="19">
-			</bounds>
+			<bounds x="560" y="98" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="562" y="100" width="15" height="15">
-			</bounds>
+			<bounds x="562" y="100" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_2_border" state="0">
-			<bounds x="524" y="98" width="19" height="19">
-			</bounds>
+			<bounds x="524" y="98" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_2" state="0">
-			<bounds x="526" y="100" width="15" height="15">
-			</bounds>
+			<bounds x="526" y="100" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_3_border" state="0">
-			<bounds x="542" y="98" width="19" height="19">
-			</bounds>
+			<bounds x="542" y="98" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_3" state="0">
-			<bounds x="544" y="100" width="15" height="15">
-			</bounds>
+			<bounds x="544" y="100" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="285" y="98" width="19" height="19">
-			</bounds>
+			<bounds x="285" y="98" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="287" y="100" width="15" height="15">
-			</bounds>
+			<bounds x="287" y="100" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2_border" state="0">
-			<bounds x="303" y="98" width="19" height="19">
-			</bounds>
+			<bounds x="303" y="98" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2" state="0">
-			<bounds x="305" y="100" width="15" height="15">
-			</bounds>
+			<bounds x="305" y="100" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_3_border" state="0">
-			<bounds x="321" y="98" width="19" height="19">
-			</bounds>
+			<bounds x="321" y="98" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_3" state="0">
-			<bounds x="323" y="100" width="15" height="15">
-			</bounds>
+			<bounds x="323" y="100" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="652" y="160" width="19" height="19">
-			</bounds>
+			<bounds x="652" y="160" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="654" y="162" width="15" height="15">
-			</bounds>
+			<bounds x="654" y="162" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_2_border" state="0">
-			<bounds x="651" y="142" width="19" height="19">
-			</bounds>
+			<bounds x="651" y="142" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_2" state="0">
-			<bounds x="653" y="144" width="15" height="15">
-			</bounds>
+			<bounds x="653" y="144" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_3_border" state="0">
-			<bounds x="651" y="124" width="19" height="19">
-			</bounds>
+			<bounds x="651" y="124" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_3" state="0">
-			<bounds x="653" y="126" width="15" height="15">
-			</bounds>
+			<bounds x="653" y="126" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="651" y="244" width="19" height="19">
-			</bounds>
+			<bounds x="651" y="244" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="653" y="246" width="15" height="15">
-			</bounds>
+			<bounds x="653" y="246" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_2_border" state="0">
-			<bounds x="651" y="226" width="19" height="19">
-			</bounds>
+			<bounds x="651" y="226" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_2" state="0">
-			<bounds x="653" y="228" width="15" height="15">
-			</bounds>
+			<bounds x="653" y="228" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_3_border" state="0">
-			<bounds x="651" y="208" width="19" height="19">
-			</bounds>
+			<bounds x="651" y="208" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_3" state="0">
-			<bounds x="653" y="210" width="15" height="15">
-			</bounds>
+			<bounds x="653" y="210" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="651" y="329" width="19" height="19">
-			</bounds>
+			<bounds x="651" y="329" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="653" y="331" width="15" height="15">
-			</bounds>
+			<bounds x="653" y="331" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_2_border" state="0">
-			<bounds x="651" y="311" width="19" height="19">
-			</bounds>
+			<bounds x="651" y="311" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_2" state="0">
-			<bounds x="653" y="313" width="15" height="15">
-			</bounds>
+			<bounds x="653" y="313" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_3_border" state="0">
-			<bounds x="651" y="293" width="19" height="19">
-			</bounds>
+			<bounds x="651" y="293" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_3" state="0">
-			<bounds x="653" y="295" width="15" height="15">
-			</bounds>
+			<bounds x="653" y="295" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="322" y="355" width="19" height="19">
-			</bounds>
+			<bounds x="322" y="355" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="324" y="357" width="15" height="15">
-			</bounds>
+			<bounds x="324" y="357" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_2_border" state="0">
-			<bounds x="304" y="355" width="19" height="19">
-			</bounds>
+			<bounds x="304" y="355" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_2" state="0">
-			<bounds x="306" y="357" width="15" height="15">
-			</bounds>
+			<bounds x="306" y="357" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_3_border" state="0">
-			<bounds x="286" y="355" width="19" height="19">
-			</bounds>
+			<bounds x="286" y="355" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_3" state="0">
-			<bounds x="288" y="357" width="15" height="15">
-			</bounds>
+			<bounds x="288" y="357" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="465" y="138" width="32" height="22">
-			</bounds>
+			<bounds x="465" y="138" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="467" y="140" width="28" height="18">
-			</bounds>
+			<bounds x="467" y="140" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="496" y="138" width="32" height="22">
-			</bounds>
+			<bounds x="496" y="138" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="498" y="140" width="28" height="18">
-			</bounds>
+			<bounds x="498" y="140" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="527" y="138" width="32" height="22">
-			</bounds>
+			<bounds x="527" y="138" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="529" y="140" width="28" height="18">
-			</bounds>
+			<bounds x="529" y="140" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_2_border" state="0">
-			<bounds x="353" y="10" width="43" height="24">
-			</bounds>
+			<bounds x="353" y="10" width="43" height="24"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_2" state="0">
-			<bounds x="355" y="12" width="39" height="20">
-			</bounds>
+			<bounds x="355" y="12" width="39" height="20"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_2_border" state="0">
-			<bounds x="476" y="10" width="38" height="24">
-			</bounds>
+			<bounds x="476" y="10" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_2" state="0">
-			<bounds x="478" y="12" width="34" height="20">
-			</bounds>
+			<bounds x="478" y="12" width="34" height="20"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="445" y="491" width="44" height="27">
-			</bounds>
+			<bounds x="445" y="491" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="447" y="493" width="40" height="23">
-			</bounds>
+			<bounds x="447" y="493" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="445" y="443" width="44" height="27">
-			</bounds>
+			<bounds x="445" y="443" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="447" y="445" width="40" height="23">
-			</bounds>
+			<bounds x="447" y="445" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="445" y="467" width="44" height="27">
-			</bounds>
+			<bounds x="445" y="467" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="447" y="469" width="40" height="23">
-			</bounds>
+			<bounds x="447" y="469" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="704" y="443" width="44" height="27">
-			</bounds>
+			<bounds x="704" y="443" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="706" y="445" width="40" height="23">
-			</bounds>
+			<bounds x="706" y="445" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="704" y="467" width="44" height="27">
-			</bounds>
+			<bounds x="704" y="467" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="706" y="469" width="40" height="23">
-			</bounds>
+			<bounds x="706" y="469" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="704" y="491" width="44" height="27">
-			</bounds>
+			<bounds x="704" y="491" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="706" y="493" width="40" height="23">
-			</bounds>
+			<bounds x="706" y="493" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="523" y="423" width="50" height="29">
-			</bounds>
+			<bounds x="523" y="423" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="525" y="425" width="46" height="25">
-			</bounds>
+			<bounds x="525" y="425" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="523" y="451" width="50" height="29">
-			</bounds>
+			<bounds x="523" y="451" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="525" y="453" width="46" height="25">
-			</bounds>
+			<bounds x="525" y="453" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="523" y="479" width="50" height="29">
-			</bounds>
+			<bounds x="523" y="479" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="525" y="481" width="46" height="25">
-			</bounds>
+			<bounds x="525" y="481" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="523" y="507" width="50" height="29">
-			</bounds>
+			<bounds x="523" y="507" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="525" y="509" width="46" height="25">
-			</bounds>
+			<bounds x="525" y="509" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="572" y="423" width="50" height="29">
-			</bounds>
+			<bounds x="572" y="423" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="574" y="425" width="46" height="25">
-			</bounds>
+			<bounds x="574" y="425" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="572" y="451" width="50" height="29">
-			</bounds>
+			<bounds x="572" y="451" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="574" y="453" width="46" height="25">
-			</bounds>
+			<bounds x="574" y="453" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="572" y="479" width="50" height="29">
-			</bounds>
+			<bounds x="572" y="479" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="574" y="481" width="46" height="25">
-			</bounds>
+			<bounds x="574" y="481" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="572" y="507" width="50" height="29">
-			</bounds>
+			<bounds x="572" y="507" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="574" y="509" width="46" height="25">
-			</bounds>
+			<bounds x="574" y="509" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="621" y="423" width="50" height="29">
-			</bounds>
+			<bounds x="621" y="423" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="623" y="425" width="46" height="25">
-			</bounds>
+			<bounds x="623" y="425" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="621" y="451" width="50" height="29">
-			</bounds>
+			<bounds x="621" y="451" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="623" y="453" width="46" height="25">
-			</bounds>
+			<bounds x="623" y="453" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="621" y="479" width="50" height="29">
-			</bounds>
+			<bounds x="621" y="479" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="623" y="481" width="46" height="25">
-			</bounds>
+			<bounds x="623" y="481" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="621" y="507" width="50" height="29">
-			</bounds>
+			<bounds x="621" y="507" width="50" height="29"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="623" y="509" width="46" height="25">
-			</bounds>
+			<bounds x="623" y="509" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="671" y="423" width="32" height="29">
-			</bounds>
+			<bounds x="671" y="423" width="32" height="29"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="673" y="425" width="28" height="25">
-			</bounds>
+			<bounds x="673" y="425" width="28" height="25"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="671" y="451" width="32" height="29">
-			</bounds>
+			<bounds x="671" y="451" width="32" height="29"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="673" y="453" width="28" height="25">
-			</bounds>
+			<bounds x="673" y="453" width="28" height="25"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="671" y="479" width="32" height="29">
-			</bounds>
+			<bounds x="671" y="479" width="32" height="29"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="673" y="481" width="28" height="25">
-			</bounds>
+			<bounds x="673" y="481" width="28" height="25"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="671" y="507" width="32" height="29">
-			</bounds>
+			<bounds x="671" y="507" width="32" height="29"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="673" y="509" width="28" height="25">
-			</bounds>
+			<bounds x="673" y="509" width="28" height="25"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="491" y="423" width="32" height="29">
-			</bounds>
+			<bounds x="491" y="423" width="32" height="29"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="493" y="425" width="28" height="25">
-			</bounds>
+			<bounds x="493" y="425" width="28" height="25"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="491" y="451" width="32" height="29">
-			</bounds>
+			<bounds x="491" y="451" width="32" height="29"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="493" y="453" width="28" height="25">
-			</bounds>
+			<bounds x="493" y="453" width="28" height="25"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="491" y="479" width="32" height="29">
-			</bounds>
+			<bounds x="491" y="479" width="32" height="29"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="493" y="481" width="28" height="25">
-			</bounds>
+			<bounds x="493" y="481" width="28" height="25"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="491" y="507" width="32" height="29">
-			</bounds>
+			<bounds x="491" y="507" width="32" height="29"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="493" y="509" width="28" height="25">
-			</bounds>
+			<bounds x="493" y="509" width="28" height="25"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="38" y="93" width="48" height="22">
-			</bounds>
+			<bounds x="38" y="93" width="48" height="22"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="40" y="95" width="44" height="18">
-			</bounds>
+			<bounds x="40" y="95" width="44" height="18"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="83" y="93" width="24" height="22">
-			</bounds>
+			<bounds x="83" y="93" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="85" y="95" width="20" height="18">
-			</bounds>
+			<bounds x="85" y="95" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="5" y="191" width="47" height="37">
-			</bounds>
+			<bounds x="5" y="191" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="7" y="193" width="43" height="33">
-			</bounds>
+			<bounds x="7" y="193" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="50" y="191" width="47" height="37">
-			</bounds>
+			<bounds x="50" y="191" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="52" y="193" width="43" height="33">
-			</bounds>
+			<bounds x="52" y="193" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="95" y="191" width="47" height="37">
-			</bounds>
+			<bounds x="95" y="191" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="97" y="193" width="43" height="33">
-			</bounds>
+			<bounds x="97" y="193" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="22" y="156" width="51" height="37">
-			</bounds>
+			<bounds x="22" y="156" width="51" height="37"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="24" y="158" width="47" height="33">
-			</bounds>
+			<bounds x="24" y="158" width="47" height="33"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="71" y="156" width="51" height="37">
-			</bounds>
+			<bounds x="71" y="156" width="51" height="37"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="73" y="158" width="47" height="33">
-			</bounds>
+			<bounds x="73" y="158" width="47" height="33"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="47" y="121" width="51" height="37">
-			</bounds>
+			<bounds x="47" y="121" width="51" height="37"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="49" y="123" width="47" height="33">
-			</bounds>
+			<bounds x="49" y="123" width="47" height="33"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_210_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="733" y="16" width="37" height="47">
-			</bounds>
+			<bounds x="733" y="16" width="37" height="47"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_210" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="735" y="18" width="33" height="43">
-			</bounds>
+			<bounds x="735" y="18" width="33" height="43"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_211_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="668" y="608" width="62" height="40">
-			</bounds>
+			<bounds x="668" y="608" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_211" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="670" y="610" width="58" height="36">
-			</bounds>
+			<bounds x="670" y="610" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_212_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="575" y="608" width="62" height="40">
-			</bounds>
+			<bounds x="575" y="608" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_212" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="577" y="610" width="58" height="36">
-			</bounds>
+			<bounds x="577" y="610" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_213_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="476" y="608" width="62" height="40">
-			</bounds>
+			<bounds x="476" y="608" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_213" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="478" y="610" width="58" height="36">
-			</bounds>
+			<bounds x="478" y="610" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_214_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="354" y="608" width="62" height="40">
-			</bounds>
+			<bounds x="354" y="608" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_214" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="356" y="610" width="58" height="36">
-			</bounds>
+			<bounds x="356" y="610" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_215_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="264" y="608" width="62" height="40">
-			</bounds>
+			<bounds x="264" y="608" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_215" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="266" y="610" width="58" height="36">
-			</bounds>
+			<bounds x="266" y="610" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_216_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="174" y="608" width="62" height="40">
-			</bounds>
+			<bounds x="174" y="608" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_216" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="176" y="610" width="58" height="36">
-			</bounds>
+			<bounds x="176" y="610" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_217_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="71" y="608" width="62" height="40">
-			</bounds>
+			<bounds x="71" y="608" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_217" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="73" y="610" width="58" height="36">
-			</bounds>
+			<bounds x="73" y="610" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp183" element="colour_button_224_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="192" y="95" width="50" height="30">
-			</bounds>
+			<bounds x="192" y="95" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="colour_button_224" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="194" y="97" width="46" height="26">
-			</bounds>
+			<bounds x="194" y="97" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp175" element="colour_button_225_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="623" y="347" width="50" height="30">
-			</bounds>
+			<bounds x="623" y="347" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="colour_button_225" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="625" y="349" width="46" height="26">
-			</bounds>
+			<bounds x="625" y="349" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp176" element="colour_button_226_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="623" y="95" width="50" height="30">
-			</bounds>
+			<bounds x="623" y="95" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="colour_button_226" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="625" y="97" width="46" height="26">
-			</bounds>
+			<bounds x="625" y="97" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp182" element="colour_button_227_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="192" y="347" width="50" height="30">
-			</bounds>
+			<bounds x="192" y="347" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="colour_button_227" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="194" y="349" width="46" height="26">
-			</bounds>
+			<bounds x="194" y="349" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="55" y="362" width="20" height="28">
-			</bounds>
+			<bounds x="55" y="362" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="57" y="364" width="14" height="2">
-			</bounds>
+			<bounds x="57" y="364" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="69" y="364" width="2" height="12">
-			</bounds>
+			<bounds x="69" y="364" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="69" y="374" width="2" height="12">
-			</bounds>
+			<bounds x="69" y="374" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="57" y="384" width="14" height="2">
-			</bounds>
+			<bounds x="57" y="384" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="57" y="374" width="2" height="12">
-			</bounds>
+			<bounds x="57" y="374" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="57" y="364" width="2" height="12">
-			</bounds>
+			<bounds x="57" y="364" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="57" y="374" width="14" height="2">
-			</bounds>
+			<bounds x="57" y="374" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="72" y="384" width="2" height="2">
-			</bounds>
+			<bounds x="72" y="384" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="57" y="364" width="14" height="2">
-			</bounds>
+			<bounds x="57" y="364" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="69" y="364" width="2" height="12">
-			</bounds>
+			<bounds x="69" y="364" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="69" y="374" width="2" height="12">
-			</bounds>
+			<bounds x="69" y="374" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="57" y="384" width="14" height="2">
-			</bounds>
+			<bounds x="57" y="384" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="57" y="374" width="2" height="12">
-			</bounds>
+			<bounds x="57" y="374" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="57" y="364" width="2" height="12">
-			</bounds>
+			<bounds x="57" y="364" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="57" y="374" width="14" height="2">
-			</bounds>
+			<bounds x="57" y="374" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="72" y="384" width="2" height="2">
-			</bounds>
+			<bounds x="72" y="384" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="75" y="362" width="20" height="28">
-			</bounds>
+			<bounds x="75" y="362" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="77" y="364" width="14" height="2">
-			</bounds>
+			<bounds x="77" y="364" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="89" y="364" width="2" height="12">
-			</bounds>
+			<bounds x="89" y="364" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="89" y="374" width="2" height="12">
-			</bounds>
+			<bounds x="89" y="374" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="77" y="384" width="14" height="2">
-			</bounds>
+			<bounds x="77" y="384" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="77" y="374" width="2" height="12">
-			</bounds>
+			<bounds x="77" y="374" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="77" y="364" width="2" height="12">
-			</bounds>
+			<bounds x="77" y="364" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="77" y="374" width="14" height="2">
-			</bounds>
+			<bounds x="77" y="374" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="92" y="384" width="2" height="2">
-			</bounds>
+			<bounds x="92" y="384" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="77" y="364" width="14" height="2">
-			</bounds>
+			<bounds x="77" y="364" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="89" y="364" width="2" height="12">
-			</bounds>
+			<bounds x="89" y="364" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="89" y="374" width="2" height="12">
-			</bounds>
+			<bounds x="89" y="374" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="77" y="384" width="14" height="2">
-			</bounds>
+			<bounds x="77" y="384" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="77" y="374" width="2" height="12">
-			</bounds>
+			<bounds x="77" y="374" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="77" y="364" width="2" height="12">
-			</bounds>
+			<bounds x="77" y="364" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="77" y="374" width="14" height="2">
-			</bounds>
+			<bounds x="77" y="374" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="92" y="384" width="2" height="2">
-			</bounds>
+			<bounds x="92" y="384" width="2" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="303" y="306" width="260" height="26">
-			</bounds>
+			<bounds x="303" y="306" width="260" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="303" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="303" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="319" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="319" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="335" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="335" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="351" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="351" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="367" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="367" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="383" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="383" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="399" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="399" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="415" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="415" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="431" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="431" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="447" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="447" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="463" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="463" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="479" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="479" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="495" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="495" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="511" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="511" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="527" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="527" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="543" y="306" width="16" height="26">
-			</bounds>
+			<bounds x="543" y="306" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="label14" element="label_14">
-			<bounds x="255" y="183" width="10" height="96">
-			</bounds>
+			<bounds x="255" y="183" width="10" height="96"/>
 		</backdrop>
 		<backdrop name="label65" element="label_65">
-			<bounds x="31" y="382" width="86" height="22">
-			</bounds>
+			<bounds x="31" y="382" width="86" height="22"/>
 		</backdrop>
 		<backdrop name="label101" element="label_101">
-			<bounds x="24" y="242" width="108" height="16">
-			</bounds>
+			<bounds x="24" y="242" width="108" height="16"/>
 		</backdrop>
 		<backdrop name="label153" element="label_153">
-			<bounds x="285" y="115" width="55" height="11">
-			</bounds>
+			<bounds x="285" y="115" width="55" height="11"/>
 		</backdrop>
 		<backdrop name="label205" element="label_205">
-			<bounds x="525" y="115" width="55" height="11">
-			</bounds>
+			<bounds x="525" y="115" width="55" height="11"/>
 		</backdrop>
 		<backdrop name="label206" element="label_206">
-			<bounds x="622" y="142" width="33" height="22">
-			</bounds>
+			<bounds x="622" y="142" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label207" element="label_207">
-			<bounds x="624" y="224" width="29" height="22">
-			</bounds>
+			<bounds x="624" y="224" width="29" height="22"/>
 		</backdrop>
 		<backdrop name="label208" element="label_208">
-			<bounds x="625" y="310" width="27" height="22">
-			</bounds>
+			<bounds x="625" y="310" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="label209" element="label_209">
-			<bounds x="285" y="340" width="51" height="11">
-			</bounds>
+			<bounds x="285" y="340" width="51" height="11"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_button" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_button" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_button" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_button" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1coro21n.lay
+++ b/src/mame/layout/m1coro21n.lay
@@ -8,11552 +8,7227 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3 SIGNS  ON WINLINE AWARDS FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 SIGNS  ON WINLINE AWARDS FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="FRUIT  STALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="FRUIT  STALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WHEEL CLAMPED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WHEEL CLAMPED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TAKE A STROLL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TAKE A STROLL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="12 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="12 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="GO TO GARAGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="GO TO GARAGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TROLLEY DASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TROLLEY DASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="CAUGHT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="BY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="PERCY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="CAUGHT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="BY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="PERCY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="8 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="8 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="VERA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="VERA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="KEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="KEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_4_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_4_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ROVERS RETURN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROVERS RETURN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string=" fruit  stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string=" fruit  stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.03">
-			</color>
+			<color red="0.03" green="0.00" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 		<text string="END OF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="PART ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="ONE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-		<text string="END OF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="PART ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="ONE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HAIR SALON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HAIR SALON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_130_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TO CORONATION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" STreet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="TO CORONATION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" STreet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.37" green="0.35" blue="0.05">
-			</color>
+			<color red="0.37" green="0.35" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.01">
-			</color>
+			<color red="0.09" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.74" green="0.69" blue="0.11">
-			</color>
+			<color red="0.74" green="0.69" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.17" blue="0.03">
-			</color>
+			<color red="0.18" green="0.17" blue="0.03"/>
 		</rect>
 		<text string="EXCHANGE FOR CORONATION STREET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.37" green="0.35" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.74" green="0.69" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.17" blue="0.03">
-			</color>
-		</rect>
-		<text string="EXCHANGE FOR CORONATION STREET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_132_2" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="run over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="run over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="take a stroll">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="take a stroll">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="DEREK &#x26;&#x26; MAVIS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="DEREK &#x26;&#x26; MAVIS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GO TO THE CABIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO TO THE CABIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="4 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ROVERS RETURN BEST BITTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROVERS RETURN BEST BITTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="EMPTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="EMPTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PAPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="PAPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" 60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string=" 60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="garage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="garage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="6 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="6 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="RITA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="RITA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACCEPT WAGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACCEPT WAGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="M  V.B MOTORS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="M  V.B MOTORS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="REJECT WAGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="REJECT WAGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WAGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WAGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string=" HOLD ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_146_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_146">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string=" HOLD ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string=" HOLD ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_152_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_152">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.10">
-			</bounds>
-		</text>
 		<text string="HOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.20" width="0.80" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.20" width="0.80" height="0.10"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.30" width="0.80" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.30" width="0.80" height="0.10"/>
 		</text>
 		<text string="       ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.40" width="0.80" height="0.10">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.10">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.60" width="0.80" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.40" width="0.80" height="0.10"/>
 		</text>
 		<text string="??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.70" width="0.80" height="0.10">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.80" width="0.80" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.70" width="0.80" height="0.10"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_17">
 		<text string="Coronation Street Classic by Ploggy and Ploggy Jnr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_62">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_63">
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_109">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.07"/>
 		</text>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.13" width="0.90" height="0.07"/>
 		</text>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.07"/>
 		</text>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.27" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.27" width="0.90" height="0.07"/>
 		</text>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.07"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.42" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.42" width="0.90" height="0.07"/>
 		</text>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.07"/>
 		</text>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.57" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.57" width="0.90" height="0.07"/>
 		</text>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.07"/>
 		</text>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.07"/>
 		</text>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.07"/>
 		</text>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.87" width="0.90" height="0.07"/>
 		</text>
 	</element>
 	<element name="label_117">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="685">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="685"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="176" y="452" width="100" height="151">
-			</bounds>
+			<bounds x="176" y="452" width="100" height="151"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="176.0000" y="452.0000" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="176.0000" y="452.0000" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="180.1667" y="454.0972" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="180.1667" y="454.0972" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="184.3333" y="456.1945" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="184.3333" y="456.1945" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="188.5000" y="458.2917" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="188.5000" y="458.2917" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="192.6667" y="460.3889" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="192.6667" y="460.3889" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="196.8333" y="462.4861" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="196.8333" y="462.4861" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="176.0000" y="502.3333" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="176.0000" y="502.3333" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="180.1667" y="504.4306" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="180.1667" y="504.4306" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="184.3333" y="506.5278" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="184.3333" y="506.5278" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="188.5000" y="508.6250" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="188.5000" y="508.6250" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="192.6667" y="510.7222" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="192.6667" y="510.7222" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="196.8333" y="512.8195" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="196.8333" y="512.8195" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="176.0000" y="552.6667" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="176.0000" y="552.6667" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="180.1667" y="554.7639" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="180.1667" y="554.7639" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="184.3333" y="556.8611" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="184.3333" y="556.8611" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="188.5000" y="558.9584" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="188.5000" y="558.9584" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="192.6667" y="561.0556" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="192.6667" y="561.0556" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="196.8333" y="563.1528" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="196.8333" y="563.1528" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="176" y="452" width="100" height="151">
-			</bounds>
+			<bounds x="176" y="452" width="100" height="151"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="307" y="453" width="100" height="151">
-			</bounds>
+			<bounds x="307" y="453" width="100" height="151"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="307.0000" y="453.0000" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="307.0000" y="453.0000" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="311.1667" y="455.0972" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="311.1667" y="455.0972" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="315.3333" y="457.1945" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="315.3333" y="457.1945" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="319.5000" y="459.2917" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="319.5000" y="459.2917" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.6667" y="461.3889" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="323.6667" y="461.3889" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="327.8333" y="463.4861" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="327.8333" y="463.4861" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="307.0000" y="503.3333" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="307.0000" y="503.3333" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="311.1667" y="505.4306" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="311.1667" y="505.4306" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="315.3333" y="507.5278" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="315.3333" y="507.5278" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="319.5000" y="509.6250" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="319.5000" y="509.6250" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.6667" y="511.7222" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="323.6667" y="511.7222" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="327.8333" y="513.8195" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="327.8333" y="513.8195" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="307.0000" y="553.6667" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="307.0000" y="553.6667" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="311.1667" y="555.7639" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="311.1667" y="555.7639" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="315.3333" y="557.8611" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="315.3333" y="557.8611" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="319.5000" y="559.9584" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="319.5000" y="559.9584" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.6667" y="562.0556" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="323.6667" y="562.0556" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="327.8333" y="564.1528" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="327.8333" y="564.1528" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="307" y="453" width="100" height="151">
-			</bounds>
+			<bounds x="307" y="453" width="100" height="151"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="441" y="452" width="100" height="151">
-			</bounds>
+			<bounds x="441" y="452" width="100" height="151"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="441.0000" y="452.0000" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="441.0000" y="452.0000" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="445.1667" y="454.0972" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="445.1667" y="454.0972" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="449.3333" y="456.1945" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="449.3333" y="456.1945" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="453.5000" y="458.2917" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="453.5000" y="458.2917" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="457.6667" y="460.3889" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="457.6667" y="460.3889" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="461.8333" y="462.4861" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="461.8333" y="462.4861" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="441.0000" y="502.3333" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="441.0000" y="502.3333" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="445.1667" y="504.4306" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="445.1667" y="504.4306" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="449.3333" y="506.5278" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="449.3333" y="506.5278" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="453.5000" y="508.6250" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="453.5000" y="508.6250" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="457.6667" y="510.7222" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="457.6667" y="510.7222" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="461.8333" y="512.8195" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="461.8333" y="512.8195" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="441.0000" y="552.6667" width="100.0000" height="50.3333">
-			</bounds>
+			<bounds x="441.0000" y="552.6667" width="100.0000" height="50.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="445.1667" y="554.7639" width="91.6667" height="46.1389">
-			</bounds>
+			<bounds x="445.1667" y="554.7639" width="91.6667" height="46.1389"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="449.3333" y="556.8611" width="83.3333" height="41.9444">
-			</bounds>
+			<bounds x="449.3333" y="556.8611" width="83.3333" height="41.9444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="453.5000" y="558.9584" width="75.0000" height="37.7500">
-			</bounds>
+			<bounds x="453.5000" y="558.9584" width="75.0000" height="37.7500"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="457.6667" y="561.0556" width="66.6667" height="33.5556">
-			</bounds>
+			<bounds x="457.6667" y="561.0556" width="66.6667" height="33.5556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="461.8333" y="563.1528" width="58.3333" height="29.3611">
-			</bounds>
+			<bounds x="461.8333" y="563.1528" width="58.3333" height="29.3611"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="441" y="452" width="100" height="151">
-			</bounds>
+			<bounds x="441" y="452" width="100" height="151"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="444" y="189" width="81" height="68">
-			</bounds>
+			<bounds x="444" y="189" width="81" height="68"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="444.0000" y="189.0000" width="81.0000" height="68.0000">
-			</bounds>
+			<bounds x="444.0000" y="189.0000" width="81.0000" height="68.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="447.3750" y="191.8333" width="74.2500" height="62.3333">
-			</bounds>
+			<bounds x="447.3750" y="191.8333" width="74.2500" height="62.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="450.7500" y="194.6667" width="67.5000" height="56.6667">
-			</bounds>
+			<bounds x="450.7500" y="194.6667" width="67.5000" height="56.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="454.1250" y="197.5000" width="60.7500" height="51.0000">
-			</bounds>
+			<bounds x="454.1250" y="197.5000" width="60.7500" height="51.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="457.5000" y="200.3333" width="54.0000" height="45.3333">
-			</bounds>
+			<bounds x="457.5000" y="200.3333" width="54.0000" height="45.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="460.8750" y="203.1667" width="47.2500" height="39.6667">
-			</bounds>
+			<bounds x="460.8750" y="203.1667" width="47.2500" height="39.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="444" y="189" width="81" height="68">
-			</bounds>
+			<bounds x="444" y="189" width="81" height="68"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="173" y="608" width="372" height="27">
-			</bounds>
+			<bounds x="173" y="608" width="372" height="27"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="175" y="610" width="368" height="23">
-			</bounds>
+			<bounds x="175" y="610" width="368" height="23"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="44" y="588" width="37" height="37">
-			</bounds>
+			<bounds x="44" y="588" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="46" y="590" width="33" height="33">
-			</bounds>
+			<bounds x="46" y="590" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="44" y="554" width="37" height="37">
-			</bounds>
+			<bounds x="44" y="554" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="46" y="556" width="33" height="33">
-			</bounds>
+			<bounds x="46" y="556" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="44" y="520" width="37" height="37">
-			</bounds>
+			<bounds x="44" y="520" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="46" y="522" width="33" height="33">
-			</bounds>
+			<bounds x="46" y="522" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="26" y="447" width="72" height="42">
-			</bounds>
+			<bounds x="26" y="447" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="28" y="449" width="68" height="38">
-			</bounds>
+			<bounds x="28" y="449" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="44" y="486" width="37" height="37">
-			</bounds>
+			<bounds x="44" y="486" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="46" y="488" width="33" height="33">
-			</bounds>
+			<bounds x="46" y="488" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="789" y="614" width="192" height="20">
-			</bounds>
+			<bounds x="789" y="614" width="192" height="20"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="791" y="616" width="188" height="16">
-			</bounds>
+			<bounds x="791" y="616" width="188" height="16"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="654" y="181" width="42" height="42">
-			</bounds>
+			<bounds x="654" y="181" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="656" y="183" width="38" height="38">
-			</bounds>
+			<bounds x="656" y="183" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="654" y="222" width="42" height="42">
-			</bounds>
+			<bounds x="654" y="222" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="656" y="224" width="38" height="38">
-			</bounds>
+			<bounds x="656" y="224" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="607" y="225" width="42" height="42">
-			</bounds>
+			<bounds x="607" y="225" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="609" y="227" width="38" height="38">
-			</bounds>
+			<bounds x="609" y="227" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="560" y="229" width="42" height="42">
-			</bounds>
+			<bounds x="560" y="229" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="562" y="231" width="38" height="38">
-			</bounds>
+			<bounds x="562" y="231" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="607" y="184" width="42" height="42">
-			</bounds>
+			<bounds x="607" y="184" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="609" y="186" width="38" height="38">
-			</bounds>
+			<bounds x="609" y="186" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="560" y="188" width="42" height="42">
-			</bounds>
+			<bounds x="560" y="188" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="562" y="190" width="38" height="38">
-			</bounds>
+			<bounds x="562" y="190" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="433" y="98" width="52" height="42">
-			</bounds>
+			<bounds x="433" y="98" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="435" y="100" width="48" height="38">
-			</bounds>
+			<bounds x="435" y="100" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="305" y="98" width="62" height="42">
-			</bounds>
+			<bounds x="305" y="98" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="307" y="100" width="58" height="38">
-			</bounds>
+			<bounds x="307" y="100" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="209" y="98" width="50" height="42">
-			</bounds>
+			<bounds x="209" y="98" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="211" y="100" width="46" height="38">
-			</bounds>
+			<bounds x="211" y="100" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="155" y="98" width="57" height="42">
-			</bounds>
+			<bounds x="155" y="98" width="57" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="157" y="100" width="53" height="38">
-			</bounds>
+			<bounds x="157" y="100" width="53" height="38"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="482" y="98" width="57" height="42">
-			</bounds>
+			<bounds x="482" y="98" width="57" height="42"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="484" y="100" width="53" height="38">
-			</bounds>
+			<bounds x="484" y="100" width="53" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="364" y="98" width="72" height="42">
-			</bounds>
+			<bounds x="364" y="98" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="366" y="100" width="68" height="38">
-			</bounds>
+			<bounds x="366" y="100" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="256" y="98" width="52" height="42">
-			</bounds>
+			<bounds x="256" y="98" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="258" y="100" width="48" height="38">
-			</bounds>
+			<bounds x="258" y="100" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="106" y="98" width="52" height="42">
-			</bounds>
+			<bounds x="106" y="98" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="108" y="100" width="48" height="38">
-			</bounds>
+			<bounds x="108" y="100" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="859" y="98" width="52" height="42">
-			</bounds>
+			<bounds x="859" y="98" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="861" y="100" width="48" height="38">
-			</bounds>
+			<bounds x="861" y="100" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="746" y="98" width="62" height="42">
-			</bounds>
+			<bounds x="746" y="98" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="748" y="100" width="58" height="38">
-			</bounds>
+			<bounds x="748" y="100" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="805" y="98" width="57" height="42">
-			</bounds>
+			<bounds x="805" y="98" width="57" height="42"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="807" y="100" width="53" height="38">
-			</bounds>
+			<bounds x="807" y="100" width="53" height="38"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="683" y="98" width="67" height="42">
-			</bounds>
+			<bounds x="683" y="98" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="685" y="100" width="63" height="38">
-			</bounds>
+			<bounds x="685" y="100" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="585" y="98" width="52" height="42">
-			</bounds>
+			<bounds x="585" y="98" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="587" y="100" width="48" height="38">
-			</bounds>
+			<bounds x="587" y="100" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="536" y="98" width="52" height="42">
-			</bounds>
+			<bounds x="536" y="98" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="538" y="100" width="48" height="38">
-			</bounds>
+			<bounds x="538" y="100" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="634" y="98" width="52" height="42">
-			</bounds>
+			<bounds x="634" y="98" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="636" y="100" width="48" height="38">
-			</bounds>
+			<bounds x="636" y="100" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="908" y="98" width="57" height="42">
-			</bounds>
+			<bounds x="908" y="98" width="57" height="42"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="910" y="100" width="53" height="38">
-			</bounds>
+			<bounds x="910" y="100" width="53" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="21" y="98" width="88" height="42">
-			</bounds>
+			<bounds x="21" y="98" width="88" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="23" y="100" width="84" height="38">
-			</bounds>
+			<bounds x="23" y="100" width="84" height="38"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="923" y="137" width="82" height="52">
-			</bounds>
+			<bounds x="923" y="137" width="82" height="52"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="925" y="139" width="78" height="48">
-			</bounds>
+			<bounds x="925" y="139" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="869" y="148" width="57" height="42">
-			</bounds>
+			<bounds x="869" y="148" width="57" height="42"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="871" y="150" width="53" height="38">
-			</bounds>
+			<bounds x="871" y="150" width="53" height="38"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="815" y="154" width="57" height="52">
-			</bounds>
+			<bounds x="815" y="154" width="57" height="52"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="817" y="156" width="53" height="48">
-			</bounds>
+			<bounds x="817" y="156" width="53" height="48"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="151" y="389" width="47" height="52">
-			</bounds>
+			<bounds x="151" y="389" width="47" height="52"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="153" y="391" width="43" height="48">
-			</bounds>
+			<bounds x="153" y="391" width="43" height="48"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="112" y="389" width="42" height="52">
-			</bounds>
+			<bounds x="112" y="389" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="114" y="391" width="38" height="48">
-			</bounds>
+			<bounds x="114" y="391" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_2_border" state="0">
-			<bounds x="149" y="375" width="49" height="19">
-			</bounds>
+			<bounds x="149" y="375" width="49" height="19"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_2" state="0">
-			<bounds x="151" y="377" width="45" height="15">
-			</bounds>
+			<bounds x="151" y="377" width="45" height="15"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="233" y="389" width="94" height="52">
-			</bounds>
+			<bounds x="233" y="389" width="94" height="52"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="235" y="391" width="90" height="48">
-			</bounds>
+			<bounds x="235" y="391" width="90" height="48"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="194" y="389" width="42" height="52">
-			</bounds>
+			<bounds x="194" y="389" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="196" y="391" width="38" height="48">
-			</bounds>
+			<bounds x="196" y="391" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="780" y="227" width="27" height="42">
-			</bounds>
+			<bounds x="780" y="227" width="27" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="782" y="229" width="23" height="38">
-			</bounds>
+			<bounds x="782" y="229" width="23" height="38"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="783" y="374" width="207" height="37">
-			</bounds>
+			<bounds x="783" y="374" width="207" height="37"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="785" y="376" width="203" height="33">
-			</bounds>
+			<bounds x="785" y="376" width="203" height="33"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_2_border" state="0">
-			<bounds x="232" y="371" width="96" height="22">
-			</bounds>
+			<bounds x="232" y="371" width="96" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_2" state="0">
-			<bounds x="234" y="373" width="92" height="18">
-			</bounds>
+			<bounds x="234" y="373" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="673" y="389" width="44" height="52">
-			</bounds>
+			<bounds x="673" y="389" width="44" height="52"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="675" y="391" width="40" height="48">
-			</bounds>
+			<bounds x="675" y="391" width="40" height="48"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="634" y="389" width="42" height="52">
-			</bounds>
+			<bounds x="634" y="389" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="636" y="391" width="38" height="48">
-			</bounds>
+			<bounds x="636" y="391" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="587" y="389" width="50" height="52">
-			</bounds>
+			<bounds x="587" y="389" width="50" height="52"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="589" y="391" width="46" height="48">
-			</bounds>
+			<bounds x="589" y="391" width="46" height="48"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="549" y="389" width="42" height="52">
-			</bounds>
+			<bounds x="549" y="389" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="551" y="391" width="38" height="48">
-			</bounds>
+			<bounds x="551" y="391" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="323" y="389" width="54" height="52">
-			</bounds>
+			<bounds x="323" y="389" width="54" height="52"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="325" y="391" width="50" height="48">
-			</bounds>
+			<bounds x="325" y="391" width="50" height="48"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="374" y="389" width="47" height="52">
-			</bounds>
+			<bounds x="374" y="389" width="47" height="52"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="376" y="391" width="43" height="48">
-			</bounds>
+			<bounds x="376" y="391" width="43" height="48"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="417" y="389" width="42" height="52">
-			</bounds>
+			<bounds x="417" y="389" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="419" y="391" width="38" height="48">
-			</bounds>
+			<bounds x="419" y="391" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="456" y="389" width="45" height="52">
-			</bounds>
+			<bounds x="456" y="389" width="45" height="52"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="458" y="391" width="41" height="48">
-			</bounds>
+			<bounds x="458" y="391" width="41" height="48"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="498" y="389" width="54" height="52">
-			</bounds>
+			<bounds x="498" y="389" width="54" height="52"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="500" y="391" width="50" height="48">
-			</bounds>
+			<bounds x="500" y="391" width="50" height="48"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="31" y="47" width="47" height="47">
-			</bounds>
+			<bounds x="31" y="47" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="33" y="49" width="43" height="43">
-			</bounds>
+			<bounds x="33" y="49" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="81" y="11" width="62" height="72">
-			</bounds>
+			<bounds x="81" y="11" width="62" height="72"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="83" y="13" width="58" height="68">
-			</bounds>
+			<bounds x="83" y="13" width="58" height="68"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="146" y="3" width="47" height="47">
-			</bounds>
+			<bounds x="146" y="3" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="148" y="5" width="43" height="43">
-			</bounds>
+			<bounds x="148" y="5" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="31" y="3" width="47" height="47">
-			</bounds>
+			<bounds x="31" y="3" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="33" y="5" width="43" height="43">
-			</bounds>
+			<bounds x="33" y="5" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="146" y="47" width="47" height="47">
-			</bounds>
+			<bounds x="146" y="47" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="148" y="49" width="43" height="43">
-			</bounds>
+			<bounds x="148" y="49" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="755" y="189" width="62" height="42">
-			</bounds>
+			<bounds x="755" y="189" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="757" y="191" width="58" height="38">
-			</bounds>
+			<bounds x="757" y="191" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2_border" state="0">
-			<bounds x="719" y="228" width="67" height="42">
-			</bounds>
+			<bounds x="719" y="228" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2" state="0">
-			<bounds x="721" y="230" width="63" height="38">
-			</bounds>
+			<bounds x="721" y="230" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="716" y="345" width="67" height="42">
-			</bounds>
+			<bounds x="716" y="345" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="718" y="347" width="63" height="38">
-			</bounds>
+			<bounds x="718" y="347" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="714" y="384" width="67" height="52">
-			</bounds>
+			<bounds x="714" y="384" width="67" height="52"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="716" y="386" width="63" height="48">
-			</bounds>
+			<bounds x="716" y="386" width="63" height="48"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="710" y="267" width="67" height="42">
-			</bounds>
+			<bounds x="710" y="267" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="712" y="269" width="63" height="38">
-			</bounds>
+			<bounds x="712" y="269" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="713" y="306" width="67" height="42">
-			</bounds>
+			<bounds x="713" y="306" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="715" y="308" width="63" height="38">
-			</bounds>
+			<bounds x="715" y="308" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="888" y="273" width="62" height="35">
-			</bounds>
+			<bounds x="888" y="273" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="890" y="275" width="58" height="31">
-			</bounds>
+			<bounds x="890" y="275" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="801" y="305" width="182" height="22">
-			</bounds>
+			<bounds x="801" y="305" width="182" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="803" y="307" width="178" height="18">
-			</bounds>
+			<bounds x="803" y="307" width="178" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="830" y="273" width="62" height="35">
-			</bounds>
+			<bounds x="830" y="273" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="832" y="275" width="58" height="31">
-			</bounds>
+			<bounds x="832" y="275" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="84" y="390" width="27" height="52">
-			</bounds>
+			<bounds x="84" y="390" width="27" height="52"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="86" y="392" width="23" height="48">
-			</bounds>
+			<bounds x="86" y="392" width="23" height="48"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_2_border" state="0">
-			<bounds x="26" y="402" width="62" height="29">
-			</bounds>
+			<bounds x="26" y="402" width="62" height="29"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_2" state="0">
-			<bounds x="28" y="404" width="58" height="25">
-			</bounds>
+			<bounds x="28" y="404" width="58" height="25"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="843" y="213" width="97" height="27">
-			</bounds>
+			<bounds x="843" y="213" width="97" height="27"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="845" y="215" width="93" height="23">
-			</bounds>
+			<bounds x="845" y="215" width="93" height="23"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="93" y="233" width="3" height="3">
-			</bounds>
+			<bounds x="93" y="233" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_142_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="896" y="634" width="72" height="52">
-			</bounds>
+			<bounds x="896" y="634" width="72" height="52"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_142" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="898" y="636" width="68" height="48">
-			</bounds>
+			<bounds x="898" y="636" width="68" height="48"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_143_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="738" y="634" width="84" height="52">
-			</bounds>
+			<bounds x="738" y="634" width="84" height="52"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_143" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="740" y="636" width="80" height="48">
-			</bounds>
+			<bounds x="740" y="636" width="80" height="48"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_144_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="609" y="634" width="67" height="52">
-			</bounds>
+			<bounds x="609" y="634" width="67" height="52"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_144" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="611" y="636" width="63" height="48">
-			</bounds>
+			<bounds x="611" y="636" width="63" height="48"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_145_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="455" y="634" width="67" height="52">
-			</bounds>
+			<bounds x="455" y="634" width="67" height="52"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_145" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="457" y="636" width="63" height="48">
-			</bounds>
+			<bounds x="457" y="636" width="63" height="48"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_146_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="324" y="634" width="67" height="52">
-			</bounds>
+			<bounds x="324" y="634" width="67" height="52"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_146" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="326" y="636" width="63" height="48">
-			</bounds>
+			<bounds x="326" y="636" width="63" height="48"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_147_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="195" y="634" width="67" height="52">
-			</bounds>
+			<bounds x="195" y="634" width="67" height="52"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_147" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="197" y="636" width="63" height="48">
-			</bounds>
+			<bounds x="197" y="636" width="63" height="48"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_148_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="32" y="634" width="62" height="52">
-			</bounds>
+			<bounds x="32" y="634" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_148" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="34" y="636" width="58" height="48">
-			</bounds>
+			<bounds x="34" y="636" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_150_border" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="869" y="57" width="75" height="27">
-			</bounds>
+			<bounds x="869" y="57" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_150" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="871" y="59" width="71" height="23">
-			</bounds>
+			<bounds x="871" y="59" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_151_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="771" y="57" width="75" height="27">
-			</bounds>
+			<bounds x="771" y="57" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_151" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="773" y="59" width="71" height="23">
-			</bounds>
+			<bounds x="773" y="59" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_152_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="869" y="15" width="75" height="27">
-			</bounds>
+			<bounds x="869" y="15" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_152" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="871" y="17" width="71" height="23">
-			</bounds>
+			<bounds x="871" y="17" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_153_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="771" y="15" width="75" height="27">
-			</bounds>
+			<bounds x="771" y="15" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_153" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="773" y="17" width="71" height="23">
-			</bounds>
+			<bounds x="773" y="17" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp184" element="colour_button_154_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="27" y="146" width="67" height="67">
-			</bounds>
+			<bounds x="27" y="146" width="67" height="67"/>
 		</backdrop>
 		<backdrop name="lamp184" element="colour_button_154" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="29" y="148" width="63" height="63">
-			</bounds>
+			<bounds x="29" y="148" width="63" height="63"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="139" y="172" width="31" height="24">
-			</bounds>
+			<bounds x="139" y="172" width="31" height="24"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="143" y="174" width="22" height="2">
-			</bounds>
+			<bounds x="143" y="174" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="161" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="161" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="161" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="161" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="143" y="191" width="22" height="2">
-			</bounds>
+			<bounds x="143" y="191" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="143" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="143" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="143" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="143" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="143" y="182" width="22" height="2">
-			</bounds>
+			<bounds x="143" y="182" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="165" y="191" width="4" height="2">
-			</bounds>
+			<bounds x="165" y="191" width="4" height="2"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="143" y="174" width="22" height="2">
-			</bounds>
+			<bounds x="143" y="174" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="161" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="161" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="161" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="161" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="143" y="191" width="22" height="2">
-			</bounds>
+			<bounds x="143" y="191" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="143" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="143" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="143" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="143" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="143" y="182" width="22" height="2">
-			</bounds>
+			<bounds x="143" y="182" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="165" y="191" width="4" height="2">
-			</bounds>
+			<bounds x="165" y="191" width="4" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="201" y="172" width="31" height="24">
-			</bounds>
+			<bounds x="201" y="172" width="31" height="24"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="205" y="174" width="22" height="2">
-			</bounds>
+			<bounds x="205" y="174" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="223" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="223" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="223" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="223" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="205" y="191" width="22" height="2">
-			</bounds>
+			<bounds x="205" y="191" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="205" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="205" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="205" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="205" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="205" y="182" width="22" height="2">
-			</bounds>
+			<bounds x="205" y="182" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="227" y="191" width="4" height="2">
-			</bounds>
+			<bounds x="227" y="191" width="4" height="2"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="205" y="174" width="22" height="2">
-			</bounds>
+			<bounds x="205" y="174" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="223" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="223" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="223" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="223" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="205" y="191" width="22" height="2">
-			</bounds>
+			<bounds x="205" y="191" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="205" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="205" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="205" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="205" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="205" y="182" width="22" height="2">
-			</bounds>
+			<bounds x="205" y="182" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="227" y="191" width="4" height="2">
-			</bounds>
+			<bounds x="227" y="191" width="4" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="170" y="172" width="31" height="24">
-			</bounds>
+			<bounds x="170" y="172" width="31" height="24"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="174" y="174" width="22" height="2">
-			</bounds>
+			<bounds x="174" y="174" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="192" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="192" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="192" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="192" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="174" y="191" width="22" height="2">
-			</bounds>
+			<bounds x="174" y="191" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="174" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="174" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="174" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="174" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="174" y="182" width="22" height="2">
-			</bounds>
+			<bounds x="174" y="182" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="196" y="191" width="4" height="2">
-			</bounds>
+			<bounds x="196" y="191" width="4" height="2"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="174" y="174" width="22" height="2">
-			</bounds>
+			<bounds x="174" y="174" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="192" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="192" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="192" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="192" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="174" y="191" width="22" height="2">
-			</bounds>
+			<bounds x="174" y="191" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="174" y="182" width="4" height="10">
-			</bounds>
+			<bounds x="174" y="182" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="174" y="174" width="4" height="10">
-			</bounds>
+			<bounds x="174" y="174" width="4" height="10"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="174" y="182" width="22" height="2">
-			</bounds>
+			<bounds x="174" y="182" width="22" height="2"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="196" y="191" width="4" height="2">
-			</bounds>
+			<bounds x="196" y="191" width="4" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="848" y="237" width="30" height="37">
-			</bounds>
+			<bounds x="848" y="237" width="30" height="37"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="852" y="240" width="21" height="3">
-			</bounds>
+			<bounds x="852" y="240" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="869" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="869" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="869" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="869" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="852" y="267" width="21" height="3">
-			</bounds>
+			<bounds x="852" y="267" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="852" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="852" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="852" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="852" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="852" y="253" width="21" height="3">
-			</bounds>
+			<bounds x="852" y="253" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="873" y="267" width="4" height="3">
-			</bounds>
+			<bounds x="873" y="267" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="852" y="240" width="21" height="3">
-			</bounds>
+			<bounds x="852" y="240" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="869" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="869" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="869" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="869" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="852" y="267" width="21" height="3">
-			</bounds>
+			<bounds x="852" y="267" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="852" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="852" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="852" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="852" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="852" y="253" width="21" height="3">
-			</bounds>
+			<bounds x="852" y="253" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="873" y="267" width="4" height="3">
-			</bounds>
+			<bounds x="873" y="267" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="876" y="237" width="30" height="37">
-			</bounds>
+			<bounds x="876" y="237" width="30" height="37"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="880" y="240" width="21" height="3">
-			</bounds>
+			<bounds x="880" y="240" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="897" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="897" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="897" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="897" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="880" y="267" width="21" height="3">
-			</bounds>
+			<bounds x="880" y="267" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="880" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="880" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="880" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="880" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="880" y="253" width="21" height="3">
-			</bounds>
+			<bounds x="880" y="253" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="901" y="267" width="4" height="3">
-			</bounds>
+			<bounds x="901" y="267" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="880" y="240" width="21" height="3">
-			</bounds>
+			<bounds x="880" y="240" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="897" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="897" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="897" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="897" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="880" y="267" width="21" height="3">
-			</bounds>
+			<bounds x="880" y="267" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="880" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="880" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="880" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="880" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="880" y="253" width="21" height="3">
-			</bounds>
+			<bounds x="880" y="253" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="901" y="267" width="4" height="3">
-			</bounds>
+			<bounds x="901" y="267" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="904" y="237" width="30" height="37">
-			</bounds>
+			<bounds x="904" y="237" width="30" height="37"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="908" y="240" width="21" height="3">
-			</bounds>
+			<bounds x="908" y="240" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="925" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="925" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="925" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="925" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="908" y="267" width="21" height="3">
-			</bounds>
+			<bounds x="908" y="267" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="908" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="908" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="908" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="908" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="908" y="253" width="21" height="3">
-			</bounds>
+			<bounds x="908" y="253" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="929" y="267" width="4" height="3">
-			</bounds>
+			<bounds x="929" y="267" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="908" y="240" width="21" height="3">
-			</bounds>
+			<bounds x="908" y="240" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="925" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="925" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="925" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="925" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="908" y="267" width="21" height="3">
-			</bounds>
+			<bounds x="908" y="267" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="908" y="253" width="4" height="16">
-			</bounds>
+			<bounds x="908" y="253" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="908" y="240" width="4" height="16">
-			</bounds>
+			<bounds x="908" y="240" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="908" y="253" width="21" height="3">
-			</bounds>
+			<bounds x="908" y="253" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="929" y="267" width="4" height="3">
-			</bounds>
+			<bounds x="929" y="267" width="4" height="3"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="313" y="315" width="320" height="45">
-			</bounds>
+			<bounds x="313" y="315" width="320" height="45"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="313" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="313" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="333" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="333" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="353" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="353" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="373" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="373" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="393" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="393" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="413" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="413" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="433" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="433" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="453" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="453" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="473" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="473" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="493" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="493" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="513" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="513" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="533" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="533" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="553" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="553" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="573" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="573" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="593" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="593" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="613" y="315" width="20" height="45">
-			</bounds>
+			<bounds x="613" y="315" width="20" height="45"/>
 		</backdrop>
 		<backdrop name="label17" element="label_17">
-			<bounds x="646" y="461" width="76" height="96">
-			</bounds>
+			<bounds x="646" y="461" width="76" height="96"/>
 		</backdrop>
 		<backdrop name="label62" element="label_62">
-			<bounds x="276" y="515" width="31" height="20">
-			</bounds>
+			<bounds x="276" y="515" width="31" height="20"/>
 		</backdrop>
 		<backdrop name="label63" element="label_63">
-			<bounds x="407" y="515" width="35" height="20">
-			</bounds>
+			<bounds x="407" y="515" width="35" height="20"/>
 		</backdrop>
 		<backdrop name="label109" element="label_109">
-			<bounds x="409" y="147" width="15" height="156">
-			</bounds>
+			<bounds x="409" y="147" width="15" height="156"/>
 		</backdrop>
 		<backdrop name="label117" element="label_117">
-			<bounds x="826" y="236" width="18" height="37">
-			</bounds>
+			<bounds x="826" y="236" width="18" height="37"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="219" y="322" width="32" height="16">
-			</bounds>
+			<bounds x="219" y="322" width="32" height="16"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="226" y="343" width="22" height="16">
-			</bounds>
+			<bounds x="226" y="343" width="22" height="16"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="219" y="283" width="32" height="16">
-			</bounds>
+			<bounds x="219" y="283" width="32" height="16"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="220" y="302" width="32" height="16">
-			</bounds>
+			<bounds x="220" y="302" width="32" height="16"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="221" y="264" width="32" height="16">
-			</bounds>
+			<bounds x="221" y="264" width="32" height="16"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="218" y="244" width="32" height="16">
-			</bounds>
+			<bounds x="218" y="244" width="32" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_button" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1cororrk.lay
+++ b/src/mame/layout/m1cororrk.lay
@@ -8,12678 +8,7636 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.20">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.20"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.30" width="0.80" height="0.20">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.30" width="0.80" height="0.20"/>
 		</text>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.20">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.20"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.70" width="0.80" height="0.20">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.20">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.30" width="0.80" height="0.20">
-			</bounds>
-		</text>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.20">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.70" width="0.80" height="0.20">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.70" width="0.80" height="0.20"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="TRAIL HELD!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="TRAIL HELD!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="JACK N VERA's BINGO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="JACK N VERA's BINGO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="JACKPOT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="JACKPOT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="JACKPOT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="JACKPOT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="PERCY'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PENSION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="PERCY'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PENSION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="DES'S DEAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CERT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="DES'S DEAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CERT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="JACK N ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="VERA'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="BINGO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACK N ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="VERA'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="BINGO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRAIL ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="DOWN IN ONE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="DOWN IN ONE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BOOST!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BOOST!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CURLY'S ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="MONEY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="SPINNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CURLY'S ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="MONEY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="SPINNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="REG!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="BALDWIN's BEST OFFER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="BALDWIN's BEST OFFER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BOOST!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BOOST!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Jackpot!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REG'S BRIGHT IDEA!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REG'S BRIGHT IDEA!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Skill ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Skill ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Trail ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Trail ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_160_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_206_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_206">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_207_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_207">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_208_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_208">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_209_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_209">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_210_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_210">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_211_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_211">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_212_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_212">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_213_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_213">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_36">
 		<text string="V1.01">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_40">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_41">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_60">
 		<text string="Get The Round In!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_192">
 		<text string="The Rovers Return Classic">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="Released 15/01/2003">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="By Ryan (Barcrestchamp)">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="Special Thanks to Harvey and Spa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="label_196">
 		<text string="Credits:">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_197">
 		<text string="25p Play">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="950" height="658">
-			</bounds>
+			<bounds x="0" y="0" width="950" height="658"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="121" y="436" width="80" height="140">
-			</bounds>
+			<bounds x="121" y="436" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="121.0000" y="436.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="121.0000" y="436.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="124.3333" y="437.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="124.3333" y="437.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="127.6667" y="439.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="127.6667" y="439.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="131.0000" y="441.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="131.0000" y="441.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="134.3333" y="443.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="134.3333" y="443.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="137.6667" y="445.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="137.6667" y="445.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="121.0000" y="482.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="121.0000" y="482.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="124.3333" y="484.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="124.3333" y="484.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="127.6667" y="486.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="127.6667" y="486.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="131.0000" y="488.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="131.0000" y="488.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="134.3333" y="490.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="134.3333" y="490.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="137.6667" y="492.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="137.6667" y="492.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="121.0000" y="529.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="121.0000" y="529.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="124.3333" y="531.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="124.3333" y="531.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="127.6667" y="533.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="127.6667" y="533.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="131.0000" y="535.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="131.0000" y="535.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="134.3333" y="537.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="134.3333" y="537.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="137.6667" y="539.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="137.6667" y="539.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="121" y="436" width="80" height="140">
-			</bounds>
+			<bounds x="121" y="436" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="236" y="436" width="80" height="140">
-			</bounds>
+			<bounds x="236" y="436" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="436.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="236.0000" y="436.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="437.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="239.3333" y="437.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="439.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="242.6667" y="439.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="441.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="246.0000" y="441.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="443.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="249.3333" y="443.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="445.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="252.6667" y="445.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="482.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="236.0000" y="482.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="484.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="239.3333" y="484.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="486.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="242.6667" y="486.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="488.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="246.0000" y="488.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="490.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="249.3333" y="490.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="492.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="252.6667" y="492.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="529.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="236.0000" y="529.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="531.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="239.3333" y="531.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="533.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="242.6667" y="533.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="535.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="246.0000" y="535.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="537.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="249.3333" y="537.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="539.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="252.6667" y="539.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="236" y="436" width="80" height="140">
-			</bounds>
+			<bounds x="236" y="436" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="354" y="436" width="80" height="140">
-			</bounds>
+			<bounds x="354" y="436" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="354.0000" y="436.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="354.0000" y="436.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="357.3333" y="437.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="357.3333" y="437.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="360.6667" y="439.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="360.6667" y="439.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="364.0000" y="441.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="364.0000" y="441.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="367.3333" y="443.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="367.3333" y="443.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="370.6667" y="445.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="370.6667" y="445.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="354.0000" y="482.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="354.0000" y="482.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="357.3333" y="484.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="357.3333" y="484.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="360.6667" y="486.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="360.6667" y="486.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="364.0000" y="488.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="364.0000" y="488.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="367.3333" y="490.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="367.3333" y="490.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="370.6667" y="492.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="370.6667" y="492.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="354.0000" y="529.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="354.0000" y="529.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="357.3333" y="531.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="357.3333" y="531.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="360.6667" y="533.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="360.6667" y="533.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="364.0000" y="535.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="364.0000" y="535.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="367.3333" y="537.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="367.3333" y="537.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="370.6667" y="539.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="370.6667" y="539.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="354" y="436" width="80" height="140">
-			</bounds>
+			<bounds x="354" y="436" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="538" y="445" width="80" height="80">
-			</bounds>
+			<bounds x="538" y="445" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="538.0000" y="445.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="538.0000" y="445.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="541.3333" y="448.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="541.3333" y="448.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="544.6667" y="451.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="544.6667" y="451.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="548.0000" y="455.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="548.0000" y="455.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="551.3333" y="458.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="551.3333" y="458.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="554.6667" y="461.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="554.6667" y="461.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="538" y="445" width="80" height="80">
-			</bounds>
+			<bounds x="538" y="445" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="30" y="575" width="65" height="32">
-			</bounds>
+			<bounds x="30" y="575" width="65" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="32" y="577" width="61" height="28">
-			</bounds>
+			<bounds x="32" y="577" width="61" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="449" y="510" width="52" height="72">
-			</bounds>
+			<bounds x="449" y="510" width="52" height="72"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="451" y="512" width="48" height="68">
-			</bounds>
+			<bounds x="451" y="512" width="48" height="68"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="449" y="432" width="52" height="72">
-			</bounds>
+			<bounds x="449" y="432" width="52" height="72"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="451" y="434" width="48" height="68">
-			</bounds>
+			<bounds x="451" y="434" width="48" height="68"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="6" y="420" width="52" height="52">
-			</bounds>
+			<bounds x="6" y="420" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="8" y="422" width="48" height="48">
-			</bounds>
+			<bounds x="8" y="422" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="178" y="347" width="32" height="32">
-			</bounds>
+			<bounds x="178" y="347" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="180" y="349" width="28" height="28">
-			</bounds>
+			<bounds x="180" y="349" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="145" y="314" width="32" height="32">
-			</bounds>
+			<bounds x="145" y="314" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="147" y="316" width="28" height="28">
-			</bounds>
+			<bounds x="147" y="316" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="145" y="347" width="32" height="32">
-			</bounds>
+			<bounds x="145" y="347" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="147" y="349" width="28" height="28">
-			</bounds>
+			<bounds x="147" y="349" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="178" y="281" width="32" height="32">
-			</bounds>
+			<bounds x="178" y="281" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="180" y="283" width="28" height="28">
-			</bounds>
+			<bounds x="180" y="283" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="112" y="314" width="32" height="32">
-			</bounds>
+			<bounds x="112" y="314" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="114" y="316" width="28" height="28">
-			</bounds>
+			<bounds x="114" y="316" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="112" y="281" width="32" height="32">
-			</bounds>
+			<bounds x="112" y="281" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="114" y="283" width="28" height="28">
-			</bounds>
+			<bounds x="114" y="283" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="79" y="348" width="32" height="32">
-			</bounds>
+			<bounds x="79" y="348" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="81" y="350" width="28" height="28">
-			</bounds>
+			<bounds x="81" y="350" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="79" y="314" width="32" height="32">
-			</bounds>
+			<bounds x="79" y="314" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="81" y="316" width="28" height="28">
-			</bounds>
+			<bounds x="81" y="316" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="46" y="314" width="32" height="32">
-			</bounds>
+			<bounds x="46" y="314" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="48" y="316" width="28" height="28">
-			</bounds>
+			<bounds x="48" y="316" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="45" y="281" width="32" height="32">
-			</bounds>
+			<bounds x="45" y="281" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="47" y="283" width="28" height="28">
-			</bounds>
+			<bounds x="47" y="283" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="13" y="347" width="32" height="32">
-			</bounds>
+			<bounds x="13" y="347" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="15" y="349" width="28" height="28">
-			</bounds>
+			<bounds x="15" y="349" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="13" y="281" width="32" height="32">
-			</bounds>
+			<bounds x="13" y="281" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="15" y="283" width="28" height="28">
-			</bounds>
+			<bounds x="15" y="283" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="20" y="255" width="182" height="22">
-			</bounds>
+			<bounds x="20" y="255" width="182" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="22" y="257" width="178" height="18">
-			</bounds>
+			<bounds x="22" y="257" width="178" height="18"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="626" y="447" width="32" height="32">
-			</bounds>
+			<bounds x="626" y="447" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="628" y="449" width="28" height="28">
-			</bounds>
+			<bounds x="628" y="449" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="627" y="487" width="32" height="32">
-			</bounds>
+			<bounds x="627" y="487" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="629" y="489" width="28" height="28">
-			</bounds>
+			<bounds x="629" y="489" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="565" y="73" width="32" height="22">
-			</bounds>
+			<bounds x="565" y="73" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="567" y="75" width="28" height="18">
-			</bounds>
+			<bounds x="567" y="75" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="604" y="80" width="32" height="22">
-			</bounds>
+			<bounds x="604" y="80" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="606" y="82" width="28" height="18">
-			</bounds>
+			<bounds x="606" y="82" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="646" y="82" width="32" height="22">
-			</bounds>
+			<bounds x="646" y="82" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="648" y="84" width="28" height="18">
-			</bounds>
+			<bounds x="648" y="84" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="727" y="25" width="32" height="22">
-			</bounds>
+			<bounds x="727" y="25" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="729" y="27" width="28" height="18">
-			</bounds>
+			<bounds x="729" y="27" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="684" y="17" width="32" height="22">
-			</bounds>
+			<bounds x="684" y="17" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="686" y="19" width="28" height="18">
-			</bounds>
+			<bounds x="686" y="19" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="562" y="23" width="32" height="22">
-			</bounds>
+			<bounds x="562" y="23" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="564" y="25" width="28" height="18">
-			</bounds>
+			<bounds x="564" y="25" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="747" y="44" width="72" height="32">
-			</bounds>
+			<bounds x="747" y="44" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="749" y="46" width="68" height="28">
-			</bounds>
+			<bounds x="749" y="46" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="726" y="74" width="32" height="22">
-			</bounds>
+			<bounds x="726" y="74" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="728" y="76" width="28" height="18">
-			</bounds>
+			<bounds x="728" y="76" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="689" y="81" width="32" height="22">
-			</bounds>
+			<bounds x="689" y="81" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="691" y="83" width="28" height="18">
-			</bounds>
+			<bounds x="691" y="83" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="645" y="16" width="32" height="22">
-			</bounds>
+			<bounds x="645" y="16" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="647" y="18" width="28" height="18">
-			</bounds>
+			<bounds x="647" y="18" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="605" y="18" width="32" height="22">
-			</bounds>
+			<bounds x="605" y="18" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="607" y="20" width="28" height="18">
-			</bounds>
+			<bounds x="607" y="20" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="503" y="44" width="72" height="32">
-			</bounds>
+			<bounds x="503" y="44" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="505" y="46" width="68" height="28">
-			</bounds>
+			<bounds x="505" y="46" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="459" y="130" width="52" height="37">
-			</bounds>
+			<bounds x="459" y="130" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="461" y="132" width="48" height="33">
-			</bounds>
+			<bounds x="461" y="132" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="515" y="130" width="52" height="37">
-			</bounds>
+			<bounds x="515" y="130" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="517" y="132" width="48" height="33">
-			</bounds>
+			<bounds x="517" y="132" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="570" y="130" width="52" height="37">
-			</bounds>
+			<bounds x="570" y="130" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="572" y="132" width="48" height="33">
-			</bounds>
+			<bounds x="572" y="132" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="710" y="130" width="52" height="37">
-			</bounds>
+			<bounds x="710" y="130" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="712" y="132" width="48" height="33">
-			</bounds>
+			<bounds x="712" y="132" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="318" y="130" width="52" height="37">
-			</bounds>
+			<bounds x="318" y="130" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="320" y="132" width="48" height="33">
-			</bounds>
+			<bounds x="320" y="132" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="374" y="120" width="82" height="47">
-			</bounds>
+			<bounds x="374" y="120" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="376" y="122" width="78" height="43">
-			</bounds>
+			<bounds x="376" y="122" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="625" y="120" width="82" height="47">
-			</bounds>
+			<bounds x="625" y="120" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="627" y="122" width="78" height="43">
-			</bounds>
+			<bounds x="627" y="122" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="625" y="169" width="82" height="47">
-			</bounds>
+			<bounds x="625" y="169" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="627" y="171" width="78" height="43">
-			</bounds>
+			<bounds x="627" y="171" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="374" y="169" width="82" height="47">
-			</bounds>
+			<bounds x="374" y="169" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="376" y="171" width="78" height="43">
-			</bounds>
+			<bounds x="376" y="171" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="570" y="179" width="52" height="37">
-			</bounds>
+			<bounds x="570" y="179" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="572" y="181" width="48" height="33">
-			</bounds>
+			<bounds x="572" y="181" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="515" y="179" width="52" height="37">
-			</bounds>
+			<bounds x="515" y="179" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="517" y="181" width="48" height="33">
-			</bounds>
+			<bounds x="517" y="181" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="459" y="180" width="52" height="37">
-			</bounds>
+			<bounds x="459" y="180" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="461" y="182" width="48" height="33">
-			</bounds>
+			<bounds x="461" y="182" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="709" y="179" width="52" height="37">
-			</bounds>
+			<bounds x="709" y="179" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="711" y="181" width="48" height="33">
-			</bounds>
+			<bounds x="711" y="181" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="318" y="179" width="52" height="37">
-			</bounds>
+			<bounds x="318" y="179" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="320" y="181" width="48" height="33">
-			</bounds>
+			<bounds x="320" y="181" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="624" y="270" width="82" height="47">
-			</bounds>
+			<bounds x="624" y="270" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="626" y="272" width="78" height="43">
-			</bounds>
+			<bounds x="626" y="272" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="374" y="270" width="82" height="47">
-			</bounds>
+			<bounds x="374" y="270" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="376" y="272" width="78" height="43">
-			</bounds>
+			<bounds x="376" y="272" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="318" y="280" width="52" height="37">
-			</bounds>
+			<bounds x="318" y="280" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="320" y="282" width="48" height="33">
-			</bounds>
+			<bounds x="320" y="282" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="459" y="280" width="52" height="37">
-			</bounds>
+			<bounds x="459" y="280" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="461" y="282" width="48" height="33">
-			</bounds>
+			<bounds x="461" y="282" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="514" y="280" width="52" height="37">
-			</bounds>
+			<bounds x="514" y="280" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="516" y="282" width="48" height="33">
-			</bounds>
+			<bounds x="516" y="282" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="569" y="280" width="52" height="37">
-			</bounds>
+			<bounds x="569" y="280" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="571" y="282" width="48" height="33">
-			</bounds>
+			<bounds x="571" y="282" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="709" y="280" width="52" height="37">
-			</bounds>
+			<bounds x="709" y="280" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="711" y="282" width="48" height="33">
-			</bounds>
+			<bounds x="711" y="282" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="374" y="219" width="82" height="47">
-			</bounds>
+			<bounds x="374" y="219" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="376" y="221" width="78" height="43">
-			</bounds>
+			<bounds x="376" y="221" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="624" y="219" width="82" height="47">
-			</bounds>
+			<bounds x="624" y="219" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="626" y="221" width="78" height="43">
-			</bounds>
+			<bounds x="626" y="221" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="709" y="229" width="52" height="37">
-			</bounds>
+			<bounds x="709" y="229" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="711" y="231" width="48" height="33">
-			</bounds>
+			<bounds x="711" y="231" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="569" y="229" width="52" height="37">
-			</bounds>
+			<bounds x="569" y="229" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="571" y="231" width="48" height="33">
-			</bounds>
+			<bounds x="571" y="231" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="514" y="229" width="52" height="37">
-			</bounds>
+			<bounds x="514" y="229" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="516" y="231" width="48" height="33">
-			</bounds>
+			<bounds x="516" y="231" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="459" y="229" width="52" height="37">
-			</bounds>
+			<bounds x="459" y="229" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="461" y="231" width="48" height="33">
-			</bounds>
+			<bounds x="461" y="231" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="318" y="229" width="52" height="37">
-			</bounds>
+			<bounds x="318" y="229" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="320" y="231" width="48" height="33">
-			</bounds>
+			<bounds x="320" y="231" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="459" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="459" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="461" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="461" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="569" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="569" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="571" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="571" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="514" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="514" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="516" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="516" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="318" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="318" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="320" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="320" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="374" y="321" width="82" height="47">
-			</bounds>
+			<bounds x="374" y="321" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="376" y="323" width="78" height="43">
-			</bounds>
+			<bounds x="376" y="323" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="624" y="321" width="82" height="47">
-			</bounds>
+			<bounds x="624" y="321" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="626" y="323" width="78" height="43">
-			</bounds>
+			<bounds x="626" y="323" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="709" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="709" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="711" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="711" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="436" y="30" width="52" height="37">
-			</bounds>
+			<bounds x="436" y="30" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="438" y="32" width="48" height="33">
-			</bounds>
+			<bounds x="438" y="32" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="377" y="30" width="52" height="37">
-			</bounds>
+			<bounds x="377" y="30" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="379" y="32" width="48" height="33">
-			</bounds>
+			<bounds x="379" y="32" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="318" y="31" width="52" height="37">
-			</bounds>
+			<bounds x="318" y="31" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="320" y="33" width="48" height="33">
-			</bounds>
+			<bounds x="320" y="33" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="318" y="80" width="52" height="37">
-			</bounds>
+			<bounds x="318" y="80" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="320" y="82" width="48" height="33">
-			</bounds>
+			<bounds x="320" y="82" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="759" y="140" width="62" height="62">
-			</bounds>
+			<bounds x="759" y="140" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="761" y="142" width="58" height="58">
-			</bounds>
+			<bounds x="761" y="142" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="253" y="191" width="62" height="62">
-			</bounds>
+			<bounds x="253" y="191" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="255" y="193" width="58" height="58">
-			</bounds>
+			<bounds x="255" y="193" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="760" y="237" width="62" height="62">
-			</bounds>
+			<bounds x="760" y="237" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="762" y="239" width="58" height="58">
-			</bounds>
+			<bounds x="762" y="239" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="570" y="382" width="52" height="37">
-			</bounds>
+			<bounds x="570" y="382" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="572" y="384" width="48" height="33">
-			</bounds>
+			<bounds x="572" y="384" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="760" y="332" width="62" height="62">
-			</bounds>
+			<bounds x="760" y="332" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="762" y="334" width="58" height="58">
-			</bounds>
+			<bounds x="762" y="334" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="459" y="382" width="52" height="37">
-			</bounds>
+			<bounds x="459" y="382" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="461" y="384" width="48" height="33">
-			</bounds>
+			<bounds x="461" y="384" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="255" y="289" width="62" height="62">
-			</bounds>
+			<bounds x="255" y="289" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="257" y="291" width="58" height="58">
-			</bounds>
+			<bounds x="257" y="291" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="709" y="382" width="52" height="37">
-			</bounds>
+			<bounds x="709" y="382" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="711" y="384" width="48" height="33">
-			</bounds>
+			<bounds x="711" y="384" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="374" y="372" width="82" height="47">
-			</bounds>
+			<bounds x="374" y="372" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="376" y="374" width="78" height="43">
-			</bounds>
+			<bounds x="376" y="374" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="514" y="382" width="52" height="37">
-			</bounds>
+			<bounds x="514" y="382" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="516" y="384" width="48" height="33">
-			</bounds>
+			<bounds x="516" y="384" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="624" y="372" width="82" height="47">
-			</bounds>
+			<bounds x="624" y="372" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="626" y="374" width="78" height="43">
-			</bounds>
+			<bounds x="626" y="374" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="266" y="382" width="52" height="37">
-			</bounds>
+			<bounds x="266" y="382" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="268" y="384" width="48" height="33">
-			</bounds>
+			<bounds x="268" y="384" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="320" y="382" width="52" height="37">
-			</bounds>
+			<bounds x="320" y="382" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="322" y="384" width="48" height="33">
-			</bounds>
+			<bounds x="322" y="384" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2_border" state="0">
-			<bounds x="852" y="436" width="82" height="22">
-			</bounds>
+			<bounds x="852" y="436" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2" state="0">
-			<bounds x="854" y="438" width="78" height="18">
-			</bounds>
+			<bounds x="854" y="438" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_2_border" state="0">
-			<bounds x="848" y="233" width="82" height="22">
-			</bounds>
+			<bounds x="848" y="233" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_2" state="0">
-			<bounds x="850" y="235" width="78" height="18">
-			</bounds>
+			<bounds x="850" y="235" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_2_border" state="0">
-			<bounds x="848" y="330" width="82" height="22">
-			</bounds>
+			<bounds x="848" y="330" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_2" state="0">
-			<bounds x="850" y="332" width="78" height="18">
-			</bounds>
+			<bounds x="850" y="332" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_2_border" state="0">
-			<bounds x="849" y="139" width="82" height="22">
-			</bounds>
+			<bounds x="849" y="139" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_2" state="0">
-			<bounds x="851" y="141" width="78" height="18">
-			</bounds>
+			<bounds x="851" y="141" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="679" y="496" width="102" height="32">
-			</bounds>
+			<bounds x="679" y="496" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="681" y="498" width="98" height="28">
-			</bounds>
+			<bounds x="681" y="498" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="40" y="115" width="152" height="22">
-			</bounds>
+			<bounds x="40" y="115" width="152" height="22"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="42" y="117" width="148" height="18">
-			</bounds>
+			<bounds x="42" y="117" width="148" height="18"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="138" y="134" width="52" height="52">
-			</bounds>
+			<bounds x="138" y="134" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="140" y="136" width="48" height="48">
-			</bounds>
+			<bounds x="140" y="136" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="88" y="134" width="52" height="52">
-			</bounds>
+			<bounds x="88" y="134" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="90" y="136" width="48" height="48">
-			</bounds>
+			<bounds x="90" y="136" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="42" y="134" width="52" height="52">
-			</bounds>
+			<bounds x="42" y="134" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="44" y="136" width="48" height="48">
-			</bounds>
+			<bounds x="44" y="136" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="64" y="178" width="52" height="52">
-			</bounds>
+			<bounds x="64" y="178" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="66" y="180" width="48" height="48">
-			</bounds>
+			<bounds x="66" y="180" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="117" y="177" width="52" height="52">
-			</bounds>
+			<bounds x="117" y="177" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="119" y="179" width="48" height="48">
-			</bounds>
+			<bounds x="119" y="179" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2_border" state="0">
-			<bounds x="849" y="60" width="82" height="22">
-			</bounds>
+			<bounds x="849" y="60" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2" state="0">
-			<bounds x="851" y="62" width="78" height="18">
-			</bounds>
+			<bounds x="851" y="62" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_206_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="236" y="610" width="82" height="42">
-			</bounds>
+			<bounds x="236" y="610" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_206" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="238" y="612" width="78" height="38">
-			</bounds>
+			<bounds x="238" y="612" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_207_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="120" y="610" width="82" height="42">
-			</bounds>
+			<bounds x="120" y="610" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_207" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="122" y="612" width="78" height="38">
-			</bounds>
+			<bounds x="122" y="612" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_208_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="22" y="610" width="82" height="42">
-			</bounds>
+			<bounds x="22" y="610" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_208" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="24" y="612" width="78" height="38">
-			</bounds>
+			<bounds x="24" y="612" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_209_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="737" y="610" width="82" height="42">
-			</bounds>
+			<bounds x="737" y="610" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_209" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="739" y="612" width="78" height="38">
-			</bounds>
+			<bounds x="739" y="612" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_210_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="624" y="610" width="82" height="42">
-			</bounds>
+			<bounds x="624" y="610" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_210" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="626" y="612" width="78" height="38">
-			</bounds>
+			<bounds x="626" y="612" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_211_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="500" y="608" width="82" height="42">
-			</bounds>
+			<bounds x="500" y="608" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_211" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="502" y="610" width="78" height="38">
-			</bounds>
+			<bounds x="502" y="610" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_212_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="355" y="611" width="82" height="42">
-			</bounds>
+			<bounds x="355" y="611" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_212" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="357" y="613" width="78" height="38">
-			</bounds>
+			<bounds x="357" y="613" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_213_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="830" y="610" width="42" height="42">
-			</bounds>
+			<bounds x="830" y="610" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_213" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="832" y="612" width="38" height="38">
-			</bounds>
+			<bounds x="832" y="612" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="162" y="34" width="50" height="50">
-			</bounds>
+			<bounds x="162" y="34" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="169" y="38" width="35" height="4">
-			</bounds>
+			<bounds x="169" y="38" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="197" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="197" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="197" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="197" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="169" y="74" width="35" height="4">
-			</bounds>
+			<bounds x="169" y="74" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="169" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="169" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="169" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="169" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="169" y="56" width="35" height="4">
-			</bounds>
+			<bounds x="169" y="56" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="204" y="74" width="7" height="4">
-			</bounds>
+			<bounds x="204" y="74" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="169" y="38" width="35" height="4">
-			</bounds>
+			<bounds x="169" y="38" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="197" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="197" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="197" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="197" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="169" y="74" width="35" height="4">
-			</bounds>
+			<bounds x="169" y="74" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="169" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="169" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="169" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="169" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="169" y="56" width="35" height="4">
-			</bounds>
+			<bounds x="169" y="56" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="204" y="74" width="7" height="4">
-			</bounds>
+			<bounds x="204" y="74" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="63" y="34" width="50" height="50">
-			</bounds>
+			<bounds x="63" y="34" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="70" y="38" width="35" height="4">
-			</bounds>
+			<bounds x="70" y="38" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="98" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="98" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="98" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="98" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="70" y="74" width="35" height="4">
-			</bounds>
+			<bounds x="70" y="74" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="70" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="70" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="70" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="70" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="70" y="56" width="35" height="4">
-			</bounds>
+			<bounds x="70" y="56" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="105" y="74" width="7" height="4">
-			</bounds>
+			<bounds x="105" y="74" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="70" y="38" width="35" height="4">
-			</bounds>
+			<bounds x="70" y="38" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="98" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="98" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="98" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="98" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="70" y="74" width="35" height="4">
-			</bounds>
+			<bounds x="70" y="74" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="70" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="70" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="70" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="70" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="70" y="56" width="35" height="4">
-			</bounds>
+			<bounds x="70" y="56" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="105" y="74" width="7" height="4">
-			</bounds>
+			<bounds x="105" y="74" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="112" y="34" width="50" height="50">
-			</bounds>
+			<bounds x="112" y="34" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="119" y="38" width="35" height="4">
-			</bounds>
+			<bounds x="119" y="38" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="147" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="147" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="147" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="147" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="119" y="74" width="35" height="4">
-			</bounds>
+			<bounds x="119" y="74" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="119" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="119" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="119" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="119" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="119" y="56" width="35" height="4">
-			</bounds>
+			<bounds x="119" y="56" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="154" y="74" width="7" height="4">
-			</bounds>
+			<bounds x="154" y="74" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="119" y="38" width="35" height="4">
-			</bounds>
+			<bounds x="119" y="38" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="147" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="147" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="147" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="147" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="119" y="74" width="35" height="4">
-			</bounds>
+			<bounds x="119" y="74" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="119" y="56" width="7" height="22">
-			</bounds>
+			<bounds x="119" y="56" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="119" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="119" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="119" y="56" width="35" height="4">
-			</bounds>
+			<bounds x="119" y="56" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="154" y="74" width="7" height="4">
-			</bounds>
+			<bounds x="154" y="74" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="708" y="548" width="25" height="30">
-			</bounds>
+			<bounds x="708" y="548" width="25" height="30"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="711" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="711" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="725" y="550" width="3" height="13">
-			</bounds>
+			<bounds x="725" y="550" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="725" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="725" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="711" y="572" width="17" height="2">
-			</bounds>
+			<bounds x="711" y="572" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="711" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="711" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="711" y="550" width="3" height="13">
-			</bounds>
+			<bounds x="711" y="550" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="711" y="561" width="17" height="2">
-			</bounds>
+			<bounds x="711" y="561" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="729" y="572" width="3" height="2">
-			</bounds>
+			<bounds x="729" y="572" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="711" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="711" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="725" y="550" width="3" height="13">
-			</bounds>
+			<bounds x="725" y="550" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="725" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="725" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="711" y="572" width="17" height="2">
-			</bounds>
+			<bounds x="711" y="572" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="711" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="711" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="711" y="550" width="3" height="13">
-			</bounds>
+			<bounds x="711" y="550" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="711" y="561" width="17" height="2">
-			</bounds>
+			<bounds x="711" y="561" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="729" y="572" width="3" height="2">
-			</bounds>
+			<bounds x="729" y="572" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="733" y="548" width="25" height="30">
-			</bounds>
+			<bounds x="733" y="548" width="25" height="30"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="736" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="736" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="750" y="550" width="3" height="13">
-			</bounds>
+			<bounds x="750" y="550" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="750" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="750" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="736" y="572" width="17" height="2">
-			</bounds>
+			<bounds x="736" y="572" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="736" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="736" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="736" y="550" width="3" height="13">
-			</bounds>
+			<bounds x="736" y="550" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="736" y="561" width="17" height="2">
-			</bounds>
+			<bounds x="736" y="561" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="754" y="572" width="3" height="2">
-			</bounds>
+			<bounds x="754" y="572" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="736" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="736" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="750" y="550" width="3" height="13">
-			</bounds>
+			<bounds x="750" y="550" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="750" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="750" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="736" y="572" width="17" height="2">
-			</bounds>
+			<bounds x="736" y="572" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="736" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="736" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="736" y="550" width="3" height="13">
-			</bounds>
+			<bounds x="736" y="550" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="736" y="561" width="17" height="2">
-			</bounds>
+			<bounds x="736" y="561" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="754" y="572" width="3" height="2">
-			</bounds>
+			<bounds x="754" y="572" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label36" element="label_36">
-			<bounds x="891" y="633" width="28" height="13">
-			</bounds>
+			<bounds x="891" y="633" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="label40" element="label_40">
-			<bounds x="98" y="12" width="118" height="23">
-			</bounds>
+			<bounds x="98" y="12" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="label41" element="label_41">
-			<bounds x="14" y="23" width="46" height="78">
-			</bounds>
+			<bounds x="14" y="23" width="46" height="78"/>
 		</backdrop>
 		<backdrop name="label60" element="label_60">
-			<bounds x="580" y="49" width="162" height="18">
-			</bounds>
+			<bounds x="580" y="49" width="162" height="18"/>
 		</backdrop>
 		<backdrop name="label192" element="label_192">
-			<bounds x="523" y="540" width="166" height="52">
-			</bounds>
+			<bounds x="523" y="540" width="166" height="52"/>
 		</backdrop>
 		<backdrop name="label196" element="label_196">
-			<bounds x="708" y="535" width="50" height="13">
-			</bounds>
+			<bounds x="708" y="535" width="50" height="13"/>
 		</backdrop>
 		<backdrop name="label197" element="label_197">
-			<bounds x="709" y="582" width="41" height="13">
-			</bounds>
+			<bounds x="709" y="582" width="41" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1dkong91n.lay
+++ b/src/mame/layout/m1dkong91n.lay
@@ -8,14822 +8,8809 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FRENZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FRENZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="POWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="POWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FRENZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FRENZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="KONG'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="KONG'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="KONG'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KLIMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="KONG'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KLIMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="POWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="POWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ROLL OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="THE BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROLL OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="THE BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ALL CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ALL CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_255_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_255_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MIXED 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MIXED 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BANANAS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BANANAS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="STOPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="STEPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="STEPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE A TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE A TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="REEL SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LADDERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LADDERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="INVINCIBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="INVINCIBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="UP + DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="UP + DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="BONUS LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="BONUS LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SINGLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SINGLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DOUBLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="DOUBLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BLUE 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BLUE 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RED 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COCONUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="COCONUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="T H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.18"/>
 		</text>
 		<text string="R E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.23" width="0.90" height="0.18"/>
 		</text>
 		<text string="A L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.41" width="0.90" height="0.18"/>
 		</text>
 		<text string="I  D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.59" width="0.90" height="0.18"/>
 		</text>
 		<text string="L    ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="T H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="R E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="A L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="I  D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="L    ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.77" width="0.90" height="0.18"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BANAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BANAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BARREL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JUMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BANANA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPLIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BANANA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPLIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="POWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="POWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="2x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="2x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="6x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="6x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="4x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="4x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="10x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="10x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_133_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_133">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="MARIO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_135_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_135">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HI RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_141_border">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_141">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_146_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_146">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1016" height="689">
-			</bounds>
+			<bounds x="0" y="0" width="1016" height="689"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="189" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="189" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="189.0000" y="444.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="189.0000" y="444.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.3333" y="445.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="192.3333" y="445.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.6667" y="447.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="195.6667" y="447.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="199.0000" y="449.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="199.0000" y="449.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="202.3333" y="451.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="202.3333" y="451.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="205.6667" y="453.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="205.6667" y="453.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="189.0000" y="490.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="189.0000" y="490.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.3333" y="492.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="192.3333" y="492.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.6667" y="494.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="195.6667" y="494.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="199.0000" y="496.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="199.0000" y="496.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="202.3333" y="498.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="202.3333" y="498.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="205.6667" y="500.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="205.6667" y="500.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="189.0000" y="537.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="189.0000" y="537.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.3333" y="539.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="192.3333" y="539.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.6667" y="541.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="195.6667" y="541.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="199.0000" y="543.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="199.0000" y="543.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="202.3333" y="545.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="202.3333" y="545.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="205.6667" y="547.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="205.6667" y="547.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="189" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="189" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="330" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="330" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="444.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="444.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="445.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="445.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="447.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="447.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="449.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="449.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="451.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="451.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="453.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="453.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="490.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="490.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="492.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="492.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="494.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="494.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="496.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="496.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="498.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="498.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="500.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="500.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="537.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="537.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="539.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="539.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="541.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="541.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="543.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="543.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="545.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="545.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="547.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="547.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="330" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="330" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="463" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="463" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="463.0000" y="444.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="463.0000" y="444.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="466.3333" y="445.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="466.3333" y="445.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="469.6667" y="447.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="469.6667" y="447.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="473.0000" y="449.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="473.0000" y="449.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="476.3333" y="451.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="476.3333" y="451.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="479.6667" y="453.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="479.6667" y="453.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="463.0000" y="490.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="463.0000" y="490.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="466.3333" y="492.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="466.3333" y="492.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="469.6667" y="494.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="469.6667" y="494.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="473.0000" y="496.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="473.0000" y="496.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="476.3333" y="498.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="476.3333" y="498.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="479.6667" y="500.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="479.6667" y="500.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="463.0000" y="537.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="463.0000" y="537.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="466.3333" y="539.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="466.3333" y="539.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="469.6667" y="541.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="469.6667" y="541.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="473.0000" y="543.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="473.0000" y="543.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="476.3333" y="545.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="476.3333" y="545.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="479.6667" y="547.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="479.6667" y="547.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="463" y="444" width="80" height="140">
-			</bounds>
+			<bounds x="463" y="444" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="140" y="140" width="70" height="70">
-			</bounds>
+			<bounds x="140" y="140" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="140.0000" y="140.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="140.0000" y="140.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="142.9167" y="142.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="142.9167" y="142.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="145.8333" y="145.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="145.8333" y="145.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="148.7500" y="148.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="148.7500" y="148.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="151.6667" y="151.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="151.6667" y="151.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="154.5833" y="154.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="154.5833" y="154.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="140" y="140" width="70" height="70">
-			</bounds>
+			<bounds x="140" y="140" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="376" y="144" width="20" height="42">
-			</bounds>
+			<bounds x="376" y="144" width="20" height="42"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="378" y="146" width="16" height="38">
-			</bounds>
+			<bounds x="378" y="146" width="16" height="38"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="336" y="66" width="32" height="19">
-			</bounds>
+			<bounds x="336" y="66" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="338" y="68" width="28" height="15">
-			</bounds>
+			<bounds x="338" y="68" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="297" y="66" width="32" height="22">
-			</bounds>
+			<bounds x="297" y="66" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="299" y="68" width="28" height="18">
-			</bounds>
+			<bounds x="299" y="68" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="466" y="41" width="122" height="32">
-			</bounds>
+			<bounds x="466" y="41" width="122" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="468" y="43" width="118" height="28">
-			</bounds>
+			<bounds x="468" y="43" width="118" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="236" y="3" width="87" height="32">
-			</bounds>
+			<bounds x="236" y="3" width="87" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="238" y="5" width="83" height="28">
-			</bounds>
+			<bounds x="238" y="5" width="83" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="516" y="71" width="20" height="42">
-			</bounds>
+			<bounds x="516" y="71" width="20" height="42"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="518" y="73" width="16" height="38">
-			</bounds>
+			<bounds x="518" y="73" width="16" height="38"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="665" y="220" width="20" height="42">
-			</bounds>
+			<bounds x="665" y="220" width="20" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="667" y="222" width="16" height="38">
-			</bounds>
+			<bounds x="667" y="222" width="16" height="38"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="271" y="309" width="20" height="42">
-			</bounds>
+			<bounds x="271" y="309" width="20" height="42"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="273" y="311" width="16" height="38">
-			</bounds>
+			<bounds x="273" y="311" width="16" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="53" y="402" width="42" height="42">
-			</bounds>
+			<bounds x="53" y="402" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="55" y="404" width="38" height="38">
-			</bounds>
+			<bounds x="55" y="404" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="53" y="444" width="42" height="42">
-			</bounds>
+			<bounds x="53" y="444" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="55" y="446" width="38" height="38">
-			</bounds>
+			<bounds x="55" y="446" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="53" y="486" width="42" height="42">
-			</bounds>
+			<bounds x="53" y="486" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="55" y="488" width="38" height="38">
-			</bounds>
+			<bounds x="55" y="488" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="53" y="528" width="42" height="42">
-			</bounds>
+			<bounds x="53" y="528" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="55" y="530" width="38" height="38">
-			</bounds>
+			<bounds x="55" y="530" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="48" y="572" width="52" height="42">
-			</bounds>
+			<bounds x="48" y="572" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="50" y="574" width="48" height="38">
-			</bounds>
+			<bounds x="50" y="574" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="62" y="314" width="52" height="32">
-			</bounds>
+			<bounds x="62" y="314" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="64" y="316" width="48" height="28">
-			</bounds>
+			<bounds x="64" y="316" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="114" y="286" width="52" height="32">
-			</bounds>
+			<bounds x="114" y="286" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="116" y="288" width="48" height="28">
-			</bounds>
+			<bounds x="116" y="288" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="607" y="31" width="102" height="102">
-			</bounds>
+			<bounds x="607" y="31" width="102" height="102"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="609" y="33" width="98" height="98">
-			</bounds>
+			<bounds x="609" y="33" width="98" height="98"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="581" y="110" width="42" height="32">
-			</bounds>
+			<bounds x="581" y="110" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="583" y="112" width="38" height="28">
-			</bounds>
+			<bounds x="583" y="112" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="295" y="132" width="52" height="32">
-			</bounds>
+			<bounds x="295" y="132" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="297" y="134" width="48" height="28">
-			</bounds>
+			<bounds x="297" y="134" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="300" y="180" width="42" height="32">
-			</bounds>
+			<bounds x="300" y="180" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="302" y="182" width="38" height="28">
-			</bounds>
+			<bounds x="302" y="182" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="365" y="184" width="42" height="32">
-			</bounds>
+			<bounds x="365" y="184" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="367" y="186" width="38" height="28">
-			</bounds>
+			<bounds x="367" y="186" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="421" y="185" width="52" height="32">
-			</bounds>
+			<bounds x="421" y="185" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="423" y="187" width="48" height="28">
-			</bounds>
+			<bounds x="423" y="187" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="498" y="187" width="52" height="32">
-			</bounds>
+			<bounds x="498" y="187" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="500" y="189" width="48" height="28">
-			</bounds>
+			<bounds x="500" y="189" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="576" y="188" width="52" height="32">
-			</bounds>
+			<bounds x="576" y="188" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="578" y="190" width="48" height="28">
-			</bounds>
+			<bounds x="578" y="190" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="653" y="190" width="42" height="32">
-			</bounds>
+			<bounds x="653" y="190" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="655" y="192" width="38" height="28">
-			</bounds>
+			<bounds x="655" y="192" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="732" y="192" width="52" height="32">
-			</bounds>
+			<bounds x="732" y="192" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="734" y="194" width="48" height="28">
-			</bounds>
+			<bounds x="734" y="194" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="800" y="193" width="42" height="32">
-			</bounds>
+			<bounds x="800" y="193" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="802" y="195" width="38" height="28">
-			</bounds>
+			<bounds x="802" y="195" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="856" y="195" width="52" height="32">
-			</bounds>
+			<bounds x="856" y="195" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="858" y="197" width="48" height="28">
-			</bounds>
+			<bounds x="858" y="197" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="900" y="227" width="42" height="32">
-			</bounds>
+			<bounds x="900" y="227" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="902" y="229" width="38" height="28">
-			</bounds>
+			<bounds x="902" y="229" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="254" y="279" width="52" height="32">
-			</bounds>
+			<bounds x="254" y="279" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="256" y="281" width="48" height="28">
-			</bounds>
+			<bounds x="256" y="281" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="186" y="281" width="42" height="32">
-			</bounds>
+			<bounds x="186" y="281" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="188" y="283" width="38" height="28">
-			</bounds>
+			<bounds x="188" y="283" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="481" y="2" width="32" height="22">
-			</bounds>
+			<bounds x="481" y="2" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="483" y="4" width="28" height="18">
-			</bounds>
+			<bounds x="483" y="4" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="422" y="55" width="32" height="19">
-			</bounds>
+			<bounds x="422" y="55" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="424" y="57" width="28" height="15">
-			</bounds>
+			<bounds x="424" y="57" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="362" y="2" width="32" height="19">
-			</bounds>
+			<bounds x="362" y="2" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="364" y="4" width="28" height="15">
-			</bounds>
+			<bounds x="364" y="4" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="442" y="16" width="32" height="19">
-			</bounds>
+			<bounds x="442" y="16" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="444" y="18" width="28" height="15">
-			</bounds>
+			<bounds x="444" y="18" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="348" y="25" width="82" height="27">
-			</bounds>
+			<bounds x="348" y="25" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="350" y="27" width="78" height="23">
-			</bounds>
+			<bounds x="350" y="27" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="376" y="55" width="32" height="22">
-			</bounds>
+			<bounds x="376" y="55" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="378" y="57" width="28" height="18">
-			</bounds>
+			<bounds x="378" y="57" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="259" y="39" width="32" height="22">
-			</bounds>
+			<bounds x="259" y="39" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="261" y="41" width="28" height="18">
-			</bounds>
+			<bounds x="261" y="41" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="300" y="42" width="32" height="19">
-			</bounds>
+			<bounds x="300" y="42" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="302" y="44" width="28" height="15">
-			</bounds>
+			<bounds x="302" y="44" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="366" y="114" width="42" height="32">
-			</bounds>
+			<bounds x="366" y="114" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="368" y="116" width="38" height="28">
-			</bounds>
+			<bounds x="368" y="116" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="431" y="112" width="42" height="32">
-			</bounds>
+			<bounds x="431" y="112" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="433" y="114" width="38" height="28">
-			</bounds>
+			<bounds x="433" y="114" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="490" y="111" width="72" height="32">
-			</bounds>
+			<bounds x="490" y="111" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="492" y="113" width="68" height="28">
-			</bounds>
+			<bounds x="492" y="113" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="15" y="3" width="132" height="72">
-			</bounds>
+			<bounds x="15" y="3" width="132" height="72"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="17" y="5" width="128" height="68">
-			</bounds>
+			<bounds x="17" y="5" width="128" height="68"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="15" y="72" width="132" height="32">
-			</bounds>
+			<bounds x="15" y="72" width="132" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="17" y="74" width="128" height="28">
-			</bounds>
+			<bounds x="17" y="74" width="128" height="28"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="15" y="101" width="132" height="32">
-			</bounds>
+			<bounds x="15" y="101" width="132" height="32"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="17" y="103" width="128" height="28">
-			</bounds>
+			<bounds x="17" y="103" width="128" height="28"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="943" y="161" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="161" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="945" y="163" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="163" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="943" y="161" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="161" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="945" y="163" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="163" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="943" y="183" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="183" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="945" y="185" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="185" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="943" y="183" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="183" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="945" y="185" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="185" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="943" y="205" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="205" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="945" y="207" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="207" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1_border" state="0">
-			<bounds x="943" y="205" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="205" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1" state="0">
-			<bounds x="945" y="207" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="207" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="943" y="227" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="227" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="945" y="229" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="229" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="943" y="227" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="227" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="945" y="229" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="229" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="943" y="249" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="249" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="945" y="251" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="251" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="943" y="249" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="249" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="945" y="251" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="251" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="943" y="271" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="271" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="945" y="273" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="273" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="943" y="271" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="271" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="945" y="273" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="273" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="943" y="293" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="293" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="945" y="295" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="295" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="943" y="293" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="293" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="945" y="295" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="295" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="943" y="315" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="315" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="945" y="317" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="317" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="943" y="315" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="315" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="945" y="317" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="317" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="943" y="337" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="337" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="945" y="339" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="339" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="943" y="337" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="337" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="945" y="339" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="339" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="943" y="359" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="359" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="945" y="361" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="361" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="943" y="359" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="359" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="945" y="361" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="361" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="943" y="381" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="381" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="945" y="383" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="383" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="943" y="381" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="381" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="945" y="383" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="383" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="943" y="403" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="403" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="945" y="405" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="405" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="943" y="403" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="403" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="945" y="405" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="405" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="943" y="425" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="425" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="945" y="427" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="427" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="943" y="425" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="425" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="945" y="427" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="427" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="943" y="447" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="447" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="945" y="449" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="449" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="943" y="447" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="447" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="945" y="449" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="449" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="943" y="139" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="139" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="945" y="141" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="141" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="943" y="139" width="52" height="22">
-			</bounds>
+			<bounds x="943" y="139" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="945" y="141" width="48" height="18">
-			</bounds>
+			<bounds x="945" y="141" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="943" y="107" width="52" height="32">
-			</bounds>
+			<bounds x="943" y="107" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="945" y="109" width="48" height="28">
-			</bounds>
+			<bounds x="945" y="109" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="943" y="107" width="52" height="32">
-			</bounds>
+			<bounds x="943" y="107" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="945" y="109" width="48" height="28">
-			</bounds>
+			<bounds x="945" y="109" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="943" y="88" width="52" height="19">
-			</bounds>
+			<bounds x="943" y="88" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="945" y="90" width="48" height="15">
-			</bounds>
+			<bounds x="945" y="90" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="162" y="587" width="82" height="32">
-			</bounds>
+			<bounds x="162" y="587" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="164" y="589" width="78" height="28">
-			</bounds>
+			<bounds x="164" y="589" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="246" y="587" width="82" height="32">
-			</bounds>
+			<bounds x="246" y="587" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="248" y="589" width="78" height="28">
-			</bounds>
+			<bounds x="248" y="589" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="330" y="587" width="82" height="32">
-			</bounds>
+			<bounds x="330" y="587" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="332" y="589" width="78" height="28">
-			</bounds>
+			<bounds x="332" y="589" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="673" y="451" width="102" height="19">
-			</bounds>
+			<bounds x="673" y="451" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="675" y="453" width="98" height="15">
-			</bounds>
+			<bounds x="675" y="453" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="673" y="471" width="102" height="19">
-			</bounds>
+			<bounds x="673" y="471" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="675" y="473" width="98" height="15">
-			</bounds>
+			<bounds x="675" y="473" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="673" y="511" width="102" height="19">
-			</bounds>
+			<bounds x="673" y="511" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="675" y="513" width="98" height="15">
-			</bounds>
+			<bounds x="675" y="513" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="673" y="531" width="102" height="19">
-			</bounds>
+			<bounds x="673" y="531" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="675" y="533" width="98" height="15">
-			</bounds>
+			<bounds x="675" y="533" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="673" y="551" width="102" height="19">
-			</bounds>
+			<bounds x="673" y="551" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="675" y="553" width="98" height="15">
-			</bounds>
+			<bounds x="675" y="553" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="673" y="491" width="102" height="19">
-			</bounds>
+			<bounds x="673" y="491" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="675" y="493" width="98" height="15">
-			</bounds>
+			<bounds x="675" y="493" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="424" y="138" width="52" height="52">
-			</bounds>
+			<bounds x="424" y="138" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="426" y="140" width="48" height="48">
-			</bounds>
+			<bounds x="426" y="140" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="470" y="153" width="27" height="27">
-			</bounds>
+			<bounds x="470" y="153" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="472" y="155" width="23" height="23">
-			</bounds>
+			<bounds x="472" y="155" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="105" y="174" width="37" height="37">
-			</bounds>
+			<bounds x="105" y="174" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="107" y="176" width="33" height="33">
-			</bounds>
+			<bounds x="107" y="176" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="105" y="139" width="37" height="37">
-			</bounds>
+			<bounds x="105" y="139" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="107" y="141" width="33" height="33">
-			</bounds>
+			<bounds x="107" y="141" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="807" y="112" width="102" height="19">
-			</bounds>
+			<bounds x="807" y="112" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="809" y="114" width="98" height="15">
-			</bounds>
+			<bounds x="809" y="114" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="807" y="93" width="102" height="19">
-			</bounds>
+			<bounds x="807" y="93" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="809" y="95" width="98" height="15">
-			</bounds>
+			<bounds x="809" y="95" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="807" y="74" width="102" height="19">
-			</bounds>
+			<bounds x="807" y="74" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="809" y="76" width="98" height="15">
-			</bounds>
+			<bounds x="809" y="76" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="807" y="55" width="102" height="19">
-			</bounds>
+			<bounds x="807" y="55" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="809" y="57" width="98" height="15">
-			</bounds>
+			<bounds x="809" y="57" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="807" y="36" width="102" height="19">
-			</bounds>
+			<bounds x="807" y="36" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="809" y="38" width="98" height="15">
-			</bounds>
+			<bounds x="809" y="38" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="807" y="17" width="102" height="19">
-			</bounds>
+			<bounds x="807" y="17" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="809" y="19" width="98" height="15">
-			</bounds>
+			<bounds x="809" y="19" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="414" y="587" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="587" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="416" y="589" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="589" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="498" y="587" width="82" height="32">
-			</bounds>
+			<bounds x="498" y="587" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="500" y="589" width="78" height="28">
-			</bounds>
+			<bounds x="500" y="589" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="582" y="587" width="82" height="32">
-			</bounds>
+			<bounds x="582" y="587" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="584" y="589" width="78" height="28">
-			</bounds>
+			<bounds x="584" y="589" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="666" y="587" width="82" height="32">
-			</bounds>
+			<bounds x="666" y="587" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="668" y="589" width="78" height="28">
-			</bounds>
+			<bounds x="668" y="589" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="750" y="587" width="82" height="32">
-			</bounds>
+			<bounds x="750" y="587" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="752" y="589" width="78" height="28">
-			</bounds>
+			<bounds x="752" y="589" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="654" y="260" width="42" height="32">
-			</bounds>
+			<bounds x="654" y="260" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="656" y="262" width="38" height="28">
-			</bounds>
+			<bounds x="656" y="262" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="576" y="261" width="52" height="32">
-			</bounds>
+			<bounds x="576" y="261" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="578" y="263" width="48" height="28">
-			</bounds>
+			<bounds x="578" y="263" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="491" y="265" width="52" height="32">
-			</bounds>
+			<bounds x="491" y="265" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="493" y="267" width="48" height="28">
-			</bounds>
+			<bounds x="493" y="267" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="720" y="260" width="62" height="32">
-			</bounds>
+			<bounds x="720" y="260" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="722" y="262" width="58" height="28">
-			</bounds>
+			<bounds x="722" y="262" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="792" y="257" width="52" height="32">
-			</bounds>
+			<bounds x="792" y="257" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="794" y="259" width="48" height="28">
-			</bounds>
+			<bounds x="794" y="259" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="857" y="251" width="42" height="32">
-			</bounds>
+			<bounds x="857" y="251" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="859" y="253" width="38" height="28">
-			</bounds>
+			<bounds x="859" y="253" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="331" y="273" width="42" height="32">
-			</bounds>
+			<bounds x="331" y="273" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="333" y="275" width="38" height="28">
-			</bounds>
+			<bounds x="333" y="275" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="407" y="268" width="42" height="32">
-			</bounds>
+			<bounds x="407" y="268" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="409" y="270" width="38" height="28">
-			</bounds>
+			<bounds x="409" y="270" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="661" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="661" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="663" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="663" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="607" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="607" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="609" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="609" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="553" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="553" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="555" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="555" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="499" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="499" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="501" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="501" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="445" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="445" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="447" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="447" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="391" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="391" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="393" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="393" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="337" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="337" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="339" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="339" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="283" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="283" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="285" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="285" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="229" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="229" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="231" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="231" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="175" y="387" width="52" height="52">
-			</bounds>
+			<bounds x="175" y="387" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="177" y="389" width="48" height="48">
-			</bounds>
+			<bounds x="177" y="389" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="716" y="387" width="32" height="52">
-			</bounds>
+			<bounds x="716" y="387" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="718" y="389" width="28" height="48">
-			</bounds>
+			<bounds x="718" y="389" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="112" y="349" width="42" height="32">
-			</bounds>
+			<bounds x="112" y="349" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="114" y="351" width="38" height="28">
-			</bounds>
+			<bounds x="114" y="351" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="173" y="350" width="62" height="32">
-			</bounds>
+			<bounds x="173" y="350" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="175" y="352" width="58" height="28">
-			</bounds>
+			<bounds x="175" y="352" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="256" y="349" width="52" height="32">
-			</bounds>
+			<bounds x="256" y="349" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="258" y="351" width="48" height="28">
-			</bounds>
+			<bounds x="258" y="351" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="344" y="349" width="42" height="32">
-			</bounds>
+			<bounds x="344" y="349" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="346" y="351" width="38" height="28">
-			</bounds>
+			<bounds x="346" y="351" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="418" y="349" width="42" height="32">
-			</bounds>
+			<bounds x="418" y="349" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="420" y="351" width="38" height="28">
-			</bounds>
+			<bounds x="420" y="351" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="493" y="349" width="42" height="32">
-			</bounds>
+			<bounds x="493" y="349" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="495" y="351" width="38" height="28">
-			</bounds>
+			<bounds x="495" y="351" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="566" y="349" width="52" height="32">
-			</bounds>
+			<bounds x="566" y="349" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="568" y="351" width="48" height="28">
-			</bounds>
+			<bounds x="568" y="351" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="635" y="349" width="52" height="32">
-			</bounds>
+			<bounds x="635" y="349" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="637" y="351" width="48" height="28">
-			</bounds>
+			<bounds x="637" y="351" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="699" y="349" width="42" height="32">
-			</bounds>
+			<bounds x="699" y="349" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="701" y="351" width="38" height="28">
-			</bounds>
+			<bounds x="701" y="351" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="745" y="349" width="42" height="32">
-			</bounds>
+			<bounds x="745" y="349" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="747" y="351" width="38" height="28">
-			</bounds>
+			<bounds x="747" y="351" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="794" y="349" width="52" height="32">
-			</bounds>
+			<bounds x="794" y="349" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="796" y="351" width="48" height="28">
-			</bounds>
+			<bounds x="796" y="351" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="848" y="349" width="42" height="32">
-			</bounds>
+			<bounds x="848" y="349" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="850" y="351" width="38" height="28">
-			</bounds>
+			<bounds x="850" y="351" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="369" y="324" width="32" height="22">
-			</bounds>
+			<bounds x="369" y="324" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="371" y="326" width="28" height="18">
-			</bounds>
+			<bounds x="371" y="326" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="465" y="302" width="32" height="22">
-			</bounds>
+			<bounds x="465" y="302" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="467" y="304" width="28" height="18">
-			</bounds>
+			<bounds x="467" y="304" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="433" y="324" width="32" height="22">
-			</bounds>
+			<bounds x="433" y="324" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="435" y="326" width="28" height="18">
-			</bounds>
+			<bounds x="435" y="326" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="369" y="302" width="32" height="22">
-			</bounds>
+			<bounds x="369" y="302" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="371" y="304" width="28" height="18">
-			</bounds>
+			<bounds x="371" y="304" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="401" y="324" width="32" height="22">
-			</bounds>
+			<bounds x="401" y="324" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="403" y="326" width="28" height="18">
-			</bounds>
+			<bounds x="403" y="326" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="401" y="302" width="32" height="22">
-			</bounds>
+			<bounds x="401" y="302" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="403" y="304" width="28" height="18">
-			</bounds>
+			<bounds x="403" y="304" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="465" y="324" width="32" height="22">
-			</bounds>
+			<bounds x="465" y="324" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="467" y="326" width="28" height="18">
-			</bounds>
+			<bounds x="467" y="326" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="433" y="302" width="32" height="22">
-			</bounds>
+			<bounds x="433" y="302" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="435" y="304" width="28" height="18">
-			</bounds>
+			<bounds x="435" y="304" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="586" y="153" width="27" height="27">
-			</bounds>
+			<bounds x="586" y="153" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="588" y="155" width="23" height="23">
-			</bounds>
+			<bounds x="588" y="155" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="557" y="153" width="27" height="27">
-			</bounds>
+			<bounds x="557" y="153" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="559" y="155" width="23" height="23">
-			</bounds>
+			<bounds x="559" y="155" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="528" y="153" width="27" height="27">
-			</bounds>
+			<bounds x="528" y="153" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="530" y="155" width="23" height="23">
-			</bounds>
+			<bounds x="530" y="155" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="499" y="153" width="27" height="27">
-			</bounds>
+			<bounds x="499" y="153" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="501" y="155" width="23" height="23">
-			</bounds>
+			<bounds x="501" y="155" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_133_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="943" y="8" width="52" height="52">
-			</bounds>
+			<bounds x="943" y="8" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_133" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="945" y="10" width="48" height="48">
-			</bounds>
+			<bounds x="945" y="10" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp99" element="colour_button_134_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="823" y="133" width="75" height="27">
-			</bounds>
+			<bounds x="823" y="133" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="colour_button_134" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="825" y="135" width="71" height="23">
-			</bounds>
+			<bounds x="825" y="135" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp139" element="colour_button_135_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="932" y="475" width="75" height="27">
-			</bounds>
+			<bounds x="932" y="475" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp139" element="colour_button_135" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="934" y="477" width="71" height="23">
-			</bounds>
+			<bounds x="934" y="477" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_140_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="917" y="620" width="75" height="42">
-			</bounds>
+			<bounds x="917" y="620" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_140" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="919" y="622" width="71" height="38">
-			</bounds>
+			<bounds x="919" y="622" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_141_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="778" y="620" width="75" height="42">
-			</bounds>
+			<bounds x="778" y="620" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_141" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="780" y="622" width="71" height="38">
-			</bounds>
+			<bounds x="780" y="622" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_142_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="638" y="620" width="75" height="42">
-			</bounds>
+			<bounds x="638" y="620" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_142" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="640" y="622" width="71" height="38">
-			</bounds>
+			<bounds x="640" y="622" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_143_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="468" y="620" width="75" height="42">
-			</bounds>
+			<bounds x="468" y="620" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_143" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="470" y="622" width="71" height="38">
-			</bounds>
+			<bounds x="470" y="622" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_144_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="329" y="620" width="75" height="42">
-			</bounds>
+			<bounds x="329" y="620" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_144" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="331" y="622" width="71" height="38">
-			</bounds>
+			<bounds x="331" y="622" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_145_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="187" y="620" width="75" height="42">
-			</bounds>
+			<bounds x="187" y="620" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_145" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="189" y="622" width="71" height="38">
-			</bounds>
+			<bounds x="189" y="622" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_146_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="22" y="620" width="75" height="42">
-			</bounds>
+			<bounds x="22" y="620" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_146" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="24" y="622" width="71" height="38">
-			</bounds>
+			<bounds x="24" y="622" width="71" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="609" y="306" width="272" height="30">
-			</bounds>
+			<bounds x="609" y="306" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="609" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="609" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="626" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="626" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="643" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="643" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="660" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="660" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="677" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="677" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="694" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="694" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="711" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="711" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="728" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="728" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="745" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="745" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="762" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="762" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="779" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="779" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="796" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="796" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="813" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="813" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="830" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="830" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="847" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="847" y="306" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="864" y="306" width="17" height="30">
-			</bounds>
+			<bounds x="864" y="306" width="17" height="30"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_button" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_button" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1dxmono51o.lay
+++ b/src/mame/layout/m1dxmono51o.lay
@@ -8,12008 +8,7294 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DOG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="DOG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="GO TO JAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="GO TO JAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Free ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Parking">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Free ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Parking">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Fenchurch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fenchurch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Trafalgar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trafalgar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Fleet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fleet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Leicester">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Leicester">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Strand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Strand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Coventry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Coventry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Water">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Works">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Water">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Works">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Pall Mall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Pall Mall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Electric">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Company">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Electric">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Company">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Whitehall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Whitehall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Nrthmblnd">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Ave">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Nrthmblnd">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Ave">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bow Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bow Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Marlboro">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Marlboro">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Vine Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Vine Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Regent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Regent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Oxford">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Oxford">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Community">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Community">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bond">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bond">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Liverpool">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Liverpool">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Park Lane">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Park Lane">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Super Tax ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super Tax ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="No Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="No Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cherries">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cherries">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mixed Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mixed Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Melons">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Melons">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bells">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bells">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Single Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Single Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Double Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Double Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Red 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Go Back Three">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Go Back Three">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Get Out Of Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Get Out Of Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Next Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Next Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="To Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="To Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Lose Wealth">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Lose Wealth">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Go To Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Go To Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Back To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Old Kent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Back To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Old Kent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Birthday Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Birthday Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Get Out Of Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Get Out Of Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Go To Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go To Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Go To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Piccadil">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Piccadil">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Visiting">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Visiting">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="In Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="In Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Pentonville">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pentonville">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Euston">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Euston">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="The Angel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Islington">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="The Angel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Islington">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Kings Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Kings Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Income Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Income Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="Whitechpl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="Whitechpl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Community">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Community">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="Old Kent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="Old Kent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mary-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="le-bone">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mary-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="le-bone">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_93_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_93">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_94_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_94">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_96_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_96">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_100_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_100">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Hold/Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_101_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_101">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Hold/Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_102_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_102">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_103_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_103">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_104_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_104">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_27">
 		<text string="1 Station &#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="2 Stations &#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="3 Stations &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="4 Stations JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="label_37">
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_54">
 		<text string="Win Values">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_61">
 		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_84">
 		<text string="Credits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_85">
 		<text string="Whitehall with hotel = &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Regent with Hotel = Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_86">
 		<text string="Roll A Double, Light a Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1000" height="768">
-			</bounds>
+			<bounds x="0" y="0" width="1000" height="768"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="152" y="520" width="100" height="200">
-			</bounds>
+			<bounds x="152" y="520" width="100" height="200"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="152.0000" y="520.0000" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="152.0000" y="520.0000" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="156.1667" y="522.7778" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="156.1667" y="522.7778" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="160.3333" y="525.5555" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="160.3333" y="525.5555" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="164.5000" y="528.3333" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="164.5000" y="528.3333" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="168.6667" y="531.1111" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="168.6667" y="531.1111" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="172.8333" y="533.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="172.8333" y="533.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="152.0000" y="586.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="152.0000" y="586.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="156.1667" y="589.4445" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="156.1667" y="589.4445" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="160.3333" y="592.2222" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="160.3333" y="592.2222" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="164.5000" y="595.0000" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="164.5000" y="595.0000" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="168.6667" y="597.7778" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="168.6667" y="597.7778" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="172.8333" y="600.5556" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="172.8333" y="600.5556" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="152.0000" y="653.3333" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="152.0000" y="653.3333" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="156.1667" y="656.1111" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="156.1667" y="656.1111" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="160.3333" y="658.8889" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="160.3333" y="658.8889" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="164.5000" y="661.6666" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="164.5000" y="661.6666" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="168.6667" y="664.4444" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="168.6667" y="664.4444" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="172.8333" y="667.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="172.8333" y="667.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="152" y="520" width="100" height="200">
-			</bounds>
+			<bounds x="152" y="520" width="100" height="200"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="272" y="520" width="100" height="200">
-			</bounds>
+			<bounds x="272" y="520" width="100" height="200"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="272.0000" y="520.0000" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="272.0000" y="520.0000" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.1667" y="522.7778" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="276.1667" y="522.7778" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="280.3333" y="525.5555" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="280.3333" y="525.5555" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.5000" y="528.3333" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="284.5000" y="528.3333" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="288.6667" y="531.1111" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="288.6667" y="531.1111" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="292.8333" y="533.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="292.8333" y="533.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="272.0000" y="586.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="272.0000" y="586.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.1667" y="589.4445" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="276.1667" y="589.4445" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="280.3333" y="592.2222" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="280.3333" y="592.2222" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.5000" y="595.0000" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="284.5000" y="595.0000" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="288.6667" y="597.7778" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="288.6667" y="597.7778" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="292.8333" y="600.5556" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="292.8333" y="600.5556" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="272.0000" y="653.3333" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="272.0000" y="653.3333" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.1667" y="656.1111" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="276.1667" y="656.1111" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="280.3333" y="658.8889" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="280.3333" y="658.8889" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.5000" y="661.6666" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="284.5000" y="661.6666" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="288.6667" y="664.4444" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="288.6667" y="664.4444" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="292.8333" y="667.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="292.8333" y="667.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="272" y="520" width="100" height="200">
-			</bounds>
+			<bounds x="272" y="520" width="100" height="200"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="387" y="520" width="100" height="200">
-			</bounds>
+			<bounds x="387" y="520" width="100" height="200"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="387.0000" y="520.0000" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="387.0000" y="520.0000" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="391.1667" y="522.7778" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="391.1667" y="522.7778" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.3333" y="525.5555" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="395.3333" y="525.5555" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="399.5000" y="528.3333" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="399.5000" y="528.3333" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="403.6667" y="531.1111" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="403.6667" y="531.1111" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="407.8333" y="533.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="407.8333" y="533.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="387.0000" y="586.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="387.0000" y="586.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="391.1667" y="589.4445" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="391.1667" y="589.4445" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.3333" y="592.2222" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="395.3333" y="592.2222" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="399.5000" y="595.0000" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="399.5000" y="595.0000" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="403.6667" y="597.7778" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="403.6667" y="597.7778" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="407.8333" y="600.5556" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="407.8333" y="600.5556" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="387.0000" y="653.3333" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="387.0000" y="653.3333" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="391.1667" y="656.1111" width="91.6667" height="61.1111">
-			</bounds>
+			<bounds x="391.1667" y="656.1111" width="91.6667" height="61.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.3333" y="658.8889" width="83.3333" height="55.5556">
-			</bounds>
+			<bounds x="395.3333" y="658.8889" width="83.3333" height="55.5556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="399.5000" y="661.6666" width="75.0000" height="50.0000">
-			</bounds>
+			<bounds x="399.5000" y="661.6666" width="75.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="403.6667" y="664.4444" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="403.6667" y="664.4444" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="407.8333" y="667.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="407.8333" y="667.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="387" y="520" width="100" height="200">
-			</bounds>
+			<bounds x="387" y="520" width="100" height="200"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="279" y="193" width="99" height="80">
-			</bounds>
+			<bounds x="279" y="193" width="99" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="279.0000" y="193.0000" width="99.0000" height="80.0000">
-			</bounds>
+			<bounds x="279.0000" y="193.0000" width="99.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="283.1250" y="196.3333" width="90.7500" height="73.3333">
-			</bounds>
+			<bounds x="283.1250" y="196.3333" width="90.7500" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="287.2500" y="199.6667" width="82.5000" height="66.6667">
-			</bounds>
+			<bounds x="287.2500" y="199.6667" width="82.5000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="291.3750" y="203.0000" width="74.2500" height="60.0000">
-			</bounds>
+			<bounds x="291.3750" y="203.0000" width="74.2500" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="295.5000" y="206.3333" width="66.0000" height="53.3333">
-			</bounds>
+			<bounds x="295.5000" y="206.3333" width="66.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="299.6250" y="209.6667" width="57.7500" height="46.6667">
-			</bounds>
+			<bounds x="299.6250" y="209.6667" width="57.7500" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="279" y="193" width="99" height="80">
-			</bounds>
+			<bounds x="279" y="193" width="99" height="80"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="380" y="193" width="99" height="80">
-			</bounds>
+			<bounds x="380" y="193" width="99" height="80"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="380.0000" y="193.0000" width="99.0000" height="80.0000">
-			</bounds>
+			<bounds x="380.0000" y="193.0000" width="99.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="384.1250" y="196.3333" width="90.7500" height="73.3333">
-			</bounds>
+			<bounds x="384.1250" y="196.3333" width="90.7500" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="388.2500" y="199.6667" width="82.5000" height="66.6667">
-			</bounds>
+			<bounds x="388.2500" y="199.6667" width="82.5000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.3750" y="203.0000" width="74.2500" height="60.0000">
-			</bounds>
+			<bounds x="392.3750" y="203.0000" width="74.2500" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="396.5000" y="206.3333" width="66.0000" height="53.3333">
-			</bounds>
+			<bounds x="396.5000" y="206.3333" width="66.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="400.6250" y="209.6667" width="57.7500" height="46.6667">
-			</bounds>
+			<bounds x="400.6250" y="209.6667" width="57.7500" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="380" y="193" width="99" height="80">
-			</bounds>
+			<bounds x="380" y="193" width="99" height="80"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="411" y="312" width="62" height="28">
-			</bounds>
+			<bounds x="411" y="312" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="413" y="314" width="58" height="24">
-			</bounds>
+			<bounds x="413" y="314" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="287" y="312" width="62" height="28">
-			</bounds>
+			<bounds x="287" y="312" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="289" y="314" width="58" height="24">
-			</bounds>
+			<bounds x="289" y="314" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="349" y="312" width="62" height="28">
-			</bounds>
+			<bounds x="349" y="312" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="351" y="314" width="58" height="24">
-			</bounds>
+			<bounds x="351" y="314" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="890" y="3" width="102" height="57">
-			</bounds>
+			<bounds x="890" y="3" width="102" height="57"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="892" y="5" width="98" height="53">
-			</bounds>
+			<bounds x="892" y="5" width="98" height="53"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="4" y="3" width="102" height="57">
-			</bounds>
+			<bounds x="4" y="3" width="102" height="57"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="6" y="5" width="98" height="53">
-			</bounds>
+			<bounds x="6" y="5" width="98" height="53"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="455" y="3" width="87" height="57">
-			</bounds>
+			<bounds x="455" y="3" width="87" height="57"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="457" y="5" width="83" height="53">
-			</bounds>
+			<bounds x="457" y="5" width="83" height="53"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="368" y="16" width="87" height="44">
-			</bounds>
+			<bounds x="368" y="16" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="370" y="18" width="83" height="40">
-			</bounds>
+			<bounds x="370" y="18" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="194" y="16" width="87" height="44">
-			</bounds>
+			<bounds x="194" y="16" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="196" y="18" width="83" height="40">
-			</bounds>
+			<bounds x="196" y="18" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="281" y="16" width="87" height="44">
-			</bounds>
+			<bounds x="281" y="16" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="283" y="18" width="83" height="40">
-			</bounds>
+			<bounds x="283" y="18" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="542" y="16" width="87" height="44">
-			</bounds>
+			<bounds x="542" y="16" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="544" y="18" width="83" height="40">
-			</bounds>
+			<bounds x="544" y="18" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="107" y="16" width="87" height="44">
-			</bounds>
+			<bounds x="107" y="16" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="109" y="18" width="83" height="40">
-			</bounds>
+			<bounds x="109" y="18" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="629" y="16" width="87" height="44">
-			</bounds>
+			<bounds x="629" y="16" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="631" y="18" width="83" height="40">
-			</bounds>
+			<bounds x="631" y="18" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="716" y="16" width="87" height="44">
-			</bounds>
+			<bounds x="716" y="16" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="718" y="18" width="83" height="40">
-			</bounds>
+			<bounds x="718" y="18" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="803" y="16" width="87" height="44">
-			</bounds>
+			<bounds x="803" y="16" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="805" y="18" width="83" height="40">
-			</bounds>
+			<bounds x="805" y="18" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="21" y="412" width="87" height="44">
-			</bounds>
+			<bounds x="21" y="412" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="23" y="414" width="83" height="40">
-			</bounds>
+			<bounds x="23" y="414" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="21" y="368" width="87" height="44">
-			</bounds>
+			<bounds x="21" y="368" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="23" y="370" width="83" height="40">
-			</bounds>
+			<bounds x="23" y="370" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="21" y="324" width="87" height="44">
-			</bounds>
+			<bounds x="21" y="324" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="23" y="326" width="83" height="40">
-			</bounds>
+			<bounds x="23" y="326" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="21" y="280" width="87" height="44">
-			</bounds>
+			<bounds x="21" y="280" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="23" y="282" width="83" height="40">
-			</bounds>
+			<bounds x="23" y="282" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="21" y="192" width="87" height="44">
-			</bounds>
+			<bounds x="21" y="192" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="23" y="194" width="83" height="40">
-			</bounds>
+			<bounds x="23" y="194" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="21" y="148" width="87" height="44">
-			</bounds>
+			<bounds x="21" y="148" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="23" y="150" width="83" height="40">
-			</bounds>
+			<bounds x="23" y="150" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="21" y="104" width="87" height="44">
-			</bounds>
+			<bounds x="21" y="104" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="23" y="106" width="83" height="40">
-			</bounds>
+			<bounds x="23" y="106" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="21" y="60" width="87" height="44">
-			</bounds>
+			<bounds x="21" y="60" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="23" y="62" width="83" height="40">
-			</bounds>
+			<bounds x="23" y="62" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="890" y="60" width="87" height="44">
-			</bounds>
+			<bounds x="890" y="60" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="892" y="62" width="83" height="40">
-			</bounds>
+			<bounds x="892" y="62" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="890" y="104" width="87" height="44">
-			</bounds>
+			<bounds x="890" y="104" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="892" y="106" width="83" height="40">
-			</bounds>
+			<bounds x="892" y="106" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="890" y="148" width="87" height="44">
-			</bounds>
+			<bounds x="890" y="148" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="892" y="150" width="83" height="40">
-			</bounds>
+			<bounds x="892" y="150" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="890" y="192" width="87" height="44">
-			</bounds>
+			<bounds x="890" y="192" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="892" y="194" width="83" height="40">
-			</bounds>
+			<bounds x="892" y="194" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="889" y="236" width="102" height="44">
-			</bounds>
+			<bounds x="889" y="236" width="102" height="44"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="891" y="238" width="98" height="40">
-			</bounds>
+			<bounds x="891" y="238" width="98" height="40"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="890" y="280" width="87" height="44">
-			</bounds>
+			<bounds x="890" y="280" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="892" y="282" width="83" height="40">
-			</bounds>
+			<bounds x="892" y="282" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="890" y="324" width="87" height="44">
-			</bounds>
+			<bounds x="890" y="324" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="892" y="326" width="83" height="40">
-			</bounds>
+			<bounds x="892" y="326" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="890" y="368" width="87" height="44">
-			</bounds>
+			<bounds x="890" y="368" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="892" y="370" width="83" height="40">
-			</bounds>
+			<bounds x="892" y="370" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="890" y="412" width="87" height="44">
-			</bounds>
+			<bounds x="890" y="412" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="892" y="414" width="83" height="40">
-			</bounds>
+			<bounds x="892" y="414" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="349" y="168" width="62" height="19">
-			</bounds>
+			<bounds x="349" y="168" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="351" y="170" width="58" height="15">
-			</bounds>
+			<bounds x="351" y="170" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="349" y="281" width="62" height="28">
-			</bounds>
+			<bounds x="349" y="281" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="351" y="283" width="58" height="24">
-			</bounds>
+			<bounds x="351" y="283" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="668" y="296" width="82" height="19">
-			</bounds>
+			<bounds x="668" y="296" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="670" y="298" width="78" height="15">
-			</bounds>
+			<bounds x="670" y="298" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="668" y="261" width="82" height="35">
-			</bounds>
+			<bounds x="668" y="261" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="670" y="263" width="78" height="31">
-			</bounds>
+			<bounds x="670" y="263" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="668" y="242" width="82" height="19">
-			</bounds>
+			<bounds x="668" y="242" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="670" y="244" width="78" height="15">
-			</bounds>
+			<bounds x="670" y="244" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="668" y="223" width="82" height="19">
-			</bounds>
+			<bounds x="668" y="223" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="670" y="225" width="78" height="15">
-			</bounds>
+			<bounds x="670" y="225" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="668" y="188" width="82" height="35">
-			</bounds>
+			<bounds x="668" y="188" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="670" y="190" width="78" height="31">
-			</bounds>
+			<bounds x="670" y="190" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="668" y="153" width="82" height="35">
-			</bounds>
+			<bounds x="668" y="153" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="670" y="155" width="78" height="31">
-			</bounds>
+			<bounds x="670" y="155" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="668" y="134" width="82" height="19">
-			</bounds>
+			<bounds x="668" y="134" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="670" y="136" width="78" height="15">
-			</bounds>
+			<bounds x="670" y="136" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="753" y="296" width="82" height="19">
-			</bounds>
+			<bounds x="753" y="296" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="755" y="298" width="78" height="15">
-			</bounds>
+			<bounds x="755" y="298" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="753" y="261" width="82" height="35">
-			</bounds>
+			<bounds x="753" y="261" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="755" y="263" width="78" height="31">
-			</bounds>
+			<bounds x="755" y="263" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="753" y="242" width="82" height="19">
-			</bounds>
+			<bounds x="753" y="242" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="755" y="244" width="78" height="15">
-			</bounds>
+			<bounds x="755" y="244" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_2_border" state="0">
-			<bounds x="753" y="223" width="82" height="19">
-			</bounds>
+			<bounds x="753" y="223" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_2" state="0">
-			<bounds x="755" y="225" width="78" height="15">
-			</bounds>
+			<bounds x="755" y="225" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="753" y="188" width="82" height="35">
-			</bounds>
+			<bounds x="753" y="188" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="755" y="190" width="78" height="31">
-			</bounds>
+			<bounds x="755" y="190" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_2_border" state="0">
-			<bounds x="753" y="153" width="82" height="35">
-			</bounds>
+			<bounds x="753" y="153" width="82" height="35"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_2" state="0">
-			<bounds x="755" y="155" width="78" height="31">
-			</bounds>
+			<bounds x="755" y="155" width="78" height="31"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_2_border" state="0">
-			<bounds x="753" y="134" width="82" height="19">
-			</bounds>
+			<bounds x="753" y="134" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_2" state="0">
-			<bounds x="755" y="136" width="78" height="15">
-			</bounds>
+			<bounds x="755" y="136" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="524" y="254" width="87" height="44">
-			</bounds>
+			<bounds x="524" y="254" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="526" y="256" width="83" height="40">
-			</bounds>
+			<bounds x="526" y="256" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="524" y="298" width="87" height="44">
-			</bounds>
+			<bounds x="524" y="298" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="526" y="300" width="83" height="40">
-			</bounds>
+			<bounds x="526" y="300" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="524" y="342" width="87" height="44">
-			</bounds>
+			<bounds x="524" y="342" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="526" y="344" width="83" height="40">
-			</bounds>
+			<bounds x="526" y="344" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="524" y="210" width="87" height="44">
-			</bounds>
+			<bounds x="524" y="210" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="526" y="212" width="83" height="40">
-			</bounds>
+			<bounds x="526" y="212" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="524" y="122" width="87" height="44">
-			</bounds>
+			<bounds x="524" y="122" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="526" y="124" width="83" height="40">
-			</bounds>
+			<bounds x="526" y="124" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="524" y="166" width="87" height="44">
-			</bounds>
+			<bounds x="524" y="166" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="526" y="168" width="83" height="40">
-			</bounds>
+			<bounds x="526" y="168" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="139" y="113" width="87" height="44">
-			</bounds>
+			<bounds x="139" y="113" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="141" y="115" width="83" height="40">
-			</bounds>
+			<bounds x="141" y="115" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="139" y="157" width="87" height="44">
-			</bounds>
+			<bounds x="139" y="157" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="141" y="159" width="83" height="40">
-			</bounds>
+			<bounds x="141" y="159" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="139" y="201" width="87" height="44">
-			</bounds>
+			<bounds x="139" y="201" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="141" y="203" width="83" height="40">
-			</bounds>
+			<bounds x="141" y="203" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="139" y="245" width="87" height="44">
-			</bounds>
+			<bounds x="139" y="245" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="141" y="247" width="83" height="40">
-			</bounds>
+			<bounds x="141" y="247" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="139" y="289" width="87" height="44">
-			</bounds>
+			<bounds x="139" y="289" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="141" y="291" width="83" height="40">
-			</bounds>
+			<bounds x="141" y="291" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="139" y="333" width="87" height="44">
-			</bounds>
+			<bounds x="139" y="333" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="141" y="335" width="83" height="40">
-			</bounds>
+			<bounds x="141" y="335" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="6" y="482" width="102" height="29">
-			</bounds>
+			<bounds x="6" y="482" width="102" height="29"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="8" y="484" width="98" height="25">
-			</bounds>
+			<bounds x="8" y="484" width="98" height="25"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="6" y="455" width="102" height="29">
-			</bounds>
+			<bounds x="6" y="455" width="102" height="29"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="8" y="457" width="98" height="25">
-			</bounds>
+			<bounds x="8" y="457" width="98" height="25"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="108" y="456" width="87" height="44">
-			</bounds>
+			<bounds x="108" y="456" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="110" y="458" width="83" height="40">
-			</bounds>
+			<bounds x="110" y="458" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="195" y="456" width="87" height="44">
-			</bounds>
+			<bounds x="195" y="456" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="197" y="458" width="83" height="40">
-			</bounds>
+			<bounds x="197" y="458" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="282" y="456" width="87" height="44">
-			</bounds>
+			<bounds x="282" y="456" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="284" y="458" width="83" height="40">
-			</bounds>
+			<bounds x="284" y="458" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="369" y="456" width="87" height="44">
-			</bounds>
+			<bounds x="369" y="456" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="371" y="458" width="83" height="40">
-			</bounds>
+			<bounds x="371" y="458" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="456" y="456" width="87" height="57">
-			</bounds>
+			<bounds x="456" y="456" width="87" height="57"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="458" y="458" width="83" height="53">
-			</bounds>
+			<bounds x="458" y="458" width="83" height="53"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="543" y="456" width="87" height="44">
-			</bounds>
+			<bounds x="543" y="456" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="545" y="458" width="83" height="40">
-			</bounds>
+			<bounds x="545" y="458" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="630" y="456" width="87" height="44">
-			</bounds>
+			<bounds x="630" y="456" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="632" y="458" width="83" height="40">
-			</bounds>
+			<bounds x="632" y="458" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="717" y="456" width="87" height="44">
-			</bounds>
+			<bounds x="717" y="456" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="719" y="458" width="83" height="40">
-			</bounds>
+			<bounds x="719" y="458" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="804" y="456" width="87" height="44">
-			</bounds>
+			<bounds x="804" y="456" width="87" height="44"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="806" y="458" width="83" height="40">
-			</bounds>
+			<bounds x="806" y="458" width="83" height="40"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="891" y="456" width="102" height="57">
-			</bounds>
+			<bounds x="891" y="456" width="102" height="57"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="893" y="458" width="98" height="53">
-			</bounds>
+			<bounds x="893" y="458" width="98" height="53"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="7" y="236" width="102" height="44">
-			</bounds>
+			<bounds x="7" y="236" width="102" height="44"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="9" y="238" width="98" height="40">
-			</bounds>
+			<bounds x="9" y="238" width="98" height="40"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="54" y="554" width="65" height="19">
-			</bounds>
+			<bounds x="54" y="554" width="65" height="19"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="56" y="556" width="61" height="15">
-			</bounds>
+			<bounds x="56" y="556" width="61" height="15"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="54" y="634" width="65" height="19">
-			</bounds>
+			<bounds x="54" y="634" width="65" height="19"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="56" y="636" width="61" height="15">
-			</bounds>
+			<bounds x="56" y="636" width="61" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="54" y="574" width="65" height="19">
-			</bounds>
+			<bounds x="54" y="574" width="65" height="19"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="56" y="576" width="61" height="15">
-			</bounds>
+			<bounds x="56" y="576" width="61" height="15"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="54" y="594" width="65" height="19">
-			</bounds>
+			<bounds x="54" y="594" width="65" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="56" y="596" width="61" height="15">
-			</bounds>
+			<bounds x="56" y="596" width="61" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="54" y="614" width="65" height="19">
-			</bounds>
+			<bounds x="54" y="614" width="65" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="56" y="616" width="61" height="15">
-			</bounds>
+			<bounds x="56" y="616" width="61" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="54" y="654" width="65" height="39">
-			</bounds>
+			<bounds x="54" y="654" width="65" height="39"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="56" y="656" width="61" height="35">
-			</bounds>
+			<bounds x="56" y="656" width="61" height="35"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_93_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="61" y="723" width="87" height="38">
-			</bounds>
+			<bounds x="61" y="723" width="87" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_93" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="63" y="725" width="83" height="34">
-			</bounds>
+			<bounds x="63" y="725" width="83" height="34"/>
 		</backdrop>
 		<backdrop name="lamp192" element="colour_button_94_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="586" y="551" width="75" height="27">
-			</bounds>
+			<bounds x="586" y="551" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp192" element="colour_button_94" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="588" y="553" width="71" height="23">
-			</bounds>
+			<bounds x="588" y="553" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_96_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="150" y="723" width="102" height="38">
-			</bounds>
+			<bounds x="150" y="723" width="102" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_96" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="152" y="725" width="98" height="34">
-			</bounds>
+			<bounds x="152" y="725" width="98" height="34"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_100_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="271" y="723" width="102" height="38">
-			</bounds>
+			<bounds x="271" y="723" width="102" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_100" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="273" y="725" width="98" height="34">
-			</bounds>
+			<bounds x="273" y="725" width="98" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_101_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="386" y="723" width="102" height="38">
-			</bounds>
+			<bounds x="386" y="723" width="102" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_101" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="388" y="725" width="98" height="34">
-			</bounds>
+			<bounds x="388" y="725" width="98" height="34"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_102_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="580" y="723" width="89" height="38">
-			</bounds>
+			<bounds x="580" y="723" width="89" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_102" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="582" y="725" width="85" height="34">
-			</bounds>
+			<bounds x="582" y="725" width="85" height="34"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_103_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="491" y="723" width="87" height="38">
-			</bounds>
+			<bounds x="491" y="723" width="87" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_103" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="493" y="725" width="83" height="34">
-			</bounds>
+			<bounds x="493" y="725" width="83" height="34"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_104_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="671" y="723" width="87" height="38">
-			</bounds>
+			<bounds x="671" y="723" width="87" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_104" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="673" y="725" width="83" height="34">
-			</bounds>
+			<bounds x="673" y="725" width="83" height="34"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="563" y="604" width="65" height="88">
-			</bounds>
+			<bounds x="563" y="604" width="65" height="88"/>
 		</backdrop>
 		<backdrop name="led_off48" element="led_off">
-			<bounds x="572" y="612" width="46" height="8">
-			</bounds>
+			<bounds x="572" y="612" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="led_off49" element="led_off">
-			<bounds x="609" y="612" width="9" height="40">
-			</bounds>
+			<bounds x="609" y="612" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="led_off50" element="led_off">
-			<bounds x="609" y="644" width="9" height="40">
-			</bounds>
+			<bounds x="609" y="644" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="led_off51" element="led_off">
-			<bounds x="572" y="676" width="46" height="8">
-			</bounds>
+			<bounds x="572" y="676" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="led_off52" element="led_off">
-			<bounds x="572" y="644" width="9" height="40">
-			</bounds>
+			<bounds x="572" y="644" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="led_off53" element="led_off">
-			<bounds x="572" y="612" width="9" height="40">
-			</bounds>
+			<bounds x="572" y="612" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="led_off54" element="led_off">
-			<bounds x="572" y="644" width="46" height="8">
-			</bounds>
+			<bounds x="572" y="644" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="led_off55" element="led_dot_off">
-			<bounds x="618" y="676" width="9" height="8">
-			</bounds>
+			<bounds x="618" y="676" width="9" height="8"/>
 		</backdrop>
 		<backdrop name="lamp48" element="led_on">
-			<bounds x="572" y="612" width="46" height="8">
-			</bounds>
+			<bounds x="572" y="612" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="lamp49" element="led_on">
-			<bounds x="609" y="612" width="9" height="40">
-			</bounds>
+			<bounds x="609" y="612" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="lamp50" element="led_on">
-			<bounds x="609" y="644" width="9" height="40">
-			</bounds>
+			<bounds x="609" y="644" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="lamp51" element="led_on">
-			<bounds x="572" y="676" width="46" height="8">
-			</bounds>
+			<bounds x="572" y="676" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="lamp52" element="led_on">
-			<bounds x="572" y="644" width="9" height="40">
-			</bounds>
+			<bounds x="572" y="644" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="lamp53" element="led_on">
-			<bounds x="572" y="612" width="9" height="40">
-			</bounds>
+			<bounds x="572" y="612" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="lamp54" element="led_on">
-			<bounds x="572" y="644" width="46" height="8">
-			</bounds>
+			<bounds x="572" y="644" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="lamp55" element="led_dot_on">
-			<bounds x="618" y="676" width="9" height="8">
-			</bounds>
+			<bounds x="618" y="676" width="9" height="8"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="628" y="604" width="65" height="88">
-			</bounds>
+			<bounds x="628" y="604" width="65" height="88"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="637" y="612" width="46" height="8">
-			</bounds>
+			<bounds x="637" y="612" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="674" y="612" width="9" height="40">
-			</bounds>
+			<bounds x="674" y="612" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="674" y="644" width="9" height="40">
-			</bounds>
+			<bounds x="674" y="644" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="637" y="676" width="46" height="8">
-			</bounds>
+			<bounds x="637" y="676" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="637" y="644" width="9" height="40">
-			</bounds>
+			<bounds x="637" y="644" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="637" y="612" width="9" height="40">
-			</bounds>
+			<bounds x="637" y="612" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="637" y="644" width="46" height="8">
-			</bounds>
+			<bounds x="637" y="644" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_dot_off">
-			<bounds x="683" y="676" width="9" height="8">
-			</bounds>
+			<bounds x="683" y="676" width="9" height="8"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="637" y="612" width="46" height="8">
-			</bounds>
+			<bounds x="637" y="612" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="674" y="612" width="9" height="40">
-			</bounds>
+			<bounds x="674" y="612" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="674" y="644" width="9" height="40">
-			</bounds>
+			<bounds x="674" y="644" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="637" y="676" width="46" height="8">
-			</bounds>
+			<bounds x="637" y="676" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="637" y="644" width="9" height="40">
-			</bounds>
+			<bounds x="637" y="644" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="637" y="612" width="9" height="40">
-			</bounds>
+			<bounds x="637" y="612" width="9" height="40"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="637" y="644" width="46" height="8">
-			</bounds>
+			<bounds x="637" y="644" width="46" height="8"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_dot_on">
-			<bounds x="683" y="676" width="9" height="8">
-			</bounds>
+			<bounds x="683" y="676" width="9" height="8"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="220" y="418" width="272" height="30">
-			</bounds>
+			<bounds x="220" y="418" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="220" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="220" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="237" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="237" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="254" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="254" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="271" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="271" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="288" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="288" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="305" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="305" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="322" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="322" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="339" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="339" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="356" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="356" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="373" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="373" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="390" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="390" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="407" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="407" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="424" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="424" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="441" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="441" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="458" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="458" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="475" y="418" width="17" height="30">
-			</bounds>
+			<bounds x="475" y="418" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label27" element="label_27">
-			<bounds x="751" y="583" width="108" height="56">
-			</bounds>
+			<bounds x="751" y="583" width="108" height="56"/>
 		</backdrop>
 		<backdrop name="label37" element="label_37">
-			<bounds x="155" y="96" width="41" height="14">
-			</bounds>
+			<bounds x="155" y="96" width="41" height="14"/>
 		</backdrop>
 		<backdrop name="label54" element="label_54">
-			<bounds x="662" y="109" width="101" height="22">
-			</bounds>
+			<bounds x="662" y="109" width="101" height="22"/>
 		</backdrop>
 		<backdrop name="label61" element="label_61">
-			<bounds x="524" y="92" width="67" height="28">
-			</bounds>
+			<bounds x="524" y="92" width="67" height="28"/>
 		</backdrop>
 		<backdrop name="label84" element="label_84">
-			<bounds x="579" y="580" width="67" height="22">
-			</bounds>
+			<bounds x="579" y="580" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="label85" element="label_85">
-			<bounds x="746" y="513" width="120" height="56">
-			</bounds>
+			<bounds x="746" y="513" width="120" height="56"/>
 		</backdrop>
 		<backdrop name="label86" element="label_86">
-			<bounds x="741" y="656" width="118" height="28">
-			</bounds>
+			<bounds x="741" y="656" width="118" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_reel" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_button" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1eastndl.lay
+++ b/src/mame/layout/m1eastndl.lay
@@ -8,13506 +8,8006 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EASTENDERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="EASTENDERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3 Eastenders on the win line ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="awards feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3 Eastenders on the win line ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="awards feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mitchell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bros Auto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mitchell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bros Auto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
+			<color red="0.50" green="0.29" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
+			<color red="1.00" green="0.58" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
+			<color red="0.25" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Grant">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Mitchell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Grant">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Mitchell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="0.37" blue="0.26">
-			</color>
+			<color red="0.24" green="0.37" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.06">
-			</color>
+			<color red="0.06" green="0.09" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.74" blue="0.52">
-			</color>
+			<color red="0.47" green="0.74" blue="0.52"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.18" blue="0.13">
-			</color>
+			<color red="0.12" green="0.18" blue="0.13"/>
 		</rect>
 		<text string="Through">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="the square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="0.37" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.74" blue="0.52">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.18" blue="0.13">
-			</color>
-		</rect>
-		<text string="Through">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="the square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
+			<color red="0.50" green="0.23" blue="0.36"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
+			<color red="0.12" green="0.05" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
+			<color red="1.00" green="0.46" blue="0.73"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
+			<color red="0.25" green="0.11" blue="0.18"/>
 		</rect>
 		<text string="Sharon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Mitchell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
-		</rect>
-		<text string="Sharon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Mitchell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bridge St.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bridge St.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
+			<color red="0.50" green="0.29" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
+			<color red="1.00" green="0.58" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
+			<color red="0.25" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
+			<color red="0.50" green="0.29" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
+			<color red="1.00" green="0.58" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
+			<color red="0.25" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="0.37" blue="0.26">
-			</color>
+			<color red="0.24" green="0.37" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.06">
-			</color>
+			<color red="0.06" green="0.09" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.74" blue="0.52">
-			</color>
+			<color red="0.47" green="0.74" blue="0.52"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.18" blue="0.13">
-			</color>
+			<color red="0.12" green="0.18" blue="0.13"/>
 		</rect>
 		<text string="Through">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="the square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="0.37" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.74" blue="0.52">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.18" blue="0.13">
-			</color>
-		</rect>
-		<text string="Through">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="the square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
+			<color red="0.50" green="0.23" blue="0.36"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
+			<color red="0.12" green="0.05" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
+			<color red="1.00" green="0.46" blue="0.73"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
+			<color red="0.25" green="0.11" blue="0.18"/>
 		</rect>
 		<text string="Pat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Butche">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
-		</rect>
-		<text string="Pat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Butche">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
+			<color red="0.50" green="0.29" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
+			<color red="1.00" green="0.58" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
+			<color red="0.25" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="The Queen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Victoria">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="The Queen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Victoria">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Empty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Empty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CHY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CHY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ORG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ORG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="BEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MLN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MLN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="GRP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="GRP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="BEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MLN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MLN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="GRP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="GRP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ORG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ORG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CHY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CHY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CHY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CHY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ORG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ORG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="GRP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="GRP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MLN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MLN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="BEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Albert">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Albert">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Launderette">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Launderette">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cafe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cafe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Lunch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lunch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Break">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="fast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Break">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="fast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
+			<color red="0.50" green="0.23" blue="0.36"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
+			<color red="0.12" green="0.05" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
+			<color red="1.00" green="0.46" blue="0.73"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
+			<color red="0.25" green="0.11" blue="0.18"/>
 		</rect>
 		<text string="Arthur">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fowler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
-		</rect>
-		<text string="Arthur">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fowler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="0.37" blue="0.26">
-			</color>
+			<color red="0.24" green="0.37" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.06">
-			</color>
+			<color red="0.06" green="0.09" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.74" blue="0.52">
-			</color>
+			<color red="0.47" green="0.74" blue="0.52"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.18" blue="0.13">
-			</color>
+			<color red="0.12" green="0.18" blue="0.13"/>
 		</rect>
 		<text string="Through">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="the square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="0.37" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.74" blue="0.52">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.18" blue="0.13">
-			</color>
-		</rect>
-		<text string="Through">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="the square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
+			<color red="0.50" green="0.29" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
+			<color red="1.00" green="0.58" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
+			<color red="0.25" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
+			<color red="0.50" green="0.23" blue="0.36"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
+			<color red="0.12" green="0.05" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
+			<color red="1.00" green="0.46" blue="0.73"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
+			<color red="0.25" green="0.11" blue="0.18"/>
 		</rect>
 		<text string="Pauline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fowler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
-		</rect>
-		<text string="Pauline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fowler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
+			<color red="0.50" green="0.29" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
+			<color red="1.00" green="0.58" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
+			<color red="0.25" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
+			<color red="0.50" green="0.23" blue="0.36"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
+			<color red="0.12" green="0.05" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
+			<color red="1.00" green="0.46" blue="0.73"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
+			<color red="0.25" green="0.11" blue="0.18"/>
 		</rect>
 		<text string="Go to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="garage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
-		</rect>
-		<text string="Go to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="garage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Wheel Clamped">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Wheel Clamped">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
+			<color red="0.50" green="0.29" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
+			<color red="1.00" green="0.58" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
+			<color red="0.25" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="0.37" blue="0.26">
-			</color>
+			<color red="0.24" green="0.37" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.06">
-			</color>
+			<color red="0.06" green="0.09" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.74" blue="0.52">
-			</color>
+			<color red="0.47" green="0.74" blue="0.52"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.18" blue="0.13">
-			</color>
+			<color red="0.12" green="0.18" blue="0.13"/>
 		</rect>
 		<text string="Through">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="the square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="0.37" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.74" blue="0.52">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.18" blue="0.13">
-			</color>
-		</rect>
-		<text string="Through">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="the square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
+			<color red="0.50" green="0.23" blue="0.36"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
+			<color red="0.12" green="0.05" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
+			<color red="1.00" green="0.46" blue="0.73"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
+			<color red="0.25" green="0.11" blue="0.18"/>
 		</rect>
 		<text string="Frank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Butcher">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.36">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.73">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.18">
-			</color>
-		</rect>
-		<text string="Frank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Butcher">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Meet the">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Mitchells">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Meet the">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Mitchells">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_44_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_3" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_4" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_130_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_130">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_131_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_131">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_132_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_132">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_133_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_133">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_21">
 		<text string="&#x3E;&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_42">
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_43">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_120">
 		<text string=" UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="708" height="609">
-			</bounds>
+			<bounds x="0" y="0" width="708" height="609"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="104" y="353" width="80" height="140">
-			</bounds>
+			<bounds x="104" y="353" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="104.0000" y="353.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="104.0000" y="353.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="107.3333" y="354.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="107.3333" y="354.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="110.6667" y="356.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="110.6667" y="356.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="114.0000" y="358.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="114.0000" y="358.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="117.3333" y="360.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="117.3333" y="360.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="120.6667" y="362.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="120.6667" y="362.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="104.0000" y="399.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="104.0000" y="399.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="107.3333" y="401.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="107.3333" y="401.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="110.6667" y="403.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="110.6667" y="403.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="114.0000" y="405.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="114.0000" y="405.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="117.3333" y="407.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="117.3333" y="407.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="120.6667" y="409.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="120.6667" y="409.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="104.0000" y="446.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="104.0000" y="446.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="107.3333" y="448.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="107.3333" y="448.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="110.6667" y="450.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="110.6667" y="450.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="114.0000" y="452.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="114.0000" y="452.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="117.3333" y="454.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="117.3333" y="454.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="120.6667" y="456.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="120.6667" y="456.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="104" y="353" width="80" height="140">
-			</bounds>
+			<bounds x="104" y="353" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="215" y="353" width="80" height="140">
-			</bounds>
+			<bounds x="215" y="353" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="215.0000" y="353.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="215.0000" y="353.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="218.3333" y="354.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="218.3333" y="354.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="221.6667" y="356.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="221.6667" y="356.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="225.0000" y="358.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="225.0000" y="358.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="228.3333" y="360.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="228.3333" y="360.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="231.6667" y="362.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="231.6667" y="362.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="215.0000" y="399.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="215.0000" y="399.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="218.3333" y="401.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="218.3333" y="401.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="221.6667" y="403.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="221.6667" y="403.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="225.0000" y="405.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="225.0000" y="405.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="228.3333" y="407.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="228.3333" y="407.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="231.6667" y="409.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="231.6667" y="409.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="215.0000" y="446.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="215.0000" y="446.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="218.3333" y="448.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="218.3333" y="448.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="221.6667" y="450.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="221.6667" y="450.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="225.0000" y="452.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="225.0000" y="452.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="228.3333" y="454.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="228.3333" y="454.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="231.6667" y="456.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="231.6667" y="456.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="215" y="353" width="80" height="140">
-			</bounds>
+			<bounds x="215" y="353" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="329" y="353" width="84" height="140">
-			</bounds>
+			<bounds x="329" y="353" width="84" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="329.0000" y="353.0000" width="84.0000" height="46.6667">
-			</bounds>
+			<bounds x="329.0000" y="353.0000" width="84.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="332.5000" y="354.9445" width="77.0000" height="42.7778">
-			</bounds>
+			<bounds x="332.5000" y="354.9445" width="77.0000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.0000" y="356.8889" width="70.0000" height="38.8889">
-			</bounds>
+			<bounds x="336.0000" y="356.8889" width="70.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="339.5000" y="358.8333" width="63.0000" height="35.0000">
-			</bounds>
+			<bounds x="339.5000" y="358.8333" width="63.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.0000" y="360.7778" width="56.0000" height="31.1111">
-			</bounds>
+			<bounds x="343.0000" y="360.7778" width="56.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.5000" y="362.7222" width="49.0000" height="27.2222">
-			</bounds>
+			<bounds x="346.5000" y="362.7222" width="49.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="329.0000" y="399.6667" width="84.0000" height="46.6667">
-			</bounds>
+			<bounds x="329.0000" y="399.6667" width="84.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="332.5000" y="401.6111" width="77.0000" height="42.7778">
-			</bounds>
+			<bounds x="332.5000" y="401.6111" width="77.0000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.0000" y="403.5555" width="70.0000" height="38.8889">
-			</bounds>
+			<bounds x="336.0000" y="403.5555" width="70.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="339.5000" y="405.5000" width="63.0000" height="35.0000">
-			</bounds>
+			<bounds x="339.5000" y="405.5000" width="63.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.0000" y="407.4444" width="56.0000" height="31.1111">
-			</bounds>
+			<bounds x="343.0000" y="407.4444" width="56.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.5000" y="409.3889" width="49.0000" height="27.2222">
-			</bounds>
+			<bounds x="346.5000" y="409.3889" width="49.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="329.0000" y="446.3333" width="84.0000" height="46.6667">
-			</bounds>
+			<bounds x="329.0000" y="446.3333" width="84.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="332.5000" y="448.2778" width="77.0000" height="42.7778">
-			</bounds>
+			<bounds x="332.5000" y="448.2778" width="77.0000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.0000" y="450.2222" width="70.0000" height="38.8889">
-			</bounds>
+			<bounds x="336.0000" y="450.2222" width="70.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="339.5000" y="452.1667" width="63.0000" height="35.0000">
-			</bounds>
+			<bounds x="339.5000" y="452.1667" width="63.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.0000" y="454.1111" width="56.0000" height="31.1111">
-			</bounds>
+			<bounds x="343.0000" y="454.1111" width="56.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.5000" y="456.0556" width="49.0000" height="27.2222">
-			</bounds>
+			<bounds x="346.5000" y="456.0556" width="49.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="329" y="353" width="84" height="140">
-			</bounds>
+			<bounds x="329" y="353" width="84" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="214" y="107" width="96" height="80">
-			</bounds>
+			<bounds x="214" y="107" width="96" height="80"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="214" y="107" width="96" height="80">
-			</bounds>
+			<bounds x="214" y="107" width="96" height="80"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="185" y="9" width="152" height="32">
-			</bounds>
+			<bounds x="185" y="9" width="152" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="187" y="11" width="148" height="28">
-			</bounds>
+			<bounds x="187" y="11" width="148" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="336" y="492" width="72" height="19">
-			</bounds>
+			<bounds x="336" y="492" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="338" y="494" width="68" height="15">
-			</bounds>
+			<bounds x="338" y="494" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="167" y="510" width="182" height="42">
-			</bounds>
+			<bounds x="167" y="510" width="182" height="42"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="169" y="512" width="178" height="38">
-			</bounds>
+			<bounds x="169" y="512" width="178" height="38"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="108" y="492" width="72" height="19">
-			</bounds>
+			<bounds x="108" y="492" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="110" y="494" width="68" height="15">
-			</bounds>
+			<bounds x="110" y="494" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="220" y="492" width="72" height="19">
-			</bounds>
+			<bounds x="220" y="492" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="222" y="494" width="68" height="15">
-			</bounds>
+			<bounds x="222" y="494" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="85" y="402" width="14" height="14">
-			</bounds>
+			<bounds x="85" y="402" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="87" y="404" width="10" height="10">
-			</bounds>
+			<bounds x="87" y="404" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="85" y="416" width="14" height="14">
-			</bounds>
+			<bounds x="85" y="416" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="87" y="418" width="10" height="10">
-			</bounds>
+			<bounds x="87" y="418" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="85" y="430" width="14" height="14">
-			</bounds>
+			<bounds x="85" y="430" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="87" y="432" width="10" height="10">
-			</bounds>
+			<bounds x="87" y="432" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="200" y="428" width="14" height="14">
-			</bounds>
+			<bounds x="200" y="428" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="202" y="430" width="10" height="10">
-			</bounds>
+			<bounds x="202" y="430" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1_border" state="0">
-			<bounds x="200" y="414" width="14" height="14">
-			</bounds>
+			<bounds x="200" y="414" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1" state="0">
-			<bounds x="202" y="416" width="10" height="10">
-			</bounds>
+			<bounds x="202" y="416" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0">
-			<bounds x="200" y="400" width="14" height="14">
-			</bounds>
+			<bounds x="200" y="400" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0">
-			<bounds x="202" y="402" width="10" height="10">
-			</bounds>
+			<bounds x="202" y="402" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="313" y="430" width="14" height="14">
-			</bounds>
+			<bounds x="313" y="430" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="315" y="432" width="10" height="10">
-			</bounds>
+			<bounds x="315" y="432" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="313" y="416" width="14" height="14">
-			</bounds>
+			<bounds x="313" y="416" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="315" y="418" width="10" height="10">
-			</bounds>
+			<bounds x="315" y="418" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="313" y="402" width="14" height="14">
-			</bounds>
+			<bounds x="313" y="402" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="315" y="404" width="10" height="10">
-			</bounds>
+			<bounds x="315" y="404" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="431" y="361" width="45" height="45">
-			</bounds>
+			<bounds x="431" y="361" width="45" height="45"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="433" y="363" width="41" height="41">
-			</bounds>
+			<bounds x="433" y="363" width="41" height="41"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="12" y="14" width="67" height="42">
-			</bounds>
+			<bounds x="12" y="14" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="14" y="16" width="63" height="38">
-			</bounds>
+			<bounds x="14" y="16" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="437" y="273" width="52" height="32">
-			</bounds>
+			<bounds x="437" y="273" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="439" y="275" width="48" height="28">
-			</bounds>
+			<bounds x="439" y="275" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="431" y="241" width="52" height="32">
-			</bounds>
+			<bounds x="431" y="241" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="433" y="243" width="48" height="28">
-			</bounds>
+			<bounds x="433" y="243" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="425" y="209" width="52" height="32">
-			</bounds>
+			<bounds x="425" y="209" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="427" y="211" width="48" height="28">
-			</bounds>
+			<bounds x="427" y="211" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="419" y="177" width="69" height="32">
-			</bounds>
+			<bounds x="419" y="177" width="69" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="421" y="179" width="65" height="28">
-			</bounds>
+			<bounds x="421" y="179" width="65" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="413" y="145" width="52" height="32">
-			</bounds>
+			<bounds x="413" y="145" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="415" y="147" width="48" height="28">
-			</bounds>
+			<bounds x="415" y="147" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="407" y="113" width="62" height="32">
-			</bounds>
+			<bounds x="407" y="113" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="409" y="115" width="58" height="28">
-			</bounds>
+			<bounds x="409" y="115" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="399" y="81" width="52" height="32">
-			</bounds>
+			<bounds x="399" y="81" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="401" y="83" width="48" height="28">
-			</bounds>
+			<bounds x="401" y="83" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="29" y="241" width="52" height="32">
-			</bounds>
+			<bounds x="29" y="241" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="31" y="243" width="48" height="28">
-			</bounds>
+			<bounds x="31" y="243" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="37" y="209" width="52" height="32">
-			</bounds>
+			<bounds x="37" y="209" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="39" y="211" width="48" height="28">
-			</bounds>
+			<bounds x="39" y="211" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="30" y="177" width="69" height="32">
-			</bounds>
+			<bounds x="30" y="177" width="69" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="32" y="179" width="65" height="28">
-			</bounds>
+			<bounds x="32" y="179" width="65" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="53" y="145" width="52" height="32">
-			</bounds>
+			<bounds x="53" y="145" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="55" y="147" width="48" height="28">
-			</bounds>
+			<bounds x="55" y="147" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="61" y="113" width="52" height="32">
-			</bounds>
+			<bounds x="61" y="113" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="63" y="115" width="48" height="28">
-			</bounds>
+			<bounds x="63" y="115" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="67" y="81" width="52" height="32">
-			</bounds>
+			<bounds x="67" y="81" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="69" y="83" width="48" height="28">
-			</bounds>
+			<bounds x="69" y="83" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="23" y="273" width="52" height="32">
-			</bounds>
+			<bounds x="23" y="273" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="25" y="275" width="48" height="28">
-			</bounds>
+			<bounds x="25" y="275" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="499" y="11" width="78" height="35">
-			</bounds>
+			<bounds x="499" y="11" width="78" height="35"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="501" y="13" width="74" height="31">
-			</bounds>
+			<bounds x="501" y="13" width="74" height="31"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="537" y="48" width="52" height="37">
-			</bounds>
+			<bounds x="537" y="48" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="539" y="50" width="48" height="33">
-			</bounds>
+			<bounds x="539" y="50" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="484" y="48" width="52" height="37">
-			</bounds>
+			<bounds x="484" y="48" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="486" y="50" width="48" height="33">
-			</bounds>
+			<bounds x="486" y="50" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="628" y="97" width="70" height="34">
-			</bounds>
+			<bounds x="628" y="97" width="70" height="34"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="630" y="99" width="66" height="30">
-			</bounds>
+			<bounds x="630" y="99" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="194" y="121" width="14" height="14">
-			</bounds>
+			<bounds x="194" y="121" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="196" y="123" width="10" height="10">
-			</bounds>
+			<bounds x="196" y="123" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="194" y="141" width="14" height="14">
-			</bounds>
+			<bounds x="194" y="141" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="196" y="143" width="10" height="10">
-			</bounds>
+			<bounds x="196" y="143" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="194" y="161" width="14" height="14">
-			</bounds>
+			<bounds x="194" y="161" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="196" y="163" width="10" height="10">
-			</bounds>
+			<bounds x="196" y="163" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="494" y="493" width="32" height="25">
-			</bounds>
+			<bounds x="494" y="493" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="496" y="495" width="28" height="21">
-			</bounds>
+			<bounds x="496" y="495" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="494" y="468" width="32" height="25">
-			</bounds>
+			<bounds x="494" y="468" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="496" y="470" width="28" height="21">
-			</bounds>
+			<bounds x="496" y="470" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="494" y="368" width="32" height="25">
-			</bounds>
+			<bounds x="494" y="368" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="496" y="370" width="28" height="21">
-			</bounds>
+			<bounds x="496" y="370" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="494" y="393" width="32" height="25">
-			</bounds>
+			<bounds x="494" y="393" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="496" y="395" width="28" height="21">
-			</bounds>
+			<bounds x="496" y="395" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="494" y="418" width="32" height="25">
-			</bounds>
+			<bounds x="494" y="418" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="496" y="420" width="28" height="21">
-			</bounds>
+			<bounds x="496" y="420" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="494" y="443" width="32" height="25">
-			</bounds>
+			<bounds x="494" y="443" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="496" y="445" width="28" height="21">
-			</bounds>
+			<bounds x="496" y="445" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="528" y="368" width="32" height="25">
-			</bounds>
+			<bounds x="528" y="368" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="530" y="370" width="28" height="21">
-			</bounds>
+			<bounds x="530" y="370" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="528" y="393" width="32" height="25">
-			</bounds>
+			<bounds x="528" y="393" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="530" y="395" width="28" height="21">
-			</bounds>
+			<bounds x="530" y="395" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="528" y="418" width="32" height="25">
-			</bounds>
+			<bounds x="528" y="418" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="530" y="420" width="28" height="21">
-			</bounds>
+			<bounds x="530" y="420" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="528" y="443" width="32" height="25">
-			</bounds>
+			<bounds x="528" y="443" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="530" y="445" width="28" height="21">
-			</bounds>
+			<bounds x="530" y="445" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="528" y="468" width="32" height="25">
-			</bounds>
+			<bounds x="528" y="468" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="530" y="470" width="28" height="21">
-			</bounds>
+			<bounds x="530" y="470" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="528" y="493" width="32" height="25">
-			</bounds>
+			<bounds x="528" y="493" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="530" y="495" width="28" height="21">
-			</bounds>
+			<bounds x="530" y="495" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="561" y="493" width="32" height="25">
-			</bounds>
+			<bounds x="561" y="493" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="563" y="495" width="28" height="21">
-			</bounds>
+			<bounds x="563" y="495" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="561" y="468" width="32" height="25">
-			</bounds>
+			<bounds x="561" y="468" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="563" y="470" width="28" height="21">
-			</bounds>
+			<bounds x="563" y="470" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="561" y="443" width="32" height="25">
-			</bounds>
+			<bounds x="561" y="443" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="563" y="445" width="28" height="21">
-			</bounds>
+			<bounds x="563" y="445" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="561" y="418" width="32" height="25">
-			</bounds>
+			<bounds x="561" y="418" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="563" y="420" width="28" height="21">
-			</bounds>
+			<bounds x="563" y="420" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="561" y="393" width="32" height="25">
-			</bounds>
+			<bounds x="561" y="393" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="563" y="395" width="28" height="21">
-			</bounds>
+			<bounds x="563" y="395" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="561" y="368" width="32" height="25">
-			</bounds>
+			<bounds x="561" y="368" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="563" y="370" width="28" height="21">
-			</bounds>
+			<bounds x="563" y="370" width="28" height="21"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="607" y="443" width="43" height="25">
-			</bounds>
+			<bounds x="607" y="443" width="43" height="25"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="609" y="445" width="39" height="21">
-			</bounds>
+			<bounds x="609" y="445" width="39" height="21"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="607" y="418" width="43" height="25">
-			</bounds>
+			<bounds x="607" y="418" width="43" height="25"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="609" y="420" width="39" height="21">
-			</bounds>
+			<bounds x="609" y="420" width="39" height="21"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="607" y="393" width="43" height="25">
-			</bounds>
+			<bounds x="607" y="393" width="43" height="25"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="609" y="395" width="39" height="21">
-			</bounds>
+			<bounds x="609" y="395" width="39" height="21"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="607" y="368" width="43" height="25">
-			</bounds>
+			<bounds x="607" y="368" width="43" height="25"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="609" y="370" width="39" height="21">
-			</bounds>
+			<bounds x="609" y="370" width="39" height="21"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="607" y="468" width="43" height="25">
-			</bounds>
+			<bounds x="607" y="468" width="43" height="25"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="609" y="470" width="39" height="21">
-			</bounds>
+			<bounds x="609" y="470" width="39" height="21"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="607" y="493" width="43" height="25">
-			</bounds>
+			<bounds x="607" y="493" width="43" height="25"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="609" y="495" width="39" height="21">
-			</bounds>
+			<bounds x="609" y="495" width="39" height="21"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="589" y="325" width="82" height="27">
-			</bounds>
+			<bounds x="589" y="325" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="591" y="327" width="78" height="23">
-			</bounds>
+			<bounds x="591" y="327" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="589" y="298" width="82" height="27">
-			</bounds>
+			<bounds x="589" y="298" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="591" y="300" width="78" height="23">
-			</bounds>
+			<bounds x="591" y="300" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="537" y="85" width="52" height="37">
-			</bounds>
+			<bounds x="537" y="85" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="539" y="87" width="48" height="33">
-			</bounds>
+			<bounds x="539" y="87" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="484" y="85" width="52" height="37">
-			</bounds>
+			<bounds x="484" y="85" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="486" y="87" width="48" height="33">
-			</bounds>
+			<bounds x="486" y="87" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="631" y="13" width="77" height="31">
-			</bounds>
+			<bounds x="631" y="13" width="77" height="31"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="633" y="15" width="73" height="27">
-			</bounds>
+			<bounds x="633" y="15" width="73" height="27"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="599" y="211" width="62" height="20">
-			</bounds>
+			<bounds x="599" y="211" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="601" y="213" width="58" height="16">
-			</bounds>
+			<bounds x="601" y="213" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="599" y="171" width="62" height="20">
-			</bounds>
+			<bounds x="599" y="171" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="601" y="173" width="58" height="16">
-			</bounds>
+			<bounds x="601" y="173" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="599" y="191" width="62" height="20">
-			</bounds>
+			<bounds x="599" y="191" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="601" y="193" width="58" height="16">
-			</bounds>
+			<bounds x="601" y="193" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="599" y="231" width="62" height="20">
-			</bounds>
+			<bounds x="599" y="231" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="601" y="233" width="58" height="16">
-			</bounds>
+			<bounds x="601" y="233" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="565" y="251" width="67" height="37">
-			</bounds>
+			<bounds x="565" y="251" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="567" y="253" width="63" height="33">
-			</bounds>
+			<bounds x="567" y="253" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="599" y="141" width="62" height="30">
-			</bounds>
+			<bounds x="599" y="141" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="601" y="143" width="58" height="26">
-			</bounds>
+			<bounds x="601" y="143" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="537" y="141" width="62" height="30">
-			</bounds>
+			<bounds x="537" y="141" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="539" y="143" width="58" height="26">
-			</bounds>
+			<bounds x="539" y="143" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="537" y="211" width="62" height="20">
-			</bounds>
+			<bounds x="537" y="211" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="539" y="213" width="58" height="16">
-			</bounds>
+			<bounds x="539" y="213" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="537" y="171" width="62" height="20">
-			</bounds>
+			<bounds x="537" y="171" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="539" y="173" width="58" height="16">
-			</bounds>
+			<bounds x="539" y="173" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="537" y="191" width="62" height="20">
-			</bounds>
+			<bounds x="537" y="191" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="539" y="193" width="58" height="16">
-			</bounds>
+			<bounds x="539" y="193" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="537" y="231" width="62" height="20">
-			</bounds>
+			<bounds x="537" y="231" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="539" y="233" width="58" height="16">
-			</bounds>
+			<bounds x="539" y="233" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="31" y="361" width="32" height="32">
-			</bounds>
+			<bounds x="31" y="361" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="33" y="363" width="28" height="28">
-			</bounds>
+			<bounds x="33" y="363" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="21" y="394" width="32" height="32">
-			</bounds>
+			<bounds x="21" y="394" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="23" y="396" width="28" height="28">
-			</bounds>
+			<bounds x="23" y="396" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="31" y="427" width="32" height="32">
-			</bounds>
+			<bounds x="31" y="427" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="33" y="429" width="28" height="28">
-			</bounds>
+			<bounds x="33" y="429" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="21" y="460" width="32" height="32">
-			</bounds>
+			<bounds x="21" y="460" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="23" y="462" width="28" height="28">
-			</bounds>
+			<bounds x="23" y="462" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="15" y="495" width="51" height="32">
-			</bounds>
+			<bounds x="15" y="495" width="51" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="17" y="497" width="47" height="28">
-			</bounds>
+			<bounds x="17" y="497" width="47" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="439" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="439" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="441" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="441" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="387" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="387" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="389" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="389" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="335" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="335" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="337" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="337" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="283" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="283" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="285" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="285" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="229" y="305" width="56" height="42">
-			</bounds>
+			<bounds x="229" y="305" width="56" height="42"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="231" y="307" width="52" height="38">
-			</bounds>
+			<bounds x="231" y="307" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="179" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="179" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="181" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="181" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="127" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="127" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="129" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="129" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="75" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="75" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="77" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="77" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="23" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="23" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="25" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="25" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="76" y="49" width="52" height="32">
-			</bounds>
+			<bounds x="76" y="49" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="78" y="51" width="48" height="28">
-			</bounds>
+			<bounds x="78" y="51" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="128" y="49" width="52" height="32">
-			</bounds>
+			<bounds x="128" y="49" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="130" y="51" width="48" height="28">
-			</bounds>
+			<bounds x="130" y="51" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="180" y="49" width="52" height="32">
-			</bounds>
+			<bounds x="180" y="49" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="182" y="51" width="48" height="28">
-			</bounds>
+			<bounds x="182" y="51" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="230" y="40" width="56" height="42">
-			</bounds>
+			<bounds x="230" y="40" width="56" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="232" y="42" width="52" height="38">
-			</bounds>
+			<bounds x="232" y="42" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="284" y="49" width="52" height="32">
-			</bounds>
+			<bounds x="284" y="49" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="286" y="51" width="48" height="28">
-			</bounds>
+			<bounds x="286" y="51" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="336" y="49" width="52" height="32">
-			</bounds>
+			<bounds x="336" y="49" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="338" y="51" width="48" height="28">
-			</bounds>
+			<bounds x="338" y="51" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="388" y="49" width="57" height="32">
-			</bounds>
+			<bounds x="388" y="49" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="390" y="51" width="53" height="28">
-			</bounds>
+			<bounds x="390" y="51" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_2_border" state="0">
-			<bounds x="419" y="340" width="22" height="22">
-			</bounds>
+			<bounds x="419" y="340" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_2" state="0">
-			<bounds x="421" y="342" width="18" height="18">
-			</bounds>
+			<bounds x="421" y="342" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_3_border" state="0">
-			<bounds x="443" y="340" width="22" height="22">
-			</bounds>
+			<bounds x="443" y="340" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_3" state="0">
-			<bounds x="445" y="342" width="18" height="18">
-			</bounds>
+			<bounds x="445" y="342" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_4_border" state="0">
-			<bounds x="466" y="340" width="22" height="22">
-			</bounds>
+			<bounds x="466" y="340" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_4" state="0">
-			<bounds x="468" y="342" width="18" height="18">
-			</bounds>
+			<bounds x="468" y="342" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="431" y="406" width="42" height="42">
-			</bounds>
+			<bounds x="431" y="406" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="433" y="408" width="38" height="38">
-			</bounds>
+			<bounds x="433" y="408" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="431" y="473" width="42" height="42">
-			</bounds>
+			<bounds x="431" y="473" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="433" y="475" width="38" height="38">
-			</bounds>
+			<bounds x="433" y="475" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="colour_button_130_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="359" y="11" width="27" height="27">
-			</bounds>
+			<bounds x="359" y="11" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp192" element="colour_button_130" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="361" y="13" width="23" height="23">
-			</bounds>
+			<bounds x="361" y="13" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_131_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="8" y="555" width="75" height="39">
-			</bounds>
+			<bounds x="8" y="555" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_131" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="10" y="557" width="71" height="35">
-			</bounds>
+			<bounds x="10" y="557" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_132_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="108" y="554" width="75" height="39">
-			</bounds>
+			<bounds x="108" y="554" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_132" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="110" y="556" width="71" height="35">
-			</bounds>
+			<bounds x="110" y="556" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_133_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="222" y="554" width="75" height="39">
-			</bounds>
+			<bounds x="222" y="554" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_133" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="224" y="556" width="71" height="35">
-			</bounds>
+			<bounds x="224" y="556" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_134_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="340" y="554" width="75" height="39">
-			</bounds>
+			<bounds x="340" y="554" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_134" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="342" y="556" width="71" height="35">
-			</bounds>
+			<bounds x="342" y="556" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_136_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="453" y="555" width="75" height="39">
-			</bounds>
+			<bounds x="453" y="555" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_136" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="455" y="557" width="71" height="35">
-			</bounds>
+			<bounds x="455" y="557" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_137_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="537" y="555" width="75" height="39">
-			</bounds>
+			<bounds x="537" y="555" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_137" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="539" y="557" width="71" height="35">
-			</bounds>
+			<bounds x="539" y="557" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_138_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="621" y="555" width="75" height="39">
-			</bounds>
+			<bounds x="621" y="555" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_138" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="623" y="557" width="71" height="35">
-			</bounds>
+			<bounds x="623" y="557" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp218" element="colour_button_139_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="508" y="305" width="57" height="47">
-			</bounds>
+			<bounds x="508" y="305" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp218" element="colour_button_139" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="510" y="307" width="53" height="43">
-			</bounds>
+			<bounds x="510" y="307" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="112" y="221" width="24" height="32">
-			</bounds>
+			<bounds x="112" y="221" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off112" element="led_off">
-			<bounds x="115" y="223" width="17" height="2">
-			</bounds>
+			<bounds x="115" y="223" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off113" element="led_off">
-			<bounds x="129" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="129" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off114" element="led_off">
-			<bounds x="129" y="235" width="3" height="14">
-			</bounds>
+			<bounds x="129" y="235" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off115" element="led_off">
-			<bounds x="115" y="247" width="17" height="2">
-			</bounds>
+			<bounds x="115" y="247" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off116" element="led_off">
-			<bounds x="115" y="235" width="3" height="14">
-			</bounds>
+			<bounds x="115" y="235" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off117" element="led_off">
-			<bounds x="115" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="115" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off118" element="led_off">
-			<bounds x="115" y="235" width="17" height="2">
-			</bounds>
+			<bounds x="115" y="235" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off119" element="led_dot_off">
-			<bounds x="132" y="247" width="3" height="2">
-			</bounds>
+			<bounds x="132" y="247" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp112" element="led_on">
-			<bounds x="115" y="223" width="17" height="2">
-			</bounds>
+			<bounds x="115" y="223" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp113" element="led_on">
-			<bounds x="129" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="129" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp114" element="led_on">
-			<bounds x="129" y="235" width="3" height="14">
-			</bounds>
+			<bounds x="129" y="235" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp115" element="led_on">
-			<bounds x="115" y="247" width="17" height="2">
-			</bounds>
+			<bounds x="115" y="247" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp116" element="led_on">
-			<bounds x="115" y="235" width="3" height="14">
-			</bounds>
+			<bounds x="115" y="235" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp117" element="led_on">
-			<bounds x="115" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="115" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp118" element="led_on">
-			<bounds x="115" y="235" width="17" height="2">
-			</bounds>
+			<bounds x="115" y="235" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp119" element="led_dot_on">
-			<bounds x="132" y="247" width="3" height="2">
-			</bounds>
+			<bounds x="132" y="247" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="136" y="221" width="24" height="32">
-			</bounds>
+			<bounds x="136" y="221" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off120" element="led_off">
-			<bounds x="139" y="223" width="17" height="2">
-			</bounds>
+			<bounds x="139" y="223" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="153" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="153" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="153" y="235" width="3" height="14">
-			</bounds>
+			<bounds x="153" y="235" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="139" y="247" width="17" height="2">
-			</bounds>
+			<bounds x="139" y="247" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="139" y="235" width="3" height="14">
-			</bounds>
+			<bounds x="139" y="235" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="139" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="139" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="139" y="235" width="17" height="2">
-			</bounds>
+			<bounds x="139" y="235" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off127" element="led_dot_off">
-			<bounds x="156" y="247" width="3" height="2">
-			</bounds>
+			<bounds x="156" y="247" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp120" element="led_on">
-			<bounds x="139" y="223" width="17" height="2">
-			</bounds>
+			<bounds x="139" y="223" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="153" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="153" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="153" y="235" width="3" height="14">
-			</bounds>
+			<bounds x="153" y="235" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="139" y="247" width="17" height="2">
-			</bounds>
+			<bounds x="139" y="247" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="139" y="235" width="3" height="14">
-			</bounds>
+			<bounds x="139" y="235" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="139" y="223" width="3" height="14">
-			</bounds>
+			<bounds x="139" y="223" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="139" y="235" width="17" height="2">
-			</bounds>
+			<bounds x="139" y="235" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp127" element="led_dot_on">
-			<bounds x="156" y="247" width="3" height="2">
-			</bounds>
+			<bounds x="156" y="247" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="339" y="217" width="24" height="32">
-			</bounds>
+			<bounds x="339" y="217" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="342" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="342" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="356" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="356" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="356" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="356" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="342" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="342" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="342" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="342" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="342" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="342" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="342" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="342" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="359" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="359" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="342" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="342" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="356" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="356" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="356" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="356" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="342" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="342" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="342" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="342" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="342" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="342" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="342" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="342" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="359" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="359" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="363" y="217" width="24" height="32">
-			</bounds>
+			<bounds x="363" y="217" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="366" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="366" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="380" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="380" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="380" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="380" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="366" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="366" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="366" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="366" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="366" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="366" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="366" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="366" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="383" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="383" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="366" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="366" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="380" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="380" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="380" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="380" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="366" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="366" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="366" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="366" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="366" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="366" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="366" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="366" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="383" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="383" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="387" y="217" width="24" height="32">
-			</bounds>
+			<bounds x="387" y="217" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="390" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="390" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="404" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="404" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="404" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="404" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="390" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="390" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="390" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="390" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="390" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="390" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="390" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="390" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="407" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="407" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="390" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="390" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="404" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="404" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="404" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="404" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="390" y="243" width="17" height="2">
-			</bounds>
+			<bounds x="390" y="243" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="390" y="231" width="3" height="14">
-			</bounds>
+			<bounds x="390" y="231" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="390" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="390" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="390" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="390" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="407" y="243" width="3" height="2">
-			</bounds>
+			<bounds x="407" y="243" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="635" y="45" width="24" height="32">
-			</bounds>
+			<bounds x="635" y="45" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="638" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="638" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="652" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="652" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="652" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="652" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="638" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="638" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="638" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="638" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="638" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="638" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="638" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="638" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="655" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="655" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="638" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="638" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="652" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="652" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="652" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="652" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="638" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="638" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="638" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="638" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="638" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="638" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="638" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="638" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="655" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="655" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="659" y="45" width="24" height="32">
-			</bounds>
+			<bounds x="659" y="45" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="662" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="662" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="676" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="676" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="676" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="676" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="662" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="662" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="662" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="662" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="662" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="662" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="662" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="662" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="679" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="679" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="662" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="662" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="676" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="676" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="676" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="676" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="662" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="662" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="662" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="662" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="662" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="662" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="662" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="662" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="679" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="679" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="683" y="45" width="24" height="32">
-			</bounds>
+			<bounds x="683" y="45" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="686" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="686" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="700" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="700" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="700" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="700" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="686" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="686" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="686" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="686" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="686" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="686" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="686" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="686" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="703" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="703" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="686" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="686" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="700" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="700" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="700" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="700" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="686" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="686" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="686" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="686" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="686" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="686" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="686" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="686" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="703" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="703" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="124" y="268" width="272" height="20">
-			</bounds>
+			<bounds x="124" y="268" width="272" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="124" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="124" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="141" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="141" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="158" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="158" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="175" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="175" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="192" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="192" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="209" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="209" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="226" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="226" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="243" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="243" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="260" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="260" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="277" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="277" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="294" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="294" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="311" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="311" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="328" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="328" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="345" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="345" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="362" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="362" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="379" y="268" width="17" height="20">
-			</bounds>
+			<bounds x="379" y="268" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="label21" element="label_21">
-			<bounds x="473" y="119" width="18" height="19">
-			</bounds>
+			<bounds x="473" y="119" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label42" element="label_42">
-			<bounds x="109" y="202" width="43" height="15">
-			</bounds>
+			<bounds x="109" y="202" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="label43" element="label_43">
-			<bounds x="321" y="217" width="15" height="32">
-			</bounds>
+			<bounds x="321" y="217" width="15" height="32"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="612" y="45" width="15" height="32">
-			</bounds>
+			<bounds x="612" y="45" width="15" height="32"/>
 		</backdrop>
 		<backdrop name="label120" element="label_120">
-			<bounds x="436" y="446" width="32" height="28">
-			</bounds>
+			<bounds x="436" y="446" width="32" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_button" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_button" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1eastqv3.lay
+++ b/src/mame/layout/m1eastqv3.lay
@@ -8,12462 +8,7812 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;4 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;4 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Phil's Night Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Phil's Night Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Peggy's Happy Hour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Peggy's Happy Hour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Grant's Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Grant's Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Deels On Wheels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Deels On Wheels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Frank's Cash Bonanza">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Frank's Cash Bonanza">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Grant's Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Grant's Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Mark's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mark's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="15, 16, 17, 18, 19, 20, 21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="To Get A Winner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="15, 16, 17, 18, 19, 20, 21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="To Get A Winner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Xtra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Xtra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Double">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Double">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Up / Down Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Up / Down Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Grant's Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Grant's Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Numbers">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="In View">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Numbers">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="In View">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Choose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Choose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="The Queen Vic Beer Pump">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="The Queen Vic Beer Pump">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="Quiz Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="Quiz Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Queen ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Queen ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="Party Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="Party Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="Karaoke Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="Karaoke Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Deals On Wheels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Deals On Wheels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Barred">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Barred">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="10 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="10 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Roll Out The Barrel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Roll Out The Barrel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Grant's Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Grant's Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_141_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_141">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Twist">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Cindy's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Secret">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Pump">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_149_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_149">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Reject">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_38">
 		<text string="Win Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_39">
 		<text string="Win Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_45">
 		<text string="Plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_46">
 		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="V1.01">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_114">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="661">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="661"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="105" y="405" width="80" height="140">
-			</bounds>
+			<bounds x="105" y="405" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="105.0000" y="405.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="105.0000" y="405.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="108.3333" y="406.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="108.3333" y="406.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="111.6667" y="408.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="111.6667" y="408.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="115.0000" y="410.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="115.0000" y="410.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="118.3333" y="412.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="118.3333" y="412.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="121.6667" y="414.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="121.6667" y="414.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="105.0000" y="451.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="105.0000" y="451.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="108.3333" y="453.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="108.3333" y="453.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="111.6667" y="455.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="111.6667" y="455.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="115.0000" y="457.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="115.0000" y="457.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="118.3333" y="459.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="118.3333" y="459.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="121.6667" y="461.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="121.6667" y="461.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="105.0000" y="498.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="105.0000" y="498.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="108.3333" y="500.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="108.3333" y="500.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="111.6667" y="502.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="111.6667" y="502.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="115.0000" y="504.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="115.0000" y="504.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="118.3333" y="506.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="118.3333" y="506.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="121.6667" y="508.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="121.6667" y="508.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="105" y="405" width="80" height="140">
-			</bounds>
+			<bounds x="105" y="405" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="200" y="405" width="80" height="140">
-			</bounds>
+			<bounds x="200" y="405" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="200.0000" y="405.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="200.0000" y="405.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="203.3333" y="406.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="203.3333" y="406.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="206.6667" y="408.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="206.6667" y="408.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="210.0000" y="410.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="210.0000" y="410.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="213.3333" y="412.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="213.3333" y="412.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="216.6667" y="414.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="216.6667" y="414.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="200.0000" y="451.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="200.0000" y="451.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="203.3333" y="453.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="203.3333" y="453.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="206.6667" y="455.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="206.6667" y="455.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="210.0000" y="457.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="210.0000" y="457.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="213.3333" y="459.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="213.3333" y="459.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="216.6667" y="461.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="216.6667" y="461.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="200.0000" y="498.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="200.0000" y="498.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="203.3333" y="500.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="203.3333" y="500.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="206.6667" y="502.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="206.6667" y="502.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="210.0000" y="504.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="210.0000" y="504.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="213.3333" y="506.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="213.3333" y="506.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="216.6667" y="508.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="216.6667" y="508.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="200" y="405" width="80" height="140">
-			</bounds>
+			<bounds x="200" y="405" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="295" y="405" width="80" height="140">
-			</bounds>
+			<bounds x="295" y="405" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="295.0000" y="405.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="295.0000" y="405.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="298.3333" y="406.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="298.3333" y="406.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="301.6667" y="408.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="301.6667" y="408.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="305.0000" y="410.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="305.0000" y="410.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="308.3333" y="412.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="308.3333" y="412.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="311.6667" y="414.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="311.6667" y="414.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="295.0000" y="451.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="295.0000" y="451.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="298.3333" y="453.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="298.3333" y="453.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="301.6667" y="455.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="301.6667" y="455.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="305.0000" y="457.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="305.0000" y="457.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="308.3333" y="459.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="308.3333" y="459.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="311.6667" y="461.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="311.6667" y="461.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="295.0000" y="498.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="295.0000" y="498.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="298.3333" y="500.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="298.3333" y="500.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="301.6667" y="502.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="301.6667" y="502.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="305.0000" y="504.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="305.0000" y="504.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="308.3333" y="506.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="308.3333" y="506.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="311.6667" y="508.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="311.6667" y="508.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="295" y="405" width="80" height="140">
-			</bounds>
+			<bounds x="295" y="405" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="295" y="90" width="80" height="80">
-			</bounds>
+			<bounds x="295" y="90" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="295.0000" y="90.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="295.0000" y="90.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="298.3333" y="93.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="298.3333" y="93.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="301.6667" y="96.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="301.6667" y="96.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="305.0000" y="100.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="305.0000" y="100.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="308.3333" y="103.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="308.3333" y="103.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="311.6667" y="106.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="311.6667" y="106.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="295" y="90" width="80" height="80">
-			</bounds>
+			<bounds x="295" y="90" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="259" y="134" width="32" height="32">
-			</bounds>
+			<bounds x="259" y="134" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="261" y="136" width="28" height="28">
-			</bounds>
+			<bounds x="261" y="136" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="259" y="94" width="32" height="32">
-			</bounds>
+			<bounds x="259" y="94" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="261" y="96" width="28" height="28">
-			</bounds>
+			<bounds x="261" y="96" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="504" y="549" width="62" height="32">
-			</bounds>
+			<bounds x="504" y="549" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="506" y="551" width="58" height="28">
-			</bounds>
+			<bounds x="506" y="551" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="584" y="549" width="62" height="32">
-			</bounds>
+			<bounds x="584" y="549" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="586" y="551" width="58" height="28">
-			</bounds>
+			<bounds x="586" y="551" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="184" y="549" width="62" height="32">
-			</bounds>
+			<bounds x="184" y="549" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="186" y="551" width="58" height="28">
-			</bounds>
+			<bounds x="186" y="551" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="264" y="549" width="62" height="32">
-			</bounds>
+			<bounds x="264" y="549" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="266" y="551" width="58" height="28">
-			</bounds>
+			<bounds x="266" y="551" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="344" y="549" width="62" height="32">
-			</bounds>
+			<bounds x="344" y="549" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="346" y="551" width="58" height="28">
-			</bounds>
+			<bounds x="346" y="551" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="424" y="549" width="62" height="32">
-			</bounds>
+			<bounds x="424" y="549" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="426" y="551" width="58" height="28">
-			</bounds>
+			<bounds x="426" y="551" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="24" y="549" width="62" height="32">
-			</bounds>
+			<bounds x="24" y="549" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="26" y="551" width="58" height="28">
-			</bounds>
+			<bounds x="26" y="551" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="104" y="549" width="62" height="32">
-			</bounds>
+			<bounds x="104" y="549" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="106" y="551" width="58" height="28">
-			</bounds>
+			<bounds x="106" y="551" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="9" y="514" width="65" height="32">
-			</bounds>
+			<bounds x="9" y="514" width="65" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="11" y="516" width="61" height="28">
-			</bounds>
+			<bounds x="11" y="516" width="61" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="679" y="44" width="62" height="32">
-			</bounds>
+			<bounds x="679" y="44" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="681" y="46" width="58" height="28">
-			</bounds>
+			<bounds x="681" y="46" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="679" y="79" width="62" height="32">
-			</bounds>
+			<bounds x="679" y="79" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="681" y="81" width="58" height="28">
-			</bounds>
+			<bounds x="681" y="81" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="334" y="184" width="62" height="32">
-			</bounds>
+			<bounds x="334" y="184" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="336" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="336" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="399" y="184" width="62" height="32">
-			</bounds>
+			<bounds x="399" y="184" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="401" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="401" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="464" y="184" width="62" height="32">
-			</bounds>
+			<bounds x="464" y="184" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="466" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="466" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="529" y="179" width="62" height="42">
-			</bounds>
+			<bounds x="529" y="179" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="531" y="181" width="58" height="38">
-			</bounds>
+			<bounds x="531" y="181" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="594" y="184" width="62" height="32">
-			</bounds>
+			<bounds x="594" y="184" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="596" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="596" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="269" y="184" width="62" height="32">
-			</bounds>
+			<bounds x="269" y="184" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="271" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="271" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="139" y="184" width="62" height="32">
-			</bounds>
+			<bounds x="139" y="184" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="141" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="141" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="74" y="184" width="62" height="32">
-			</bounds>
+			<bounds x="74" y="184" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="76" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="76" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="9" y="194" width="62" height="32">
-			</bounds>
+			<bounds x="9" y="194" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="11" y="196" width="58" height="28">
-			</bounds>
+			<bounds x="11" y="196" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="9" y="229" width="62" height="32">
-			</bounds>
+			<bounds x="9" y="229" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="11" y="231" width="58" height="28">
-			</bounds>
+			<bounds x="11" y="231" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="204" y="184" width="62" height="32">
-			</bounds>
+			<bounds x="204" y="184" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="206" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="206" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="9" y="264" width="62" height="32">
-			</bounds>
+			<bounds x="9" y="264" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="11" y="266" width="58" height="28">
-			</bounds>
+			<bounds x="11" y="266" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="74" y="274" width="62" height="32">
-			</bounds>
+			<bounds x="74" y="274" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="76" y="276" width="58" height="28">
-			</bounds>
+			<bounds x="76" y="276" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="204" y="274" width="62" height="32">
-			</bounds>
+			<bounds x="204" y="274" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="206" y="276" width="58" height="28">
-			</bounds>
+			<bounds x="206" y="276" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="269" y="269" width="62" height="42">
-			</bounds>
+			<bounds x="269" y="269" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="271" y="271" width="58" height="38">
-			</bounds>
+			<bounds x="271" y="271" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="334" y="274" width="62" height="32">
-			</bounds>
+			<bounds x="334" y="274" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="336" y="276" width="58" height="28">
-			</bounds>
+			<bounds x="336" y="276" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="399" y="274" width="62" height="32">
-			</bounds>
+			<bounds x="399" y="274" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="401" y="276" width="58" height="28">
-			</bounds>
+			<bounds x="401" y="276" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="464" y="274" width="62" height="32">
-			</bounds>
+			<bounds x="464" y="274" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="466" y="276" width="58" height="28">
-			</bounds>
+			<bounds x="466" y="276" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="529" y="274" width="62" height="32">
-			</bounds>
+			<bounds x="529" y="274" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="531" y="276" width="58" height="28">
-			</bounds>
+			<bounds x="531" y="276" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="594" y="274" width="62" height="32">
-			</bounds>
+			<bounds x="594" y="274" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="596" y="276" width="58" height="28">
-			</bounds>
+			<bounds x="596" y="276" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="594" y="339" width="62" height="32">
-			</bounds>
+			<bounds x="594" y="339" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="596" y="341" width="58" height="28">
-			</bounds>
+			<bounds x="596" y="341" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="594" y="339" width="62" height="32">
-			</bounds>
+			<bounds x="594" y="339" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="596" y="341" width="58" height="28">
-			</bounds>
+			<bounds x="596" y="341" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="139" y="274" width="62" height="32">
-			</bounds>
+			<bounds x="139" y="274" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="141" y="276" width="58" height="28">
-			</bounds>
+			<bounds x="141" y="276" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="559" y="239" width="132" height="32">
-			</bounds>
+			<bounds x="559" y="239" width="132" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="561" y="241" width="128" height="28">
-			</bounds>
+			<bounds x="561" y="241" width="128" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="529" y="94" width="62" height="32">
-			</bounds>
+			<bounds x="529" y="94" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="531" y="96" width="58" height="28">
-			</bounds>
+			<bounds x="531" y="96" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="459" y="94" width="62" height="32">
-			</bounds>
+			<bounds x="459" y="94" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="461" y="96" width="58" height="28">
-			</bounds>
+			<bounds x="461" y="96" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="494" y="59" width="62" height="32">
-			</bounds>
+			<bounds x="494" y="59" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="496" y="61" width="58" height="28">
-			</bounds>
+			<bounds x="496" y="61" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="424" y="59" width="62" height="32">
-			</bounds>
+			<bounds x="424" y="59" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="426" y="61" width="58" height="28">
-			</bounds>
+			<bounds x="426" y="61" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="564" y="59" width="62" height="32">
-			</bounds>
+			<bounds x="564" y="59" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="566" y="61" width="58" height="28">
-			</bounds>
+			<bounds x="566" y="61" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="659" y="324" width="62" height="32">
-			</bounds>
+			<bounds x="659" y="324" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="661" y="326" width="58" height="28">
-			</bounds>
+			<bounds x="661" y="326" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="659" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="659" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="661" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="661" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="654" y="114" width="62" height="32">
-			</bounds>
+			<bounds x="654" y="114" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="656" y="116" width="58" height="28">
-			</bounds>
+			<bounds x="656" y="116" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="624" y="149" width="62" height="32">
-			</bounds>
+			<bounds x="624" y="149" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="626" y="151" width="58" height="28">
-			</bounds>
+			<bounds x="626" y="151" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="459" y="484" width="67" height="32">
-			</bounds>
+			<bounds x="459" y="484" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="461" y="486" width="63" height="28">
-			</bounds>
+			<bounds x="461" y="486" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="534" y="484" width="67" height="32">
-			</bounds>
+			<bounds x="534" y="484" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="536" y="486" width="63" height="28">
-			</bounds>
+			<bounds x="536" y="486" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="609" y="484" width="67" height="32">
-			</bounds>
+			<bounds x="609" y="484" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="611" y="486" width="63" height="28">
-			</bounds>
+			<bounds x="611" y="486" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="569" y="449" width="67" height="32">
-			</bounds>
+			<bounds x="569" y="449" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="571" y="451" width="63" height="28">
-			</bounds>
+			<bounds x="571" y="451" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="534" y="414" width="67" height="32">
-			</bounds>
+			<bounds x="534" y="414" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="536" y="416" width="63" height="28">
-			</bounds>
+			<bounds x="536" y="416" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="494" y="449" width="67" height="32">
-			</bounds>
+			<bounds x="494" y="449" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="496" y="451" width="63" height="28">
-			</bounds>
+			<bounds x="496" y="451" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="279" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="279" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="281" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="281" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="279" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="279" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="281" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="281" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="314" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="314" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="316" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="316" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="314" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="314" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="316" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="316" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="349" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="349" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="351" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="351" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="349" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="349" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="351" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="351" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="384" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="384" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="386" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="386" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="384" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="384" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="386" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="386" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="244" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="244" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="246" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="246" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="244" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="244" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="246" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="246" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="209" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="209" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="211" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="211" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="209" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="209" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="211" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="211" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="174" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="174" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="176" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="176" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="174" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="174" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="176" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="176" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="139" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="139" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="141" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="141" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="139" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="139" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="141" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="141" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="104" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="104" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="106" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="106" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="104" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="104" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="106" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="106" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="69" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="69" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="71" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="71" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="69" y="349" width="32" height="32">
-			</bounds>
+			<bounds x="69" y="349" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="71" y="351" width="28" height="28">
-			</bounds>
+			<bounds x="71" y="351" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="199" y="324" width="82" height="22">
-			</bounds>
+			<bounds x="199" y="324" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="201" y="326" width="78" height="18">
-			</bounds>
+			<bounds x="201" y="326" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="694" y="569" width="92" height="32">
-			</bounds>
+			<bounds x="694" y="569" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="696" y="571" width="88" height="28">
-			</bounds>
+			<bounds x="696" y="571" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="724" y="174" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="174" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="726" y="176" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="176" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="704" y="119" width="82" height="82">
-			</bounds>
+			<bounds x="704" y="119" width="82" height="82"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="706" y="121" width="78" height="78">
-			</bounds>
+			<bounds x="706" y="121" width="78" height="78"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="9" y="9" width="67" height="67">
-			</bounds>
+			<bounds x="9" y="9" width="67" height="67"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="11" y="11" width="63" height="63">
-			</bounds>
+			<bounds x="11" y="11" width="63" height="63"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="324" y="9" width="67" height="67">
-			</bounds>
+			<bounds x="324" y="9" width="67" height="67"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="326" y="11" width="63" height="63">
-			</bounds>
+			<bounds x="326" y="11" width="63" height="63"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="79" y="9" width="67" height="67">
-			</bounds>
+			<bounds x="79" y="9" width="67" height="67"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="81" y="11" width="63" height="63">
-			</bounds>
+			<bounds x="81" y="11" width="63" height="63"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="149" y="9" width="67" height="67">
-			</bounds>
+			<bounds x="149" y="9" width="67" height="67"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="151" y="11" width="63" height="63">
-			</bounds>
+			<bounds x="151" y="11" width="63" height="63"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="44" y="84" width="177" height="22">
-			</bounds>
+			<bounds x="44" y="84" width="177" height="22"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="46" y="86" width="173" height="18">
-			</bounds>
+			<bounds x="46" y="86" width="173" height="18"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="394" y="9" width="62" height="32">
-			</bounds>
+			<bounds x="394" y="9" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="396" y="11" width="58" height="28">
-			</bounds>
+			<bounds x="396" y="11" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="459" y="9" width="62" height="32">
-			</bounds>
+			<bounds x="459" y="9" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="461" y="11" width="58" height="28">
-			</bounds>
+			<bounds x="461" y="11" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="524" y="9" width="62" height="32">
-			</bounds>
+			<bounds x="524" y="9" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="526" y="11" width="58" height="28">
-			</bounds>
+			<bounds x="526" y="11" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="589" y="9" width="62" height="32">
-			</bounds>
+			<bounds x="589" y="9" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="591" y="11" width="58" height="28">
-			</bounds>
+			<bounds x="591" y="11" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="654" y="9" width="62" height="32">
-			</bounds>
+			<bounds x="654" y="9" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="656" y="11" width="58" height="28">
-			</bounds>
+			<bounds x="656" y="11" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="724" y="524" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="524" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="726" y="526" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="526" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="724" y="499" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="499" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="726" y="501" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="501" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="724" y="474" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="474" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="726" y="476" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="476" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="724" y="449" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="449" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="726" y="451" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="451" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="724" y="424" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="424" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="726" y="426" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="426" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="724" y="399" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="399" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="726" y="401" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="401" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="724" y="374" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="374" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="726" y="376" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="376" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="724" y="324" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="324" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="726" y="326" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="326" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="724" y="299" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="299" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="726" y="301" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="301" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="724" y="274" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="274" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="726" y="276" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="276" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="724" y="249" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="249" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="726" y="251" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="251" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="724" y="224" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="224" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="726" y="226" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="226" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="724" y="199" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="199" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="726" y="201" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="201" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="724" y="349" width="42" height="42">
-			</bounds>
+			<bounds x="724" y="349" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="726" y="351" width="38" height="38">
-			</bounds>
+			<bounds x="726" y="351" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_138_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="734" y="9" width="50" height="16">
-			</bounds>
+			<bounds x="734" y="9" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_138" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="736" y="11" width="46" height="12">
-			</bounds>
+			<bounds x="736" y="11" width="46" height="12"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_139_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="9" y="609" width="82" height="42">
-			</bounds>
+			<bounds x="9" y="609" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_139" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="11" y="611" width="78" height="38">
-			</bounds>
+			<bounds x="11" y="611" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_140_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="104" y="609" width="82" height="42">
-			</bounds>
+			<bounds x="104" y="609" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_140" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="106" y="611" width="78" height="38">
-			</bounds>
+			<bounds x="106" y="611" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_141_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="199" y="609" width="82" height="42">
-			</bounds>
+			<bounds x="199" y="609" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_141" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="201" y="611" width="78" height="38">
-			</bounds>
+			<bounds x="201" y="611" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_142_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="294" y="609" width="82" height="42">
-			</bounds>
+			<bounds x="294" y="609" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_142" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="296" y="611" width="78" height="38">
-			</bounds>
+			<bounds x="296" y="611" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_143_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="389" y="609" width="82" height="42">
-			</bounds>
+			<bounds x="389" y="609" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_143" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="391" y="611" width="78" height="38">
-			</bounds>
+			<bounds x="391" y="611" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_144_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="484" y="609" width="82" height="42">
-			</bounds>
+			<bounds x="484" y="609" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_144" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="486" y="611" width="78" height="38">
-			</bounds>
+			<bounds x="486" y="611" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_145_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="579" y="609" width="82" height="42">
-			</bounds>
+			<bounds x="579" y="609" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_145" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="581" y="611" width="78" height="38">
-			</bounds>
+			<bounds x="581" y="611" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp223" element="colour_button_147_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="484" y="129" width="82" height="42">
-			</bounds>
+			<bounds x="484" y="129" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp223" element="colour_button_147" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="486" y="131" width="78" height="38">
-			</bounds>
+			<bounds x="486" y="131" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="colour_button_148_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="709" y="604" width="62" height="27">
-			</bounds>
+			<bounds x="709" y="604" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="colour_button_148" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="711" y="606" width="58" height="23">
-			</bounds>
+			<bounds x="711" y="606" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="colour_button_149_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="134" y="149" width="82" height="27">
-			</bounds>
+			<bounds x="134" y="149" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="colour_button_149" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="136" y="151" width="78" height="23">
-			</bounds>
+			<bounds x="136" y="151" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp207" element="colour_button_150_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="49" y="149" width="82" height="27">
-			</bounds>
+			<bounds x="49" y="149" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp207" element="colour_button_150" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="51" y="151" width="78" height="23">
-			</bounds>
+			<bounds x="51" y="151" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="95" y="110" width="30" height="37">
-			</bounds>
+			<bounds x="95" y="110" width="30" height="37"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="99" y="113" width="21" height="3">
-			</bounds>
+			<bounds x="99" y="113" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="116" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="116" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="116" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="116" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="99" y="140" width="21" height="3">
-			</bounds>
+			<bounds x="99" y="140" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="99" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="99" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="99" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="99" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="99" y="126" width="21" height="3">
-			</bounds>
+			<bounds x="99" y="126" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="120" y="140" width="4" height="3">
-			</bounds>
+			<bounds x="120" y="140" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="99" y="113" width="21" height="3">
-			</bounds>
+			<bounds x="99" y="113" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="116" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="116" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="116" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="116" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="99" y="140" width="21" height="3">
-			</bounds>
+			<bounds x="99" y="140" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="99" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="99" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="99" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="99" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="99" y="126" width="21" height="3">
-			</bounds>
+			<bounds x="99" y="126" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="120" y="140" width="4" height="3">
-			</bounds>
+			<bounds x="120" y="140" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="155" y="110" width="30" height="37">
-			</bounds>
+			<bounds x="155" y="110" width="30" height="37"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="159" y="113" width="21" height="3">
-			</bounds>
+			<bounds x="159" y="113" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="176" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="176" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="176" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="176" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="159" y="140" width="21" height="3">
-			</bounds>
+			<bounds x="159" y="140" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="159" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="159" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="159" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="159" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="159" y="126" width="21" height="3">
-			</bounds>
+			<bounds x="159" y="126" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="180" y="140" width="4" height="3">
-			</bounds>
+			<bounds x="180" y="140" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="159" y="113" width="21" height="3">
-			</bounds>
+			<bounds x="159" y="113" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="176" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="176" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="176" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="176" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="159" y="140" width="21" height="3">
-			</bounds>
+			<bounds x="159" y="140" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="159" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="159" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="159" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="159" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="159" y="126" width="21" height="3">
-			</bounds>
+			<bounds x="159" y="126" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="180" y="140" width="4" height="3">
-			</bounds>
+			<bounds x="180" y="140" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="125" y="110" width="30" height="37">
-			</bounds>
+			<bounds x="125" y="110" width="30" height="37"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="129" y="113" width="21" height="3">
-			</bounds>
+			<bounds x="129" y="113" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="146" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="146" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="146" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="146" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="129" y="140" width="21" height="3">
-			</bounds>
+			<bounds x="129" y="140" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="129" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="129" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="129" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="129" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="129" y="126" width="21" height="3">
-			</bounds>
+			<bounds x="129" y="126" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="150" y="140" width="4" height="3">
-			</bounds>
+			<bounds x="150" y="140" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="129" y="113" width="21" height="3">
-			</bounds>
+			<bounds x="129" y="113" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="146" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="146" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="146" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="146" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="129" y="140" width="21" height="3">
-			</bounds>
+			<bounds x="129" y="140" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="129" y="126" width="4" height="16">
-			</bounds>
+			<bounds x="129" y="126" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="129" y="113" width="4" height="16">
-			</bounds>
+			<bounds x="129" y="113" width="4" height="16"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="129" y="126" width="21" height="3">
-			</bounds>
+			<bounds x="129" y="126" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="150" y="140" width="4" height="3">
-			</bounds>
+			<bounds x="150" y="140" width="4" height="3"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="165" y="225" width="272" height="30">
-			</bounds>
+			<bounds x="165" y="225" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="165" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="165" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="182" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="182" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="199" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="199" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="216" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="216" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="233" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="233" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="250" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="250" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="267" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="267" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="284" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="284" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="301" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="301" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="318" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="318" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="335" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="335" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="352" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="352" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="369" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="369" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="386" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="386" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="403" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="403" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="420" y="225" width="17" height="30">
-			</bounds>
+			<bounds x="420" y="225" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label38" element="label_38">
-			<bounds x="380" y="465" width="24" height="28">
-			</bounds>
+			<bounds x="380" y="465" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label39" element="label_39">
-			<bounds x="75" y="465" width="24" height="28">
-			</bounds>
+			<bounds x="75" y="465" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label45" element="label_45">
-			<bounds x="386" y="255" width="29" height="14">
-			</bounds>
+			<bounds x="386" y="255" width="29" height="14"/>
 		</backdrop>
 		<backdrop name="label46" element="label_46">
-			<bounds x="181" y="255" width="27" height="14">
-			</bounds>
+			<bounds x="181" y="255" width="27" height="14"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="755" y="640" width="28" height="13">
-			</bounds>
+			<bounds x="755" y="640" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="60" y="100" width="27" height="56">
-			</bounds>
+			<bounds x="60" y="100" width="27" height="56"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_button" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_button" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_button" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_button" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1fantfbb.lay
+++ b/src/mame/layout/m1fantfbb.lay
@@ -8,14186 +8,8333 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.04" blue="0.46">
-			</color>
+			<color red="0.39" green="0.04" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.01" blue="0.11">
-			</color>
+			<color red="0.09" green="0.01" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.78" green="0.07" blue="0.93">
-			</color>
+			<color red="0.78" green="0.07" blue="0.93"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.02" blue="0.23">
-			</color>
+			<color red="0.19" green="0.02" blue="0.23"/>
 		</rect>
 		<text string="Phoenix From">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="The Flames">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.04" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.01" blue="0.11">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.78" green="0.07" blue="0.93">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.02" blue="0.23">
-			</color>
-		</rect>
-		<text string="Phoenix From">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="The Flames">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
+			<color red="0.40" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
+			<color red="0.79" green="0.99" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Trails Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Trails Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
+			<color red="0.40" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
+			<color red="0.79" green="0.99" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Transfer Deadline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Transfer Deadline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.17">
-			</color>
+			<color red="0.49" green="0.45" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
+			<color red="0.12" green="0.11" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.91" blue="0.34">
-			</color>
+			<color red="0.99" green="0.91" blue="0.34"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
+			<color red="0.25" green="0.23" blue="0.08"/>
 		</rect>
 		<text string="Forward Pass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.91" blue="0.34">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
-		</rect>
-		<text string="Forward Pass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Top Of The League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Top Of The League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.00">
-			</color>
+			<color red="0.49" green="0.43" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.87" blue="0.01">
-			</color>
+			<color red="0.99" green="0.87" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="Transfer Market">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.87" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="Transfer Market">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
+			<color red="0.40" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
+			<color red="0.79" green="0.99" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.00">
-			</color>
+			<color red="0.49" green="0.43" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.87" blue="0.01">
-			</color>
+			<color red="0.99" green="0.87" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="Transfer Market">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.87" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="Transfer Market">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fantasy Football League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fantasy Football League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Trails Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trails Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="STATTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="STATTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.50">
-			</color>
+			<color red="0.50" green="0.31" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.12">
-			</color>
+			<color red="0.12" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.62" blue="1.00">
-			</color>
+			<color red="1.00" green="0.62" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.25">
-			</color>
+			<color red="0.25" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="Advance Up Pitch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.62" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="Advance Up Pitch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.21">
-			</color>
+			<color red="0.50" green="0.50" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.05">
-			</color>
+			<color red="0.12" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.42">
-			</color>
+			<color red="1.00" green="1.00" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.11">
-			</color>
+			<color red="0.25" green="0.25" blue="0.11"/>
 		</rect>
 		<text string="Skillshot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.11">
-			</color>
-		</rect>
-		<text string="Skillshot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Stoppa Ball">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stoppa Ball">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Extra Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Extra Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.17">
-			</color>
+			<color red="0.49" green="0.45" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
+			<color red="0.12" green="0.11" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.91" blue="0.34">
-			</color>
+			<color red="0.99" green="0.91" blue="0.34"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
+			<color red="0.25" green="0.23" blue="0.08"/>
 		</rect>
 		<text string="Forward Pass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.91" blue="0.34">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
-		</rect>
-		<text string="Forward Pass">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.21">
-			</color>
+			<color red="0.50" green="0.27" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.55" blue="0.42">
-			</color>
+			<color red="1.00" green="0.55" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.10">
-			</color>
+			<color red="0.25" green="0.14" blue="0.10"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.55" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.10">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.24" blue="0.17">
-			</color>
+			<color red="0.49" green="0.24" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.04">
-			</color>
+			<color red="0.12" green="0.06" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.49" blue="0.34">
-			</color>
+			<color red="0.99" green="0.49" blue="0.34"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.12" blue="0.08">
-			</color>
+			<color red="0.25" green="0.12" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.49" blue="0.34">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.12" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.21" blue="0.13">
-			</color>
+			<color red="0.49" green="0.21" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.03">
-			</color>
+			<color red="0.12" green="0.05" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.42" blue="0.26">
-			</color>
+			<color red="0.99" green="0.42" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.06">
-			</color>
+			<color red="0.25" green="0.11" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.21" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.42" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.18" blue="0.09">
-			</color>
+			<color red="0.49" green="0.18" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.02">
-			</color>
+			<color red="0.12" green="0.04" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.36" blue="0.18">
-			</color>
+			<color red="0.99" green="0.36" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.04">
-			</color>
+			<color red="0.25" green="0.09" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.18" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.36" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.15" blue="0.04">
-			</color>
+			<color red="0.49" green="0.15" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.01">
-			</color>
+			<color red="0.12" green="0.04" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.29" blue="0.09">
-			</color>
+			<color red="0.99" green="0.29" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.02">
-			</color>
+			<color red="0.25" green="0.07" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.15" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.29" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.11" blue="0.00">
-			</color>
+			<color red="0.49" green="0.11" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.23" blue="0.01">
-			</color>
+			<color red="0.99" green="0.23" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.00">
-			</color>
+			<color red="0.25" green="0.05" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.11" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.23" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="In The Box">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="In The Box">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.44" blue="0.09">
-			</color>
+			<color red="0.49" green="0.44" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.02">
-			</color>
+			<color red="0.12" green="0.11" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.89" blue="0.18">
-			</color>
+			<color red="0.99" green="0.89" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.04">
-			</color>
+			<color red="0.25" green="0.22" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.44" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.89" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.13">
-			</color>
+			<color red="0.49" green="0.45" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.03">
-			</color>
+			<color red="0.12" green="0.11" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.89" blue="0.26">
-			</color>
+			<color red="0.99" green="0.89" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.06">
-			</color>
+			<color red="0.25" green="0.22" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.89" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.46" blue="0.21">
-			</color>
+			<color red="0.49" green="0.46" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
+			<color red="0.12" green="0.11" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.92" blue="0.42">
-			</color>
+			<color red="0.99" green="0.92" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.11">
-			</color>
+			<color red="0.25" green="0.23" blue="0.11"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.46" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.92" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.11">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.17">
-			</color>
+			<color red="0.49" green="0.45" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
+			<color red="0.12" green="0.11" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.91" blue="0.34">
-			</color>
+			<color red="0.99" green="0.91" blue="0.34"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
+			<color red="0.25" green="0.23" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.91" blue="0.34">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
+			<color red="0.40" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
+			<color red="0.79" green="0.99" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Trails Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Trails Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.44" blue="0.05">
-			</color>
+			<color red="0.49" green="0.44" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.01">
-			</color>
+			<color red="0.12" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.87" blue="0.09">
-			</color>
+			<color red="0.99" green="0.87" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.02">
-			</color>
+			<color red="0.25" green="0.22" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.44" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.87" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Trails Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Trails Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
+			<color red="0.40" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
+			<color red="0.79" green="0.99" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
+			<color red="0.40" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
+			<color red="0.79" green="0.99" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Statto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="^">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.50">
-			</color>
+			<color red="0.13" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.12">
-			</color>
+			<color red="0.03" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="1.00" blue="1.00">
-			</color>
+			<color red="0.25" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.25">
-			</color>
+			<color red="0.06" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.50">
-			</color>
+			<color red="0.08" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.12">
-			</color>
+			<color red="0.02" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="1.00" blue="1.00">
-			</color>
+			<color red="0.17" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.25">
-			</color>
+			<color red="0.04" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.50">
-			</color>
+			<color red="0.04" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.12">
-			</color>
+			<color red="0.01" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="1.00" blue="1.00">
-			</color>
+			<color red="0.08" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.25">
-			</color>
+			<color red="0.02" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.50">
-			</color>
+			<color red="0.16" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.12">
-			</color>
+			<color red="0.04" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="1.00" blue="1.00">
-			</color>
+			<color red="0.33" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.25">
-			</color>
+			<color red="0.08" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_51_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="FOO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="FOO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="TB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="TB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="ALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="ALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="FA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="FA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="NT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="NT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="ASY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="ASY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.00">
-			</color>
+			<color red="0.49" green="0.43" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.87" blue="0.01">
-			</color>
+			<color red="0.99" green="0.87" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="TRANSFER MARKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.87" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRANSFER MARKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_49_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_49_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_50_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_146_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_146">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Token">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_4">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_51">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_66">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_105">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.07"/>
 		</text>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.13" width="0.90" height="0.07"/>
 		</text>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.07"/>
 		</text>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.27" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.27" width="0.90" height="0.07"/>
 		</text>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.07"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.42" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.42" width="0.90" height="0.07"/>
 		</text>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.07"/>
 		</text>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.57" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.57" width="0.90" height="0.07"/>
 		</text>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.07"/>
 		</text>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.07"/>
 		</text>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.07"/>
 		</text>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.87" width="0.90" height="0.07"/>
 		</text>
 	</element>
 	<element name="label_140">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_141">
 		<text string="v1.1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="683" height="673">
-			</bounds>
+			<bounds x="0" y="0" width="683" height="673"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="85" y="433" width="80" height="140">
-			</bounds>
+			<bounds x="85" y="433" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="85.0000" y="433.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="85.0000" y="433.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="88.3333" y="434.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="88.3333" y="434.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="91.6667" y="436.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="91.6667" y="436.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="95.0000" y="438.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="95.0000" y="438.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="98.3333" y="440.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="98.3333" y="440.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="101.6667" y="442.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="101.6667" y="442.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="85.0000" y="479.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="85.0000" y="479.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="88.3333" y="481.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="88.3333" y="481.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="91.6667" y="483.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="91.6667" y="483.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="95.0000" y="485.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="95.0000" y="485.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="98.3333" y="487.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="98.3333" y="487.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="101.6667" y="489.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="101.6667" y="489.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="85.0000" y="526.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="85.0000" y="526.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="88.3333" y="528.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="88.3333" y="528.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="91.6667" y="530.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="91.6667" y="530.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="95.0000" y="532.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="95.0000" y="532.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="98.3333" y="534.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="98.3333" y="534.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="101.6667" y="536.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="101.6667" y="536.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="85" y="433" width="80" height="140">
-			</bounds>
+			<bounds x="85" y="433" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="204" y="433" width="80" height="140">
-			</bounds>
+			<bounds x="204" y="433" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="204.0000" y="433.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="204.0000" y="433.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="207.3333" y="434.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="207.3333" y="434.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="210.6667" y="436.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="210.6667" y="436.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="214.0000" y="438.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="214.0000" y="438.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="217.3333" y="440.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="217.3333" y="440.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="220.6667" y="442.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="220.6667" y="442.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="204.0000" y="479.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="204.0000" y="479.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="207.3333" y="481.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="207.3333" y="481.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="210.6667" y="483.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="210.6667" y="483.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="214.0000" y="485.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="214.0000" y="485.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="217.3333" y="487.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="217.3333" y="487.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="220.6667" y="489.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="220.6667" y="489.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="204.0000" y="526.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="204.0000" y="526.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="207.3333" y="528.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="207.3333" y="528.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="210.6667" y="530.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="210.6667" y="530.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="214.0000" y="532.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="214.0000" y="532.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="217.3333" y="534.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="217.3333" y="534.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="220.6667" y="536.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="220.6667" y="536.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="204" y="433" width="80" height="140">
-			</bounds>
+			<bounds x="204" y="433" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="322" y="433" width="80" height="140">
-			</bounds>
+			<bounds x="322" y="433" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="433.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="433.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="434.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="434.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="436.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="436.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="438.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="438.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="440.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="440.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="442.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="442.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="479.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="479.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="481.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="481.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="483.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="483.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="485.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="485.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="487.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="487.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="489.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="489.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="526.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="526.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="528.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="528.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="530.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="530.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="532.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="532.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="534.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="534.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="536.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="536.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="322" y="433" width="80" height="140">
-			</bounds>
+			<bounds x="322" y="433" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="278" y="169" width="50" height="70">
-			</bounds>
+			<bounds x="278" y="169" width="50" height="70"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="278.0000" y="169.0000" width="50.0000" height="23.3333">
-			</bounds>
+			<bounds x="278.0000" y="169.0000" width="50.0000" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="280.0833" y="169.9722" width="45.8333" height="21.3889">
-			</bounds>
+			<bounds x="280.0833" y="169.9722" width="45.8333" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.1667" y="170.9444" width="41.6667" height="19.4444">
-			</bounds>
+			<bounds x="282.1667" y="170.9444" width="41.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.2500" y="171.9167" width="37.5000" height="17.5000">
-			</bounds>
+			<bounds x="284.2500" y="171.9167" width="37.5000" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="172.8889" width="33.3333" height="15.5556">
-			</bounds>
+			<bounds x="286.3333" y="172.8889" width="33.3333" height="15.5556"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.4167" y="173.8611" width="29.1667" height="13.6111">
-			</bounds>
+			<bounds x="288.4167" y="173.8611" width="29.1667" height="13.6111"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="278.0000" y="192.3333" width="50.0000" height="23.3333">
-			</bounds>
+			<bounds x="278.0000" y="192.3333" width="50.0000" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="280.0833" y="193.3056" width="45.8333" height="21.3889">
-			</bounds>
+			<bounds x="280.0833" y="193.3056" width="45.8333" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.1667" y="194.2778" width="41.6667" height="19.4444">
-			</bounds>
+			<bounds x="282.1667" y="194.2778" width="41.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.2500" y="195.2500" width="37.5000" height="17.5000">
-			</bounds>
+			<bounds x="284.2500" y="195.2500" width="37.5000" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="196.2222" width="33.3333" height="15.5556">
-			</bounds>
+			<bounds x="286.3333" y="196.2222" width="33.3333" height="15.5556"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.4167" y="197.1944" width="29.1667" height="13.6111">
-			</bounds>
+			<bounds x="288.4167" y="197.1944" width="29.1667" height="13.6111"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="278.0000" y="215.6667" width="50.0000" height="23.3333">
-			</bounds>
+			<bounds x="278.0000" y="215.6667" width="50.0000" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="280.0833" y="216.6389" width="45.8333" height="21.3889">
-			</bounds>
+			<bounds x="280.0833" y="216.6389" width="45.8333" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.1667" y="217.6111" width="41.6667" height="19.4444">
-			</bounds>
+			<bounds x="282.1667" y="217.6111" width="41.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="284.2500" y="218.5833" width="37.5000" height="17.5000">
-			</bounds>
+			<bounds x="284.2500" y="218.5833" width="37.5000" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="219.5556" width="33.3333" height="15.5556">
-			</bounds>
+			<bounds x="286.3333" y="219.5556" width="33.3333" height="15.5556"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.4167" y="220.5278" width="29.1667" height="13.6111">
-			</bounds>
+			<bounds x="288.4167" y="220.5278" width="29.1667" height="13.6111"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="278" y="169" width="50" height="70">
-			</bounds>
+			<bounds x="278" y="169" width="50" height="70"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="444" y="141" width="52" height="50">
-			</bounds>
+			<bounds x="444" y="141" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="446" y="143" width="48" height="46">
-			</bounds>
+			<bounds x="446" y="143" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="554" y="369" width="47" height="32">
-			</bounds>
+			<bounds x="554" y="369" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="556" y="371" width="43" height="28">
-			</bounds>
+			<bounds x="556" y="371" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="494" y="279" width="47" height="32">
-			</bounds>
+			<bounds x="494" y="279" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="496" y="281" width="43" height="28">
-			</bounds>
+			<bounds x="496" y="281" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="539" y="279" width="47" height="32">
-			</bounds>
+			<bounds x="539" y="279" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="541" y="281" width="43" height="28">
-			</bounds>
+			<bounds x="541" y="281" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="494" y="339" width="47" height="32">
-			</bounds>
+			<bounds x="494" y="339" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="496" y="341" width="43" height="28">
-			</bounds>
+			<bounds x="496" y="341" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="539" y="339" width="47" height="32">
-			</bounds>
+			<bounds x="539" y="339" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="541" y="341" width="43" height="28">
-			</bounds>
+			<bounds x="541" y="341" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="539" y="159" width="47" height="32">
-			</bounds>
+			<bounds x="539" y="159" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="541" y="161" width="43" height="28">
-			</bounds>
+			<bounds x="541" y="161" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="494" y="159" width="47" height="32">
-			</bounds>
+			<bounds x="494" y="159" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="496" y="161" width="43" height="28">
-			</bounds>
+			<bounds x="496" y="161" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="494" y="219" width="47" height="32">
-			</bounds>
+			<bounds x="494" y="219" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="496" y="221" width="43" height="28">
-			</bounds>
+			<bounds x="496" y="221" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="539" y="219" width="47" height="32">
-			</bounds>
+			<bounds x="539" y="219" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="541" y="221" width="43" height="28">
-			</bounds>
+			<bounds x="541" y="221" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="554" y="249" width="47" height="32">
-			</bounds>
+			<bounds x="554" y="249" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="556" y="251" width="43" height="28">
-			</bounds>
+			<bounds x="556" y="251" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="444" y="261" width="52" height="50">
-			</bounds>
+			<bounds x="444" y="261" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="446" y="263" width="48" height="46">
-			</bounds>
+			<bounds x="446" y="263" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="444" y="321" width="52" height="50">
-			</bounds>
+			<bounds x="444" y="321" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="446" y="323" width="48" height="46">
-			</bounds>
+			<bounds x="446" y="323" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="444" y="201" width="52" height="50">
-			</bounds>
+			<bounds x="444" y="201" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="446" y="203" width="48" height="46">
-			</bounds>
+			<bounds x="446" y="203" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="399" y="219" width="47" height="32">
-			</bounds>
+			<bounds x="399" y="219" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="401" y="221" width="43" height="28">
-			</bounds>
+			<bounds x="401" y="221" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="399" y="159" width="47" height="32">
-			</bounds>
+			<bounds x="399" y="159" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="401" y="161" width="43" height="28">
-			</bounds>
+			<bounds x="401" y="161" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="399" y="339" width="47" height="32">
-			</bounds>
+			<bounds x="399" y="339" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="401" y="341" width="43" height="28">
-			</bounds>
+			<bounds x="401" y="341" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="399" y="279" width="47" height="32">
-			</bounds>
+			<bounds x="399" y="279" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="401" y="281" width="43" height="28">
-			</bounds>
+			<bounds x="401" y="281" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="539" y="129" width="47" height="32">
-			</bounds>
+			<bounds x="539" y="129" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="541" y="131" width="43" height="28">
-			</bounds>
+			<bounds x="541" y="131" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="494" y="109" width="47" height="32">
-			</bounds>
+			<bounds x="494" y="109" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="496" y="111" width="43" height="28">
-			</bounds>
+			<bounds x="496" y="111" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="444" y="109" width="52" height="32">
-			</bounds>
+			<bounds x="444" y="109" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="446" y="111" width="48" height="28">
-			</bounds>
+			<bounds x="446" y="111" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="339" y="189" width="47" height="32">
-			</bounds>
+			<bounds x="339" y="189" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="341" y="191" width="43" height="28">
-			</bounds>
+			<bounds x="341" y="191" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="339" y="309" width="47" height="32">
-			</bounds>
+			<bounds x="339" y="309" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="341" y="311" width="43" height="28">
-			</bounds>
+			<bounds x="341" y="311" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="354" y="219" width="47" height="32">
-			</bounds>
+			<bounds x="354" y="219" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="356" y="221" width="43" height="28">
-			</bounds>
+			<bounds x="356" y="221" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="354" y="279" width="47" height="32">
-			</bounds>
+			<bounds x="354" y="279" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="356" y="281" width="43" height="28">
-			</bounds>
+			<bounds x="356" y="281" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="354" y="339" width="47" height="32">
-			</bounds>
+			<bounds x="354" y="339" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="356" y="341" width="43" height="28">
-			</bounds>
+			<bounds x="356" y="341" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="354" y="159" width="47" height="32">
-			</bounds>
+			<bounds x="354" y="159" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="356" y="161" width="43" height="28">
-			</bounds>
+			<bounds x="356" y="161" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="62" y="109" width="47" height="32">
-			</bounds>
+			<bounds x="62" y="109" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="64" y="111" width="43" height="28">
-			</bounds>
+			<bounds x="64" y="111" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="107" y="109" width="52" height="32">
-			</bounds>
+			<bounds x="107" y="109" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="109" y="111" width="48" height="28">
-			</bounds>
+			<bounds x="109" y="111" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="236" y="143" width="132" height="16">
-			</bounds>
+			<bounds x="236" y="143" width="132" height="16"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="238" y="145" width="128" height="12">
-			</bounds>
+			<bounds x="238" y="145" width="128" height="12"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="69" y="9" width="90" height="72">
-			</bounds>
+			<bounds x="69" y="9" width="90" height="72"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="71" y="11" width="86" height="68">
-			</bounds>
+			<bounds x="71" y="11" width="86" height="68"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="53" y="78" width="122" height="26">
-			</bounds>
+			<bounds x="53" y="78" width="122" height="26"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="55" y="80" width="118" height="22">
-			</bounds>
+			<bounds x="55" y="80" width="118" height="22"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="281" y="370" width="36" height="27">
-			</bounds>
+			<bounds x="281" y="370" width="36" height="27"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="283" y="372" width="32" height="23">
-			</bounds>
+			<bounds x="283" y="372" width="32" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="247" y="399" width="42" height="32">
-			</bounds>
+			<bounds x="247" y="399" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="249" y="401" width="38" height="28">
-			</bounds>
+			<bounds x="249" y="401" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="629" y="374" width="24" height="24">
-			</bounds>
+			<bounds x="629" y="374" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="631" y="376" width="20" height="20">
-			</bounds>
+			<bounds x="631" y="376" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="629" y="351" width="24" height="24">
-			</bounds>
+			<bounds x="629" y="351" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="631" y="353" width="20" height="20">
-			</bounds>
+			<bounds x="631" y="353" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="629" y="328" width="24" height="24">
-			</bounds>
+			<bounds x="629" y="328" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="631" y="330" width="20" height="20">
-			</bounds>
+			<bounds x="631" y="330" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="629" y="305" width="24" height="24">
-			</bounds>
+			<bounds x="629" y="305" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="631" y="307" width="20" height="20">
-			</bounds>
+			<bounds x="631" y="307" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="625" y="284" width="32" height="22">
-			</bounds>
+			<bounds x="625" y="284" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="627" y="286" width="28" height="18">
-			</bounds>
+			<bounds x="627" y="286" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="594" y="109" width="86" height="26">
-			</bounds>
+			<bounds x="594" y="109" width="86" height="26"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="596" y="111" width="82" height="22">
-			</bounds>
+			<bounds x="596" y="111" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="603" y="236" width="68" height="32">
-			</bounds>
+			<bounds x="603" y="236" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="605" y="238" width="64" height="28">
-			</bounds>
+			<bounds x="605" y="238" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="603" y="136" width="68" height="27">
-			</bounds>
+			<bounds x="603" y="136" width="68" height="27"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="605" y="138" width="64" height="23">
-			</bounds>
+			<bounds x="605" y="138" width="64" height="23"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="603" y="161" width="68" height="27">
-			</bounds>
+			<bounds x="603" y="161" width="68" height="27"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="605" y="163" width="64" height="23">
-			</bounds>
+			<bounds x="605" y="163" width="64" height="23"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="603" y="186" width="68" height="27">
-			</bounds>
+			<bounds x="603" y="186" width="68" height="27"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="605" y="188" width="64" height="23">
-			</bounds>
+			<bounds x="605" y="188" width="64" height="23"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="603" y="211" width="68" height="27">
-			</bounds>
+			<bounds x="603" y="211" width="68" height="27"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="605" y="213" width="64" height="23">
-			</bounds>
+			<bounds x="605" y="213" width="64" height="23"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="615" y="397" width="52" height="32">
-			</bounds>
+			<bounds x="615" y="397" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="617" y="399" width="48" height="28">
-			</bounds>
+			<bounds x="617" y="399" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="83" y="576" width="82" height="24">
-			</bounds>
+			<bounds x="83" y="576" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="85" y="578" width="78" height="20">
-			</bounds>
+			<bounds x="85" y="578" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="163" y="576" width="82" height="24">
-			</bounds>
+			<bounds x="163" y="576" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="165" y="578" width="78" height="20">
-			</bounds>
+			<bounds x="165" y="578" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="243" y="576" width="82" height="24">
-			</bounds>
+			<bounds x="243" y="576" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="245" y="578" width="78" height="20">
-			</bounds>
+			<bounds x="245" y="578" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="323" y="576" width="82" height="24">
-			</bounds>
+			<bounds x="323" y="576" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="325" y="578" width="78" height="20">
-			</bounds>
+			<bounds x="325" y="578" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="403" y="576" width="82" height="24">
-			</bounds>
+			<bounds x="403" y="576" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="405" y="578" width="78" height="20">
-			</bounds>
+			<bounds x="405" y="578" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="483" y="576" width="82" height="24">
-			</bounds>
+			<bounds x="483" y="576" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="485" y="578" width="78" height="20">
-			</bounds>
+			<bounds x="485" y="578" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="309" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="309" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="311" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="311" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="354" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="354" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="356" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="356" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="444" y="381" width="52" height="50">
-			</bounds>
+			<bounds x="444" y="381" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="446" y="383" width="48" height="46">
-			</bounds>
+			<bounds x="446" y="383" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="399" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="399" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="401" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="401" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="254" y="282" width="47" height="19">
-			</bounds>
+			<bounds x="254" y="282" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="256" y="284" width="43" height="15">
-			</bounds>
+			<bounds x="256" y="284" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="298" y="282" width="52" height="19">
-			</bounds>
+			<bounds x="298" y="282" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="300" y="284" width="48" height="15">
-			</bounds>
+			<bounds x="300" y="284" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="107" y="201" width="52" height="50">
-			</bounds>
+			<bounds x="107" y="201" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="109" y="203" width="48" height="46">
-			</bounds>
+			<bounds x="109" y="203" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="107" y="261" width="52" height="50">
-			</bounds>
+			<bounds x="107" y="261" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="109" y="263" width="48" height="46">
-			</bounds>
+			<bounds x="109" y="263" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="107" y="381" width="52" height="50">
-			</bounds>
+			<bounds x="107" y="381" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="109" y="383" width="48" height="46">
-			</bounds>
+			<bounds x="109" y="383" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="107" y="321" width="52" height="50">
-			</bounds>
+			<bounds x="107" y="321" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="109" y="323" width="48" height="46">
-			</bounds>
+			<bounds x="109" y="323" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="17" y="129" width="47" height="32">
-			</bounds>
+			<bounds x="17" y="129" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="19" y="131" width="43" height="28">
-			</bounds>
+			<bounds x="19" y="131" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="62" y="339" width="47" height="32">
-			</bounds>
+			<bounds x="62" y="339" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="64" y="341" width="43" height="28">
-			</bounds>
+			<bounds x="64" y="341" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="17" y="339" width="47" height="32">
-			</bounds>
+			<bounds x="17" y="339" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="19" y="341" width="43" height="28">
-			</bounds>
+			<bounds x="19" y="341" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="2" y="369" width="47" height="32">
-			</bounds>
+			<bounds x="2" y="369" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="4" y="371" width="43" height="28">
-			</bounds>
+			<bounds x="4" y="371" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="17" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="17" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="19" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="19" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="62" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="62" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="64" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="64" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="17" y="279" width="47" height="32">
-			</bounds>
+			<bounds x="17" y="279" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="19" y="281" width="43" height="28">
-			</bounds>
+			<bounds x="19" y="281" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="62" y="279" width="47" height="32">
-			</bounds>
+			<bounds x="62" y="279" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="64" y="281" width="43" height="28">
-			</bounds>
+			<bounds x="64" y="281" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="62" y="219" width="47" height="32">
-			</bounds>
+			<bounds x="62" y="219" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="64" y="221" width="43" height="28">
-			</bounds>
+			<bounds x="64" y="221" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="17" y="219" width="47" height="32">
-			</bounds>
+			<bounds x="17" y="219" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="19" y="221" width="43" height="28">
-			</bounds>
+			<bounds x="19" y="221" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="2" y="249" width="47" height="32">
-			</bounds>
+			<bounds x="2" y="249" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="4" y="251" width="43" height="28">
-			</bounds>
+			<bounds x="4" y="251" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="202" y="159" width="47" height="32">
-			</bounds>
+			<bounds x="202" y="159" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="204" y="161" width="43" height="28">
-			</bounds>
+			<bounds x="204" y="161" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="157" y="159" width="47" height="32">
-			</bounds>
+			<bounds x="157" y="159" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="159" y="161" width="43" height="28">
-			</bounds>
+			<bounds x="159" y="161" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="107" y="141" width="52" height="50">
-			</bounds>
+			<bounds x="107" y="141" width="52" height="50"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="109" y="143" width="48" height="46">
-			</bounds>
+			<bounds x="109" y="143" width="48" height="46"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="62" y="159" width="47" height="32">
-			</bounds>
+			<bounds x="62" y="159" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="64" y="161" width="43" height="28">
-			</bounds>
+			<bounds x="64" y="161" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="17" y="159" width="47" height="32">
-			</bounds>
+			<bounds x="17" y="159" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="19" y="161" width="43" height="28">
-			</bounds>
+			<bounds x="19" y="161" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="157" y="219" width="47" height="32">
-			</bounds>
+			<bounds x="157" y="219" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="159" y="221" width="43" height="28">
-			</bounds>
+			<bounds x="159" y="221" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="202" y="219" width="47" height="32">
-			</bounds>
+			<bounds x="202" y="219" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="204" y="221" width="43" height="28">
-			</bounds>
+			<bounds x="204" y="221" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="202" y="279" width="47" height="32">
-			</bounds>
+			<bounds x="202" y="279" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="204" y="281" width="43" height="28">
-			</bounds>
+			<bounds x="204" y="281" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="157" y="279" width="47" height="32">
-			</bounds>
+			<bounds x="157" y="279" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="159" y="281" width="43" height="28">
-			</bounds>
+			<bounds x="159" y="281" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="217" y="189" width="47" height="32">
-			</bounds>
+			<bounds x="217" y="189" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="219" y="191" width="43" height="28">
-			</bounds>
+			<bounds x="219" y="191" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="157" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="157" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="159" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="159" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="202" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="202" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="204" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="204" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="157" y="339" width="47" height="32">
-			</bounds>
+			<bounds x="157" y="339" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="159" y="341" width="43" height="28">
-			</bounds>
+			<bounds x="159" y="341" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="202" y="339" width="47" height="32">
-			</bounds>
+			<bounds x="202" y="339" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="204" y="341" width="43" height="28">
-			</bounds>
+			<bounds x="204" y="341" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="217" y="309" width="47" height="32">
-			</bounds>
+			<bounds x="217" y="309" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="219" y="311" width="43" height="28">
-			</bounds>
+			<bounds x="219" y="311" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="329" y="224" width="22" height="22">
-			</bounds>
+			<bounds x="329" y="224" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="331" y="226" width="18" height="18">
-			</bounds>
+			<bounds x="331" y="226" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="329" y="163" width="22" height="22">
-			</bounds>
+			<bounds x="329" y="163" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="331" y="165" width="18" height="18">
-			</bounds>
+			<bounds x="331" y="165" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="494" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="494" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="496" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="496" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="539" y="399" width="47" height="32">
-			</bounds>
+			<bounds x="539" y="399" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="541" y="401" width="43" height="28">
-			</bounds>
+			<bounds x="541" y="401" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="24" y="541" width="42" height="28">
-			</bounds>
+			<bounds x="24" y="541" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="26" y="543" width="38" height="24">
-			</bounds>
+			<bounds x="26" y="543" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="24" y="515" width="42" height="28">
-			</bounds>
+			<bounds x="24" y="515" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="26" y="517" width="38" height="24">
-			</bounds>
+			<bounds x="26" y="517" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="24" y="489" width="42" height="28">
-			</bounds>
+			<bounds x="24" y="489" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="26" y="491" width="38" height="24">
-			</bounds>
+			<bounds x="26" y="491" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="24" y="463" width="42" height="28">
-			</bounds>
+			<bounds x="24" y="463" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="26" y="465" width="38" height="24">
-			</bounds>
+			<bounds x="26" y="465" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="24" y="568" width="42" height="32">
-			</bounds>
+			<bounds x="24" y="568" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="26" y="570" width="38" height="28">
-			</bounds>
+			<bounds x="26" y="570" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="618" y="498" width="22" height="52">
-			</bounds>
+			<bounds x="618" y="498" width="22" height="52"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="620" y="500" width="18" height="48">
-			</bounds>
+			<bounds x="620" y="500" width="18" height="48"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="492" y="498" width="22" height="52">
-			</bounds>
+			<bounds x="492" y="498" width="22" height="52"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="494" y="500" width="18" height="48">
-			</bounds>
+			<bounds x="494" y="500" width="18" height="48"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_2_border" state="0">
-			<bounds x="511" y="498" width="46" height="52">
-			</bounds>
+			<bounds x="511" y="498" width="46" height="52"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_2" state="0">
-			<bounds x="513" y="500" width="42" height="48">
-			</bounds>
+			<bounds x="513" y="500" width="42" height="48"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="554" y="498" width="32" height="52">
-			</bounds>
+			<bounds x="554" y="498" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="556" y="500" width="28" height="48">
-			</bounds>
+			<bounds x="556" y="500" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_2_border" state="0">
-			<bounds x="583" y="498" width="38" height="52">
-			</bounds>
+			<bounds x="583" y="498" width="38" height="52"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_2" state="0">
-			<bounds x="585" y="500" width="34" height="48">
-			</bounds>
+			<bounds x="585" y="500" width="34" height="48"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="515" y="459" width="32" height="42">
-			</bounds>
+			<bounds x="515" y="459" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="517" y="461" width="28" height="38">
-			</bounds>
+			<bounds x="517" y="461" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="544" y="459" width="32" height="42">
-			</bounds>
+			<bounds x="544" y="459" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="546" y="461" width="28" height="38">
-			</bounds>
+			<bounds x="546" y="461" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="573" y="459" width="44" height="42">
-			</bounds>
+			<bounds x="573" y="459" width="44" height="42"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="575" y="461" width="40" height="38">
-			</bounds>
+			<bounds x="575" y="461" width="40" height="38"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="360" y="118" width="36" height="26">
-			</bounds>
+			<bounds x="360" y="118" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="362" y="120" width="32" height="22">
-			</bounds>
+			<bounds x="362" y="120" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="322" y="118" width="36" height="26">
-			</bounds>
+			<bounds x="322" y="118" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="324" y="120" width="32" height="22">
-			</bounds>
+			<bounds x="324" y="120" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="284" y="118" width="36" height="26">
-			</bounds>
+			<bounds x="284" y="118" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="286" y="120" width="32" height="22">
-			</bounds>
+			<bounds x="286" y="120" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="246" y="118" width="36" height="26">
-			</bounds>
+			<bounds x="246" y="118" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="248" y="120" width="32" height="22">
-			</bounds>
+			<bounds x="248" y="120" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="208" y="118" width="36" height="26">
-			</bounds>
+			<bounds x="208" y="118" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="210" y="120" width="32" height="22">
-			</bounds>
+			<bounds x="210" y="120" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="360" y="94" width="36" height="26">
-			</bounds>
+			<bounds x="360" y="94" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="362" y="96" width="32" height="22">
-			</bounds>
+			<bounds x="362" y="96" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="246" y="94" width="36" height="26">
-			</bounds>
+			<bounds x="246" y="94" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="248" y="96" width="32" height="22">
-			</bounds>
+			<bounds x="248" y="96" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="284" y="94" width="36" height="26">
-			</bounds>
+			<bounds x="284" y="94" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="286" y="96" width="32" height="22">
-			</bounds>
+			<bounds x="286" y="96" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="322" y="94" width="36" height="26">
-			</bounds>
+			<bounds x="322" y="94" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="324" y="96" width="32" height="22">
-			</bounds>
+			<bounds x="324" y="96" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="208" y="78" width="188" height="17">
-			</bounds>
+			<bounds x="208" y="78" width="188" height="17"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="210" y="80" width="184" height="13">
-			</bounds>
+			<bounds x="210" y="80" width="184" height="13"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="208" y="94" width="36" height="26">
-			</bounds>
+			<bounds x="208" y="94" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="210" y="96" width="32" height="22">
-			</bounds>
+			<bounds x="210" y="96" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="417" y="508" width="16" height="22">
-			</bounds>
+			<bounds x="417" y="508" width="16" height="22"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="419" y="510" width="12" height="18">
-			</bounds>
+			<bounds x="419" y="510" width="12" height="18"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_2_border" state="0">
-			<bounds x="409" y="527" width="32" height="22">
-			</bounds>
+			<bounds x="409" y="527" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_2" state="0">
-			<bounds x="411" y="529" width="28" height="18">
-			</bounds>
+			<bounds x="411" y="529" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="409" y="461" width="32" height="22">
-			</bounds>
+			<bounds x="409" y="461" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="411" y="463" width="28" height="18">
-			</bounds>
+			<bounds x="411" y="463" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_2_border" state="0">
-			<bounds x="417" y="480" width="16" height="22">
-			</bounds>
+			<bounds x="417" y="480" width="16" height="22"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_2" state="0">
-			<bounds x="419" y="482" width="12" height="18">
-			</bounds>
+			<bounds x="419" y="482" width="12" height="18"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_142_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="4" y="631" width="68" height="42">
-			</bounds>
+			<bounds x="4" y="631" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_142" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="6" y="633" width="64" height="38">
-			</bounds>
+			<bounds x="6" y="633" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_143_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="95" y="631" width="68" height="42">
-			</bounds>
+			<bounds x="95" y="631" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_143" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="97" y="633" width="64" height="38">
-			</bounds>
+			<bounds x="97" y="633" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_144_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="212" y="631" width="68" height="42">
-			</bounds>
+			<bounds x="212" y="631" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_144" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="214" y="633" width="64" height="38">
-			</bounds>
+			<bounds x="214" y="633" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_145_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="328" y="631" width="68" height="42">
-			</bounds>
+			<bounds x="328" y="631" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_145" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="330" y="633" width="64" height="38">
-			</bounds>
+			<bounds x="330" y="633" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_146_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="433" y="631" width="68" height="42">
-			</bounds>
+			<bounds x="433" y="631" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_146" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="435" y="633" width="64" height="38">
-			</bounds>
+			<bounds x="435" y="633" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_147_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="519" y="631" width="68" height="42">
-			</bounds>
+			<bounds x="519" y="631" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_147" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="521" y="633" width="64" height="38">
-			</bounds>
+			<bounds x="521" y="633" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_148_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="606" y="631" width="68" height="42">
-			</bounds>
+			<bounds x="606" y="631" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_148" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="608" y="633" width="64" height="38">
-			</bounds>
+			<bounds x="608" y="633" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_158_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="489" y="25" width="47" height="62">
-			</bounds>
+			<bounds x="489" y="25" width="47" height="62"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_158" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="491" y="27" width="43" height="58">
-			</bounds>
+			<bounds x="491" y="27" width="43" height="58"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_159_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="444" y="25" width="47" height="62">
-			</bounds>
+			<bounds x="444" y="25" width="47" height="62"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_159" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="446" y="27" width="43" height="58">
-			</bounds>
+			<bounds x="446" y="27" width="43" height="58"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_160_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="4" y="631" width="68" height="42">
-			</bounds>
+			<bounds x="4" y="631" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_160" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="6" y="633" width="64" height="38">
-			</bounds>
+			<bounds x="6" y="633" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="632" y="592" width="24" height="32">
-			</bounds>
+			<bounds x="632" y="592" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="635" y="594" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="594" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="649" y="594" width="3" height="14">
-			</bounds>
+			<bounds x="649" y="594" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="649" y="606" width="3" height="14">
-			</bounds>
+			<bounds x="649" y="606" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="635" y="618" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="618" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="635" y="606" width="3" height="14">
-			</bounds>
+			<bounds x="635" y="606" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="635" y="594" width="3" height="14">
-			</bounds>
+			<bounds x="635" y="594" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="635" y="606" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="606" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="652" y="618" width="3" height="2">
-			</bounds>
+			<bounds x="652" y="618" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="635" y="594" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="594" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="649" y="594" width="3" height="14">
-			</bounds>
+			<bounds x="649" y="594" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="649" y="606" width="3" height="14">
-			</bounds>
+			<bounds x="649" y="606" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="635" y="618" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="618" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="635" y="606" width="3" height="14">
-			</bounds>
+			<bounds x="635" y="606" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="635" y="594" width="3" height="14">
-			</bounds>
+			<bounds x="635" y="594" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="635" y="606" width="17" height="2">
-			</bounds>
+			<bounds x="635" y="606" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="652" y="618" width="3" height="2">
-			</bounds>
+			<bounds x="652" y="618" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="608" y="592" width="24" height="32">
-			</bounds>
+			<bounds x="608" y="592" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="611" y="594" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="594" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="625" y="594" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="594" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="625" y="606" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="606" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="611" y="618" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="618" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="611" y="606" width="3" height="14">
-			</bounds>
+			<bounds x="611" y="606" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="611" y="594" width="3" height="14">
-			</bounds>
+			<bounds x="611" y="594" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="611" y="606" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="606" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="628" y="618" width="3" height="2">
-			</bounds>
+			<bounds x="628" y="618" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="611" y="594" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="594" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="625" y="594" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="594" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="625" y="606" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="606" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="611" y="618" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="618" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="611" y="606" width="3" height="14">
-			</bounds>
+			<bounds x="611" y="606" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="611" y="594" width="3" height="14">
-			</bounds>
+			<bounds x="611" y="594" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="611" y="606" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="606" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="628" y="618" width="3" height="2">
-			</bounds>
+			<bounds x="628" y="618" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="234" y="27" width="45" height="50">
-			</bounds>
+			<bounds x="234" y="27" width="45" height="50"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="240" y="31" width="32" height="4">
-			</bounds>
+			<bounds x="240" y="31" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="266" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="266" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="266" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="266" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="240" y="67" width="32" height="4">
-			</bounds>
+			<bounds x="240" y="67" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="240" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="240" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="240" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="240" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="240" y="49" width="32" height="4">
-			</bounds>
+			<bounds x="240" y="49" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="272" y="67" width="6" height="4">
-			</bounds>
+			<bounds x="272" y="67" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="240" y="31" width="32" height="4">
-			</bounds>
+			<bounds x="240" y="31" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="266" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="266" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="266" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="266" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="240" y="67" width="32" height="4">
-			</bounds>
+			<bounds x="240" y="67" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="240" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="240" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="240" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="240" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="240" y="49" width="32" height="4">
-			</bounds>
+			<bounds x="240" y="49" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="272" y="67" width="6" height="4">
-			</bounds>
+			<bounds x="272" y="67" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="279" y="27" width="45" height="50">
-			</bounds>
+			<bounds x="279" y="27" width="45" height="50"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="285" y="31" width="32" height="4">
-			</bounds>
+			<bounds x="285" y="31" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="311" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="311" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="311" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="311" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="285" y="67" width="32" height="4">
-			</bounds>
+			<bounds x="285" y="67" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="285" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="285" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="285" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="285" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="285" y="49" width="32" height="4">
-			</bounds>
+			<bounds x="285" y="49" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="317" y="67" width="6" height="4">
-			</bounds>
+			<bounds x="317" y="67" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="285" y="31" width="32" height="4">
-			</bounds>
+			<bounds x="285" y="31" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="311" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="311" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="311" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="311" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="285" y="67" width="32" height="4">
-			</bounds>
+			<bounds x="285" y="67" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="285" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="285" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="285" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="285" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="285" y="49" width="32" height="4">
-			</bounds>
+			<bounds x="285" y="49" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="317" y="67" width="6" height="4">
-			</bounds>
+			<bounds x="317" y="67" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="324" y="27" width="45" height="50">
-			</bounds>
+			<bounds x="324" y="27" width="45" height="50"/>
 		</backdrop>
 		<backdrop name="led_off248" element="led_off">
-			<bounds x="330" y="31" width="32" height="4">
-			</bounds>
+			<bounds x="330" y="31" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off249" element="led_off">
-			<bounds x="356" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="356" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off250" element="led_off">
-			<bounds x="356" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="356" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off251" element="led_off">
-			<bounds x="330" y="67" width="32" height="4">
-			</bounds>
+			<bounds x="330" y="67" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off252" element="led_off">
-			<bounds x="330" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="330" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off253" element="led_off">
-			<bounds x="330" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="330" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off254" element="led_off">
-			<bounds x="330" y="49" width="32" height="4">
-			</bounds>
+			<bounds x="330" y="49" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="led_off255" element="led_dot_off">
-			<bounds x="362" y="67" width="6" height="4">
-			</bounds>
+			<bounds x="362" y="67" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="lamp248" element="led_on">
-			<bounds x="330" y="31" width="32" height="4">
-			</bounds>
+			<bounds x="330" y="31" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp249" element="led_on">
-			<bounds x="356" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="356" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="led_on">
-			<bounds x="356" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="356" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp251" element="led_on">
-			<bounds x="330" y="67" width="32" height="4">
-			</bounds>
+			<bounds x="330" y="67" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp252" element="led_on">
-			<bounds x="330" y="49" width="6" height="22">
-			</bounds>
+			<bounds x="330" y="49" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp253" element="led_on">
-			<bounds x="330" y="31" width="6" height="22">
-			</bounds>
+			<bounds x="330" y="31" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp254" element="led_on">
-			<bounds x="330" y="49" width="32" height="4">
-			</bounds>
+			<bounds x="330" y="49" width="32" height="4"/>
 		</backdrop>
 		<backdrop name="lamp255" element="led_dot_on">
-			<bounds x="362" y="67" width="6" height="4">
-			</bounds>
+			<bounds x="362" y="67" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="label4" element="label_4">
-			<bounds x="185" y="2" width="51" height="90">
-			</bounds>
+			<bounds x="185" y="2" width="51" height="90"/>
 		</backdrop>
 		<backdrop name="label51" element="label_51">
-			<bounds x="607" y="573" width="51" height="23">
-			</bounds>
+			<bounds x="607" y="573" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="label66" element="label_66">
-			<bounds x="239" y="2" width="124" height="30">
-			</bounds>
+			<bounds x="239" y="2" width="124" height="30"/>
 		</backdrop>
 		<backdrop name="label105" element="label_105">
-			<bounds x="267" y="168" width="9" height="72">
-			</bounds>
+			<bounds x="267" y="168" width="9" height="72"/>
 		</backdrop>
 		<backdrop name="label140" element="label_140">
-			<bounds x="568" y="63" width="112" height="13">
-			</bounds>
+			<bounds x="568" y="63" width="112" height="13"/>
 		</backdrop>
 		<backdrop name="label141" element="label_141">
-			<bounds x="2" y="2" width="21" height="13">
-			</bounds>
+			<bounds x="2" y="2" width="21" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_button" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1fightb.lay
+++ b/src/mame/layout/m1fightb.lay
@@ -8,13218 +8,8160 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Revolver">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Revolver">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Weigh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Weigh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Step To Nearest Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Step To Nearest Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Line Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Line Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Stop 'N' Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop 'N' Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Go To Blue Corner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go To Blue Corner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Split Dicision">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Split Dicision">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Out For The Count">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Out For The Count">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bob 'n' Weave">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bob 'n' Weave">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Saved By The Bell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Saved By The Bell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="World Title">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="World Title">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Go To Corner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go To Corner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Go To Red Corner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go To Red Corner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Light Weigh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Light Weigh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Hi Lo Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hi Lo Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
+			<color red="0.39" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
+			<color red="0.09" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
+			<color red="0.78" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
+			<color red="0.19" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
+			<color red="0.39" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
+			<color red="0.09" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
+			<color red="0.78" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
+			<color red="0.19" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
+			<color red="0.39" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
+			<color red="0.09" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
+			<color red="0.78" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
+			<color red="0.19" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
+			<color red="0.39" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
+			<color red="0.09" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
+			<color red="0.78" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
+			<color red="0.19" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
+			<color red="0.39" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
+			<color red="0.09" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
+			<color red="0.78" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
+			<color red="0.19" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Big Win Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big Win Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
+			<color red="0.39" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
+			<color red="0.09" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
+			<color red="0.78" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
+			<color red="0.19" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.39" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.78" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1 + Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Ref">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Ref">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2 + Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 + Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Ref">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Ref">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Ref">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Ref">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Out For The Count">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Out For The Count">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 + Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1 + Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 + Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1 + KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1 + KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Ref">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Ref">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Out For The Count">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Out For The Count">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Out For The Count">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Out For The Count">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boxer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 + Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 + Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1 + KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1 + KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="4 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="4 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Knoc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Knoc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="5 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="5 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="6 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="6 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 + Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 + Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1 + KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1 + KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_4_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_4_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 boxes on winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 boxes on winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10 JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10 JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_133_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_133">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="POUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_135_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_135">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Swap">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Swap">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Swap">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Swap">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_141_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_141">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_149_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_149">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_11">
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_28">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_29">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_30">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_31">
 		<text string="321">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_32">
 		<text string="312">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_33">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="795" height="652">
-			</bounds>
+			<bounds x="0" y="0" width="795" height="652"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="185" y="393" width="80" height="140">
-			</bounds>
+			<bounds x="185" y="393" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="185.0000" y="393.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="185.0000" y="393.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="188.3333" y="394.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="188.3333" y="394.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="191.6667" y="396.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="191.6667" y="396.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="195.0000" y="398.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="195.0000" y="398.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="198.3333" y="400.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="198.3333" y="400.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="201.6667" y="402.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="201.6667" y="402.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="185.0000" y="439.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="185.0000" y="439.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="188.3333" y="441.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="188.3333" y="441.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="191.6667" y="443.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="191.6667" y="443.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="195.0000" y="445.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="195.0000" y="445.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="198.3333" y="447.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="198.3333" y="447.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="201.6667" y="449.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="201.6667" y="449.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="185.0000" y="486.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="185.0000" y="486.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="188.3333" y="488.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="188.3333" y="488.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="191.6667" y="490.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="191.6667" y="490.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="195.0000" y="492.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="195.0000" y="492.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="198.3333" y="494.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="198.3333" y="494.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="201.6667" y="496.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="201.6667" y="496.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="185" y="393" width="80" height="140">
-			</bounds>
+			<bounds x="185" y="393" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="313" y="393" width="80" height="140">
-			</bounds>
+			<bounds x="313" y="393" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="393.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="313.0000" y="393.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="394.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="316.3333" y="394.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="396.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="319.6667" y="396.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="398.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="323.0000" y="398.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="400.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="326.3333" y="400.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="402.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="329.6667" y="402.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="439.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="313.0000" y="439.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="441.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="316.3333" y="441.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="443.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="319.6667" y="443.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="445.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="323.0000" y="445.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="447.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="326.3333" y="447.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="449.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="329.6667" y="449.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="486.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="313.0000" y="486.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="488.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="316.3333" y="488.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="490.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="319.6667" y="490.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="492.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="323.0000" y="492.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="494.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="326.3333" y="494.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="496.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="329.6667" y="496.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="313" y="393" width="80" height="140">
-			</bounds>
+			<bounds x="313" y="393" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="435" y="393" width="80" height="140">
-			</bounds>
+			<bounds x="435" y="393" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="435.0000" y="393.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="435.0000" y="393.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="438.3333" y="394.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="438.3333" y="394.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="441.6667" y="396.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="441.6667" y="396.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="445.0000" y="398.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="445.0000" y="398.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="448.3333" y="400.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="448.3333" y="400.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="451.6667" y="402.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="451.6667" y="402.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="435.0000" y="439.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="435.0000" y="439.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="438.3333" y="441.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="438.3333" y="441.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="441.6667" y="443.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="441.6667" y="443.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="445.0000" y="445.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="445.0000" y="445.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="448.3333" y="447.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="448.3333" y="447.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="451.6667" y="449.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="451.6667" y="449.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="435.0000" y="486.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="435.0000" y="486.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="438.3333" y="488.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="438.3333" y="488.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="441.6667" y="490.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="441.6667" y="490.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="445.0000" y="492.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="445.0000" y="492.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="448.3333" y="494.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="448.3333" y="494.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="451.6667" y="496.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="451.6667" y="496.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="435" y="393" width="80" height="140">
-			</bounds>
+			<bounds x="435" y="393" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="229" y="136" width="70" height="70">
-			</bounds>
+			<bounds x="229" y="136" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="229.0000" y="136.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="229.0000" y="136.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="231.9167" y="138.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="231.9167" y="138.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="234.8333" y="141.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="234.8333" y="141.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="237.7500" y="144.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="237.7500" y="144.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="240.6667" y="147.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="240.6667" y="147.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="243.5833" y="150.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="243.5833" y="150.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="229" y="136" width="70" height="70">
-			</bounds>
+			<bounds x="229" y="136" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="25" y="7" width="78" height="32">
-			</bounds>
+			<bounds x="25" y="7" width="78" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="27" y="9" width="74" height="28">
-			</bounds>
+			<bounds x="27" y="9" width="74" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="25" y="38" width="78" height="19">
-			</bounds>
+			<bounds x="25" y="38" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="27" y="40" width="74" height="15">
-			</bounds>
+			<bounds x="27" y="40" width="74" height="15"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="25" y="56" width="78" height="19">
-			</bounds>
+			<bounds x="25" y="56" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="27" y="58" width="74" height="15">
-			</bounds>
+			<bounds x="27" y="58" width="74" height="15"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="25" y="120" width="78" height="40">
-			</bounds>
+			<bounds x="25" y="120" width="78" height="40"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="27" y="122" width="74" height="36">
-			</bounds>
+			<bounds x="27" y="122" width="74" height="36"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="25" y="102" width="78" height="19">
-			</bounds>
+			<bounds x="25" y="102" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="27" y="104" width="74" height="15">
-			</bounds>
+			<bounds x="27" y="104" width="74" height="15"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="25" y="74" width="78" height="29">
-			</bounds>
+			<bounds x="25" y="74" width="78" height="29"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="27" y="76" width="74" height="25">
-			</bounds>
+			<bounds x="27" y="76" width="74" height="25"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="73" y="167" width="61" height="42">
-			</bounds>
+			<bounds x="73" y="167" width="61" height="42"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="75" y="169" width="57" height="38">
-			</bounds>
+			<bounds x="75" y="169" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="13" y="167" width="61" height="42">
-			</bounds>
+			<bounds x="13" y="167" width="61" height="42"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="15" y="169" width="57" height="38">
-			</bounds>
+			<bounds x="15" y="169" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="13" y="290" width="61" height="42">
-			</bounds>
+			<bounds x="13" y="290" width="61" height="42"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="15" y="292" width="57" height="38">
-			</bounds>
+			<bounds x="15" y="292" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="73" y="290" width="61" height="42">
-			</bounds>
+			<bounds x="73" y="290" width="61" height="42"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="75" y="292" width="57" height="38">
-			</bounds>
+			<bounds x="75" y="292" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="13" y="208" width="61" height="42">
-			</bounds>
+			<bounds x="13" y="208" width="61" height="42"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="15" y="210" width="57" height="38">
-			</bounds>
+			<bounds x="15" y="210" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="73" y="208" width="61" height="42">
-			</bounds>
+			<bounds x="73" y="208" width="61" height="42"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="75" y="210" width="57" height="38">
-			</bounds>
+			<bounds x="75" y="210" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="13" y="249" width="61" height="42">
-			</bounds>
+			<bounds x="13" y="249" width="61" height="42"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="15" y="251" width="57" height="38">
-			</bounds>
+			<bounds x="15" y="251" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="73" y="249" width="61" height="42">
-			</bounds>
+			<bounds x="73" y="249" width="61" height="42"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="75" y="251" width="57" height="38">
-			</bounds>
+			<bounds x="75" y="251" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="496" y="319" width="60" height="19">
-			</bounds>
+			<bounds x="496" y="319" width="60" height="19"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="498" y="321" width="56" height="15">
-			</bounds>
+			<bounds x="498" y="321" width="56" height="15"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="438" y="319" width="60" height="19">
-			</bounds>
+			<bounds x="438" y="319" width="60" height="19"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="440" y="321" width="56" height="15">
-			</bounds>
+			<bounds x="440" y="321" width="56" height="15"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="380" y="319" width="60" height="19">
-			</bounds>
+			<bounds x="380" y="319" width="60" height="19"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="382" y="321" width="56" height="15">
-			</bounds>
+			<bounds x="382" y="321" width="56" height="15"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="206" y="319" width="60" height="19">
-			</bounds>
+			<bounds x="206" y="319" width="60" height="19"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="208" y="321" width="56" height="15">
-			</bounds>
+			<bounds x="208" y="321" width="56" height="15"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="264" y="319" width="60" height="19">
-			</bounds>
+			<bounds x="264" y="319" width="60" height="19"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="266" y="321" width="56" height="15">
-			</bounds>
+			<bounds x="266" y="321" width="56" height="15"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="322" y="319" width="60" height="19">
-			</bounds>
+			<bounds x="322" y="319" width="60" height="19"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="324" y="321" width="56" height="15">
-			</bounds>
+			<bounds x="324" y="321" width="56" height="15"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="331" y="126" width="95" height="25">
-			</bounds>
+			<bounds x="331" y="126" width="95" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="333" y="128" width="91" height="21">
-			</bounds>
+			<bounds x="333" y="128" width="91" height="21"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="331" y="101" width="95" height="25">
-			</bounds>
+			<bounds x="331" y="101" width="95" height="25"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="333" y="103" width="91" height="21">
-			</bounds>
+			<bounds x="333" y="103" width="91" height="21"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="331" y="175" width="95" height="25">
-			</bounds>
+			<bounds x="331" y="175" width="95" height="25"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="333" y="177" width="91" height="21">
-			</bounds>
+			<bounds x="333" y="177" width="91" height="21"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="331" y="150" width="95" height="25">
-			</bounds>
+			<bounds x="331" y="150" width="95" height="25"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="333" y="152" width="91" height="21">
-			</bounds>
+			<bounds x="333" y="152" width="91" height="21"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="469" y="105" width="60" height="30">
-			</bounds>
+			<bounds x="469" y="105" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="471" y="107" width="56" height="26">
-			</bounds>
+			<bounds x="471" y="107" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="469" y="136" width="60" height="30">
-			</bounds>
+			<bounds x="469" y="136" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="471" y="138" width="56" height="26">
-			</bounds>
+			<bounds x="471" y="138" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="469" y="166" width="60" height="30">
-			</bounds>
+			<bounds x="469" y="166" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="471" y="168" width="56" height="26">
-			</bounds>
+			<bounds x="471" y="168" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="469" y="197" width="60" height="30">
-			</bounds>
+			<bounds x="469" y="197" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="471" y="199" width="56" height="26">
-			</bounds>
+			<bounds x="471" y="199" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="469" y="228" width="60" height="30">
-			</bounds>
+			<bounds x="469" y="228" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="471" y="230" width="56" height="26">
-			</bounds>
+			<bounds x="471" y="230" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="331" y="225" width="95" height="25">
-			</bounds>
+			<bounds x="331" y="225" width="95" height="25"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="333" y="227" width="91" height="21">
-			</bounds>
+			<bounds x="333" y="227" width="91" height="21"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="331" y="200" width="95" height="25">
-			</bounds>
+			<bounds x="331" y="200" width="95" height="25"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="333" y="202" width="91" height="21">
-			</bounds>
+			<bounds x="333" y="202" width="91" height="21"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="150" y="7" width="56" height="31">
-			</bounds>
+			<bounds x="150" y="7" width="56" height="31"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="152" y="9" width="52" height="27">
-			</bounds>
+			<bounds x="152" y="9" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="557" y="62" width="44" height="39">
-			</bounds>
+			<bounds x="557" y="62" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="559" y="64" width="40" height="35">
-			</bounds>
+			<bounds x="559" y="64" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="150" y="321" width="56" height="31">
-			</bounds>
+			<bounds x="150" y="321" width="56" height="31"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="152" y="323" width="52" height="27">
-			</bounds>
+			<bounds x="152" y="323" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="162" y="62" width="44" height="39">
-			</bounds>
+			<bounds x="162" y="62" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="164" y="64" width="40" height="35">
-			</bounds>
+			<bounds x="164" y="64" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="162" y="99" width="44" height="39">
-			</bounds>
+			<bounds x="162" y="99" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="164" y="101" width="40" height="35">
-			</bounds>
+			<bounds x="164" y="101" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="162" y="173" width="44" height="39">
-			</bounds>
+			<bounds x="162" y="173" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="164" y="175" width="40" height="35">
-			</bounds>
+			<bounds x="164" y="175" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="162" y="210" width="44" height="39">
-			</bounds>
+			<bounds x="162" y="210" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="164" y="212" width="40" height="35">
-			</bounds>
+			<bounds x="164" y="212" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="162" y="247" width="44" height="39">
-			</bounds>
+			<bounds x="162" y="247" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="164" y="249" width="40" height="35">
-			</bounds>
+			<bounds x="164" y="249" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="162" y="284" width="44" height="39">
-			</bounds>
+			<bounds x="162" y="284" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="164" y="286" width="40" height="35">
-			</bounds>
+			<bounds x="164" y="286" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="515" y="339" width="44" height="39">
-			</bounds>
+			<bounds x="515" y="339" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="517" y="341" width="40" height="35">
-			</bounds>
+			<bounds x="517" y="341" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="409" y="339" width="55" height="39">
-			</bounds>
+			<bounds x="409" y="339" width="55" height="39"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="411" y="341" width="51" height="35">
-			</bounds>
+			<bounds x="411" y="341" width="51" height="35"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="356" y="339" width="55" height="39">
-			</bounds>
+			<bounds x="356" y="339" width="55" height="39"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="358" y="341" width="51" height="35">
-			</bounds>
+			<bounds x="358" y="341" width="51" height="35"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="204" y="339" width="54" height="39">
-			</bounds>
+			<bounds x="204" y="339" width="54" height="39"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="206" y="341" width="50" height="35">
-			</bounds>
+			<bounds x="206" y="341" width="50" height="35"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="462" y="339" width="55" height="39">
-			</bounds>
+			<bounds x="462" y="339" width="55" height="39"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="464" y="341" width="51" height="35">
-			</bounds>
+			<bounds x="464" y="341" width="51" height="35"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="256" y="339" width="51" height="39">
-			</bounds>
+			<bounds x="256" y="339" width="51" height="39"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="258" y="341" width="47" height="35">
-			</bounds>
+			<bounds x="258" y="341" width="47" height="35"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="305" y="339" width="53" height="39">
-			</bounds>
+			<bounds x="305" y="339" width="53" height="39"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="307" y="341" width="49" height="35">
-			</bounds>
+			<bounds x="307" y="341" width="49" height="35"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="557" y="321" width="56" height="31">
-			</bounds>
+			<bounds x="557" y="321" width="56" height="31"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="559" y="323" width="52" height="27">
-			</bounds>
+			<bounds x="559" y="323" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="557" y="7" width="56" height="31">
-			</bounds>
+			<bounds x="557" y="7" width="56" height="31"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="559" y="9" width="52" height="27">
-			</bounds>
+			<bounds x="559" y="9" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="557" y="210" width="44" height="39">
-			</bounds>
+			<bounds x="557" y="210" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="559" y="212" width="40" height="35">
-			</bounds>
+			<bounds x="559" y="212" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="557" y="173" width="44" height="39">
-			</bounds>
+			<bounds x="557" y="173" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="559" y="175" width="40" height="35">
-			</bounds>
+			<bounds x="559" y="175" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="557" y="151" width="44" height="24">
-			</bounds>
+			<bounds x="557" y="151" width="44" height="24"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="559" y="153" width="40" height="20">
-			</bounds>
+			<bounds x="559" y="153" width="40" height="20"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="557" y="99" width="44" height="54">
-			</bounds>
+			<bounds x="557" y="99" width="44" height="54"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="559" y="101" width="40" height="50">
-			</bounds>
+			<bounds x="559" y="101" width="40" height="50"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="557" y="247" width="44" height="28">
-			</bounds>
+			<bounds x="557" y="247" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="559" y="249" width="40" height="24">
-			</bounds>
+			<bounds x="559" y="249" width="40" height="24"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="204" y="7" width="54" height="39">
-			</bounds>
+			<bounds x="204" y="7" width="54" height="39"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="206" y="9" width="50" height="35">
-			</bounds>
+			<bounds x="206" y="9" width="50" height="35"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="256" y="7" width="51" height="39">
-			</bounds>
+			<bounds x="256" y="7" width="51" height="39"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="258" y="9" width="47" height="35">
-			</bounds>
+			<bounds x="258" y="9" width="47" height="35"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="305" y="7" width="53" height="39">
-			</bounds>
+			<bounds x="305" y="7" width="53" height="39"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="307" y="9" width="49" height="35">
-			</bounds>
+			<bounds x="307" y="9" width="49" height="35"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="356" y="7" width="55" height="39">
-			</bounds>
+			<bounds x="356" y="7" width="55" height="39"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="358" y="9" width="51" height="35">
-			</bounds>
+			<bounds x="358" y="9" width="51" height="35"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="409" y="7" width="55" height="39">
-			</bounds>
+			<bounds x="409" y="7" width="55" height="39"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="411" y="9" width="51" height="35">
-			</bounds>
+			<bounds x="411" y="9" width="51" height="35"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="462" y="7" width="55" height="39">
-			</bounds>
+			<bounds x="462" y="7" width="55" height="39"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="464" y="9" width="51" height="35">
-			</bounds>
+			<bounds x="464" y="9" width="51" height="35"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="515" y="7" width="44" height="39">
-			</bounds>
+			<bounds x="515" y="7" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="517" y="9" width="40" height="35">
-			</bounds>
+			<bounds x="517" y="9" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="162" y="136" width="44" height="39">
-			</bounds>
+			<bounds x="162" y="136" width="44" height="39"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="164" y="138" width="40" height="35">
-			</bounds>
+			<bounds x="164" y="138" width="40" height="35"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="379" y="53" width="58" height="32">
-			</bounds>
+			<bounds x="379" y="53" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="381" y="55" width="54" height="28">
-			</bounds>
+			<bounds x="381" y="55" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="324" y="53" width="58" height="32">
-			</bounds>
+			<bounds x="324" y="53" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="326" y="55" width="54" height="28">
-			</bounds>
+			<bounds x="326" y="55" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="269" y="53" width="58" height="32">
-			</bounds>
+			<bounds x="269" y="53" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="271" y="55" width="54" height="28">
-			</bounds>
+			<bounds x="271" y="55" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="214" y="53" width="58" height="32">
-			</bounds>
+			<bounds x="214" y="53" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="216" y="55" width="54" height="28">
-			</bounds>
+			<bounds x="216" y="55" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="434" y="53" width="58" height="32">
-			</bounds>
+			<bounds x="434" y="53" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="436" y="55" width="54" height="28">
-			</bounds>
+			<bounds x="436" y="55" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="489" y="53" width="58" height="32">
-			</bounds>
+			<bounds x="489" y="53" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="491" y="55" width="54" height="28">
-			</bounds>
+			<bounds x="491" y="55" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="557" y="292" width="44" height="31">
-			</bounds>
+			<bounds x="557" y="292" width="44" height="31"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="559" y="294" width="40" height="27">
-			</bounds>
+			<bounds x="559" y="294" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="557" y="273" width="44" height="21">
-			</bounds>
+			<bounds x="557" y="273" width="44" height="21"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="559" y="275" width="40" height="17">
-			</bounds>
+			<bounds x="559" y="275" width="40" height="17"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="630" y="117" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="117" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="632" y="119" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="119" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="630" y="117" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="117" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="632" y="119" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="119" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="630" y="92" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="92" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="632" y="94" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="94" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="630" y="92" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="92" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="632" y="94" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="94" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="630" y="142" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="142" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="632" y="144" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="144" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="630" y="142" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="142" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="632" y="144" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="144" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="630" y="215" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="215" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="632" y="217" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="217" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="630" y="215" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="215" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="632" y="217" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="217" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="630" y="240" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="240" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="632" y="242" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="242" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="630" y="240" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="240" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="632" y="242" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="242" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="630" y="191" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="191" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="632" y="193" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="193" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="630" y="191" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="191" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="632" y="193" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="193" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="630" y="167" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="167" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="632" y="169" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="169" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="630" y="167" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="167" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="632" y="169" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="169" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="630" y="264" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="264" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="632" y="266" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="266" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="630" y="264" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="264" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="632" y="266" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="266" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="630" y="289" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="289" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="632" y="291" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="291" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="630" y="289" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="289" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="632" y="291" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="291" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="630" y="314" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="314" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="632" y="316" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="316" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="630" y="314" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="314" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="632" y="316" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="316" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="628" y="18" width="59" height="28">
-			</bounds>
+			<bounds x="628" y="18" width="59" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="630" y="20" width="55" height="24">
-			</bounds>
+			<bounds x="630" y="20" width="55" height="24"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="630" y="43" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="43" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="632" y="45" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="45" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="630" y="43" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="43" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="632" y="45" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="45" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="630" y="68" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="68" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="632" y="70" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="70" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="630" y="68" width="55" height="28">
-			</bounds>
+			<bounds x="630" y="68" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="632" y="70" width="51" height="24">
-			</bounds>
+			<bounds x="632" y="70" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="689" y="429" width="38" height="38">
-			</bounds>
+			<bounds x="689" y="429" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="691" y="431" width="34" height="34">
-			</bounds>
+			<bounds x="691" y="431" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="539" y="429" width="38" height="38">
-			</bounds>
+			<bounds x="539" y="429" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="541" y="431" width="34" height="34">
-			</bounds>
+			<bounds x="541" y="431" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="689" y="386" width="38" height="38">
-			</bounds>
+			<bounds x="689" y="386" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="691" y="388" width="34" height="34">
-			</bounds>
+			<bounds x="691" y="388" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="539" y="386" width="38" height="38">
-			</bounds>
+			<bounds x="539" y="386" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="541" y="388" width="34" height="34">
-			</bounds>
+			<bounds x="541" y="388" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="539" y="472" width="38" height="38">
-			</bounds>
+			<bounds x="539" y="472" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="541" y="474" width="34" height="34">
-			</bounds>
+			<bounds x="541" y="474" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="539" y="513" width="38" height="38">
-			</bounds>
+			<bounds x="539" y="513" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="541" y="515" width="34" height="34">
-			</bounds>
+			<bounds x="541" y="515" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="689" y="512" width="38" height="38">
-			</bounds>
+			<bounds x="689" y="512" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="691" y="514" width="34" height="34">
-			</bounds>
+			<bounds x="691" y="514" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="689" y="471" width="38" height="38">
-			</bounds>
+			<bounds x="689" y="471" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="691" y="473" width="34" height="34">
-			</bounds>
+			<bounds x="691" y="473" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="89" y="505" width="59" height="27">
-			</bounds>
+			<bounds x="89" y="505" width="59" height="27"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="91" y="507" width="55" height="23">
-			</bounds>
+			<bounds x="91" y="507" width="55" height="23"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="89" y="480" width="59" height="27">
-			</bounds>
+			<bounds x="89" y="480" width="59" height="27"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="91" y="482" width="55" height="23">
-			</bounds>
+			<bounds x="91" y="482" width="55" height="23"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="89" y="455" width="59" height="27">
-			</bounds>
+			<bounds x="89" y="455" width="59" height="27"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="91" y="457" width="55" height="23">
-			</bounds>
+			<bounds x="91" y="457" width="55" height="23"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="89" y="430" width="59" height="27">
-			</bounds>
+			<bounds x="89" y="430" width="59" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="91" y="432" width="55" height="23">
-			</bounds>
+			<bounds x="91" y="432" width="55" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1_border" state="0">
-			<bounds x="77" y="598" width="57" height="28">
-			</bounds>
+			<bounds x="77" y="598" width="57" height="28"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1" state="0">
-			<bounds x="79" y="600" width="53" height="24">
-			</bounds>
+			<bounds x="79" y="600" width="53" height="24"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="217" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="217" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="219" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="219" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="69" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="69" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="71" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="71" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="143" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="143" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="145" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="145" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="292" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="292" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="294" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="294" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="663" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="663" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="665" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="665" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="589" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="589" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="591" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="591" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="515" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="515" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="517" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="517" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="441" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="441" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="443" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="443" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="367" y="625" width="72" height="19">
-			</bounds>
+			<bounds x="367" y="625" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="369" y="627" width="68" height="15">
-			</bounds>
+			<bounds x="369" y="627" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_133_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="697" y="11" width="75" height="27">
-			</bounds>
+			<bounds x="697" y="11" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_133" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="699" y="13" width="71" height="23">
-			</bounds>
+			<bounds x="699" y="13" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp153" element="colour_button_135_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="557" y="36" width="56" height="29">
-			</bounds>
+			<bounds x="557" y="36" width="56" height="29"/>
 		</backdrop>
 		<backdrop name="lamp153" element="colour_button_135" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="559" y="38" width="52" height="25">
-			</bounds>
+			<bounds x="559" y="38" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp144" element="colour_button_136_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="150" y="36" width="56" height="29">
-			</bounds>
+			<bounds x="150" y="36" width="56" height="29"/>
 		</backdrop>
 		<backdrop name="lamp144" element="colour_button_136" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="152" y="38" width="52" height="25">
-			</bounds>
+			<bounds x="152" y="38" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp136" element="colour_button_137_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="150" y="349" width="56" height="29">
-			</bounds>
+			<bounds x="150" y="349" width="56" height="29"/>
 		</backdrop>
 		<backdrop name="lamp136" element="colour_button_137" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="152" y="351" width="52" height="25">
-			</bounds>
+			<bounds x="152" y="351" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp164" element="colour_button_138_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="557" y="349" width="56" height="29">
-			</bounds>
+			<bounds x="557" y="349" width="56" height="29"/>
 		</backdrop>
 		<backdrop name="lamp164" element="colour_button_138" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="559" y="351" width="52" height="25">
-			</bounds>
+			<bounds x="559" y="351" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_139_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="189" y="558" width="75" height="39">
-			</bounds>
+			<bounds x="189" y="558" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_139" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="191" y="560" width="71" height="35">
-			</bounds>
+			<bounds x="191" y="560" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_140_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="318" y="558" width="75" height="39">
-			</bounds>
+			<bounds x="318" y="558" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_140" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="320" y="560" width="71" height="35">
-			</bounds>
+			<bounds x="320" y="560" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_141_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="439" y="558" width="75" height="39">
-			</bounds>
+			<bounds x="439" y="558" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_141" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="441" y="560" width="71" height="35">
-			</bounds>
+			<bounds x="441" y="560" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_142_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="524" y="558" width="75" height="39">
-			</bounds>
+			<bounds x="524" y="558" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_142" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="526" y="560" width="71" height="35">
-			</bounds>
+			<bounds x="526" y="560" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_143_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="611" y="558" width="75" height="39">
-			</bounds>
+			<bounds x="611" y="558" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_143" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="613" y="560" width="71" height="35">
-			</bounds>
+			<bounds x="613" y="560" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_144_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="699" y="558" width="75" height="39">
-			</bounds>
+			<bounds x="699" y="558" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_144" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="701" y="560" width="71" height="35">
-			</bounds>
+			<bounds x="701" y="560" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_149_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="86" y="558" width="75" height="39">
-			</bounds>
+			<bounds x="86" y="558" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_149" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="88" y="560" width="71" height="35">
-			</bounds>
+			<bounds x="88" y="560" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="49" y="370" width="24" height="32">
-			</bounds>
+			<bounds x="49" y="370" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="52" y="372" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="372" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="66" y="372" width="3" height="14">
-			</bounds>
+			<bounds x="66" y="372" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="66" y="384" width="3" height="14">
-			</bounds>
+			<bounds x="66" y="384" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="52" y="396" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="396" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="52" y="384" width="3" height="14">
-			</bounds>
+			<bounds x="52" y="384" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="52" y="372" width="3" height="14">
-			</bounds>
+			<bounds x="52" y="372" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="52" y="384" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="384" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="69" y="396" width="3" height="2">
-			</bounds>
+			<bounds x="69" y="396" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="52" y="372" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="372" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="66" y="372" width="3" height="14">
-			</bounds>
+			<bounds x="66" y="372" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="66" y="384" width="3" height="14">
-			</bounds>
+			<bounds x="66" y="384" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="52" y="396" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="396" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="52" y="384" width="3" height="14">
-			</bounds>
+			<bounds x="52" y="384" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="52" y="372" width="3" height="14">
-			</bounds>
+			<bounds x="52" y="372" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="52" y="384" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="384" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="69" y="396" width="3" height="2">
-			</bounds>
+			<bounds x="69" y="396" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="73" y="370" width="24" height="32">
-			</bounds>
+			<bounds x="73" y="370" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="76" y="372" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="372" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="90" y="372" width="3" height="14">
-			</bounds>
+			<bounds x="90" y="372" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="90" y="384" width="3" height="14">
-			</bounds>
+			<bounds x="90" y="384" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="76" y="396" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="396" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="76" y="384" width="3" height="14">
-			</bounds>
+			<bounds x="76" y="384" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="76" y="372" width="3" height="14">
-			</bounds>
+			<bounds x="76" y="372" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="76" y="384" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="384" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="93" y="396" width="3" height="2">
-			</bounds>
+			<bounds x="93" y="396" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="76" y="372" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="372" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="90" y="372" width="3" height="14">
-			</bounds>
+			<bounds x="90" y="372" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="90" y="384" width="3" height="14">
-			</bounds>
+			<bounds x="90" y="384" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="76" y="396" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="396" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="76" y="384" width="3" height="14">
-			</bounds>
+			<bounds x="76" y="384" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="76" y="372" width="3" height="14">
-			</bounds>
+			<bounds x="76" y="372" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="76" y="384" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="384" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="93" y="396" width="3" height="2">
-			</bounds>
+			<bounds x="93" y="396" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="242" y="266" width="272" height="30">
-			</bounds>
+			<bounds x="242" y="266" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="242" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="242" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="259" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="259" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="276" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="276" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="293" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="293" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="310" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="310" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="327" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="327" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="344" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="344" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="361" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="361" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="378" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="378" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="395" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="395" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="412" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="412" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="429" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="429" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="446" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="446" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="463" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="463" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="480" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="480" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="497" y="266" width="17" height="30">
-			</bounds>
+			<bounds x="497" y="266" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="53" y="351" width="37" height="13">
-			</bounds>
+			<bounds x="53" y="351" width="37" height="13"/>
 		</backdrop>
 		<backdrop name="label28" element="label_28">
-			<bounds x="227" y="307" width="18" height="13">
-			</bounds>
+			<bounds x="227" y="307" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label29" element="label_29">
-			<bounds x="288" y="307" width="18" height="13">
-			</bounds>
+			<bounds x="288" y="307" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label30" element="label_30">
-			<bounds x="343" y="307" width="18" height="13">
-			</bounds>
+			<bounds x="343" y="307" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label31" element="label_31">
-			<bounds x="400" y="307" width="18" height="13">
-			</bounds>
+			<bounds x="400" y="307" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label32" element="label_32">
-			<bounds x="459" y="306" width="18" height="13">
-			</bounds>
+			<bounds x="459" y="306" width="18" height="13"/>
 		</backdrop>
 		<backdrop name="label33" element="label_33">
-			<bounds x="511" y="306" width="18" height="13">
-			</bounds>
+			<bounds x="511" y="306" width="18" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_button" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_button" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_button" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_button" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1frexplc.lay
+++ b/src/mame/layout/m1frexplc.lay
@@ -8,18356 +8,9958 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.00" blue="0.00">
-			</color>
+			<color red="0.48" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.00" blue="0.00">
-			</color>
+			<color red="0.96" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.00" blue="0.00">
-			</color>
+			<color red="0.24" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_33_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.00">
-			</color>
+			<color red="0.46" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.00">
-			</color>
+			<color red="0.11" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_2" defstate="0">
 		<rect state="1">
-			<color red="0.92" green="0.00" blue="0.00">
-			</color>
+			<color red="0.92" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.00">
-			</color>
+			<color red="0.23" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.92" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
+			<color red="0.50" green="0.02" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
+			<color red="1.00" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
+			<color red="0.25" green="0.01" blue="0.01"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
+			<color red="0.46" green="0.38" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
+			<color red="0.11" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
+			<color red="0.93" green="0.76" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
+			<color red="0.23" green="0.19" blue="0.02"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
+			<color red="0.46" green="0.38" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
+			<color red="0.11" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
+			<color red="0.93" green="0.76" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
+			<color red="0.23" green="0.19" blue="0.02"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_255_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_255_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Roll Even">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Roll Even">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Continue?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Continue?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Collect Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Collect Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Super Pots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super Pots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Game Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Game Over">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fruit Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Fruit Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Fruit Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Stopper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stopper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
+			<color red="0.46" green="0.38" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
+			<color red="0.11" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
+			<color red="0.93" green="0.76" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
+			<color red="0.23" green="0.19" blue="0.02"/>
 		</rect>
 		<text string="Slider">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
-		</rect>
-		<text string="Slider">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
+			<color red="0.46" green="0.38" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
+			<color red="0.11" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
+			<color red="0.93" green="0.76" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
+			<color red="0.23" green="0.19" blue="0.02"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Fruit Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Fruit Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Melon Madness">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Melon Madness">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Pick A Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Pick A Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Pick A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Pick A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.00">
-			</color>
+			<color red="0.50" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.85" blue="0.00">
-			</color>
+			<color red="1.00" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.00">
-			</color>
+			<color red="0.25" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.85" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.00">
-			</color>
+			<color red="0.50" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.85" blue="0.00">
-			</color>
+			<color red="1.00" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.00">
-			</color>
+			<color red="0.25" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.85" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fruit Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
+			<color red="0.46" green="0.38" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
+			<color red="0.11" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
+			<color red="0.93" green="0.76" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
+			<color red="0.23" green="0.19" blue="0.02"/>
 		</rect>
 		<text string="J A C K P O T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
-		</rect>
-		<text string="J A C K P O T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Reel Runner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Reel Runner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Skill Pots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Skill Pots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Twist Again">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Twist Again">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Preserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.32" blue="0.49">
-			</color>
+			<color red="0.01" green="0.32" blue="0.49"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.12">
-			</color>
+			<color red="0.00" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.65" blue="0.98">
-			</color>
+			<color red="0.02" green="0.65" blue="0.98"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.24">
-			</color>
+			<color red="0.00" green="0.16" blue="0.24"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.32" blue="0.49">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.65" blue="0.98">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.24">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.32" blue="0.49">
-			</color>
+			<color red="0.01" green="0.32" blue="0.49"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.12">
-			</color>
+			<color red="0.00" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_50_2" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.65" blue="0.98">
-			</color>
+			<color red="0.02" green="0.65" blue="0.98"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.24">
-			</color>
+			<color red="0.00" green="0.16" blue="0.24"/>
 		</rect>
 		<text string="BONUIS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.32" blue="0.49">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.65" blue="0.98">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.24">
-			</color>
-		</rect>
-		<text string="BONUIS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.20" blue="0.00">
-			</color>
+			<color red="0.50" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.00">
-			</color>
+			<color red="0.12" green="0.05" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.39" blue="0.00">
-			</color>
+			<color red="1.00" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.00">
-			</color>
+			<color red="0.25" green="0.10" blue="0.00"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Holds">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="wl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="wl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_3" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="uit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="uit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_139_4" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Fr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Fr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_5_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_5" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_139_6_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_139_6" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_139_7_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_7" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_139_8_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_139_8" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_143_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_143_2" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Fr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Fr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_3" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="uit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="uit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_4" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_143_5_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_143_5" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_143_6_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_143_6" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="wl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="wl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_7_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_7" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_8_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_8" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_157_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_157_2" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="wl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="wl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_3" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_4" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_157_5_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_5" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_157_6_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_6" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="uit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="uit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_7_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_157_7" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Fr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Fr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_8_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_157_8" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
+			<color red="0.40" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
+			<color red="0.80" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="UIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="UIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
+			<color red="0.40" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
+			<color red="0.80" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
+			<color red="0.40" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
+			<color red="0.80" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
+			<color red="0.40" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
+			<color red="0.80" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
+			<color red="0.40" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
+			<color red="0.10" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
+			<color red="0.80" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
+			<color red="0.20" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.80" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_142_2" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_138_2" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_134_2" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_162_2" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_158_2" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_153_2" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Strawberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
+			<color red="0.06" green="0.46" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
+			<color red="0.02" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_148_2" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
+			<color red="0.13" green="0.92" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
+			<color red="0.03" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.46" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.92" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
+			<color red="0.01" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_146_2" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
+			<color red="0.02" green="0.98" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
+			<color red="0.00" green="0.24" blue="0.17"/>
 		</rect>
 		<text string="Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<text string="Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_236_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_236_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.00">
-			</color>
+			<color red="0.50" green="0.06" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.00">
-			</color>
+			<color red="0.12" green="0.02" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.00">
-			</color>
+			<color red="1.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.00">
-			</color>
+			<color red="0.25" green="0.03" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.00">
-			</color>
+			<color red="0.50" green="0.06" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.00">
-			</color>
+			<color red="0.12" green="0.02" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.00">
-			</color>
+			<color red="1.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.00">
-			</color>
+			<color red="0.25" green="0.03" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_301_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_301">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_302_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_302">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_303_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_303">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_304_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_304">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_305_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_305">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_306_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.35">
-			</color>
+			<color red="0.00" green="0.50" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.09">
-			</color>
+			<color red="0.00" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_306">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.70">
-			</color>
+			<color red="0.00" green="1.00" blue="0.70"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.17">
-			</color>
+			<color red="0.00" green="0.25" blue="0.17"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_307_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_307">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_308_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_308">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_309_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_309">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_310_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_310">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_311_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_311">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_312_border">
 		<rect state="1">
-			<color red="0.50" green="0.40" blue="0.04">
-			</color>
+			<color red="0.50" green="0.40" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.01">
-			</color>
+			<color red="0.12" green="0.10" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="colour_button_312">
 		<rect state="1">
-			<color red="1.00" green="0.80" blue="0.08">
-			</color>
+			<color red="1.00" green="0.80" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.02">
-			</color>
+			<color red="0.25" green="0.20" blue="0.02"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist=",,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_195">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_196">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_197">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_198">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_233">
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_257">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_258">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="718" height="657">
-			</bounds>
+			<bounds x="0" y="0" width="718" height="657"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="120" y="407" width="80" height="140">
-			</bounds>
+			<bounds x="120" y="407" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="120.0000" y="407.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="120.0000" y="407.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="123.3333" y="408.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="123.3333" y="408.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="126.6667" y="410.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="126.6667" y="410.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="130.0000" y="412.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="130.0000" y="412.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="133.3333" y="414.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="133.3333" y="414.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="136.6667" y="416.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="136.6667" y="416.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="120.0000" y="453.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="120.0000" y="453.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="123.3333" y="455.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="123.3333" y="455.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="126.6667" y="457.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="126.6667" y="457.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="130.0000" y="459.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="130.0000" y="459.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="133.3333" y="461.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="133.3333" y="461.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="136.6667" y="463.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="136.6667" y="463.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="120.0000" y="500.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="120.0000" y="500.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="123.3333" y="502.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="123.3333" y="502.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="126.6667" y="504.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="126.6667" y="504.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="130.0000" y="506.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="130.0000" y="506.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="133.3333" y="508.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="133.3333" y="508.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="136.6667" y="510.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="136.6667" y="510.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="120" y="407" width="80" height="140">
-			</bounds>
+			<bounds x="120" y="407" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="257" y="407" width="80" height="140">
-			</bounds>
+			<bounds x="257" y="407" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="257.0000" y="407.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="257.0000" y="407.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="260.3333" y="408.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="260.3333" y="408.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="263.6667" y="410.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="263.6667" y="410.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="267.0000" y="412.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="267.0000" y="412.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.3333" y="414.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="270.3333" y="414.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="273.6667" y="416.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="273.6667" y="416.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="257.0000" y="453.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="257.0000" y="453.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="260.3333" y="455.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="260.3333" y="455.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="263.6667" y="457.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="263.6667" y="457.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="267.0000" y="459.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="267.0000" y="459.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.3333" y="461.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="270.3333" y="461.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="273.6667" y="463.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="273.6667" y="463.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="257.0000" y="500.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="257.0000" y="500.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="260.3333" y="502.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="260.3333" y="502.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="263.6667" y="504.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="263.6667" y="504.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="267.0000" y="506.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="267.0000" y="506.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.3333" y="508.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="270.3333" y="508.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="273.6667" y="510.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="273.6667" y="510.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="257" y="407" width="80" height="140">
-			</bounds>
+			<bounds x="257" y="407" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="394" y="407" width="80" height="140">
-			</bounds>
+			<bounds x="394" y="407" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="394.0000" y="407.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="394.0000" y="407.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="397.3333" y="408.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="397.3333" y="408.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="400.6667" y="410.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="400.6667" y="410.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="404.0000" y="412.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="404.0000" y="412.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="407.3333" y="414.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="407.3333" y="414.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="410.6667" y="416.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="410.6667" y="416.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="394.0000" y="453.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="394.0000" y="453.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="397.3333" y="455.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="397.3333" y="455.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="400.6667" y="457.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="400.6667" y="457.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="404.0000" y="459.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="404.0000" y="459.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="407.3333" y="461.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="407.3333" y="461.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="410.6667" y="463.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="410.6667" y="463.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="394.0000" y="500.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="394.0000" y="500.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="397.3333" y="502.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="397.3333" y="502.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="400.6667" y="504.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="400.6667" y="504.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="404.0000" y="506.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="404.0000" y="506.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="407.3333" y="508.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="407.3333" y="508.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="410.6667" y="510.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="410.6667" y="510.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="394" y="407" width="80" height="140">
-			</bounds>
+			<bounds x="394" y="407" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="147" y="146" width="70" height="56">
-			</bounds>
+			<bounds x="147" y="146" width="70" height="56"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="147.0000" y="146.0000" width="70.0000" height="56.0000">
-			</bounds>
+			<bounds x="147.0000" y="146.0000" width="70.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="149.9167" y="148.3333" width="64.1667" height="51.3333">
-			</bounds>
+			<bounds x="149.9167" y="148.3333" width="64.1667" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="152.8333" y="150.6667" width="58.3333" height="46.6667">
-			</bounds>
+			<bounds x="152.8333" y="150.6667" width="58.3333" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="155.7500" y="153.0000" width="52.5000" height="42.0000">
-			</bounds>
+			<bounds x="155.7500" y="153.0000" width="52.5000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="158.6667" y="155.3333" width="46.6667" height="37.3333">
-			</bounds>
+			<bounds x="158.6667" y="155.3333" width="46.6667" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="161.5833" y="157.6667" width="40.8333" height="32.6667">
-			</bounds>
+			<bounds x="161.5833" y="157.6667" width="40.8333" height="32.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="147" y="146" width="70" height="56">
-			</bounds>
+			<bounds x="147" y="146" width="70" height="56"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="42" y="504" width="51" height="14">
-			</bounds>
+			<bounds x="42" y="504" width="51" height="14"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="44" y="506" width="47" height="10">
-			</bounds>
+			<bounds x="44" y="506" width="47" height="10"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_2_border" state="0">
-			<bounds x="42" y="482" width="51" height="25">
-			</bounds>
+			<bounds x="42" y="482" width="51" height="25"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_2" state="0">
-			<bounds x="44" y="484" width="47" height="21">
-			</bounds>
+			<bounds x="44" y="484" width="47" height="21"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="32" y="444" width="51" height="25">
-			</bounds>
+			<bounds x="32" y="444" width="51" height="25"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="34" y="446" width="47" height="21">
-			</bounds>
+			<bounds x="34" y="446" width="47" height="21"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_2_border" state="0">
-			<bounds x="32" y="466" width="51" height="14">
-			</bounds>
+			<bounds x="32" y="466" width="51" height="14"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_2" state="0">
-			<bounds x="34" y="468" width="47" height="10">
-			</bounds>
+			<bounds x="34" y="468" width="47" height="10"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="54" y="428" width="51" height="14">
-			</bounds>
+			<bounds x="54" y="428" width="51" height="14"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="56" y="430" width="47" height="10">
-			</bounds>
+			<bounds x="56" y="430" width="47" height="10"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_2_border" state="0">
-			<bounds x="54" y="406" width="51" height="25">
-			</bounds>
+			<bounds x="54" y="406" width="51" height="25"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_2" state="0">
-			<bounds x="56" y="408" width="47" height="21">
-			</bounds>
+			<bounds x="56" y="408" width="47" height="21"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="19" y="542" width="51" height="14">
-			</bounds>
+			<bounds x="19" y="542" width="51" height="14"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="21" y="544" width="47" height="10">
-			</bounds>
+			<bounds x="21" y="544" width="47" height="10"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_2_border" state="0">
-			<bounds x="19" y="520" width="51" height="25">
-			</bounds>
+			<bounds x="19" y="520" width="51" height="25"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_2" state="0">
-			<bounds x="21" y="522" width="47" height="21">
-			</bounds>
+			<bounds x="21" y="522" width="47" height="21"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="262" y="138" width="35" height="67">
-			</bounds>
+			<bounds x="262" y="138" width="35" height="67"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="264" y="140" width="31" height="63">
-			</bounds>
+			<bounds x="264" y="140" width="31" height="63"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="270" y="202" width="32" height="20">
-			</bounds>
+			<bounds x="270" y="202" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="272" y="204" width="28" height="16">
-			</bounds>
+			<bounds x="272" y="204" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="127" y="89" width="35" height="12">
-			</bounds>
+			<bounds x="127" y="89" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="129" y="91" width="31" height="8">
-			</bounds>
+			<bounds x="129" y="91" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1_border" state="0">
-			<bounds x="505" y="235" width="72" height="20">
-			</bounds>
+			<bounds x="505" y="235" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1" state="0">
-			<bounds x="507" y="237" width="68" height="16">
-			</bounds>
+			<bounds x="507" y="237" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="506" y="254" width="72" height="20">
-			</bounds>
+			<bounds x="506" y="254" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="508" y="256" width="68" height="16">
-			</bounds>
+			<bounds x="508" y="256" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="509" y="311" width="72" height="20">
-			</bounds>
+			<bounds x="509" y="311" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="511" y="313" width="68" height="16">
-			</bounds>
+			<bounds x="511" y="313" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="508" y="292" width="72" height="20">
-			</bounds>
+			<bounds x="508" y="292" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="510" y="294" width="68" height="16">
-			</bounds>
+			<bounds x="510" y="294" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="507" y="273" width="72" height="20">
-			</bounds>
+			<bounds x="507" y="273" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="509" y="275" width="68" height="16">
-			</bounds>
+			<bounds x="509" y="275" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="504" y="216" width="72" height="20">
-			</bounds>
+			<bounds x="504" y="216" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="506" y="218" width="68" height="16">
-			</bounds>
+			<bounds x="506" y="218" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="503" y="197" width="72" height="20">
-			</bounds>
+			<bounds x="503" y="197" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="505" y="199" width="68" height="16">
-			</bounds>
+			<bounds x="505" y="199" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="502" y="178" width="72" height="20">
-			</bounds>
+			<bounds x="502" y="178" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="504" y="180" width="68" height="16">
-			</bounds>
+			<bounds x="504" y="180" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="501" y="159" width="72" height="20">
-			</bounds>
+			<bounds x="501" y="159" width="72" height="20"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="503" y="161" width="68" height="16">
-			</bounds>
+			<bounds x="503" y="161" width="68" height="16"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="269" y="121" width="32" height="20">
-			</bounds>
+			<bounds x="269" y="121" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="271" y="123" width="28" height="16">
-			</bounds>
+			<bounds x="271" y="123" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="337" y="189" width="35" height="18">
-			</bounds>
+			<bounds x="337" y="189" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="339" y="191" width="31" height="14">
-			</bounds>
+			<bounds x="339" y="191" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="337" y="216" width="35" height="18">
-			</bounds>
+			<bounds x="337" y="216" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="339" y="218" width="31" height="14">
-			</bounds>
+			<bounds x="339" y="218" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="127" y="243" width="35" height="18">
-			</bounds>
+			<bounds x="127" y="243" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="129" y="245" width="31" height="14">
-			</bounds>
+			<bounds x="129" y="245" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="162" y="243" width="35" height="18">
-			</bounds>
+			<bounds x="162" y="243" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="164" y="245" width="31" height="14">
-			</bounds>
+			<bounds x="164" y="245" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="197" y="243" width="35" height="18">
-			</bounds>
+			<bounds x="197" y="243" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="199" y="245" width="31" height="14">
-			</bounds>
+			<bounds x="199" y="245" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="232" y="243" width="35" height="18">
-			</bounds>
+			<bounds x="232" y="243" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="234" y="245" width="31" height="14">
-			</bounds>
+			<bounds x="234" y="245" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="267" y="243" width="35" height="18">
-			</bounds>
+			<bounds x="267" y="243" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="269" y="245" width="31" height="14">
-			</bounds>
+			<bounds x="269" y="245" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="302" y="243" width="35" height="18">
-			</bounds>
+			<bounds x="302" y="243" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="304" y="245" width="31" height="14">
-			</bounds>
+			<bounds x="304" y="245" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="337" y="243" width="35" height="18">
-			</bounds>
+			<bounds x="337" y="243" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="339" y="245" width="31" height="14">
-			</bounds>
+			<bounds x="339" y="245" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2_border" state="0">
-			<bounds x="127" y="74" width="35" height="18">
-			</bounds>
+			<bounds x="127" y="74" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2" state="0">
-			<bounds x="129" y="76" width="31" height="14">
-			</bounds>
+			<bounds x="129" y="76" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="162" y="74" width="35" height="18">
-			</bounds>
+			<bounds x="162" y="74" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="164" y="76" width="31" height="14">
-			</bounds>
+			<bounds x="164" y="76" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="197" y="74" width="35" height="18">
-			</bounds>
+			<bounds x="197" y="74" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="199" y="76" width="31" height="14">
-			</bounds>
+			<bounds x="199" y="76" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="232" y="74" width="35" height="18">
-			</bounds>
+			<bounds x="232" y="74" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="234" y="76" width="31" height="14">
-			</bounds>
+			<bounds x="234" y="76" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="267" y="74" width="35" height="18">
-			</bounds>
+			<bounds x="267" y="74" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="269" y="76" width="31" height="14">
-			</bounds>
+			<bounds x="269" y="76" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="302" y="74" width="35" height="18">
-			</bounds>
+			<bounds x="302" y="74" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="304" y="76" width="31" height="14">
-			</bounds>
+			<bounds x="304" y="76" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="337" y="74" width="35" height="18">
-			</bounds>
+			<bounds x="337" y="74" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="339" y="76" width="31" height="14">
-			</bounds>
+			<bounds x="339" y="76" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="377" y="273" width="49" height="27">
-			</bounds>
+			<bounds x="377" y="273" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="379" y="275" width="45" height="23">
-			</bounds>
+			<bounds x="379" y="275" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="327" y="273" width="49" height="27">
-			</bounds>
+			<bounds x="327" y="273" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="329" y="275" width="45" height="23">
-			</bounds>
+			<bounds x="329" y="275" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="277" y="273" width="49" height="27">
-			</bounds>
+			<bounds x="277" y="273" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="279" y="275" width="45" height="23">
-			</bounds>
+			<bounds x="279" y="275" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="227" y="273" width="49" height="27">
-			</bounds>
+			<bounds x="227" y="273" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="229" y="275" width="45" height="23">
-			</bounds>
+			<bounds x="229" y="275" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="177" y="273" width="49" height="27">
-			</bounds>
+			<bounds x="177" y="273" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="179" y="275" width="45" height="23">
-			</bounds>
+			<bounds x="179" y="275" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="127" y="273" width="49" height="27">
-			</bounds>
+			<bounds x="127" y="273" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="129" y="275" width="45" height="23">
-			</bounds>
+			<bounds x="129" y="275" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="377" y="44" width="49" height="27">
-			</bounds>
+			<bounds x="377" y="44" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="379" y="46" width="45" height="23">
-			</bounds>
+			<bounds x="379" y="46" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="327" y="44" width="49" height="27">
-			</bounds>
+			<bounds x="327" y="44" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="329" y="46" width="45" height="23">
-			</bounds>
+			<bounds x="329" y="46" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="277" y="44" width="49" height="27">
-			</bounds>
+			<bounds x="277" y="44" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="279" y="46" width="45" height="23">
-			</bounds>
+			<bounds x="279" y="46" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="227" y="44" width="49" height="27">
-			</bounds>
+			<bounds x="227" y="44" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="229" y="46" width="45" height="23">
-			</bounds>
+			<bounds x="229" y="46" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="177" y="44" width="49" height="27">
-			</bounds>
+			<bounds x="177" y="44" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="179" y="46" width="45" height="23">
-			</bounds>
+			<bounds x="179" y="46" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="127" y="44" width="49" height="27">
-			</bounds>
+			<bounds x="127" y="44" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="129" y="46" width="45" height="23">
-			</bounds>
+			<bounds x="129" y="46" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="431" y="106" width="62" height="34">
-			</bounds>
+			<bounds x="431" y="106" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="433" y="108" width="58" height="30">
-			</bounds>
+			<bounds x="433" y="108" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="431" y="73" width="62" height="21">
-			</bounds>
+			<bounds x="431" y="73" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="433" y="75" width="58" height="17">
-			</bounds>
+			<bounds x="433" y="75" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="431" y="139" width="62" height="34">
-			</bounds>
+			<bounds x="431" y="139" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="433" y="141" width="58" height="30">
-			</bounds>
+			<bounds x="433" y="141" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="431" y="172" width="62" height="34">
-			</bounds>
+			<bounds x="431" y="172" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="433" y="174" width="58" height="30">
-			</bounds>
+			<bounds x="433" y="174" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="431" y="205" width="62" height="21">
-			</bounds>
+			<bounds x="431" y="205" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="433" y="207" width="58" height="17">
-			</bounds>
+			<bounds x="433" y="207" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="431" y="238" width="62" height="34">
-			</bounds>
+			<bounds x="431" y="238" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="433" y="240" width="58" height="30">
-			</bounds>
+			<bounds x="433" y="240" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="431" y="271" width="62" height="21">
-			</bounds>
+			<bounds x="431" y="271" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="433" y="273" width="58" height="17">
-			</bounds>
+			<bounds x="433" y="273" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="431" y="7" width="62" height="21">
-			</bounds>
+			<bounds x="431" y="7" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="433" y="9" width="58" height="17">
-			</bounds>
+			<bounds x="433" y="9" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="431" y="304" width="62" height="21">
-			</bounds>
+			<bounds x="431" y="304" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="433" y="306" width="58" height="17">
-			</bounds>
+			<bounds x="433" y="306" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="4" y="40" width="62" height="21">
-			</bounds>
+			<bounds x="4" y="40" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="6" y="42" width="58" height="17">
-			</bounds>
+			<bounds x="6" y="42" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="4" y="304" width="62" height="21">
-			</bounds>
+			<bounds x="4" y="304" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="6" y="306" width="58" height="17">
-			</bounds>
+			<bounds x="6" y="306" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="4" y="271" width="62" height="34">
-			</bounds>
+			<bounds x="4" y="271" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="6" y="273" width="58" height="30">
-			</bounds>
+			<bounds x="6" y="273" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="4" y="7" width="62" height="21">
-			</bounds>
+			<bounds x="4" y="7" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="6" y="9" width="58" height="17">
-			</bounds>
+			<bounds x="6" y="9" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="4" y="73" width="62" height="34">
-			</bounds>
+			<bounds x="4" y="73" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="6" y="75" width="58" height="30">
-			</bounds>
+			<bounds x="6" y="75" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="4" y="106" width="62" height="21">
-			</bounds>
+			<bounds x="4" y="106" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="6" y="108" width="58" height="17">
-			</bounds>
+			<bounds x="6" y="108" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="4" y="139" width="62" height="34">
-			</bounds>
+			<bounds x="4" y="139" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="6" y="141" width="58" height="30">
-			</bounds>
+			<bounds x="6" y="141" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="4" y="172" width="62" height="21">
-			</bounds>
+			<bounds x="4" y="172" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="6" y="174" width="58" height="17">
-			</bounds>
+			<bounds x="6" y="174" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="4" y="238" width="62" height="21">
-			</bounds>
+			<bounds x="4" y="238" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="6" y="240" width="58" height="17">
-			</bounds>
+			<bounds x="6" y="240" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="500" y="130" width="72" height="30">
-			</bounds>
+			<bounds x="500" y="130" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="502" y="132" width="68" height="26">
-			</bounds>
+			<bounds x="502" y="132" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="294" y="158" width="132" height="29">
-			</bounds>
+			<bounds x="294" y="158" width="132" height="29"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="296" y="160" width="128" height="25">
-			</bounds>
+			<bounds x="296" y="160" width="128" height="25"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="126" y="304" width="62" height="21">
-			</bounds>
+			<bounds x="126" y="304" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="128" y="306" width="58" height="17">
-			</bounds>
+			<bounds x="128" y="306" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="377" y="72" width="49" height="27">
-			</bounds>
+			<bounds x="377" y="72" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="379" y="74" width="45" height="23">
-			</bounds>
+			<bounds x="379" y="74" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="187" y="304" width="62" height="34">
-			</bounds>
+			<bounds x="187" y="304" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="189" y="306" width="58" height="30">
-			</bounds>
+			<bounds x="189" y="306" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="248" y="304" width="62" height="21">
-			</bounds>
+			<bounds x="248" y="304" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="250" y="306" width="58" height="17">
-			</bounds>
+			<bounds x="250" y="306" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="370" y="304" width="62" height="21">
-			</bounds>
+			<bounds x="370" y="304" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="372" y="306" width="58" height="17">
-			</bounds>
+			<bounds x="372" y="306" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="309" y="304" width="62" height="21">
-			</bounds>
+			<bounds x="309" y="304" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="311" y="306" width="58" height="17">
-			</bounds>
+			<bounds x="311" y="306" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="65" y="7" width="62" height="34">
-			</bounds>
+			<bounds x="65" y="7" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="67" y="9" width="58" height="30">
-			</bounds>
+			<bounds x="67" y="9" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="126" y="7" width="62" height="34">
-			</bounds>
+			<bounds x="126" y="7" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="128" y="9" width="58" height="30">
-			</bounds>
+			<bounds x="128" y="9" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="377" y="245" width="49" height="27">
-			</bounds>
+			<bounds x="377" y="245" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="379" y="247" width="45" height="23">
-			</bounds>
+			<bounds x="379" y="247" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="377" y="217" width="49" height="27">
-			</bounds>
+			<bounds x="377" y="217" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="379" y="219" width="45" height="23">
-			</bounds>
+			<bounds x="379" y="219" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="377" y="189" width="49" height="27">
-			</bounds>
+			<bounds x="377" y="189" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="379" y="191" width="45" height="23">
-			</bounds>
+			<bounds x="379" y="191" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="337" y="128" width="35" height="18">
-			</bounds>
+			<bounds x="337" y="128" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="339" y="130" width="31" height="14">
-			</bounds>
+			<bounds x="339" y="130" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="337" y="101" width="35" height="18">
-			</bounds>
+			<bounds x="337" y="101" width="35" height="18"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="339" y="103" width="31" height="14">
-			</bounds>
+			<bounds x="339" y="103" width="31" height="14"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="377" y="128" width="49" height="27">
-			</bounds>
+			<bounds x="377" y="128" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="379" y="130" width="45" height="23">
-			</bounds>
+			<bounds x="379" y="130" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="377" y="100" width="49" height="27">
-			</bounds>
+			<bounds x="377" y="100" width="49" height="27"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="379" y="102" width="45" height="23">
-			</bounds>
+			<bounds x="379" y="102" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="370" y="7" width="62" height="21">
-			</bounds>
+			<bounds x="370" y="7" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="372" y="9" width="58" height="17">
-			</bounds>
+			<bounds x="372" y="9" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="309" y="7" width="62" height="21">
-			</bounds>
+			<bounds x="309" y="7" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="311" y="9" width="58" height="17">
-			</bounds>
+			<bounds x="311" y="9" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="248" y="7" width="62" height="21">
-			</bounds>
+			<bounds x="248" y="7" width="62" height="21"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="250" y="9" width="58" height="17">
-			</bounds>
+			<bounds x="250" y="9" width="58" height="17"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="187" y="7" width="62" height="34">
-			</bounds>
+			<bounds x="187" y="7" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="189" y="9" width="58" height="30">
-			</bounds>
+			<bounds x="189" y="9" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="672" y="513" width="43" height="8">
-			</bounds>
+			<bounds x="672" y="513" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="674" y="515" width="39" height="4">
-			</bounds>
+			<bounds x="674" y="515" width="39" height="4"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="655" y="444" width="52" height="19">
-			</bounds>
+			<bounds x="655" y="444" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="657" y="446" width="48" height="15">
-			</bounds>
+			<bounds x="657" y="446" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="654" y="425" width="57" height="19">
-			</bounds>
+			<bounds x="654" y="425" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="656" y="427" width="53" height="15">
-			</bounds>
+			<bounds x="656" y="427" width="53" height="15"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="647" y="482" width="42" height="19">
-			</bounds>
+			<bounds x="647" y="482" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="649" y="484" width="38" height="15">
-			</bounds>
+			<bounds x="649" y="484" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="656" y="463" width="47" height="19">
-			</bounds>
+			<bounds x="656" y="463" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="658" y="465" width="43" height="15">
-			</bounds>
+			<bounds x="658" y="465" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="637" y="501" width="37" height="19">
-			</bounds>
+			<bounds x="637" y="501" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="639" y="503" width="33" height="15">
-			</bounds>
+			<bounds x="639" y="503" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="627" y="520" width="32" height="19">
-			</bounds>
+			<bounds x="627" y="520" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="629" y="522" width="28" height="15">
-			</bounds>
+			<bounds x="629" y="522" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="600" y="526" width="27" height="19">
-			</bounds>
+			<bounds x="600" y="526" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="602" y="528" width="23" height="15">
-			</bounds>
+			<bounds x="602" y="528" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="578" y="532" width="22" height="19">
-			</bounds>
+			<bounds x="578" y="532" width="22" height="19"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="580" y="534" width="18" height="15">
-			</bounds>
+			<bounds x="580" y="534" width="18" height="15"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_2_border" state="0">
-			<bounds x="665" y="518" width="50" height="14">
-			</bounds>
+			<bounds x="665" y="518" width="50" height="14"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_2" state="0">
-			<bounds x="667" y="520" width="46" height="10">
-			</bounds>
+			<bounds x="667" y="520" width="46" height="10"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="522" y="535" width="55" height="16">
-			</bounds>
+			<bounds x="522" y="535" width="55" height="16"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="524" y="537" width="51" height="12">
-			</bounds>
+			<bounds x="524" y="537" width="51" height="12"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2_border" state="0">
-			<bounds x="162" y="89" width="35" height="12">
-			</bounds>
+			<bounds x="162" y="89" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2" state="0">
-			<bounds x="164" y="91" width="31" height="8">
-			</bounds>
+			<bounds x="164" y="91" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_2_border" state="0">
-			<bounds x="197" y="89" width="35" height="12">
-			</bounds>
+			<bounds x="197" y="89" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_2" state="0">
-			<bounds x="199" y="91" width="31" height="8">
-			</bounds>
+			<bounds x="199" y="91" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2_border" state="0">
-			<bounds x="337" y="89" width="35" height="12">
-			</bounds>
+			<bounds x="337" y="89" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2" state="0">
-			<bounds x="339" y="91" width="31" height="8">
-			</bounds>
+			<bounds x="339" y="91" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_2_border" state="0">
-			<bounds x="337" y="116" width="35" height="12">
-			</bounds>
+			<bounds x="337" y="116" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_2" state="0">
-			<bounds x="339" y="118" width="31" height="8">
-			</bounds>
+			<bounds x="339" y="118" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_2_border" state="0">
-			<bounds x="337" y="143" width="35" height="12">
-			</bounds>
+			<bounds x="337" y="143" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_2" state="0">
-			<bounds x="339" y="145" width="31" height="8">
-			</bounds>
+			<bounds x="339" y="145" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_2_border" state="0">
-			<bounds x="232" y="89" width="35" height="12">
-			</bounds>
+			<bounds x="232" y="89" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_2" state="0">
-			<bounds x="234" y="91" width="31" height="8">
-			</bounds>
+			<bounds x="234" y="91" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2_border" state="0">
-			<bounds x="267" y="89" width="35" height="12">
-			</bounds>
+			<bounds x="267" y="89" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2" state="0">
-			<bounds x="269" y="91" width="31" height="8">
-			</bounds>
+			<bounds x="269" y="91" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_2_border" state="0">
-			<bounds x="302" y="89" width="35" height="12">
-			</bounds>
+			<bounds x="302" y="89" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_2" state="0">
-			<bounds x="304" y="91" width="31" height="8">
-			</bounds>
+			<bounds x="304" y="91" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="94" y="319" width="17" height="19">
-			</bounds>
+			<bounds x="94" y="319" width="17" height="19"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="96" y="321" width="13" height="15">
-			</bounds>
+			<bounds x="96" y="321" width="13" height="15"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_2_border" state="0">
-			<bounds x="77" y="319" width="20" height="19">
-			</bounds>
+			<bounds x="77" y="319" width="20" height="19"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_2" state="0">
-			<bounds x="79" y="321" width="16" height="15">
-			</bounds>
+			<bounds x="79" y="321" width="16" height="15"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_3_border" state="0">
-			<bounds x="94" y="304" width="19" height="18">
-			</bounds>
+			<bounds x="94" y="304" width="19" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_3" state="0">
-			<bounds x="96" y="306" width="15" height="14">
-			</bounds>
+			<bounds x="96" y="306" width="15" height="14"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_4_border" state="0">
-			<bounds x="82" y="304" width="15" height="18">
-			</bounds>
+			<bounds x="82" y="304" width="15" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_4" state="0">
-			<bounds x="84" y="306" width="11" height="14">
-			</bounds>
+			<bounds x="84" y="306" width="11" height="14"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_5_border" state="0">
-			<bounds x="110" y="304" width="17" height="18">
-			</bounds>
+			<bounds x="110" y="304" width="17" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_5" state="0">
-			<bounds x="112" y="306" width="13" height="14">
-			</bounds>
+			<bounds x="112" y="306" width="13" height="14"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_6_border" state="0">
-			<bounds x="65" y="304" width="20" height="18">
-			</bounds>
+			<bounds x="65" y="304" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_6" state="0">
-			<bounds x="67" y="306" width="16" height="14">
-			</bounds>
+			<bounds x="67" y="306" width="16" height="14"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_7_border" state="0">
-			<bounds x="65" y="319" width="15" height="19">
-			</bounds>
+			<bounds x="65" y="319" width="15" height="19"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_7" state="0">
-			<bounds x="67" y="321" width="11" height="15">
-			</bounds>
+			<bounds x="67" y="321" width="11" height="15"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_8_border" state="0">
-			<bounds x="108" y="319" width="19" height="19">
-			</bounds>
+			<bounds x="108" y="319" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_8" state="0">
-			<bounds x="110" y="321" width="15" height="15">
-			</bounds>
+			<bounds x="110" y="321" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="4" y="205" width="20" height="18">
-			</bounds>
+			<bounds x="4" y="205" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="6" y="207" width="16" height="14">
-			</bounds>
+			<bounds x="6" y="207" width="16" height="14"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2_border" state="0">
-			<bounds x="21" y="205" width="15" height="18">
-			</bounds>
+			<bounds x="21" y="205" width="15" height="18"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2" state="0">
-			<bounds x="23" y="207" width="11" height="14">
-			</bounds>
+			<bounds x="23" y="207" width="11" height="14"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_3_border" state="0">
-			<bounds x="33" y="205" width="19" height="18">
-			</bounds>
+			<bounds x="33" y="205" width="19" height="18"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_3" state="0">
-			<bounds x="35" y="207" width="15" height="14">
-			</bounds>
+			<bounds x="35" y="207" width="15" height="14"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_4_border" state="0">
-			<bounds x="49" y="205" width="17" height="18">
-			</bounds>
+			<bounds x="49" y="205" width="17" height="18"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_4" state="0">
-			<bounds x="51" y="207" width="13" height="14">
-			</bounds>
+			<bounds x="51" y="207" width="13" height="14"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_5_border" state="0">
-			<bounds x="47" y="220" width="19" height="19">
-			</bounds>
+			<bounds x="47" y="220" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_5" state="0">
-			<bounds x="49" y="222" width="15" height="15">
-			</bounds>
+			<bounds x="49" y="222" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_6_border" state="0">
-			<bounds x="33" y="220" width="17" height="19">
-			</bounds>
+			<bounds x="33" y="220" width="17" height="19"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_6" state="0">
-			<bounds x="35" y="222" width="13" height="15">
-			</bounds>
+			<bounds x="35" y="222" width="13" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_7_border" state="0">
-			<bounds x="16" y="220" width="20" height="19">
-			</bounds>
+			<bounds x="16" y="220" width="20" height="19"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_7" state="0">
-			<bounds x="18" y="222" width="16" height="15">
-			</bounds>
+			<bounds x="18" y="222" width="16" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_8_border" state="0">
-			<bounds x="4" y="220" width="15" height="19">
-			</bounds>
+			<bounds x="4" y="220" width="15" height="19"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_8" state="0">
-			<bounds x="6" y="222" width="11" height="15">
-			</bounds>
+			<bounds x="6" y="222" width="11" height="15"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="474" y="55" width="19" height="19">
-			</bounds>
+			<bounds x="474" y="55" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="476" y="57" width="15" height="15">
-			</bounds>
+			<bounds x="476" y="57" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_2_border" state="0">
-			<bounds x="460" y="55" width="17" height="19">
-			</bounds>
+			<bounds x="460" y="55" width="17" height="19"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_2" state="0">
-			<bounds x="462" y="57" width="13" height="15">
-			</bounds>
+			<bounds x="462" y="57" width="13" height="15"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_3_border" state="0">
-			<bounds x="443" y="55" width="20" height="19">
-			</bounds>
+			<bounds x="443" y="55" width="20" height="19"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_3" state="0">
-			<bounds x="445" y="57" width="16" height="15">
-			</bounds>
+			<bounds x="445" y="57" width="16" height="15"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_4_border" state="0">
-			<bounds x="431" y="55" width="15" height="19">
-			</bounds>
+			<bounds x="431" y="55" width="15" height="19"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_4" state="0">
-			<bounds x="433" y="57" width="11" height="15">
-			</bounds>
+			<bounds x="433" y="57" width="11" height="15"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_5_border" state="0">
-			<bounds x="476" y="40" width="17" height="18">
-			</bounds>
+			<bounds x="476" y="40" width="17" height="18"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_5" state="0">
-			<bounds x="478" y="42" width="13" height="14">
-			</bounds>
+			<bounds x="478" y="42" width="13" height="14"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_6_border" state="0">
-			<bounds x="460" y="40" width="19" height="18">
-			</bounds>
+			<bounds x="460" y="40" width="19" height="18"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_6" state="0">
-			<bounds x="462" y="42" width="15" height="14">
-			</bounds>
+			<bounds x="462" y="42" width="15" height="14"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_7_border" state="0">
-			<bounds x="448" y="40" width="15" height="18">
-			</bounds>
+			<bounds x="448" y="40" width="15" height="18"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_7" state="0">
-			<bounds x="450" y="42" width="11" height="14">
-			</bounds>
+			<bounds x="450" y="42" width="11" height="14"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_8_border" state="0">
-			<bounds x="431" y="40" width="20" height="18">
-			</bounds>
+			<bounds x="431" y="40" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_8" state="0">
-			<bounds x="433" y="42" width="16" height="14">
-			</bounds>
+			<bounds x="433" y="42" width="16" height="14"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="483" y="344" width="37" height="27">
-			</bounds>
+			<bounds x="483" y="344" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="485" y="346" width="33" height="23">
-			</bounds>
+			<bounds x="485" y="346" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="456" y="344" width="30" height="27">
-			</bounds>
+			<bounds x="456" y="344" width="30" height="27"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="458" y="346" width="26" height="23">
-			</bounds>
+			<bounds x="458" y="346" width="26" height="23"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="506" y="368" width="40" height="27">
-			</bounds>
+			<bounds x="506" y="368" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="508" y="370" width="36" height="23">
-			</bounds>
+			<bounds x="508" y="370" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="423" y="368" width="45" height="27">
-			</bounds>
+			<bounds x="423" y="368" width="45" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="425" y="370" width="41" height="23">
-			</bounds>
+			<bounds x="425" y="370" width="41" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="465" y="368" width="44" height="27">
-			</bounds>
+			<bounds x="465" y="368" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="467" y="370" width="40" height="23">
-			</bounds>
+			<bounds x="467" y="370" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_2_border" state="0">
-			<bounds x="4" y="322" width="62" height="16">
-			</bounds>
+			<bounds x="4" y="322" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_2" state="0">
-			<bounds x="6" y="324" width="58" height="12">
-			</bounds>
+			<bounds x="6" y="324" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_2_border" state="0">
-			<bounds x="4" y="256" width="62" height="16">
-			</bounds>
+			<bounds x="4" y="256" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_2" state="0">
-			<bounds x="6" y="258" width="58" height="12">
-			</bounds>
+			<bounds x="6" y="258" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_2_border" state="0">
-			<bounds x="126" y="322" width="62" height="16">
-			</bounds>
+			<bounds x="126" y="322" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_2" state="0">
-			<bounds x="128" y="324" width="58" height="12">
-			</bounds>
+			<bounds x="128" y="324" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_2_border" state="0">
-			<bounds x="248" y="322" width="62" height="16">
-			</bounds>
+			<bounds x="248" y="322" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_2" state="0">
-			<bounds x="250" y="324" width="58" height="12">
-			</bounds>
+			<bounds x="250" y="324" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_2_border" state="0">
-			<bounds x="309" y="322" width="62" height="16">
-			</bounds>
+			<bounds x="309" y="322" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_2" state="0">
-			<bounds x="311" y="324" width="58" height="12">
-			</bounds>
+			<bounds x="311" y="324" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_2_border" state="0">
-			<bounds x="370" y="322" width="62" height="16">
-			</bounds>
+			<bounds x="370" y="322" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_2" state="0">
-			<bounds x="372" y="324" width="58" height="12">
-			</bounds>
+			<bounds x="372" y="324" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_2_border" state="0">
-			<bounds x="431" y="322" width="62" height="16">
-			</bounds>
+			<bounds x="431" y="322" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_2" state="0">
-			<bounds x="433" y="324" width="58" height="12">
-			</bounds>
+			<bounds x="433" y="324" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_2_border" state="0">
-			<bounds x="431" y="289" width="62" height="16">
-			</bounds>
+			<bounds x="431" y="289" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_2" state="0">
-			<bounds x="433" y="291" width="58" height="12">
-			</bounds>
+			<bounds x="433" y="291" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_2_border" state="0">
-			<bounds x="431" y="223" width="62" height="16">
-			</bounds>
+			<bounds x="431" y="223" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_2" state="0">
-			<bounds x="433" y="225" width="58" height="12">
-			</bounds>
+			<bounds x="433" y="225" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_2_border" state="0">
-			<bounds x="431" y="91" width="62" height="16">
-			</bounds>
+			<bounds x="431" y="91" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_2" state="0">
-			<bounds x="433" y="93" width="58" height="12">
-			</bounds>
+			<bounds x="433" y="93" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_2_border" state="0">
-			<bounds x="431" y="25" width="62" height="16">
-			</bounds>
+			<bounds x="431" y="25" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_2" state="0">
-			<bounds x="433" y="27" width="58" height="12">
-			</bounds>
+			<bounds x="433" y="27" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2_border" state="0">
-			<bounds x="370" y="25" width="62" height="16">
-			</bounds>
+			<bounds x="370" y="25" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2" state="0">
-			<bounds x="372" y="27" width="58" height="12">
-			</bounds>
+			<bounds x="372" y="27" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_2_border" state="0">
-			<bounds x="309" y="25" width="62" height="16">
-			</bounds>
+			<bounds x="309" y="25" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_2" state="0">
-			<bounds x="311" y="27" width="58" height="12">
-			</bounds>
+			<bounds x="311" y="27" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_2_border" state="0">
-			<bounds x="248" y="25" width="62" height="16">
-			</bounds>
+			<bounds x="248" y="25" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_2" state="0">
-			<bounds x="250" y="27" width="58" height="12">
-			</bounds>
+			<bounds x="250" y="27" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_2_border" state="0">
-			<bounds x="4" y="25" width="62" height="16">
-			</bounds>
+			<bounds x="4" y="25" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_2" state="0">
-			<bounds x="6" y="27" width="58" height="12">
-			</bounds>
+			<bounds x="6" y="27" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_2_border" state="0">
-			<bounds x="4" y="58" width="62" height="16">
-			</bounds>
+			<bounds x="4" y="58" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_2" state="0">
-			<bounds x="6" y="60" width="58" height="12">
-			</bounds>
+			<bounds x="6" y="60" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2_border" state="0">
-			<bounds x="4" y="124" width="62" height="16">
-			</bounds>
+			<bounds x="4" y="124" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2" state="0">
-			<bounds x="6" y="126" width="58" height="12">
-			</bounds>
+			<bounds x="6" y="126" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_2_border" state="0">
-			<bounds x="4" y="190" width="62" height="16">
-			</bounds>
+			<bounds x="4" y="190" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_2" state="0">
-			<bounds x="6" y="192" width="58" height="12">
-			</bounds>
+			<bounds x="6" y="192" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="621" y="270" width="92" height="26">
-			</bounds>
+			<bounds x="621" y="270" width="92" height="26"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="623" y="272" width="88" height="22">
-			</bounds>
+			<bounds x="623" y="272" width="88" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="611" y="217" width="102" height="28">
-			</bounds>
+			<bounds x="611" y="217" width="102" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="613" y="219" width="98" height="24">
-			</bounds>
+			<bounds x="613" y="219" width="98" height="24"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="601" y="160" width="112" height="30">
-			</bounds>
+			<bounds x="601" y="160" width="112" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="603" y="162" width="108" height="26">
-			</bounds>
+			<bounds x="603" y="162" width="108" height="26"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="606" y="189" width="107" height="29">
-			</bounds>
+			<bounds x="606" y="189" width="107" height="29"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="608" y="191" width="103" height="25">
-			</bounds>
+			<bounds x="608" y="191" width="103" height="25"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="616" y="244" width="97" height="27">
-			</bounds>
+			<bounds x="616" y="244" width="97" height="27"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="618" y="246" width="93" height="23">
-			</bounds>
+			<bounds x="618" y="246" width="93" height="23"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="626" y="295" width="87" height="25">
-			</bounds>
+			<bounds x="626" y="295" width="87" height="25"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="628" y="297" width="83" height="21">
-			</bounds>
+			<bounds x="628" y="297" width="83" height="21"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="631" y="319" width="82" height="24">
-			</bounds>
+			<bounds x="631" y="319" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="633" y="321" width="78" height="20">
-			</bounds>
+			<bounds x="633" y="321" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="641" y="364" width="72" height="22">
-			</bounds>
+			<bounds x="641" y="364" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="643" y="366" width="68" height="18">
-			</bounds>
+			<bounds x="643" y="366" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="646" y="385" width="67" height="21">
-			</bounds>
+			<bounds x="646" y="385" width="67" height="21"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="648" y="387" width="63" height="17">
-			</bounds>
+			<bounds x="648" y="387" width="63" height="17"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="651" y="405" width="62" height="20">
-			</bounds>
+			<bounds x="651" y="405" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="653" y="407" width="58" height="16">
-			</bounds>
+			<bounds x="653" y="407" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="636" y="342" width="77" height="23">
-			</bounds>
+			<bounds x="636" y="342" width="77" height="23"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="638" y="344" width="73" height="19">
-			</bounds>
+			<bounds x="638" y="344" width="73" height="19"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="591" y="99" width="122" height="32">
-			</bounds>
+			<bounds x="591" y="99" width="122" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="593" y="101" width="118" height="28">
-			</bounds>
+			<bounds x="593" y="101" width="118" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="596" y="130" width="117" height="31">
-			</bounds>
+			<bounds x="596" y="130" width="117" height="31"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="598" y="132" width="113" height="27">
-			</bounds>
+			<bounds x="598" y="132" width="113" height="27"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="566" y="62" width="147" height="27">
-			</bounds>
+			<bounds x="566" y="62" width="147" height="27"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="568" y="64" width="143" height="23">
-			</bounds>
+			<bounds x="568" y="64" width="143" height="23"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="571" y="105" width="20" height="20">
-			</bounds>
+			<bounds x="571" y="105" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="573" y="107" width="16" height="16">
-			</bounds>
+			<bounds x="573" y="107" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="576" y="135" width="20" height="20">
-			</bounds>
+			<bounds x="576" y="135" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="578" y="137" width="16" height="16">
-			</bounds>
+			<bounds x="578" y="137" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="611" y="321" width="20" height="20">
-			</bounds>
+			<bounds x="611" y="321" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="613" y="323" width="16" height="16">
-			</bounds>
+			<bounds x="613" y="323" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="606" y="297" width="20" height="20">
-			</bounds>
+			<bounds x="606" y="297" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="608" y="299" width="16" height="16">
-			</bounds>
+			<bounds x="608" y="299" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="601" y="273" width="20" height="20">
-			</bounds>
+			<bounds x="601" y="273" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="603" y="275" width="16" height="16">
-			</bounds>
+			<bounds x="603" y="275" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="596" y="247" width="20" height="20">
-			</bounds>
+			<bounds x="596" y="247" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="598" y="249" width="16" height="16">
-			</bounds>
+			<bounds x="598" y="249" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="581" y="165" width="20" height="20">
-			</bounds>
+			<bounds x="581" y="165" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="583" y="167" width="16" height="16">
-			</bounds>
+			<bounds x="583" y="167" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="586" y="193" width="20" height="20">
-			</bounds>
+			<bounds x="586" y="193" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="588" y="195" width="16" height="16">
-			</bounds>
+			<bounds x="588" y="195" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="591" y="221" width="20" height="20">
-			</bounds>
+			<bounds x="591" y="221" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="593" y="223" width="16" height="16">
-			</bounds>
+			<bounds x="593" y="223" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="616" y="343" width="20" height="20">
-			</bounds>
+			<bounds x="616" y="343" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="618" y="345" width="16" height="16">
-			</bounds>
+			<bounds x="618" y="345" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="621" y="365" width="20" height="20">
-			</bounds>
+			<bounds x="621" y="365" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="623" y="367" width="16" height="16">
-			</bounds>
+			<bounds x="623" y="367" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="626" y="385" width="20" height="20">
-			</bounds>
+			<bounds x="626" y="385" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="628" y="387" width="16" height="16">
-			</bounds>
+			<bounds x="628" y="387" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="631" y="405" width="20" height="20">
-			</bounds>
+			<bounds x="631" y="405" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="633" y="407" width="16" height="16">
-			</bounds>
+			<bounds x="633" y="407" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_2_border" state="0">
-			<bounds x="566" y="86" width="147" height="14">
-			</bounds>
+			<bounds x="566" y="86" width="147" height="14"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_2" state="0">
-			<bounds x="568" y="88" width="143" height="10">
-			</bounds>
+			<bounds x="568" y="88" width="143" height="10"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2_border" state="0">
-			<bounds x="337" y="204" width="35" height="12">
-			</bounds>
+			<bounds x="337" y="204" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2" state="0">
-			<bounds x="339" y="206" width="31" height="8">
-			</bounds>
+			<bounds x="339" y="206" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_2_border" state="0">
-			<bounds x="337" y="231" width="35" height="12">
-			</bounds>
+			<bounds x="337" y="231" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_2" state="0">
-			<bounds x="339" y="233" width="31" height="8">
-			</bounds>
+			<bounds x="339" y="233" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_2_border" state="0">
-			<bounds x="337" y="258" width="35" height="12">
-			</bounds>
+			<bounds x="337" y="258" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_2" state="0">
-			<bounds x="339" y="260" width="31" height="8">
-			</bounds>
+			<bounds x="339" y="260" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_2_border" state="0">
-			<bounds x="127" y="258" width="35" height="12">
-			</bounds>
+			<bounds x="127" y="258" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_2" state="0">
-			<bounds x="129" y="260" width="31" height="8">
-			</bounds>
+			<bounds x="129" y="260" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_2_border" state="0">
-			<bounds x="162" y="258" width="35" height="12">
-			</bounds>
+			<bounds x="162" y="258" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_2" state="0">
-			<bounds x="164" y="260" width="31" height="8">
-			</bounds>
+			<bounds x="164" y="260" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_2_border" state="0">
-			<bounds x="197" y="258" width="35" height="12">
-			</bounds>
+			<bounds x="197" y="258" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_2" state="0">
-			<bounds x="199" y="260" width="31" height="8">
-			</bounds>
+			<bounds x="199" y="260" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_2_border" state="0">
-			<bounds x="232" y="258" width="35" height="12">
-			</bounds>
+			<bounds x="232" y="258" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_2" state="0">
-			<bounds x="234" y="260" width="31" height="8">
-			</bounds>
+			<bounds x="234" y="260" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_2_border" state="0">
-			<bounds x="267" y="258" width="35" height="12">
-			</bounds>
+			<bounds x="267" y="258" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_2" state="0">
-			<bounds x="269" y="260" width="31" height="8">
-			</bounds>
+			<bounds x="269" y="260" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_2_border" state="0">
-			<bounds x="303" y="258" width="35" height="12">
-			</bounds>
+			<bounds x="303" y="258" width="35" height="12"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_2" state="0">
-			<bounds x="305" y="260" width="31" height="8">
-			</bounds>
+			<bounds x="305" y="260" width="31" height="8"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="88" y="147" width="30" height="27">
-			</bounds>
+			<bounds x="88" y="147" width="30" height="27"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="90" y="149" width="26" height="23">
-			</bounds>
+			<bounds x="90" y="149" width="26" height="23"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="88" y="174" width="30" height="27">
-			</bounds>
+			<bounds x="88" y="174" width="30" height="27"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="90" y="176" width="26" height="23">
-			</bounds>
+			<bounds x="90" y="176" width="26" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_301_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="618" y="7" width="42" height="47">
-			</bounds>
+			<bounds x="618" y="7" width="42" height="47"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_301" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="620" y="9" width="38" height="43">
-			</bounds>
+			<bounds x="620" y="9" width="38" height="43"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_302_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="22" y="605" width="67" height="42">
-			</bounds>
+			<bounds x="22" y="605" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_302" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="24" y="607" width="63" height="38">
-			</bounds>
+			<bounds x="24" y="607" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_303_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="126" y="604" width="67" height="42">
-			</bounds>
+			<bounds x="126" y="604" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_303" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="128" y="606" width="63" height="38">
-			</bounds>
+			<bounds x="128" y="606" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_304_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="263" y="605" width="67" height="42">
-			</bounds>
+			<bounds x="263" y="605" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_304" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="265" y="607" width="63" height="38">
-			</bounds>
+			<bounds x="265" y="607" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_305_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="400" y="605" width="67" height="42">
-			</bounds>
+			<bounds x="400" y="605" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_305" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="402" y="607" width="63" height="38">
-			</bounds>
+			<bounds x="402" y="607" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp202" element="colour_button_306_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="71" y="46" width="55" height="23">
-			</bounds>
+			<bounds x="71" y="46" width="55" height="23"/>
 		</backdrop>
 		<backdrop name="lamp202" element="colour_button_306" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="73" y="48" width="51" height="19">
-			</bounds>
+			<bounds x="73" y="48" width="51" height="19"/>
 		</backdrop>
 		<backdrop name="lamp175" element="colour_button_307_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="71" y="245" width="55" height="23">
-			</bounds>
+			<bounds x="71" y="245" width="55" height="23"/>
 		</backdrop>
 		<backdrop name="lamp175" element="colour_button_307" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="73" y="247" width="51" height="19">
-			</bounds>
+			<bounds x="73" y="247" width="51" height="19"/>
 		</backdrop>
 		<backdrop name="lamp201" element="colour_button_308_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="71" y="76" width="55" height="23">
-			</bounds>
+			<bounds x="71" y="76" width="55" height="23"/>
 		</backdrop>
 		<backdrop name="lamp201" element="colour_button_308" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="73" y="78" width="51" height="19">
-			</bounds>
+			<bounds x="73" y="78" width="51" height="19"/>
 		</backdrop>
 		<backdrop name="lamp165" element="colour_button_309_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="71" y="275" width="55" height="23">
-			</bounds>
+			<bounds x="71" y="275" width="55" height="23"/>
 		</backdrop>
 		<backdrop name="lamp165" element="colour_button_309" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="73" y="277" width="51" height="19">
-			</bounds>
+			<bounds x="73" y="277" width="51" height="19"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_310_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="495" y="605" width="67" height="42">
-			</bounds>
+			<bounds x="495" y="605" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_310" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="497" y="607" width="63" height="38">
-			</bounds>
+			<bounds x="497" y="607" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_311_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="644" y="605" width="67" height="42">
-			</bounds>
+			<bounds x="644" y="605" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_311" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="646" y="607" width="63" height="38">
-			</bounds>
+			<bounds x="646" y="607" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_312_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="569" y="605" width="67" height="42">
-			</bounds>
+			<bounds x="569" y="605" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_312" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="571" y="607" width="63" height="38">
-			</bounds>
+			<bounds x="571" y="607" width="63" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="116" y="354" width="240" height="26">
-			</bounds>
+			<bounds x="116" y="354" width="240" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="116" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="116" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="131" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="131" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="146" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="146" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="161" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="161" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="176" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="176" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="191" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="191" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="206" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="206" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="221" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="221" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="236" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="236" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="251" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="251" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="266" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="266" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="281" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="281" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="296" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="296" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="311" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="311" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="326" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="326" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="341" y="354" width="15" height="26">
-			</bounds>
+			<bounds x="341" y="354" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="label195" element="label_195">
-			<bounds x="207" y="453" width="42" height="27">
-			</bounds>
+			<bounds x="207" y="453" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="label196" element="label_196">
-			<bounds x="344" y="453" width="42" height="27">
-			</bounds>
+			<bounds x="344" y="453" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="label197" element="label_197">
-			<bounds x="204" y="468" width="50" height="27">
-			</bounds>
+			<bounds x="204" y="468" width="50" height="27"/>
 		</backdrop>
 		<backdrop name="label198" element="label_198">
-			<bounds x="341" y="468" width="50" height="27">
-			</bounds>
+			<bounds x="341" y="468" width="50" height="27"/>
 		</backdrop>
 		<backdrop name="label233" element="label_233">
-			<bounds x="388" y="337" width="26" height="11">
-			</bounds>
+			<bounds x="388" y="337" width="26" height="11"/>
 		</backdrop>
 		<backdrop name="label257" element="label_257">
-			<bounds x="127" y="375" width="50" height="23">
-			</bounds>
+			<bounds x="127" y="375" width="50" height="23"/>
 		</backdrop>
 		<backdrop name="label258" element="label_258">
-			<bounds x="300" y="376" width="59" height="23">
-			</bounds>
+			<bounds x="300" y="376" width="59" height="23"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_button" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_button" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_button" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_button" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1gladg.lay
+++ b/src/mame/layout/m1gladg.lay
@@ -8,15520 +8,8737 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHEERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHEERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MIXED BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MIXED BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YELLOW BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YELLOW BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BLUE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BLUE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RED 7S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED 7S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ATLASP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ATLASP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HERES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HERES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="GAME OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="GAME OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_142_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_143_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_144_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_145_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_146_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GLA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GLA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DIAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="DIAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ORS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ORS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HANG TOUGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HANG TOUGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="THE WALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="THE WALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JOUST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JOUST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BITE THE DUST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BITE THE DUST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="POLE AXE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="POLE AXE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HANG TOUGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HANG TOUGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE PMY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE PMY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ATLASPHERES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ATLASPHERES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HANG TOUGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HANG TOUGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ELMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ELMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SKY TRAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKY TRAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE PYM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ELIMINATOD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ELIMINATOD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BITE THE DUST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BITE THE DUST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.OO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.OO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PYRAIMID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PYRAIMID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WHISTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BITE THE DUST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BITE THE DUST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PYRAMID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PYRAMID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="POWERBALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="POWERBALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SWING SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SWING SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HIT &#x26; RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HIT &#x26; RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_255_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_255_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RE MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RE MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MATRIX HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MATRIX HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist=",,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1127" height="816">
-			</bounds>
+			<bounds x="0" y="0" width="1127" height="816"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="172" y="624" width="80" height="140">
-			</bounds>
+			<bounds x="172" y="624" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="172.0000" y="624.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="172.0000" y="624.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="175.3333" y="625.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="175.3333" y="625.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="178.6667" y="627.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="178.6667" y="627.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="182.0000" y="629.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="182.0000" y="629.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="185.3333" y="631.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="185.3333" y="631.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="188.6667" y="633.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="188.6667" y="633.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="172.0000" y="670.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="172.0000" y="670.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="175.3333" y="672.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="175.3333" y="672.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="178.6667" y="674.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="178.6667" y="674.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="182.0000" y="676.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="182.0000" y="676.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="185.3333" y="678.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="185.3333" y="678.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="188.6667" y="680.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="188.6667" y="680.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="172.0000" y="717.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="172.0000" y="717.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="175.3333" y="719.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="175.3333" y="719.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="178.6667" y="721.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="178.6667" y="721.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="182.0000" y="723.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="182.0000" y="723.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="185.3333" y="725.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="185.3333" y="725.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="188.6667" y="727.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="188.6667" y="727.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="172" y="624" width="80" height="140">
-			</bounds>
+			<bounds x="172" y="624" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="260" y="623" width="80" height="140">
-			</bounds>
+			<bounds x="260" y="623" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="260.0000" y="623.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="260.0000" y="623.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="263.3333" y="624.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="263.3333" y="624.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="266.6667" y="626.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="266.6667" y="626.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="270.0000" y="628.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="270.0000" y="628.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="273.3333" y="630.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="273.3333" y="630.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="276.6667" y="632.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="276.6667" y="632.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="260.0000" y="669.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="260.0000" y="669.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="263.3333" y="671.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="263.3333" y="671.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="266.6667" y="673.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="266.6667" y="673.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="270.0000" y="675.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="270.0000" y="675.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="273.3333" y="677.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="273.3333" y="677.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="276.6667" y="679.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="276.6667" y="679.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="260.0000" y="716.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="260.0000" y="716.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="263.3333" y="718.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="263.3333" y="718.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="266.6667" y="720.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="266.6667" y="720.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="270.0000" y="722.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="270.0000" y="722.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="273.3333" y="724.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="273.3333" y="724.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="276.6667" y="726.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="276.6667" y="726.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="260" y="623" width="80" height="140">
-			</bounds>
+			<bounds x="260" y="623" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="347" y="623" width="80" height="140">
-			</bounds>
+			<bounds x="347" y="623" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="347.0000" y="623.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="347.0000" y="623.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="350.3333" y="624.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="350.3333" y="624.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="353.6667" y="626.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="353.6667" y="626.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="357.0000" y="628.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="357.0000" y="628.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="360.3333" y="630.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="360.3333" y="630.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="363.6667" y="632.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="363.6667" y="632.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="347.0000" y="669.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="347.0000" y="669.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="350.3333" y="671.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="350.3333" y="671.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="353.6667" y="673.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="353.6667" y="673.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="357.0000" y="675.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="357.0000" y="675.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="360.3333" y="677.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="360.3333" y="677.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="363.6667" y="679.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="363.6667" y="679.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="347.0000" y="716.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="347.0000" y="716.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="350.3333" y="718.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="350.3333" y="718.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="353.6667" y="720.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="353.6667" y="720.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="357.0000" y="722.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="357.0000" y="722.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="360.3333" y="724.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="360.3333" y="724.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="363.6667" y="726.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="363.6667" y="726.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="347" y="623" width="80" height="140">
-			</bounds>
+			<bounds x="347" y="623" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="116" y="228" width="80" height="140">
-			</bounds>
+			<bounds x="116" y="228" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="228.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="228.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="119.3333" y="229.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="119.3333" y="229.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="122.6667" y="231.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="122.6667" y="231.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="126.0000" y="233.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="126.0000" y="233.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="129.3333" y="235.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="129.3333" y="235.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="132.6667" y="237.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="132.6667" y="237.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="274.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="274.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="119.3333" y="276.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="119.3333" y="276.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="122.6667" y="278.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="122.6667" y="278.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="126.0000" y="280.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="126.0000" y="280.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="129.3333" y="282.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="129.3333" y="282.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="132.6667" y="284.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="132.6667" y="284.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="321.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="321.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="119.3333" y="323.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="119.3333" y="323.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="122.6667" y="325.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="122.6667" y="325.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="126.0000" y="327.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="126.0000" y="327.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="129.3333" y="329.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="129.3333" y="329.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="132.6667" y="331.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="132.6667" y="331.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="116" y="228" width="80" height="140">
-			</bounds>
+			<bounds x="116" y="228" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="446" y="529" width="70" height="22">
-			</bounds>
+			<bounds x="446" y="529" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="448" y="531" width="66" height="18">
-			</bounds>
+			<bounds x="448" y="531" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="114" y="545" width="42" height="42">
-			</bounds>
+			<bounds x="114" y="545" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="116" y="547" width="38" height="38">
-			</bounds>
+			<bounds x="116" y="547" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="114" y="589" width="42" height="42">
-			</bounds>
+			<bounds x="114" y="589" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="116" y="591" width="38" height="38">
-			</bounds>
+			<bounds x="116" y="591" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="114" y="633" width="42" height="42">
-			</bounds>
+			<bounds x="114" y="633" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="116" y="635" width="38" height="38">
-			</bounds>
+			<bounds x="116" y="635" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="115" y="677" width="42" height="42">
-			</bounds>
+			<bounds x="115" y="677" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="117" y="679" width="38" height="38">
-			</bounds>
+			<bounds x="117" y="679" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="115" y="722" width="42" height="42">
-			</bounds>
+			<bounds x="115" y="722" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="117" y="724" width="38" height="38">
-			</bounds>
+			<bounds x="117" y="724" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="671" y="741" width="102" height="52">
-			</bounds>
+			<bounds x="671" y="741" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="673" y="743" width="98" height="48">
-			</bounds>
+			<bounds x="673" y="743" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="770" y="741" width="52" height="52">
-			</bounds>
+			<bounds x="770" y="741" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="772" y="743" width="48" height="48">
-			</bounds>
+			<bounds x="772" y="743" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="820" y="741" width="102" height="52">
-			</bounds>
+			<bounds x="820" y="741" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="822" y="743" width="98" height="48">
-			</bounds>
+			<bounds x="822" y="743" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="919" y="741" width="52" height="52">
-			</bounds>
+			<bounds x="919" y="741" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="921" y="743" width="48" height="48">
-			</bounds>
+			<bounds x="921" y="743" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="969" y="741" width="102" height="52">
-			</bounds>
+			<bounds x="969" y="741" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="971" y="743" width="98" height="48">
-			</bounds>
+			<bounds x="971" y="743" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="1068" y="741" width="52" height="52">
-			</bounds>
+			<bounds x="1068" y="741" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="1070" y="743" width="48" height="48">
-			</bounds>
+			<bounds x="1070" y="743" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="749" y="691" width="102" height="52">
-			</bounds>
+			<bounds x="749" y="691" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="751" y="693" width="98" height="48">
-			</bounds>
+			<bounds x="751" y="693" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="848" y="691" width="52" height="52">
-			</bounds>
+			<bounds x="848" y="691" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="850" y="693" width="48" height="48">
-			</bounds>
+			<bounds x="850" y="693" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="899" y="691" width="102" height="52">
-			</bounds>
+			<bounds x="899" y="691" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="901" y="693" width="98" height="48">
-			</bounds>
+			<bounds x="901" y="693" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="998" y="691" width="52" height="52">
-			</bounds>
+			<bounds x="998" y="691" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="1000" y="693" width="48" height="48">
-			</bounds>
+			<bounds x="1000" y="693" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="830" y="641" width="102" height="52">
-			</bounds>
+			<bounds x="830" y="641" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="832" y="643" width="98" height="48">
-			</bounds>
+			<bounds x="832" y="643" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="929" y="641" width="52" height="52">
-			</bounds>
+			<bounds x="929" y="641" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="931" y="643" width="48" height="48">
-			</bounds>
+			<bounds x="931" y="643" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="830" y="591" width="102" height="52">
-			</bounds>
+			<bounds x="830" y="591" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="832" y="593" width="98" height="48">
-			</bounds>
+			<bounds x="832" y="593" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="929" y="591" width="52" height="52">
-			</bounds>
+			<bounds x="929" y="591" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="931" y="593" width="48" height="48">
-			</bounds>
+			<bounds x="931" y="593" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="275" y="268" width="66" height="22">
-			</bounds>
+			<bounds x="275" y="268" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="277" y="270" width="62" height="18">
-			</bounds>
+			<bounds x="277" y="270" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="11" y="443" width="19" height="52">
-			</bounds>
+			<bounds x="11" y="443" width="19" height="52"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="13" y="445" width="15" height="48">
-			</bounds>
+			<bounds x="13" y="445" width="15" height="48"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="11" y="492" width="19" height="29">
-			</bounds>
+			<bounds x="11" y="492" width="19" height="29"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="13" y="494" width="15" height="25">
-			</bounds>
+			<bounds x="13" y="494" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="11" y="518" width="19" height="29">
-			</bounds>
+			<bounds x="11" y="518" width="19" height="29"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="13" y="520" width="15" height="25">
-			</bounds>
+			<bounds x="13" y="520" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="88" y="545" width="24" height="24">
-			</bounds>
+			<bounds x="88" y="545" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="90" y="547" width="20" height="20">
-			</bounds>
+			<bounds x="90" y="547" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="68" y="523" width="24" height="24">
-			</bounds>
+			<bounds x="68" y="523" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="70" y="525" width="20" height="20">
-			</bounds>
+			<bounds x="70" y="525" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="96" y="517" width="24" height="24">
-			</bounds>
+			<bounds x="96" y="517" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="98" y="519" width="20" height="20">
-			</bounds>
+			<bounds x="98" y="519" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="58" y="500" width="24" height="24">
-			</bounds>
+			<bounds x="58" y="500" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="60" y="502" width="20" height="20">
-			</bounds>
+			<bounds x="60" y="502" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="88" y="489" width="24" height="24">
-			</bounds>
+			<bounds x="88" y="489" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="90" y="491" width="20" height="20">
-			</bounds>
+			<bounds x="90" y="491" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="47" y="472" width="26" height="26">
-			</bounds>
+			<bounds x="47" y="472" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="49" y="474" width="22" height="22">
-			</bounds>
+			<bounds x="49" y="474" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="76" y="464" width="24" height="24">
-			</bounds>
+			<bounds x="76" y="464" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="78" y="466" width="20" height="20">
-			</bounds>
+			<bounds x="78" y="466" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="34" y="446" width="26" height="26">
-			</bounds>
+			<bounds x="34" y="446" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="36" y="448" width="22" height="22">
-			</bounds>
+			<bounds x="36" y="448" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="61" y="437" width="24" height="24">
-			</bounds>
+			<bounds x="61" y="437" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="63" y="439" width="20" height="20">
-			</bounds>
+			<bounds x="63" y="439" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="37" y="417" width="24" height="24">
-			</bounds>
+			<bounds x="37" y="417" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="39" y="419" width="20" height="20">
-			</bounds>
+			<bounds x="39" y="419" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="22" y="205" width="19" height="42">
-			</bounds>
+			<bounds x="22" y="205" width="19" height="42"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="24" y="207" width="15" height="38">
-			</bounds>
+			<bounds x="24" y="207" width="15" height="38"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="22" y="166" width="19" height="42">
-			</bounds>
+			<bounds x="22" y="166" width="19" height="42"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="24" y="168" width="15" height="38">
-			</bounds>
+			<bounds x="24" y="168" width="15" height="38"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="22" y="127" width="19" height="42">
-			</bounds>
+			<bounds x="22" y="127" width="19" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="24" y="129" width="15" height="38">
-			</bounds>
+			<bounds x="24" y="129" width="15" height="38"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="22" y="88" width="19" height="42">
-			</bounds>
+			<bounds x="22" y="88" width="19" height="42"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="24" y="90" width="15" height="38">
-			</bounds>
+			<bounds x="24" y="90" width="15" height="38"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="22" y="50" width="19" height="42">
-			</bounds>
+			<bounds x="22" y="50" width="19" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="24" y="52" width="15" height="38">
-			</bounds>
+			<bounds x="24" y="52" width="15" height="38"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="22" y="1" width="19" height="52">
-			</bounds>
+			<bounds x="22" y="1" width="19" height="52"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="24" y="3" width="15" height="48">
-			</bounds>
+			<bounds x="24" y="3" width="15" height="48"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="6" y="9" width="19" height="19">
-			</bounds>
+			<bounds x="6" y="9" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="8" y="11" width="15" height="15">
-			</bounds>
+			<bounds x="8" y="11" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="37" y="10" width="19" height="19">
-			</bounds>
+			<bounds x="37" y="10" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="39" y="12" width="15" height="15">
-			</bounds>
+			<bounds x="39" y="12" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="166" y="10" width="47" height="19">
-			</bounds>
+			<bounds x="166" y="10" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="168" y="12" width="43" height="15">
-			</bounds>
+			<bounds x="168" y="12" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="210" y="10" width="42" height="19">
-			</bounds>
+			<bounds x="210" y="10" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="212" y="12" width="38" height="15">
-			</bounds>
+			<bounds x="212" y="12" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="99" y="43" width="37" height="37">
-			</bounds>
+			<bounds x="99" y="43" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="101" y="45" width="33" height="33">
-			</bounds>
+			<bounds x="101" y="45" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="65" y="33" width="32" height="32">
-			</bounds>
+			<bounds x="65" y="33" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="67" y="35" width="28" height="28">
-			</bounds>
+			<bounds x="67" y="35" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_2_border" state="0">
-			<bounds x="38" y="205" width="19" height="19">
-			</bounds>
+			<bounds x="38" y="205" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_2" state="0">
-			<bounds x="40" y="207" width="15" height="15">
-			</bounds>
+			<bounds x="40" y="207" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2_border" state="0">
-			<bounds x="6" y="174" width="19" height="19">
-			</bounds>
+			<bounds x="6" y="174" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2" state="0">
-			<bounds x="8" y="176" width="15" height="15">
-			</bounds>
+			<bounds x="8" y="176" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_2_border" state="0">
-			<bounds x="38" y="136" width="19" height="19">
-			</bounds>
+			<bounds x="38" y="136" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_2" state="0">
-			<bounds x="40" y="138" width="15" height="15">
-			</bounds>
+			<bounds x="40" y="138" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_2_border" state="0">
-			<bounds x="6" y="98" width="19" height="19">
-			</bounds>
+			<bounds x="6" y="98" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_2" state="0">
-			<bounds x="8" y="100" width="15" height="15">
-			</bounds>
+			<bounds x="8" y="100" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2_border" state="0">
-			<bounds x="38" y="56" width="19" height="19">
-			</bounds>
+			<bounds x="38" y="56" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2" state="0">
-			<bounds x="40" y="58" width="15" height="15">
-			</bounds>
+			<bounds x="40" y="58" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="422" y="114" width="32" height="22">
-			</bounds>
+			<bounds x="422" y="114" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="424" y="116" width="28" height="18">
-			</bounds>
+			<bounds x="424" y="116" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="391" y="114" width="32" height="22">
-			</bounds>
+			<bounds x="391" y="114" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="393" y="116" width="28" height="18">
-			</bounds>
+			<bounds x="393" y="116" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="360" y="114" width="32" height="22">
-			</bounds>
+			<bounds x="360" y="114" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="362" y="116" width="28" height="18">
-			</bounds>
+			<bounds x="362" y="116" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="329" y="114" width="32" height="22">
-			</bounds>
+			<bounds x="329" y="114" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="331" y="116" width="28" height="18">
-			</bounds>
+			<bounds x="331" y="116" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="298" y="114" width="32" height="22">
-			</bounds>
+			<bounds x="298" y="114" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="300" y="116" width="28" height="18">
-			</bounds>
+			<bounds x="300" y="116" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="306" y="143" width="47" height="27">
-			</bounds>
+			<bounds x="306" y="143" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="308" y="145" width="43" height="23">
-			</bounds>
+			<bounds x="308" y="145" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="350" y="143" width="52" height="27">
-			</bounds>
+			<bounds x="350" y="143" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="352" y="145" width="48" height="23">
-			</bounds>
+			<bounds x="352" y="145" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="399" y="143" width="52" height="27">
-			</bounds>
+			<bounds x="399" y="143" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="401" y="145" width="48" height="23">
-			</bounds>
+			<bounds x="401" y="145" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="418" y="504" width="70" height="22">
-			</bounds>
+			<bounds x="418" y="504" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="420" y="506" width="66" height="18">
-			</bounds>
+			<bounds x="420" y="506" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="389" y="479" width="70" height="22">
-			</bounds>
+			<bounds x="389" y="479" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="391" y="481" width="66" height="18">
-			</bounds>
+			<bounds x="391" y="481" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="348" y="453" width="70" height="22">
-			</bounds>
+			<bounds x="348" y="453" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="350" y="455" width="66" height="18">
-			</bounds>
+			<bounds x="350" y="455" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="308" y="478" width="70" height="22">
-			</bounds>
+			<bounds x="308" y="478" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="310" y="480" width="66" height="18">
-			</bounds>
+			<bounds x="310" y="480" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="274" y="503" width="70" height="22">
-			</bounds>
+			<bounds x="274" y="503" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="276" y="505" width="66" height="18">
-			</bounds>
+			<bounds x="276" y="505" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="241" y="529" width="70" height="22">
-			</bounds>
+			<bounds x="241" y="529" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="243" y="531" width="66" height="18">
-			</bounds>
+			<bounds x="243" y="531" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="161" y="498" width="82" height="82">
-			</bounds>
+			<bounds x="161" y="498" width="82" height="82"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="163" y="500" width="78" height="78">
-			</bounds>
+			<bounds x="163" y="500" width="78" height="78"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="167" y="478" width="70" height="22">
-			</bounds>
+			<bounds x="167" y="478" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="169" y="480" width="66" height="18">
-			</bounds>
+			<bounds x="169" y="480" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="143" y="453" width="70" height="22">
-			</bounds>
+			<bounds x="143" y="453" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="145" y="455" width="66" height="18">
-			</bounds>
+			<bounds x="145" y="455" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="121" y="428" width="70" height="22">
-			</bounds>
+			<bounds x="121" y="428" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="123" y="430" width="66" height="18">
-			</bounds>
+			<bounds x="123" y="430" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="93" y="405" width="70" height="22">
-			</bounds>
+			<bounds x="93" y="405" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="95" y="407" width="66" height="18">
-			</bounds>
+			<bounds x="95" y="407" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="60" y="380" width="70" height="22">
-			</bounds>
+			<bounds x="60" y="380" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="62" y="382" width="66" height="18">
-			</bounds>
+			<bounds x="62" y="382" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="30" y="355" width="70" height="22">
-			</bounds>
+			<bounds x="30" y="355" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="32" y="357" width="66" height="18">
-			</bounds>
+			<bounds x="32" y="357" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="8" y="324" width="70" height="27">
-			</bounds>
+			<bounds x="8" y="324" width="70" height="27"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="10" y="326" width="66" height="23">
-			</bounds>
+			<bounds x="10" y="326" width="66" height="23"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="1" y="243" width="82" height="82">
-			</bounds>
+			<bounds x="1" y="243" width="82" height="82"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="3" y="245" width="78" height="78">
-			</bounds>
+			<bounds x="3" y="245" width="78" height="78"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="41" y="224" width="70" height="22">
-			</bounds>
+			<bounds x="41" y="224" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="43" y="226" width="66" height="18">
-			</bounds>
+			<bounds x="43" y="226" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="68" y="192" width="70" height="22">
-			</bounds>
+			<bounds x="68" y="192" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="70" y="194" width="66" height="18">
-			</bounds>
+			<bounds x="70" y="194" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="100" y="161" width="70" height="22">
-			</bounds>
+			<bounds x="100" y="161" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="102" y="163" width="66" height="18">
-			</bounds>
+			<bounds x="102" y="163" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="129" y="129" width="70" height="22">
-			</bounds>
+			<bounds x="129" y="129" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="131" y="131" width="66" height="18">
-			</bounds>
+			<bounds x="131" y="131" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="162" y="99" width="70" height="22">
-			</bounds>
+			<bounds x="162" y="99" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="164" y="101" width="66" height="18">
-			</bounds>
+			<bounds x="164" y="101" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="202" y="69" width="70" height="22">
-			</bounds>
+			<bounds x="202" y="69" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="204" y="71" width="66" height="18">
-			</bounds>
+			<bounds x="204" y="71" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="256" y="39" width="70" height="22">
-			</bounds>
+			<bounds x="256" y="39" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="258" y="41" width="66" height="18">
-			</bounds>
+			<bounds x="258" y="41" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="327" y="1" width="94" height="94">
-			</bounds>
+			<bounds x="327" y="1" width="94" height="94"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="329" y="3" width="90" height="90">
-			</bounds>
+			<bounds x="329" y="3" width="90" height="90"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="423" y="39" width="70" height="22">
-			</bounds>
+			<bounds x="423" y="39" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="425" y="41" width="66" height="18">
-			</bounds>
+			<bounds x="425" y="41" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="454" y="69" width="70" height="22">
-			</bounds>
+			<bounds x="454" y="69" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="456" y="71" width="66" height="18">
-			</bounds>
+			<bounds x="456" y="71" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="476" y="101" width="70" height="22">
-			</bounds>
+			<bounds x="476" y="101" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="478" y="103" width="66" height="18">
-			</bounds>
+			<bounds x="478" y="103" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="514" y="130" width="70" height="22">
-			</bounds>
+			<bounds x="514" y="130" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="516" y="132" width="66" height="18">
-			</bounds>
+			<bounds x="516" y="132" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="543" y="157" width="70" height="22">
-			</bounds>
+			<bounds x="543" y="157" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="545" y="159" width="66" height="18">
-			</bounds>
+			<bounds x="545" y="159" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="570" y="185" width="70" height="22">
-			</bounds>
+			<bounds x="570" y="185" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="572" y="187" width="66" height="18">
-			</bounds>
+			<bounds x="572" y="187" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="602" y="214" width="70" height="22">
-			</bounds>
+			<bounds x="602" y="214" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="604" y="216" width="66" height="18">
-			</bounds>
+			<bounds x="604" y="216" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="629" y="230" width="82" height="82">
-			</bounds>
+			<bounds x="629" y="230" width="82" height="82"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="631" y="232" width="78" height="78">
-			</bounds>
+			<bounds x="631" y="232" width="78" height="78"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="633" y="311" width="70" height="22">
-			</bounds>
+			<bounds x="633" y="311" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="635" y="313" width="66" height="18">
-			</bounds>
+			<bounds x="635" y="313" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="622" y="336" width="70" height="22">
-			</bounds>
+			<bounds x="622" y="336" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="624" y="338" width="66" height="18">
-			</bounds>
+			<bounds x="624" y="338" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="609" y="363" width="70" height="22">
-			</bounds>
+			<bounds x="609" y="363" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="611" y="365" width="66" height="18">
-			</bounds>
+			<bounds x="611" y="365" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="591" y="391" width="70" height="22">
-			</bounds>
+			<bounds x="591" y="391" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="593" y="393" width="66" height="18">
-			</bounds>
+			<bounds x="593" y="393" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="568" y="419" width="70" height="27">
-			</bounds>
+			<bounds x="568" y="419" width="70" height="27"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="570" y="421" width="66" height="23">
-			</bounds>
+			<bounds x="570" y="421" width="66" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="548" y="452" width="70" height="22">
-			</bounds>
+			<bounds x="548" y="452" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="550" y="454" width="66" height="18">
-			</bounds>
+			<bounds x="550" y="454" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="522" y="478" width="70" height="22">
-			</bounds>
+			<bounds x="522" y="478" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="524" y="480" width="66" height="18">
-			</bounds>
+			<bounds x="524" y="480" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="513" y="497" width="82" height="82">
-			</bounds>
+			<bounds x="513" y="497" width="82" height="82"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="515" y="499" width="78" height="78">
-			</bounds>
+			<bounds x="515" y="499" width="78" height="78"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="668" y="455" width="19" height="56">
-			</bounds>
+			<bounds x="668" y="455" width="19" height="56"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="670" y="457" width="15" height="52">
-			</bounds>
+			<bounds x="670" y="457" width="15" height="52"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="709" y="388" width="19" height="42">
-			</bounds>
+			<bounds x="709" y="388" width="19" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="711" y="390" width="15" height="38">
-			</bounds>
+			<bounds x="711" y="390" width="15" height="38"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="680" y="513" width="22" height="22">
-			</bounds>
+			<bounds x="680" y="513" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="682" y="515" width="18" height="18">
-			</bounds>
+			<bounds x="682" y="515" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="691" y="483" width="22" height="22">
-			</bounds>
+			<bounds x="691" y="483" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="693" y="485" width="18" height="18">
-			</bounds>
+			<bounds x="693" y="485" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="693" y="450" width="22" height="22">
-			</bounds>
+			<bounds x="693" y="450" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="695" y="452" width="18" height="18">
-			</bounds>
+			<bounds x="695" y="452" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="732" y="409" width="22" height="22">
-			</bounds>
+			<bounds x="732" y="409" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="734" y="411" width="18" height="18">
-			</bounds>
+			<bounds x="734" y="411" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="719" y="363" width="22" height="22">
-			</bounds>
+			<bounds x="719" y="363" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="721" y="365" width="18" height="18">
-			</bounds>
+			<bounds x="721" y="365" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="681" y="395" width="22" height="22">
-			</bounds>
+			<bounds x="681" y="395" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="683" y="397" width="18" height="18">
-			</bounds>
+			<bounds x="683" y="397" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="672" y="424" width="22" height="22">
-			</bounds>
+			<bounds x="672" y="424" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="674" y="426" width="18" height="18">
-			</bounds>
+			<bounds x="674" y="426" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="642" y="445" width="22" height="22">
-			</bounds>
+			<bounds x="642" y="445" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="644" y="447" width="18" height="18">
-			</bounds>
+			<bounds x="644" y="447" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="645" y="507" width="22" height="22">
-			</bounds>
+			<bounds x="645" y="507" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="647" y="509" width="18" height="18">
-			</bounds>
+			<bounds x="647" y="509" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="637" y="476" width="22" height="22">
-			</bounds>
+			<bounds x="637" y="476" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="639" y="478" width="18" height="18">
-			</bounds>
+			<bounds x="639" y="478" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="662" y="133" width="70" height="19">
-			</bounds>
+			<bounds x="662" y="133" width="70" height="19"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="664" y="135" width="66" height="15">
-			</bounds>
+			<bounds x="664" y="135" width="66" height="15"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="592" y="133" width="70" height="19">
-			</bounds>
+			<bounds x="592" y="133" width="70" height="19"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="594" y="135" width="66" height="15">
-			</bounds>
+			<bounds x="594" y="135" width="66" height="15"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="690" y="107" width="27" height="27">
-			</bounds>
+			<bounds x="690" y="107" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="692" y="109" width="23" height="23">
-			</bounds>
+			<bounds x="692" y="109" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="664" y="107" width="27" height="27">
-			</bounds>
+			<bounds x="664" y="107" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="666" y="109" width="23" height="23">
-			</bounds>
+			<bounds x="666" y="109" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="638" y="107" width="27" height="27">
-			</bounds>
+			<bounds x="638" y="107" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="640" y="109" width="23" height="23">
-			</bounds>
+			<bounds x="640" y="109" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="612" y="107" width="27" height="27">
-			</bounds>
+			<bounds x="612" y="107" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="614" y="109" width="23" height="23">
-			</bounds>
+			<bounds x="614" y="109" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="677" y="82" width="27" height="27">
-			</bounds>
+			<bounds x="677" y="82" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="679" y="84" width="23" height="23">
-			</bounds>
+			<bounds x="679" y="84" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="651" y="82" width="27" height="27">
-			</bounds>
+			<bounds x="651" y="82" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="653" y="84" width="23" height="23">
-			</bounds>
+			<bounds x="653" y="84" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="625" y="82" width="27" height="27">
-			</bounds>
+			<bounds x="625" y="82" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="627" y="84" width="23" height="23">
-			</bounds>
+			<bounds x="627" y="84" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="665" y="57" width="27" height="27">
-			</bounds>
+			<bounds x="665" y="57" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="667" y="59" width="23" height="23">
-			</bounds>
+			<bounds x="667" y="59" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="639" y="57" width="27" height="27">
-			</bounds>
+			<bounds x="639" y="57" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="641" y="59" width="23" height="23">
-			</bounds>
+			<bounds x="641" y="59" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="652" y="32" width="27" height="27">
-			</bounds>
+			<bounds x="652" y="32" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="654" y="34" width="23" height="23">
-			</bounds>
+			<bounds x="654" y="34" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="349" y="267" width="66" height="22">
-			</bounds>
+			<bounds x="349" y="267" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="351" y="269" width="62" height="18">
-			</bounds>
+			<bounds x="351" y="269" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="274" y="199" width="66" height="22">
-			</bounds>
+			<bounds x="274" y="199" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="276" y="201" width="62" height="18">
-			</bounds>
+			<bounds x="276" y="201" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="349" y="233" width="66" height="22">
-			</bounds>
+			<bounds x="349" y="233" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="351" y="235" width="62" height="18">
-			</bounds>
+			<bounds x="351" y="235" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="349" y="199" width="66" height="22">
-			</bounds>
+			<bounds x="349" y="199" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="351" y="201" width="62" height="18">
-			</bounds>
+			<bounds x="351" y="201" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="423" y="199" width="66" height="22">
-			</bounds>
+			<bounds x="423" y="199" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="425" y="201" width="62" height="18">
-			</bounds>
+			<bounds x="425" y="201" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="423" y="267" width="66" height="22">
-			</bounds>
+			<bounds x="423" y="267" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="425" y="269" width="62" height="18">
-			</bounds>
+			<bounds x="425" y="269" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="252" y="342" width="70" height="22">
-			</bounds>
+			<bounds x="252" y="342" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="254" y="344" width="66" height="18">
-			</bounds>
+			<bounds x="254" y="344" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="291" y="411" width="70" height="22">
-			</bounds>
+			<bounds x="291" y="411" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="293" y="413" width="66" height="18">
-			</bounds>
+			<bounds x="293" y="413" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="291" y="388" width="70" height="22">
-			</bounds>
+			<bounds x="291" y="388" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="293" y="390" width="66" height="18">
-			</bounds>
+			<bounds x="293" y="390" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="217" y="365" width="70" height="22">
-			</bounds>
+			<bounds x="217" y="365" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="219" y="367" width="66" height="18">
-			</bounds>
+			<bounds x="219" y="367" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="217" y="388" width="70" height="22">
-			</bounds>
+			<bounds x="217" y="388" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="219" y="390" width="66" height="18">
-			</bounds>
+			<bounds x="219" y="390" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="291" y="365" width="70" height="22">
-			</bounds>
+			<bounds x="291" y="365" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="293" y="367" width="66" height="18">
-			</bounds>
+			<bounds x="293" y="367" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1_border" state="0">
-			<bounds x="218" y="411" width="70" height="22">
-			</bounds>
+			<bounds x="218" y="411" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1" state="0">
-			<bounds x="220" y="413" width="66" height="18">
-			</bounds>
+			<bounds x="220" y="413" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="137" y="32" width="32" height="32">
-			</bounds>
+			<bounds x="137" y="32" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="139" y="34" width="28" height="28">
-			</bounds>
+			<bounds x="139" y="34" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="100" y="6" width="32" height="32">
-			</bounds>
+			<bounds x="100" y="6" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="102" y="8" width="28" height="28">
-			</bounds>
+			<bounds x="102" y="8" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="341" y="92" width="70" height="22">
-			</bounds>
+			<bounds x="341" y="92" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="343" y="94" width="66" height="18">
-			</bounds>
+			<bounds x="343" y="94" width="66" height="18"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="443" y="690" width="62" height="62">
-			</bounds>
+			<bounds x="443" y="690" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="445" y="692" width="58" height="58">
-			</bounds>
+			<bounds x="445" y="692" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="495" y="690" width="62" height="62">
-			</bounds>
+			<bounds x="495" y="690" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="497" y="692" width="58" height="58">
-			</bounds>
+			<bounds x="497" y="692" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="546" y="691" width="62" height="62">
-			</bounds>
+			<bounds x="546" y="691" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="548" y="693" width="58" height="58">
-			</bounds>
+			<bounds x="548" y="693" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="612" y="649" width="46" height="42">
-			</bounds>
+			<bounds x="612" y="649" width="46" height="42"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="614" y="651" width="42" height="38">
-			</bounds>
+			<bounds x="614" y="651" width="42" height="38"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="443" y="638" width="62" height="62">
-			</bounds>
+			<bounds x="443" y="638" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="445" y="640" width="58" height="58">
-			</bounds>
+			<bounds x="445" y="640" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="495" y="638" width="62" height="62">
-			</bounds>
+			<bounds x="495" y="638" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="497" y="640" width="58" height="58">
-			</bounds>
+			<bounds x="497" y="640" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="547" y="638" width="62" height="62">
-			</bounds>
+			<bounds x="547" y="638" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="549" y="640" width="58" height="58">
-			</bounds>
+			<bounds x="549" y="640" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="547" y="586" width="62" height="62">
-			</bounds>
+			<bounds x="547" y="586" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="549" y="588" width="58" height="58">
-			</bounds>
+			<bounds x="549" y="588" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="495" y="585" width="62" height="62">
-			</bounds>
+			<bounds x="495" y="585" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="497" y="587" width="58" height="58">
-			</bounds>
+			<bounds x="497" y="587" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="442" y="585" width="62" height="62">
-			</bounds>
+			<bounds x="442" y="585" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="444" y="587" width="58" height="58">
-			</bounds>
+			<bounds x="444" y="587" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_153_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="588" y="766" width="75" height="27">
-			</bounds>
+			<bounds x="588" y="766" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_153" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="590" y="768" width="71" height="23">
-			</bounds>
+			<bounds x="590" y="768" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_154_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="427" y="767" width="75" height="27">
-			</bounds>
+			<bounds x="427" y="767" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_154" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="429" y="769" width="71" height="23">
-			</bounds>
+			<bounds x="429" y="769" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_155_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="348" y="767" width="75" height="27">
-			</bounds>
+			<bounds x="348" y="767" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_155" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="350" y="769" width="71" height="23">
-			</bounds>
+			<bounds x="350" y="769" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_156_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="263" y="768" width="75" height="27">
-			</bounds>
+			<bounds x="263" y="768" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_156" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="265" y="770" width="71" height="23">
-			</bounds>
+			<bounds x="265" y="770" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_157_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="176" y="770" width="75" height="27">
-			</bounds>
+			<bounds x="176" y="770" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_157" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="178" y="772" width="71" height="23">
-			</bounds>
+			<bounds x="178" y="772" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_158_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="92" y="771" width="75" height="27">
-			</bounds>
+			<bounds x="92" y="771" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_158" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="94" y="773" width="71" height="23">
-			</bounds>
+			<bounds x="94" y="773" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_160_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="732" y="8" width="75" height="27">
-			</bounds>
+			<bounds x="732" y="8" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_160" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="734" y="10" width="71" height="23">
-			</bounds>
+			<bounds x="734" y="10" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_162_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="508" y="767" width="75" height="27">
-			</bounds>
+			<bounds x="508" y="767" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_162" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="510" y="769" width="71" height="23">
-			</bounds>
+			<bounds x="510" y="769" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="163" y="588" width="272" height="30">
-			</bounds>
+			<bounds x="163" y="588" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="163" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="163" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="180" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="180" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="197" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="197" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="214" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="214" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="231" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="231" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="248" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="248" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="265" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="265" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="282" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="282" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="299" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="299" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="316" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="316" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="333" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="333" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="350" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="350" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="367" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="367" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="384" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="384" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="401" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="401" y="588" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="418" y="588" width="17" height="30">
-			</bounds>
+			<bounds x="418" y="588" width="17" height="30"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1grescb.lay
+++ b/src/mame/layout/m1grescb.lay
@@ -8,13090 +8,7811 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Gotcha">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gotcha">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Follow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Me">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Follow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Me">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bid For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Freedom">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bid For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Freedom">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mutiplier">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mutiplier">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Look">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Around">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Look">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Around">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.00" blue="0.33">
-			</color>
+			<color red="0.16" green="0.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.00" blue="0.08">
-			</color>
+			<color red="0.04" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.66">
-			</color>
+			<color red="0.33" green="0.00" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.16">
-			</color>
+			<color red="0.08" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="Search">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="Search">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Gotcha">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gotcha">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Tran-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="sport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Tran-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="sport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Search">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Search">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.00" blue="0.33">
-			</color>
+			<color red="0.16" green="0.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.00" blue="0.08">
-			</color>
+			<color red="0.04" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.66">
-			</color>
+			<color red="0.33" green="0.00" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.16">
-			</color>
+			<color red="0.08" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="Search">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="Search">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Forger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Forger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.00" blue="0.33">
-			</color>
+			<color red="0.16" green="0.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.00" blue="0.08">
-			</color>
+			<color red="0.04" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.66">
-			</color>
+			<color red="0.33" green="0.00" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.16">
-			</color>
+			<color red="0.08" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="Search">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="Search">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Tunnel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Tunnel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Forger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Forger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Tran-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="sport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Tran-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="sport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Against">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Against">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Stir">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Crazy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stir">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Crazy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Heaven">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Above">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Heaven">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Above">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Even">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Break">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Even">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Break">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Big Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Disguise">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Disguise">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Passport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Passport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Suit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Suit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Camera">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Camera">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Shovel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Shovel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Plane">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Plane">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bike">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bike">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Train">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Train">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Forger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Forger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Transport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Transport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.16" green="0.00" blue="0.00">
-			</color>
+			<color red="0.16" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.00" blue="0.00">
-			</color>
+			<color red="0.04" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="0.32" green="0.00" blue="0.00">
-			</color>
+			<color red="0.32" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.00">
-			</color>
+			<color red="0.08" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_141_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_141">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_146_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_146">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" XCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_71">
 		<text string="The Great Escape By Jayzeewood ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="10p play &#xA3;5 Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="ROMS Thanks to Hitthesix Reels from duplu Tested and ed">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="label_73">
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_95">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_96">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_97">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_99">
 		<text string="Escape Committee">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_100">
 		<text string="Win Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_101">
 		<text string="Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_102">
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_103">
 		<text string="Hi-Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_104">
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeate">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_105">
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_106">
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="DO OR DIE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="DECOY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="BONUS TUNNEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="TRANSPORT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="FORGER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="Cooler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_134">
 		<text string="COLLASPED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TUNNEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_135">
 		<text string="CAUGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1146" height="662">
-			</bounds>
+			<bounds x="0" y="0" width="1146" height="662"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="656" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="656" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="656.0000" y="379.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="656.0000" y="379.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="659.3333" y="380.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="659.3333" y="380.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="662.6667" y="382.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="662.6667" y="382.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="666.0000" y="384.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="666.0000" y="384.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="669.3333" y="386.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="669.3333" y="386.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="672.6667" y="388.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="672.6667" y="388.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="656.0000" y="425.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="656.0000" y="425.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="659.3333" y="427.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="659.3333" y="427.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="662.6667" y="429.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="662.6667" y="429.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="666.0000" y="431.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="666.0000" y="431.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="669.3333" y="433.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="669.3333" y="433.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="672.6667" y="435.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="672.6667" y="435.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="656.0000" y="472.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="656.0000" y="472.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="659.3333" y="474.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="659.3333" y="474.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="662.6667" y="476.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="662.6667" y="476.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="666.0000" y="478.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="666.0000" y="478.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="669.3333" y="480.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="669.3333" y="480.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="672.6667" y="482.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="672.6667" y="482.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="656" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="656" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="738" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="738" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="738.0000" y="379.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="738.0000" y="379.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="741.3333" y="380.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="741.3333" y="380.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="744.6667" y="382.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="744.6667" y="382.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="748.0000" y="384.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="748.0000" y="384.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="751.3333" y="386.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="751.3333" y="386.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="754.6667" y="388.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="754.6667" y="388.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="738.0000" y="425.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="738.0000" y="425.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="741.3333" y="427.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="741.3333" y="427.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="744.6667" y="429.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="744.6667" y="429.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="748.0000" y="431.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="748.0000" y="431.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="751.3333" y="433.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="751.3333" y="433.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="754.6667" y="435.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="754.6667" y="435.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="738.0000" y="472.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="738.0000" y="472.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="741.3333" y="474.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="741.3333" y="474.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="744.6667" y="476.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="744.6667" y="476.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="748.0000" y="478.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="748.0000" y="478.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="751.3333" y="480.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="751.3333" y="480.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="754.6667" y="482.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="754.6667" y="482.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="738" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="738" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="820" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="820" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="820.0000" y="379.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="820.0000" y="379.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="823.3333" y="380.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="823.3333" y="380.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="826.6667" y="382.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="826.6667" y="382.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="830.0000" y="384.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="830.0000" y="384.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="833.3333" y="386.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="833.3333" y="386.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="836.6667" y="388.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="836.6667" y="388.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="820.0000" y="425.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="820.0000" y="425.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="823.3333" y="427.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="823.3333" y="427.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="826.6667" y="429.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="826.6667" y="429.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="830.0000" y="431.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="830.0000" y="431.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="833.3333" y="433.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="833.3333" y="433.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="836.6667" y="435.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="836.6667" y="435.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="820.0000" y="472.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="820.0000" y="472.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="823.3333" y="474.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="823.3333" y="474.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="826.6667" y="476.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="826.6667" y="476.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="830.0000" y="478.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="830.0000" y="478.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="833.3333" y="480.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="833.3333" y="480.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="836.6667" y="482.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="836.6667" y="482.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="820" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="820" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="173" y="288" width="100" height="100">
-			</bounds>
+			<bounds x="173" y="288" width="100" height="100"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="173.0000" y="288.0000" width="100.0000" height="100.0000">
-			</bounds>
+			<bounds x="173.0000" y="288.0000" width="100.0000" height="100.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="177.1667" y="292.1667" width="91.6667" height="91.6667">
-			</bounds>
+			<bounds x="177.1667" y="292.1667" width="91.6667" height="91.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="181.3333" y="296.3333" width="83.3333" height="83.3333">
-			</bounds>
+			<bounds x="181.3333" y="296.3333" width="83.3333" height="83.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="185.5000" y="300.5000" width="75.0000" height="75.0000">
-			</bounds>
+			<bounds x="185.5000" y="300.5000" width="75.0000" height="75.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="189.6667" y="304.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="189.6667" y="304.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="193.8333" y="308.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="193.8333" y="308.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="173" y="288" width="100" height="100">
-			</bounds>
+			<bounds x="173" y="288" width="100" height="100"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="220" y="27" width="62" height="62">
-			</bounds>
+			<bounds x="220" y="27" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="222" y="29" width="58" height="58">
-			</bounds>
+			<bounds x="222" y="29" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="166" y="27" width="52" height="52">
-			</bounds>
+			<bounds x="166" y="27" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="168" y="29" width="48" height="48">
-			</bounds>
+			<bounds x="168" y="29" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="122" y="27" width="42" height="42">
-			</bounds>
+			<bounds x="122" y="27" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="124" y="29" width="38" height="38">
-			</bounds>
+			<bounds x="124" y="29" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="97" y="42" width="42" height="82">
-			</bounds>
+			<bounds x="97" y="42" width="42" height="82"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="99" y="44" width="38" height="78">
-			</bounds>
+			<bounds x="99" y="44" width="38" height="78"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="195" y="186" width="42" height="42">
-			</bounds>
+			<bounds x="195" y="186" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="197" y="188" width="38" height="38">
-			</bounds>
+			<bounds x="197" y="188" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="240" y="188" width="42" height="42">
-			</bounds>
+			<bounds x="240" y="188" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="242" y="190" width="38" height="38">
-			</bounds>
+			<bounds x="242" y="190" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="285" y="189" width="42" height="42">
-			</bounds>
+			<bounds x="285" y="189" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="287" y="191" width="38" height="38">
-			</bounds>
+			<bounds x="287" y="191" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="330" y="194" width="42" height="42">
-			</bounds>
+			<bounds x="330" y="194" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="332" y="196" width="38" height="38">
-			</bounds>
+			<bounds x="332" y="196" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="497" y="457" width="47" height="42">
-			</bounds>
+			<bounds x="497" y="457" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="499" y="459" width="43" height="38">
-			</bounds>
+			<bounds x="499" y="459" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="453" y="491" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="491" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="455" y="493" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="493" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="453" y="447" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="447" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="455" y="449" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="449" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="453" y="403" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="403" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="455" y="405" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="405" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="453" y="359" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="359" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="455" y="361" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="361" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="453" y="315" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="315" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="455" y="317" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="317" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="453" y="271" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="271" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="455" y="273" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="273" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="453" y="227" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="227" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="455" y="229" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="229" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="453" y="183" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="183" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="455" y="185" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="185" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="360" y="474" width="47" height="42">
-			</bounds>
+			<bounds x="360" y="474" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="362" y="476" width="43" height="38">
-			</bounds>
+			<bounds x="362" y="476" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="407" y="468" width="47" height="42">
-			</bounds>
+			<bounds x="407" y="468" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="409" y="470" width="43" height="38">
-			</bounds>
+			<bounds x="409" y="470" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="268" y="483" width="47" height="42">
-			</bounds>
+			<bounds x="268" y="483" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="270" y="485" width="43" height="38">
-			</bounds>
+			<bounds x="270" y="485" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="314" y="478" width="47" height="42">
-			</bounds>
+			<bounds x="314" y="478" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="316" y="480" width="43" height="38">
-			</bounds>
+			<bounds x="316" y="480" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="57" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="59" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="101" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="101" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="103" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="103" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="145" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="145" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="147" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="147" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="189" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="189" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="191" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="191" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="233" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="233" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="235" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="235" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="277" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="277" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="279" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="279" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="321" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="321" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="323" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="323" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="365" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="365" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="367" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="367" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="409" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="409" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="411" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="411" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="453" y="139" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="139" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="455" y="141" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="141" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="453" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="455" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="455" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="409" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="409" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="411" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="411" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="365" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="365" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="367" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="367" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="321" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="321" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="323" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="323" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="277" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="277" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="279" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="279" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="233" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="233" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="235" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="235" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="189" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="189" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="191" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="191" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="145" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="145" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="147" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="147" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="101" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="101" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="103" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="103" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="57" y="535" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="535" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="59" y="537" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="537" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="57" y="183" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="183" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="59" y="185" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="185" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="57" y="227" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="227" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="59" y="229" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="229" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="57" y="271" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="271" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="59" y="273" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="273" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="57" y="315" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="315" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="59" y="317" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="317" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="57" y="359" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="359" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="59" y="361" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="361" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="57" y="403" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="403" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="59" y="405" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="405" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="57" y="447" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="447" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="59" y="449" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="449" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="57" y="490" width="42" height="42">
-			</bounds>
+			<bounds x="57" y="490" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="59" y="492" width="38" height="38">
-			</bounds>
+			<bounds x="59" y="492" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="501" y="217" width="62" height="62">
-			</bounds>
+			<bounds x="501" y="217" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="503" y="219" width="58" height="58">
-			</bounds>
+			<bounds x="503" y="219" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="503" y="279" width="52" height="52">
-			</bounds>
+			<bounds x="503" y="279" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="505" y="281" width="48" height="48">
-			</bounds>
+			<bounds x="505" y="281" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="504" y="331" width="47" height="42">
-			</bounds>
+			<bounds x="504" y="331" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="506" y="333" width="43" height="38">
-			</bounds>
+			<bounds x="506" y="333" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="501" y="373" width="47" height="42">
-			</bounds>
+			<bounds x="501" y="373" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="503" y="375" width="43" height="38">
-			</bounds>
+			<bounds x="503" y="375" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="499" y="415" width="47" height="42">
-			</bounds>
+			<bounds x="499" y="415" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="501" y="417" width="43" height="38">
-			</bounds>
+			<bounds x="501" y="417" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="124" y="96" width="42" height="42">
-			</bounds>
+			<bounds x="124" y="96" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="126" y="98" width="38" height="38">
-			</bounds>
+			<bounds x="126" y="98" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="169" y="96" width="42" height="42">
-			</bounds>
+			<bounds x="169" y="96" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="171" y="98" width="38" height="38">
-			</bounds>
+			<bounds x="171" y="98" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="367" y="578" width="42" height="42">
-			</bounds>
+			<bounds x="367" y="578" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="369" y="580" width="38" height="38">
-			</bounds>
+			<bounds x="369" y="580" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="325" y="577" width="42" height="42">
-			</bounds>
+			<bounds x="325" y="577" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="327" y="579" width="38" height="38">
-			</bounds>
+			<bounds x="327" y="579" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="283" y="577" width="42" height="42">
-			</bounds>
+			<bounds x="283" y="577" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="285" y="579" width="38" height="38">
-			</bounds>
+			<bounds x="285" y="579" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="241" y="577" width="42" height="42">
-			</bounds>
+			<bounds x="241" y="577" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="243" y="579" width="38" height="38">
-			</bounds>
+			<bounds x="243" y="579" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="199" y="577" width="42" height="42">
-			</bounds>
+			<bounds x="199" y="577" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="201" y="579" width="38" height="38">
-			</bounds>
+			<bounds x="201" y="579" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="156" y="577" width="42" height="42">
-			</bounds>
+			<bounds x="156" y="577" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="158" y="579" width="38" height="38">
-			</bounds>
+			<bounds x="158" y="579" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="113" y="315" width="42" height="42">
-			</bounds>
+			<bounds x="113" y="315" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="115" y="317" width="38" height="38">
-			</bounds>
+			<bounds x="115" y="317" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="124" y="482" width="42" height="42">
-			</bounds>
+			<bounds x="124" y="482" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="126" y="484" width="38" height="38">
-			</bounds>
+			<bounds x="126" y="484" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="120" y="441" width="42" height="42">
-			</bounds>
+			<bounds x="120" y="441" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="122" y="443" width="38" height="38">
-			</bounds>
+			<bounds x="122" y="443" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="118" y="400" width="42" height="42">
-			</bounds>
+			<bounds x="118" y="400" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="120" y="402" width="38" height="38">
-			</bounds>
+			<bounds x="120" y="402" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="116" y="358" width="42" height="42">
-			</bounds>
+			<bounds x="116" y="358" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="118" y="360" width="38" height="38">
-			</bounds>
+			<bounds x="118" y="360" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="616" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="616" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="618" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="618" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="654" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="654" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="656" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="656" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="693" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="693" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="695" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="695" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="732" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="732" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="734" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="734" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="771" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="771" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="773" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="773" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="810" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="810" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="812" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="812" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="849" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="849" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="851" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="851" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="888" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="888" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="890" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="890" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="927" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="927" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="929" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="929" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="966" y="560" width="42" height="19">
-			</bounds>
+			<bounds x="966" y="560" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="968" y="562" width="38" height="15">
-			</bounds>
+			<bounds x="968" y="562" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="664" y="184" width="77" height="32">
-			</bounds>
+			<bounds x="664" y="184" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="666" y="186" width="73" height="28">
-			</bounds>
+			<bounds x="666" y="186" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="664" y="300" width="77" height="32">
-			</bounds>
+			<bounds x="664" y="300" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="666" y="302" width="73" height="28">
-			</bounds>
+			<bounds x="666" y="302" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="664" y="271" width="77" height="32">
-			</bounds>
+			<bounds x="664" y="271" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="666" y="273" width="73" height="28">
-			</bounds>
+			<bounds x="666" y="273" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="664" y="242" width="77" height="32">
-			</bounds>
+			<bounds x="664" y="242" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="666" y="244" width="73" height="28">
-			</bounds>
+			<bounds x="666" y="244" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="664" y="213" width="77" height="32">
-			</bounds>
+			<bounds x="664" y="213" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="666" y="215" width="73" height="28">
-			</bounds>
+			<bounds x="666" y="215" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="615" y="249" width="52" height="19">
-			</bounds>
+			<bounds x="615" y="249" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="617" y="251" width="48" height="15">
-			</bounds>
+			<bounds x="617" y="251" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="615" y="220" width="52" height="19">
-			</bounds>
+			<bounds x="615" y="220" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="617" y="222" width="48" height="15">
-			</bounds>
+			<bounds x="617" y="222" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="615" y="192" width="52" height="19">
-			</bounds>
+			<bounds x="615" y="192" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="617" y="194" width="48" height="15">
-			</bounds>
+			<bounds x="617" y="194" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="615" y="308" width="52" height="19">
-			</bounds>
+			<bounds x="615" y="308" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="617" y="310" width="48" height="15">
-			</bounds>
+			<bounds x="617" y="310" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="615" y="279" width="52" height="19">
-			</bounds>
+			<bounds x="615" y="279" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="617" y="281" width="48" height="15">
-			</bounds>
+			<bounds x="617" y="281" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="738" y="192" width="52" height="19">
-			</bounds>
+			<bounds x="738" y="192" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="740" y="194" width="48" height="15">
-			</bounds>
+			<bounds x="740" y="194" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="738" y="306" width="52" height="19">
-			</bounds>
+			<bounds x="738" y="306" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="740" y="308" width="48" height="15">
-			</bounds>
+			<bounds x="740" y="308" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="738" y="278" width="52" height="19">
-			</bounds>
+			<bounds x="738" y="278" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="740" y="280" width="48" height="15">
-			</bounds>
+			<bounds x="740" y="280" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="738" y="248" width="52" height="19">
-			</bounds>
+			<bounds x="738" y="248" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="740" y="250" width="48" height="15">
-			</bounds>
+			<bounds x="740" y="250" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="738" y="219" width="52" height="19">
-			</bounds>
+			<bounds x="738" y="219" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="740" y="221" width="48" height="15">
-			</bounds>
+			<bounds x="740" y="221" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="627" y="168" width="52" height="19">
-			</bounds>
+			<bounds x="627" y="168" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="629" y="170" width="48" height="15">
-			</bounds>
+			<bounds x="629" y="170" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="725" y="168" width="52" height="19">
-			</bounds>
+			<bounds x="725" y="168" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="727" y="170" width="48" height="15">
-			</bounds>
+			<bounds x="727" y="170" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="650" y="80" width="102" height="52">
-			</bounds>
+			<bounds x="650" y="80" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="652" y="82" width="98" height="48">
-			</bounds>
+			<bounds x="652" y="82" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="676" y="129" width="52" height="19">
-			</bounds>
+			<bounds x="676" y="129" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="678" y="131" width="48" height="15">
-			</bounds>
+			<bounds x="678" y="131" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="676" y="158" width="52" height="19">
-			</bounds>
+			<bounds x="676" y="158" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="678" y="160" width="48" height="15">
-			</bounds>
+			<bounds x="678" y="160" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_136_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1089" y="38" width="46" height="36">
-			</bounds>
+			<bounds x="1089" y="38" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_136" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1091" y="40" width="42" height="32">
-			</bounds>
+			<bounds x="1091" y="40" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="colour_button_137_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="378" y="194" width="52" height="52">
-			</bounds>
+			<bounds x="378" y="194" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp218" element="colour_button_137" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="380" y="196" width="48" height="48">
-			</bounds>
+			<bounds x="380" y="196" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp189" element="colour_button_138_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="216" y="478" width="52" height="52">
-			</bounds>
+			<bounds x="216" y="478" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp189" element="colour_button_138" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="218" y="480" width="48" height="48">
-			</bounds>
+			<bounds x="218" y="480" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp206" element="colour_button_139_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="109" y="263" width="52" height="52">
-			</bounds>
+			<bounds x="109" y="263" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp206" element="colour_button_139" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="111" y="265" width="48" height="48">
-			</bounds>
+			<bounds x="111" y="265" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_141_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="575" y="580" width="75" height="27">
-			</bounds>
+			<bounds x="575" y="580" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_141" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="577" y="582" width="71" height="23">
-			</bounds>
+			<bounds x="577" y="582" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_142_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="658" y="580" width="75" height="27">
-			</bounds>
+			<bounds x="658" y="580" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_142" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="660" y="582" width="71" height="23">
-			</bounds>
+			<bounds x="660" y="582" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_143_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="740" y="580" width="75" height="27">
-			</bounds>
+			<bounds x="740" y="580" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_143" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="742" y="582" width="71" height="23">
-			</bounds>
+			<bounds x="742" y="582" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_144_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="823" y="580" width="75" height="27">
-			</bounds>
+			<bounds x="823" y="580" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_144" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="825" y="582" width="71" height="23">
-			</bounds>
+			<bounds x="825" y="582" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_145_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="901" y="580" width="75" height="27">
-			</bounds>
+			<bounds x="901" y="580" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_145" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="903" y="582" width="71" height="23">
-			</bounds>
+			<bounds x="903" y="582" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_146_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1050" y="580" width="75" height="27">
-			</bounds>
+			<bounds x="1050" y="580" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_146" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1052" y="582" width="71" height="23">
-			</bounds>
+			<bounds x="1052" y="582" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_147_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="975" y="580" width="75" height="27">
-			</bounds>
+			<bounds x="975" y="580" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_147" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="977" y="582" width="71" height="23">
-			</bounds>
+			<bounds x="977" y="582" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="656" y="349" width="272" height="30">
-			</bounds>
+			<bounds x="656" y="349" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="656" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="656" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="673" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="673" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="690" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="690" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="707" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="707" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="724" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="724" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="741" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="741" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="758" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="758" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="775" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="775" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="792" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="792" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="809" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="809" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="826" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="826" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="843" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="843" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="860" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="860" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="877" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="877" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="894" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="894" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="911" y="349" width="17" height="30">
-			</bounds>
+			<bounds x="911" y="349" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label71" element="label_71">
-			<bounds x="657" y="611" width="348" height="39">
-			</bounds>
+			<bounds x="657" y="611" width="348" height="39"/>
 		</backdrop>
 		<backdrop name="label73" element="label_73">
-			<bounds x="585" y="496" width="56" height="24">
-			</bounds>
+			<bounds x="585" y="496" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="label95" element="label_95">
-			<bounds x="590" y="459" width="49" height="36">
-			</bounds>
+			<bounds x="590" y="459" width="49" height="36"/>
 		</backdrop>
 		<backdrop name="label96" element="label_96">
-			<bounds x="588" y="426" width="58" height="36">
-			</bounds>
+			<bounds x="588" y="426" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="589" y="389" width="58" height="36">
-			</bounds>
+			<bounds x="589" y="389" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="590" y="351" width="58" height="36">
-			</bounds>
+			<bounds x="590" y="351" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="label99" element="label_99">
-			<bounds x="969" y="343" width="93" height="44">
-			</bounds>
+			<bounds x="969" y="343" width="93" height="44"/>
 		</backdrop>
 		<backdrop name="label100" element="label_100">
-			<bounds x="1046" y="398" width="38" height="32">
-			</bounds>
+			<bounds x="1046" y="398" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="label101" element="label_101">
-			<bounds x="960" y="398" width="32" height="32">
-			</bounds>
+			<bounds x="960" y="398" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="label102" element="label_102">
-			<bounds x="1055" y="440" width="24" height="32">
-			</bounds>
+			<bounds x="1055" y="440" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="label103" element="label_103">
-			<bounds x="960" y="442" width="30" height="32">
-			</bounds>
+			<bounds x="960" y="442" width="30" height="32"/>
 		</backdrop>
 		<backdrop name="label104" element="label_104">
-			<bounds x="1042" y="483" width="52" height="32">
-			</bounds>
+			<bounds x="1042" y="483" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="label105" element="label_105">
-			<bounds x="960" y="480" width="34" height="32">
-			</bounds>
+			<bounds x="960" y="480" width="34" height="32"/>
 		</backdrop>
 		<backdrop name="label106" element="label_106">
-			<bounds x="681" y="146" width="43" height="13">
-			</bounds>
+			<bounds x="681" y="146" width="43" height="13"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="323" y="436" width="23" height="48">
-			</bounds>
+			<bounds x="323" y="436" width="23" height="48"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="323" y="416" width="44" height="16">
-			</bounds>
+			<bounds x="323" y="416" width="44" height="16"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="318" y="379" width="51" height="32">
-			</bounds>
+			<bounds x="318" y="379" width="51" height="32"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="305" y="362" width="80" height="16">
-			</bounds>
+			<bounds x="305" y="362" width="80" height="16"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="318" y="345" width="54" height="16">
-			</bounds>
+			<bounds x="318" y="345" width="54" height="16"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="302" y="251" width="88" height="32">
-			</bounds>
+			<bounds x="302" y="251" width="88" height="32"/>
 		</backdrop>
 		<backdrop name="label134" element="label_134">
-			<bounds x="307" y="286" width="79" height="32">
-			</bounds>
+			<bounds x="307" y="286" width="79" height="32"/>
 		</backdrop>
 		<backdrop name="label135" element="label_135">
-			<bounds x="316" y="327" width="54" height="16">
-			</bounds>
+			<bounds x="316" y="327" width="54" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_button" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_button" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_button" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1guvnor.lay
+++ b/src/mame/layout/m1guvnor.lay
@@ -8,9938 +8,6376 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TERRIFIC 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TERRIFIC 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="TAKE MY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="ADVICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="TAKE MY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="ADVICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="PICK A ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BUTTON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="PICK A ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="BUTTON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_168_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="DOUBLE YA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOSH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="DOUBLE YA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOSH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_273_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_273">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_279_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_279">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_280_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_280">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_281_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_281">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_282_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_282">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_283_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_283">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_284_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_284">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_286_border">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_286">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_287_border">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_287">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_288_border">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_288">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_13">
 		<text string="ANY 3 LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STARTS FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_23">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_24">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_25">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_26">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_41">
 		<text string="ANY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_42">
 		<text string="ANY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_43">
 		<text string="ANY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_44">
 		<text string="ANY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_45">
 		<text string="ANY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_46">
 		<text string="ANY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_58">
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_214">
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_215">
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_216">
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_258">
 		<text string="plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_272">
 		<text string="THANKS TO  DAVE  ( TREASURE ISLAND)">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TTX  PLOGGY AND CAPTAIN HADDOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="943" height="607">
-			</bounds>
+			<bounds x="0" y="0" width="943" height="607"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="303" y="359" width="80" height="160">
-			</bounds>
+			<bounds x="303" y="359" width="80" height="160"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="359.0000" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="303.0000" y="359.0000" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="361.2222" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="306.3333" y="361.2222" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="363.4445" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="309.6667" y="363.4445" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="365.6667" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="313.0000" y="365.6667" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="367.8889" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="316.3333" y="367.8889" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="370.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="319.6667" y="370.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="412.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="303.0000" y="412.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="414.5556" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="306.3333" y="414.5556" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="416.7778" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="309.6667" y="416.7778" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="419.0000" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="313.0000" y="419.0000" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="421.2222" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="316.3333" y="421.2222" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="423.4445" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="319.6667" y="423.4445" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="465.6667" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="303.0000" y="465.6667" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="467.8889" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="306.3333" y="467.8889" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="470.1111" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="309.6667" y="470.1111" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="472.3333" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="313.0000" y="472.3333" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="474.5555" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="316.3333" y="474.5555" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="476.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="319.6667" y="476.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="303" y="359" width="80" height="160">
-			</bounds>
+			<bounds x="303" y="359" width="80" height="160"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="386" y="358" width="80" height="160">
-			</bounds>
+			<bounds x="386" y="358" width="80" height="160"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="358.0000" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="386.0000" y="358.0000" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="360.2222" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="389.3333" y="360.2222" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="362.4445" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="392.6667" y="362.4445" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="364.6667" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="396.0000" y="364.6667" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="366.8889" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="399.3333" y="366.8889" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="369.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="402.6667" y="369.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="411.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="386.0000" y="411.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="413.5556" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="389.3333" y="413.5556" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="415.7778" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="392.6667" y="415.7778" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="418.0000" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="396.0000" y="418.0000" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="420.2222" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="399.3333" y="420.2222" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="422.4445" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="402.6667" y="422.4445" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="464.6667" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="386.0000" y="464.6667" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="466.8889" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="389.3333" y="466.8889" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="469.1111" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="392.6667" y="469.1111" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="471.3333" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="396.0000" y="471.3333" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="473.5555" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="399.3333" y="473.5555" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="475.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="402.6667" y="475.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="386" y="358" width="80" height="160">
-			</bounds>
+			<bounds x="386" y="358" width="80" height="160"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="471" y="358" width="80" height="160">
-			</bounds>
+			<bounds x="471" y="358" width="80" height="160"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="471.0000" y="358.0000" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="471.0000" y="358.0000" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="474.3333" y="360.2222" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="474.3333" y="360.2222" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="477.6667" y="362.4445" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="477.6667" y="362.4445" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="481.0000" y="364.6667" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="481.0000" y="364.6667" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="484.3333" y="366.8889" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="484.3333" y="366.8889" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="487.6667" y="369.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="487.6667" y="369.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="471.0000" y="411.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="471.0000" y="411.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="474.3333" y="413.5556" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="474.3333" y="413.5556" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="477.6667" y="415.7778" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="477.6667" y="415.7778" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="481.0000" y="418.0000" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="481.0000" y="418.0000" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="484.3333" y="420.2222" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="484.3333" y="420.2222" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="487.6667" y="422.4445" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="487.6667" y="422.4445" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="471.0000" y="464.6667" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="471.0000" y="464.6667" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="474.3333" y="466.8889" width="73.3333" height="48.8889">
-			</bounds>
+			<bounds x="474.3333" y="466.8889" width="73.3333" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="477.6667" y="469.1111" width="66.6667" height="44.4444">
-			</bounds>
+			<bounds x="477.6667" y="469.1111" width="66.6667" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="481.0000" y="471.3333" width="60.0000" height="40.0000">
-			</bounds>
+			<bounds x="481.0000" y="471.3333" width="60.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="484.3333" y="473.5555" width="53.3333" height="35.5556">
-			</bounds>
+			<bounds x="484.3333" y="473.5555" width="53.3333" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="487.6667" y="475.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="487.6667" y="475.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="471" y="358" width="80" height="160">
-			</bounds>
+			<bounds x="471" y="358" width="80" height="160"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="240" y="513" width="46" height="46">
-			</bounds>
+			<bounds x="240" y="513" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="242" y="515" width="42" height="42">
-			</bounds>
+			<bounds x="242" y="515" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="304" y="529" width="28" height="28">
-			</bounds>
+			<bounds x="304" y="529" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="306" y="531" width="24" height="24">
-			</bounds>
+			<bounds x="306" y="531" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="340" y="529" width="28" height="28">
-			</bounds>
+			<bounds x="340" y="529" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="342" y="531" width="24" height="24">
-			</bounds>
+			<bounds x="342" y="531" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="377" y="527" width="28" height="28">
-			</bounds>
+			<bounds x="377" y="527" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="379" y="529" width="24" height="24">
-			</bounds>
+			<bounds x="379" y="529" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="747" y="425" width="35" height="35">
-			</bounds>
+			<bounds x="747" y="425" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="749" y="427" width="31" height="31">
-			</bounds>
+			<bounds x="749" y="427" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="747" y="463" width="35" height="35">
-			</bounds>
+			<bounds x="747" y="463" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="749" y="465" width="31" height="31">
-			</bounds>
+			<bounds x="749" y="465" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="747" y="500" width="35" height="35">
-			</bounds>
+			<bounds x="747" y="500" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="749" y="502" width="31" height="31">
-			</bounds>
+			<bounds x="749" y="502" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="789" y="289" width="70" height="24">
-			</bounds>
+			<bounds x="789" y="289" width="70" height="24"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="791" y="291" width="66" height="20">
-			</bounds>
+			<bounds x="791" y="291" width="66" height="20"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="645" y="356" width="58" height="58">
-			</bounds>
+			<bounds x="645" y="356" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="647" y="358" width="54" height="54">
-			</bounds>
+			<bounds x="647" y="358" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="802" y="317" width="46" height="35">
-			</bounds>
+			<bounds x="802" y="317" width="46" height="35"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="804" y="319" width="42" height="31">
-			</bounds>
+			<bounds x="804" y="319" width="42" height="31"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="802" y="353" width="46" height="35">
-			</bounds>
+			<bounds x="802" y="353" width="46" height="35"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="804" y="355" width="42" height="31">
-			</bounds>
+			<bounds x="804" y="355" width="42" height="31"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="803" y="389" width="46" height="35">
-			</bounds>
+			<bounds x="803" y="389" width="46" height="35"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="805" y="391" width="42" height="31">
-			</bounds>
+			<bounds x="805" y="391" width="42" height="31"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="392" y="214" width="70" height="70">
-			</bounds>
+			<bounds x="392" y="214" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="394" y="216" width="66" height="66">
-			</bounds>
+			<bounds x="394" y="216" width="66" height="66"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_2_border" state="0">
-			<bounds x="470" y="288" width="46" height="28">
-			</bounds>
+			<bounds x="470" y="288" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_2" state="0">
-			<bounds x="472" y="290" width="42" height="24">
-			</bounds>
+			<bounds x="472" y="290" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="344" y="285" width="46" height="28">
-			</bounds>
+			<bounds x="344" y="285" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="346" y="287" width="42" height="24">
-			</bounds>
+			<bounds x="346" y="287" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="344" y="177" width="46" height="28">
-			</bounds>
+			<bounds x="344" y="177" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="346" y="179" width="42" height="24">
-			</bounds>
+			<bounds x="346" y="179" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="467" y="179" width="46" height="28">
-			</bounds>
+			<bounds x="467" y="179" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="469" y="181" width="42" height="24">
-			</bounds>
+			<bounds x="469" y="181" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="863" y="288" width="48" height="30">
-			</bounds>
+			<bounds x="863" y="288" width="48" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="865" y="290" width="44" height="26">
-			</bounds>
+			<bounds x="865" y="290" width="44" height="26"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="45" y="1" width="58" height="46">
-			</bounds>
+			<bounds x="45" y="1" width="58" height="46"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="47" y="3" width="54" height="42">
-			</bounds>
+			<bounds x="47" y="3" width="54" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="290" y="4" width="36" height="36">
-			</bounds>
+			<bounds x="290" y="4" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="292" y="6" width="32" height="32">
-			</bounds>
+			<bounds x="292" y="6" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="221" y="4" width="36" height="36">
-			</bounds>
+			<bounds x="221" y="4" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="223" y="6" width="32" height="32">
-			</bounds>
+			<bounds x="223" y="6" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="255" y="4" width="36" height="36">
-			</bounds>
+			<bounds x="255" y="4" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="257" y="6" width="32" height="32">
-			</bounds>
+			<bounds x="257" y="6" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="136" y="1" width="58" height="46">
-			</bounds>
+			<bounds x="136" y="1" width="58" height="46"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="138" y="3" width="54" height="42">
-			</bounds>
+			<bounds x="138" y="3" width="54" height="42"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="136" y="1" width="58" height="46">
-			</bounds>
+			<bounds x="136" y="1" width="58" height="46"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="138" y="3" width="54" height="42">
-			</bounds>
+			<bounds x="138" y="3" width="54" height="42"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="804" y="425" width="46" height="35">
-			</bounds>
+			<bounds x="804" y="425" width="46" height="35"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="806" y="427" width="42" height="31">
-			</bounds>
+			<bounds x="806" y="427" width="42" height="31"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="804" y="467" width="46" height="25">
-			</bounds>
+			<bounds x="804" y="467" width="46" height="25"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="806" y="469" width="42" height="21">
-			</bounds>
+			<bounds x="806" y="469" width="42" height="21"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_2_border" state="0">
-			<bounds x="166" y="161" width="34" height="34">
-			</bounds>
+			<bounds x="166" y="161" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_2" state="0">
-			<bounds x="168" y="163" width="30" height="30">
-			</bounds>
+			<bounds x="168" y="163" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="166" y="123" width="34" height="34">
-			</bounds>
+			<bounds x="166" y="123" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="168" y="125" width="30" height="30">
-			</bounds>
+			<bounds x="168" y="125" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="103" y="84" width="34" height="34">
-			</bounds>
+			<bounds x="103" y="84" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="105" y="86" width="30" height="30">
-			</bounds>
+			<bounds x="105" y="86" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="103" y="162" width="34" height="34">
-			</bounds>
+			<bounds x="103" y="162" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="105" y="164" width="30" height="30">
-			</bounds>
+			<bounds x="105" y="164" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="166" y="84" width="34" height="34">
-			</bounds>
+			<bounds x="166" y="84" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="168" y="86" width="30" height="30">
-			</bounds>
+			<bounds x="168" y="86" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="47" y="122" width="34" height="34">
-			</bounds>
+			<bounds x="47" y="122" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="49" y="124" width="30" height="30">
-			</bounds>
+			<bounds x="49" y="124" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="46" y="161" width="34" height="34">
-			</bounds>
+			<bounds x="46" y="161" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="48" y="163" width="30" height="30">
-			</bounds>
+			<bounds x="48" y="163" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="46" y="85" width="34" height="34">
-			</bounds>
+			<bounds x="46" y="85" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="48" y="87" width="30" height="30">
-			</bounds>
+			<bounds x="48" y="87" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="103" y="123" width="34" height="34">
-			</bounds>
+			<bounds x="103" y="123" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="105" y="125" width="30" height="30">
-			</bounds>
+			<bounds x="105" y="125" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="455" y="6" width="36" height="36">
-			</bounds>
+			<bounds x="455" y="6" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="457" y="8" width="32" height="32">
-			</bounds>
+			<bounds x="457" y="8" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="421" y="6" width="36" height="36">
-			</bounds>
+			<bounds x="421" y="6" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="423" y="8" width="32" height="32">
-			</bounds>
+			<bounds x="423" y="8" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="387" y="6" width="36" height="36">
-			</bounds>
+			<bounds x="387" y="6" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="389" y="8" width="32" height="32">
-			</bounds>
+			<bounds x="389" y="8" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="354" y="6" width="36" height="36">
-			</bounds>
+			<bounds x="354" y="6" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="356" y="8" width="32" height="32">
-			</bounds>
+			<bounds x="356" y="8" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="488" y="6" width="36" height="36">
-			</bounds>
+			<bounds x="488" y="6" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="490" y="8" width="32" height="32">
-			</bounds>
+			<bounds x="490" y="8" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="521" y="6" width="36" height="36">
-			</bounds>
+			<bounds x="521" y="6" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="523" y="8" width="32" height="32">
-			</bounds>
+			<bounds x="523" y="8" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="619" y="74" width="18" height="12">
-			</bounds>
+			<bounds x="619" y="74" width="18" height="12"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="621" y="76" width="14" height="8">
-			</bounds>
+			<bounds x="621" y="76" width="14" height="8"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="609" y="57" width="12" height="24">
-			</bounds>
+			<bounds x="609" y="57" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="611" y="59" width="8" height="20">
-			</bounds>
+			<bounds x="611" y="59" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="619" y="90" width="18" height="12">
-			</bounds>
+			<bounds x="619" y="90" width="18" height="12"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="621" y="92" width="14" height="8">
-			</bounds>
+			<bounds x="621" y="92" width="14" height="8"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="635" y="77" width="12" height="24">
-			</bounds>
+			<bounds x="635" y="77" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="637" y="79" width="8" height="20">
-			</bounds>
+			<bounds x="637" y="79" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="619" y="57" width="18" height="12">
-			</bounds>
+			<bounds x="619" y="57" width="18" height="12"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="621" y="59" width="14" height="8">
-			</bounds>
+			<bounds x="621" y="59" width="14" height="8"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="635" y="57" width="12" height="24">
-			</bounds>
+			<bounds x="635" y="57" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="637" y="59" width="8" height="20">
-			</bounds>
+			<bounds x="637" y="59" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="609" y="78" width="12" height="24">
-			</bounds>
+			<bounds x="609" y="78" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="611" y="80" width="8" height="20">
-			</bounds>
+			<bounds x="611" y="80" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="676" y="57" width="12" height="24">
-			</bounds>
+			<bounds x="676" y="57" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="678" y="59" width="8" height="20">
-			</bounds>
+			<bounds x="678" y="59" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="660" y="57" width="18" height="12">
-			</bounds>
+			<bounds x="660" y="57" width="18" height="12"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="662" y="59" width="14" height="8">
-			</bounds>
+			<bounds x="662" y="59" width="14" height="8"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="651" y="57" width="12" height="24">
-			</bounds>
+			<bounds x="651" y="57" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="653" y="59" width="8" height="20">
-			</bounds>
+			<bounds x="653" y="59" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="660" y="72" width="18" height="12">
-			</bounds>
+			<bounds x="660" y="72" width="18" height="12"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="662" y="74" width="14" height="8">
-			</bounds>
+			<bounds x="662" y="74" width="14" height="8"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="651" y="77" width="12" height="24">
-			</bounds>
+			<bounds x="651" y="77" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="653" y="79" width="8" height="20">
-			</bounds>
+			<bounds x="653" y="79" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="676" y="77" width="12" height="24">
-			</bounds>
+			<bounds x="676" y="77" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="678" y="79" width="8" height="20">
-			</bounds>
+			<bounds x="678" y="79" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="661" y="89" width="18" height="12">
-			</bounds>
+			<bounds x="661" y="89" width="18" height="12"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="663" y="91" width="14" height="8">
-			</bounds>
+			<bounds x="663" y="91" width="14" height="8"/>
 		</backdrop>
 		<backdrop name="lamp229" element="colour_button_273_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="624" y="16" width="55" height="27">
-			</bounds>
+			<bounds x="624" y="16" width="55" height="27"/>
 		</backdrop>
 		<backdrop name="lamp229" element="colour_button_273" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="626" y="18" width="51" height="23">
-			</bounds>
+			<bounds x="626" y="18" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_279_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="572" y="559" width="75" height="37">
-			</bounds>
+			<bounds x="572" y="559" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_279" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="574" y="561" width="71" height="33">
-			</bounds>
+			<bounds x="574" y="561" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_280_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="481" y="558" width="75" height="37">
-			</bounds>
+			<bounds x="481" y="558" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_280" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="483" y="560" width="71" height="33">
-			</bounds>
+			<bounds x="483" y="560" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_281_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="317" y="559" width="75" height="37">
-			</bounds>
+			<bounds x="317" y="559" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_281" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="319" y="561" width="71" height="33">
-			</bounds>
+			<bounds x="319" y="561" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_282_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="230" y="560" width="75" height="37">
-			</bounds>
+			<bounds x="230" y="560" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_282" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="232" y="562" width="71" height="33">
-			</bounds>
+			<bounds x="232" y="562" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_283_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="665" y="558" width="75" height="37">
-			</bounds>
+			<bounds x="665" y="558" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_283" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="667" y="560" width="71" height="33">
-			</bounds>
+			<bounds x="667" y="560" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_284_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="398" y="558" width="75" height="37">
-			</bounds>
+			<bounds x="398" y="558" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_284" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="400" y="560" width="71" height="33">
-			</bounds>
+			<bounds x="400" y="560" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp144" element="colour_button_286_border" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="162" y="196" width="46" height="27">
-			</bounds>
+			<bounds x="162" y="196" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp144" element="colour_button_286" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="164" y="198" width="42" height="23">
-			</bounds>
+			<bounds x="164" y="198" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp145" element="colour_button_287_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="98" y="197" width="46" height="27">
-			</bounds>
+			<bounds x="98" y="197" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp145" element="colour_button_287" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="100" y="199" width="42" height="23">
-			</bounds>
+			<bounds x="100" y="199" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp147" element="colour_button_288_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="40" y="197" width="46" height="27">
-			</bounds>
+			<bounds x="40" y="197" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp147" element="colour_button_288" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="42" y="199" width="42" height="23">
-			</bounds>
+			<bounds x="42" y="199" width="42" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="288" y="323" width="272" height="30">
-			</bounds>
+			<bounds x="288" y="323" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="288" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="288" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="305" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="305" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="322" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="322" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="339" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="339" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="356" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="356" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="373" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="373" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="390" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="390" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="407" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="407" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="424" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="424" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="441" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="441" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="458" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="458" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="475" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="475" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="492" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="492" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="509" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="509" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="526" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="526" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="543" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="543" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label13" element="label_13">
-			<bounds x="91" y="409" width="84" height="60">
-			</bounds>
+			<bounds x="91" y="409" width="84" height="60"/>
 		</backdrop>
 		<backdrop name="label23" element="label_23">
-			<bounds x="149" y="334" width="16" height="24">
-			</bounds>
+			<bounds x="149" y="334" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label24" element="label_24">
-			<bounds x="150" y="270" width="16" height="24">
-			</bounds>
+			<bounds x="150" y="270" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label25" element="label_25">
-			<bounds x="87" y="333" width="16" height="24">
-			</bounds>
+			<bounds x="87" y="333" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label26" element="label_26">
-			<bounds x="88" y="270" width="16" height="24">
-			</bounds>
+			<bounds x="88" y="270" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label41" element="label_41">
-			<bounds x="694" y="481" width="22" height="13">
-			</bounds>
+			<bounds x="694" y="481" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label42" element="label_42">
-			<bounds x="667" y="440" width="22" height="13">
-			</bounds>
+			<bounds x="667" y="440" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label43" element="label_43">
-			<bounds x="697" y="440" width="22" height="13">
-			</bounds>
+			<bounds x="697" y="440" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label44" element="label_44">
-			<bounds x="634" y="483" width="22" height="13">
-			</bounds>
+			<bounds x="634" y="483" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label45" element="label_45">
-			<bounds x="668" y="517" width="22" height="13">
-			</bounds>
+			<bounds x="668" y="517" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label46" element="label_46">
-			<bounds x="634" y="518" width="22" height="13">
-			</bounds>
+			<bounds x="634" y="518" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label58" element="label_58">
-			<bounds x="612" y="205" width="94" height="48">
-			</bounds>
+			<bounds x="612" y="205" width="94" height="48"/>
 		</backdrop>
 		<backdrop name="label214" element="label_214">
-			<bounds x="886" y="220" width="51" height="24">
-			</bounds>
+			<bounds x="886" y="220" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="label215" element="label_215">
-			<bounds x="885" y="171" width="51" height="24">
-			</bounds>
+			<bounds x="885" y="171" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="label216" element="label_216">
-			<bounds x="885" y="121" width="51" height="24">
-			</bounds>
+			<bounds x="885" y="121" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="label258" element="label_258">
-			<bounds x="630" y="102" width="49" height="24">
-			</bounds>
+			<bounds x="630" y="102" width="49" height="24"/>
 		</backdrop>
 		<backdrop name="label272" element="label_272">
-			<bounds x="862" y="489" width="80" height="117">
-			</bounds>
+			<bounds x="862" y="489" width="80" height="117"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_button" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_button" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_button" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_button" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1hotpoth.lay
+++ b/src/mame/layout/m1hotpoth.lay
@@ -8,15776 +8,8838 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_255_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_255_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SWAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SWAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="A POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="A POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
+			<color red="0.50" green="0.02" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
+			<color red="1.00" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
+			<color red="0.25" green="0.01" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
+			<color red="0.50" green="0.10" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
+			<color red="1.00" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
+			<color red="0.50" green="0.06" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
+			<color red="1.00" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
+			<color red="0.25" green="0.03" blue="0.03"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
+			<color red="0.16" green="0.50" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
+			<color red="0.04" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
+			<color red="0.33" green="1.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
+			<color red="0.08" green="0.25" blue="0.08"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
+			<color red="0.13" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
+			<color red="0.25" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
+			<color red="0.08" green="0.50" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
+			<color red="0.02" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
+			<color red="0.17" green="1.00" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
+			<color red="0.04" green="0.25" blue="0.04"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
+			<color red="0.04" green="0.50" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
+			<color red="0.01" green="0.12" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
+			<color red="0.08" green="1.00" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
+			<color red="0.02" green="0.25" blue="0.02"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_209_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_210_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_210_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_211_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_211_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_212_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_212_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_213_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_213_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_214_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_214_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_215_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_215_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_216_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_216_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_217_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_217_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_218_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_218_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_219_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_219_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_220_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_220_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_221_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_224_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_223_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_222_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_222_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
+			<color red="0.48" green="0.41" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
+			<color red="0.97" green="0.82" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
+			<color red="0.24" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="GOLDEN SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="GOLDEN SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE A TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE A TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="POT SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="POT SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="POT ADVANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="POT ADVANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SKILLSHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILLSHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
+			<color red="0.50" green="0.06" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
+			<color red="1.00" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
+			<color red="0.25" green="0.03" blue="0.03"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
+			<color red="0.50" green="0.02" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
+			<color red="1.00" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
+			<color red="0.25" green="0.01" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
+			<color red="0.50" green="0.10" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
+			<color red="1.00" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
+			<color red="0.16" green="0.50" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
+			<color red="0.04" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
+			<color red="0.33" green="1.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
+			<color red="0.08" green="0.25" blue="0.08"/>
 		</rect>
 		<text string="Step To Nearest Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
-		</rect>
-		<text string="Step To Nearest Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.15" green="0.32" blue="0.50">
-			</color>
+			<color red="0.15" green="0.32" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
+			<color red="0.04" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.65" blue="1.00">
-			</color>
+			<color red="0.29" green="0.65" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.16" blue="0.25">
-			</color>
+			<color red="0.07" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="Spin N Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.15" green="0.32" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.65" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="Spin N Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.50">
-			</color>
+			<color red="0.50" green="0.13" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.12">
-			</color>
+			<color red="0.12" green="0.03" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="1.00">
-			</color>
+			<color red="1.00" green="0.25" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.25">
-			</color>
+			<color red="0.25" green="0.06" blue="0.25"/>
 		</rect>
 		<text string="Cash Stopper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cash Stopper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.10" green="0.50" blue="0.50">
-			</color>
+			<color red="0.10" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.12">
-			</color>
+			<color red="0.02" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="1.00" blue="1.00">
-			</color>
+			<color red="0.21" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.25" blue="0.25">
-			</color>
+			<color red="0.05" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Hi-Lo Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.10" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Hi-Lo Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="Skill Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="Skill Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.28">
-			</color>
+			<color red="0.50" green="0.06" blue="0.28"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.07">
-			</color>
+			<color red="0.12" green="0.02" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.56">
-			</color>
+			<color red="1.00" green="0.13" blue="0.56"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.14">
-			</color>
+			<color red="0.25" green="0.03" blue="0.14"/>
 		</rect>
 		<text string="Link Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.28">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.56">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.14">
-			</color>
-		</rect>
-		<text string="Link Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.07" blue="0.47">
-			</color>
+			<color red="0.25" green="0.07" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.02" blue="0.11">
-			</color>
+			<color red="0.06" green="0.02" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.15" blue="0.94">
-			</color>
+			<color red="0.51" green="0.15" blue="0.94"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.04" blue="0.23">
-			</color>
+			<color red="0.13" green="0.04" blue="0.23"/>
 		</rect>
 		<text string="Cash Filla">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.07" blue="0.47">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.02" blue="0.11">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.15" blue="0.94">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.04" blue="0.23">
-			</color>
-		</rect>
-		<text string="Cash Filla">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.35" blue="0.01">
-			</color>
+			<color red="0.49" green="0.35" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.98" green="0.69" blue="0.02">
-			</color>
+			<color red="0.98" green="0.69" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.17" blue="0.00">
-			</color>
+			<color red="0.24" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="Cash Grabber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.35" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.98" green="0.69" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Grabber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Super Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="99 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="99 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.26">
-			</color>
+			<color red="0.50" green="0.02" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.52">
-			</color>
+			<color red="1.00" green="0.04" blue="0.52"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.13">
-			</color>
+			<color red="0.25" green="0.01" blue="0.13"/>
 		</rect>
 		<text string="8 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.52">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.13">
-			</color>
-		</rect>
-		<text string="8 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.27">
-			</color>
+			<color red="0.50" green="0.04" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.07">
-			</color>
+			<color red="0.12" green="0.01" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.54">
-			</color>
+			<color red="1.00" green="0.08" blue="0.54"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.13">
-			</color>
+			<color red="0.25" green="0.02" blue="0.13"/>
 		</rect>
 		<text string="7 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.54">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.13">
-			</color>
-		</rect>
-		<text string="7 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.28">
-			</color>
+			<color red="0.50" green="0.06" blue="0.28"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.07">
-			</color>
+			<color red="0.12" green="0.02" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.56">
-			</color>
+			<color red="1.00" green="0.13" blue="0.56"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.14">
-			</color>
+			<color red="0.25" green="0.03" blue="0.14"/>
 		</rect>
 		<text string="6 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.28">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.56">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.14">
-			</color>
-		</rect>
-		<text string="6 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.29">
-			</color>
+			<color red="0.50" green="0.08" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.07">
-			</color>
+			<color red="0.12" green="0.02" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.58">
-			</color>
+			<color red="1.00" green="0.17" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.15">
-			</color>
+			<color red="0.25" green="0.04" blue="0.15"/>
 		</rect>
 		<text string="5 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.15">
-			</color>
-		</rect>
-		<text string="5 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.30">
-			</color>
+			<color red="0.50" green="0.10" blue="0.30"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.07">
-			</color>
+			<color red="0.12" green="0.02" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.60">
-			</color>
+			<color red="1.00" green="0.21" blue="0.60"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.15">
-			</color>
+			<color red="0.25" green="0.05" blue="0.15"/>
 		</rect>
 		<text string="4 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.30">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.60">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.15">
-			</color>
-		</rect>
-		<text string="4 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.31">
-			</color>
+			<color red="0.50" green="0.13" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.07">
-			</color>
+			<color red="0.12" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.62">
-			</color>
+			<color red="1.00" green="0.25" blue="0.62"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.15">
-			</color>
+			<color red="0.25" green="0.06" blue="0.15"/>
 		</rect>
 		<text string="3 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.62">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.15">
-			</color>
-		</rect>
-		<text string="3 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.32">
-			</color>
+			<color red="0.50" green="0.15" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.08">
-			</color>
+			<color red="0.12" green="0.04" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.65">
-			</color>
+			<color red="1.00" green="0.29" blue="0.65"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.16">
-			</color>
+			<color red="0.25" green="0.07" blue="0.16"/>
 		</rect>
 		<text string="2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.32">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.65">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.16">
-			</color>
-		</rect>
-		<text string="2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.33">
-			</color>
+			<color red="0.50" green="0.16" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.08">
-			</color>
+			<color red="0.12" green="0.04" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.67">
-			</color>
+			<color red="1.00" green="0.33" blue="0.67"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.16">
-			</color>
+			<color red="0.25" green="0.08" blue="0.16"/>
 		</rect>
 		<text string="1 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.67">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.16">
-			</color>
-		</rect>
-		<text string="1 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.15">
-			</color>
+			<color red="0.50" green="0.50" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.04">
-			</color>
+			<color red="0.12" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.29">
-			</color>
+			<color red="1.00" green="1.00" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.07">
-			</color>
+			<color red="0.25" green="0.25" blue="0.07"/>
 		</rect>
 		<text string="Super Skillshot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.15">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.07">
-			</color>
-		</rect>
-		<text string="Super Skillshot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.13">
-			</color>
+			<color red="0.50" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.03">
-			</color>
+			<color red="0.12" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.25">
-			</color>
+			<color red="1.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.06">
-			</color>
+			<color red="0.25" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Super Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Super Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.10">
-			</color>
+			<color red="0.50" green="0.50" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.02">
-			</color>
+			<color red="0.12" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.21">
-			</color>
+			<color red="1.00" green="1.00" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.05">
-			</color>
+			<color red="0.25" green="0.25" blue="0.05"/>
 		</rect>
 		<text string="&#xA3;4.00 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.05">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00 Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.08">
-			</color>
+			<color red="0.50" green="0.50" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.02">
-			</color>
+			<color red="0.12" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.17">
-			</color>
+			<color red="1.00" green="1.00" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.04">
-			</color>
+			<color red="0.25" green="0.25" blue="0.04"/>
 		</rect>
 		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.04">
-			</color>
-		</rect>
-		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.06">
-			</color>
+			<color red="0.50" green="0.50" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.02">
-			</color>
+			<color red="0.12" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.13">
-			</color>
+			<color red="1.00" green="1.00" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.03">
-			</color>
+			<color red="0.25" green="0.25" blue="0.03"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.03">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.04">
-			</color>
+			<color red="0.50" green="0.50" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.01">
-			</color>
+			<color red="0.12" green="0.12" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.08">
-			</color>
+			<color red="1.00" green="1.00" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.02">
-			</color>
+			<color red="0.25" green="0.25" blue="0.02"/>
 		</rect>
 		<text string="Big Win Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.02">
-			</color>
-		</rect>
-		<text string="Big Win Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.02">
-			</color>
+			<color red="0.50" green="0.50" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.04">
-			</color>
+			<color red="1.00" green="1.00" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.01">
-			</color>
+			<color red="0.25" green="0.25" blue="0.01"/>
 		</rect>
 		<text string="99 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.01">
-			</color>
-		</rect>
-		<text string="99 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.16">
-			</color>
+			<color red="0.50" green="0.50" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.04">
-			</color>
+			<color red="0.12" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.33">
-			</color>
+			<color red="1.00" green="1.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.08">
-			</color>
+			<color red="0.25" green="0.25" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_225_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_226_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_227_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_207_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_231_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_231_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_230_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_229_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_228_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="JACKP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="JACKP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="H ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="H ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="O T ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="O T ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string=" P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string=" P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string=" O T ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string=" O T ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string=" S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string=" S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<disk state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
+			<color red="0.48" green="0.41" blue="0.02"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<disk state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
+			<color red="0.97" green="0.82" blue="0.04"/>
 		</disk>
 		<disk state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
+			<color red="0.24" green="0.20" blue="0.01"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<disk state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
+			<color red="0.48" green="0.41" blue="0.02"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<disk state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
+			<color red="0.97" green="0.82" blue="0.04"/>
 		</disk>
 		<disk state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
+			<color red="0.24" green="0.20" blue="0.01"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<disk state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
+			<color red="0.48" green="0.41" blue="0.02"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<disk state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
+			<color red="0.97" green="0.82" blue="0.04"/>
 		</disk>
 		<disk state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
+			<color red="0.24" green="0.20" blue="0.01"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<disk state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
+			<color red="0.48" green="0.41" blue="0.02"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
+			<color red="0.97" green="0.82" blue="0.04"/>
 		</disk>
 		<disk state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
+			<color red="0.24" green="0.20" blue="0.01"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.48" green="0.41" blue="0.02">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.97" green="0.82" blue="0.04">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
+			<color red="0.34" green="0.37" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
+			<color red="0.08" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
+			<color red="0.67" green="0.74" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
+			<color red="0.17" green="0.18" blue="0.18"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.37" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="0.74" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.18" blue="0.18">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_186_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_186">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SWAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_187_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_187">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_188_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_188">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_189_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_189">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_190_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_190">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_191_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_191">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_192_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_192">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Token">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_136">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.07"/>
 		</text>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.13" width="0.90" height="0.07"/>
 		</text>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.07"/>
 		</text>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.27" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.27" width="0.90" height="0.07"/>
 		</text>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.07"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.42" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.42" width="0.90" height="0.07"/>
 		</text>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.07"/>
 		</text>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.57" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.57" width="0.90" height="0.07"/>
 		</text>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.07"/>
 		</text>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.07"/>
 		</text>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.07"/>
 		</text>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.87" width="0.90" height="0.07"/>
 		</text>
 	</element>
 	<element name="label_137">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_138">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_171">
 		<text string="Bugs And Trouty V1.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_172">
 		<text string="Prime Mover">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="758" height="663">
-			</bounds>
+			<bounds x="0" y="0" width="758" height="663"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="122" y="423" width="80" height="140">
-			</bounds>
+			<bounds x="122" y="423" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="122.0000" y="423.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="122.0000" y="423.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="125.3333" y="424.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="125.3333" y="424.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="128.6667" y="426.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="128.6667" y="426.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="132.0000" y="428.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="132.0000" y="428.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="135.3333" y="430.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="135.3333" y="430.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="138.6667" y="432.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="138.6667" y="432.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="122.0000" y="469.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="122.0000" y="469.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="125.3333" y="471.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="125.3333" y="471.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="128.6667" y="473.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="128.6667" y="473.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="132.0000" y="475.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="132.0000" y="475.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="135.3333" y="477.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="135.3333" y="477.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="138.6667" y="479.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="138.6667" y="479.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="122.0000" y="516.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="122.0000" y="516.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="125.3333" y="518.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="125.3333" y="518.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="128.6667" y="520.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="128.6667" y="520.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="132.0000" y="522.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="132.0000" y="522.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="135.3333" y="524.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="135.3333" y="524.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="138.6667" y="526.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="138.6667" y="526.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="122" y="423" width="80" height="140">
-			</bounds>
+			<bounds x="122" y="423" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="252" y="423" width="80" height="140">
-			</bounds>
+			<bounds x="252" y="423" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="252.0000" y="423.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="252.0000" y="423.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="255.3333" y="424.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="255.3333" y="424.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="258.6667" y="426.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="258.6667" y="426.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="262.0000" y="428.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="262.0000" y="428.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="265.3333" y="430.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="265.3333" y="430.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="268.6667" y="432.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="268.6667" y="432.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="252.0000" y="469.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="252.0000" y="469.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="255.3333" y="471.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="255.3333" y="471.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="258.6667" y="473.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="258.6667" y="473.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="262.0000" y="475.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="262.0000" y="475.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="265.3333" y="477.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="265.3333" y="477.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="268.6667" y="479.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="268.6667" y="479.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="252.0000" y="516.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="252.0000" y="516.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="255.3333" y="518.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="255.3333" y="518.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="258.6667" y="520.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="258.6667" y="520.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="262.0000" y="522.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="262.0000" y="522.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="265.3333" y="524.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="265.3333" y="524.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="268.6667" y="526.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="268.6667" y="526.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="252" y="423" width="80" height="140">
-			</bounds>
+			<bounds x="252" y="423" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="382" y="423" width="80" height="140">
-			</bounds>
+			<bounds x="382" y="423" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="382.0000" y="423.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="382.0000" y="423.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="385.3333" y="424.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="385.3333" y="424.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="388.6667" y="426.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="388.6667" y="426.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.0000" y="428.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="392.0000" y="428.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.3333" y="430.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="395.3333" y="430.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.6667" y="432.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="398.6667" y="432.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="382.0000" y="469.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="382.0000" y="469.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="385.3333" y="471.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="385.3333" y="471.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="388.6667" y="473.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="388.6667" y="473.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.0000" y="475.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="392.0000" y="475.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.3333" y="477.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="395.3333" y="477.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.6667" y="479.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="398.6667" y="479.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="382.0000" y="516.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="382.0000" y="516.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="385.3333" y="518.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="385.3333" y="518.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="388.6667" y="520.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="388.6667" y="520.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.0000" y="522.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="392.0000" y="522.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.3333" y="524.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="395.3333" y="524.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.6667" y="526.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="398.6667" y="526.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="382" y="423" width="80" height="140">
-			</bounds>
+			<bounds x="382" y="423" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="92" y="159" width="60" height="51">
-			</bounds>
+			<bounds x="92" y="159" width="60" height="51"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="92.0000" y="159.0000" width="60.0000" height="51.0000">
-			</bounds>
+			<bounds x="92.0000" y="159.0000" width="60.0000" height="51.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="94.5000" y="161.1250" width="55.0000" height="46.7500">
-			</bounds>
+			<bounds x="94.5000" y="161.1250" width="55.0000" height="46.7500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="97.0000" y="163.2500" width="50.0000" height="42.5000">
-			</bounds>
+			<bounds x="97.0000" y="163.2500" width="50.0000" height="42.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="99.5000" y="165.3750" width="45.0000" height="38.2500">
-			</bounds>
+			<bounds x="99.5000" y="165.3750" width="45.0000" height="38.2500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="102.0000" y="167.5000" width="40.0000" height="34.0000">
-			</bounds>
+			<bounds x="102.0000" y="167.5000" width="40.0000" height="34.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="104.5000" y="169.6250" width="35.0000" height="29.7500">
-			</bounds>
+			<bounds x="104.5000" y="169.6250" width="35.0000" height="29.7500"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="92" y="159" width="60" height="51">
-			</bounds>
+			<bounds x="92" y="159" width="60" height="51"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="547" y="383" width="30" height="19">
-			</bounds>
+			<bounds x="547" y="383" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="549" y="385" width="26" height="15">
-			</bounds>
+			<bounds x="549" y="385" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="530" y="383" width="19" height="19">
-			</bounds>
+			<bounds x="530" y="383" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="532" y="385" width="15" height="15">
-			</bounds>
+			<bounds x="532" y="385" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="513" y="383" width="19" height="19">
-			</bounds>
+			<bounds x="513" y="383" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="515" y="385" width="15" height="15">
-			</bounds>
+			<bounds x="515" y="385" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1_border" state="0">
-			<bounds x="523" y="368" width="40" height="16">
-			</bounds>
+			<bounds x="523" y="368" width="40" height="16"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1" state="0">
-			<bounds x="525" y="370" width="36" height="12">
-			</bounds>
+			<bounds x="525" y="370" width="36" height="12"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="560" y="368" width="42" height="16">
-			</bounds>
+			<bounds x="560" y="368" width="42" height="16"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="562" y="370" width="38" height="12">
-			</bounds>
+			<bounds x="562" y="370" width="38" height="12"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="522" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="522" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="524" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="524" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="592" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="592" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="594" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="594" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="102" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="102" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="104" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="104" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="172" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="172" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="174" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="174" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="312" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="312" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="314" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="314" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="662" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="662" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="664" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="664" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="452" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="452" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="454" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="454" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="382" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="382" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="384" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="384" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="242" y="565" width="58" height="21">
-			</bounds>
+			<bounds x="242" y="565" width="58" height="21"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="244" y="567" width="54" height="17">
-			</bounds>
+			<bounds x="244" y="567" width="54" height="17"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="51" y="555" width="42" height="32">
-			</bounds>
+			<bounds x="51" y="555" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="53" y="557" width="38" height="28">
-			</bounds>
+			<bounds x="53" y="557" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="51" y="523" width="42" height="32">
-			</bounds>
+			<bounds x="51" y="523" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="53" y="525" width="38" height="28">
-			</bounds>
+			<bounds x="53" y="525" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="51" y="491" width="42" height="32">
-			</bounds>
+			<bounds x="51" y="491" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="53" y="493" width="38" height="28">
-			</bounds>
+			<bounds x="53" y="493" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="51" y="459" width="42" height="32">
-			</bounds>
+			<bounds x="51" y="459" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="53" y="461" width="38" height="28">
-			</bounds>
+			<bounds x="53" y="461" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="51" y="427" width="42" height="32">
-			</bounds>
+			<bounds x="51" y="427" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="53" y="429" width="38" height="28">
-			</bounds>
+			<bounds x="53" y="429" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="308" y="64" width="52" height="16">
-			</bounds>
+			<bounds x="308" y="64" width="52" height="16"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="310" y="66" width="48" height="12">
-			</bounds>
+			<bounds x="310" y="66" width="48" height="12"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="358" y="64" width="36" height="16">
-			</bounds>
+			<bounds x="358" y="64" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="360" y="66" width="32" height="12">
-			</bounds>
+			<bounds x="360" y="66" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="392" y="64" width="52" height="16">
-			</bounds>
+			<bounds x="392" y="64" width="52" height="16"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="394" y="66" width="48" height="12">
-			</bounds>
+			<bounds x="394" y="66" width="48" height="12"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="442" y="64" width="36" height="16">
-			</bounds>
+			<bounds x="442" y="64" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="444" y="66" width="32" height="12">
-			</bounds>
+			<bounds x="444" y="66" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="476" y="64" width="52" height="16">
-			</bounds>
+			<bounds x="476" y="64" width="52" height="16"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="478" y="66" width="48" height="12">
-			</bounds>
+			<bounds x="478" y="66" width="48" height="12"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="526" y="64" width="36" height="16">
-			</bounds>
+			<bounds x="526" y="64" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="528" y="66" width="32" height="12">
-			</bounds>
+			<bounds x="528" y="66" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="695" y="388" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="388" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="697" y="390" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="390" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="695" y="364" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="364" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="697" y="366" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="366" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="695" y="340" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="340" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="697" y="342" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="342" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="695" y="316" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="316" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="697" y="318" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="318" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="695" y="292" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="292" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="697" y="294" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="294" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="695" y="268" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="268" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="697" y="270" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="270" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="695" y="244" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="244" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="697" y="246" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="246" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="695" y="220" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="220" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="697" y="222" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="222" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="695" y="196" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="196" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="697" y="198" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="198" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="695" y="172" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="172" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="697" y="174" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="174" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="695" y="148" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="148" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="697" y="150" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="150" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_2_border" state="0">
-			<bounds x="689" y="379" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="379" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_2" state="0">
-			<bounds x="691" y="381" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="381" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_2_border" state="0">
-			<bounds x="689" y="355" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="355" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_2" state="0">
-			<bounds x="691" y="357" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="357" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_2_border" state="0">
-			<bounds x="689" y="331" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="331" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_2" state="0">
-			<bounds x="691" y="333" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="333" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_2_border" state="0">
-			<bounds x="689" y="307" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="307" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_2" state="0">
-			<bounds x="691" y="309" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="309" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_2_border" state="0">
-			<bounds x="689" y="283" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="283" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_2" state="0">
-			<bounds x="691" y="285" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="285" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_2_border" state="0">
-			<bounds x="689" y="259" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="259" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_2" state="0">
-			<bounds x="691" y="261" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="261" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_2_border" state="0">
-			<bounds x="689" y="235" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="235" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_2" state="0">
-			<bounds x="691" y="237" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="237" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_2_border" state="0">
-			<bounds x="689" y="211" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="211" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_2" state="0">
-			<bounds x="691" y="213" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="213" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_2_border" state="0">
-			<bounds x="689" y="187" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="187" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_2" state="0">
-			<bounds x="691" y="189" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="189" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_2_border" state="0">
-			<bounds x="689" y="163" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="163" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_2" state="0">
-			<bounds x="691" y="165" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="165" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_2_border" state="0">
-			<bounds x="689" y="139" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="139" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_2" state="0">
-			<bounds x="691" y="141" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="141" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="689" y="115" width="47" height="12">
-			</bounds>
+			<bounds x="689" y="115" width="47" height="12"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="691" y="117" width="43" height="8">
-			</bounds>
+			<bounds x="691" y="117" width="43" height="8"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_2_border" state="0">
-			<bounds x="695" y="124" width="36" height="16">
-			</bounds>
+			<bounds x="695" y="124" width="36" height="16"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_2" state="0">
-			<bounds x="697" y="126" width="32" height="12">
-			</bounds>
+			<bounds x="697" y="126" width="32" height="12"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="682" y="403" width="62" height="16">
-			</bounds>
+			<bounds x="682" y="403" width="62" height="16"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="684" y="405" width="58" height="12">
-			</bounds>
+			<bounds x="684" y="405" width="58" height="12"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="698" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="698" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="700" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="700" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_2_border" state="0">
-			<bounds x="689" y="88" width="12" height="28">
-			</bounds>
+			<bounds x="689" y="88" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_2" state="0">
-			<bounds x="691" y="90" width="8" height="24">
-			</bounds>
+			<bounds x="691" y="90" width="8" height="24"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="573" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="573" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="575" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="575" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_2_border" state="0">
-			<bounds x="564" y="88" width="12" height="28">
-			</bounds>
+			<bounds x="564" y="88" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_2" state="0">
-			<bounds x="566" y="90" width="8" height="24">
-			</bounds>
+			<bounds x="566" y="90" width="8" height="24"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="611" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="611" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="613" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="613" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_2_border" state="0">
-			<bounds x="607" y="109" width="37" height="19">
-			</bounds>
+			<bounds x="607" y="109" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_2" state="0">
-			<bounds x="609" y="111" width="33" height="15">
-			</bounds>
+			<bounds x="609" y="111" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="647" y="88" width="12" height="28">
-			</bounds>
+			<bounds x="647" y="88" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="649" y="90" width="8" height="24">
-			</bounds>
+			<bounds x="649" y="90" width="8" height="24"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_2_border" state="0">
-			<bounds x="655" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="655" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_2" state="0">
-			<bounds x="657" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="657" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="4" y="246" width="52" height="19">
-			</bounds>
+			<bounds x="4" y="246" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="6" y="248" width="48" height="15">
-			</bounds>
+			<bounds x="6" y="248" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="61" y="234" width="112" height="16">
-			</bounds>
+			<bounds x="61" y="234" width="112" height="16"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="63" y="236" width="108" height="12">
-			</bounds>
+			<bounds x="63" y="236" width="108" height="12"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="61" y="248" width="112" height="16">
-			</bounds>
+			<bounds x="61" y="248" width="112" height="16"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="63" y="250" width="108" height="12">
-			</bounds>
+			<bounds x="63" y="250" width="108" height="12"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="61" y="262" width="112" height="16">
-			</bounds>
+			<bounds x="61" y="262" width="112" height="16"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="63" y="264" width="108" height="12">
-			</bounds>
+			<bounds x="63" y="264" width="108" height="12"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="61" y="276" width="112" height="16">
-			</bounds>
+			<bounds x="61" y="276" width="112" height="16"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="63" y="278" width="108" height="12">
-			</bounds>
+			<bounds x="63" y="278" width="108" height="12"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="61" y="290" width="112" height="16">
-			</bounds>
+			<bounds x="61" y="290" width="112" height="16"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="63" y="292" width="108" height="12">
-			</bounds>
+			<bounds x="63" y="292" width="108" height="12"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="61" y="304" width="112" height="16">
-			</bounds>
+			<bounds x="61" y="304" width="112" height="16"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="63" y="306" width="108" height="12">
-			</bounds>
+			<bounds x="63" y="306" width="108" height="12"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="61" y="318" width="112" height="16">
-			</bounds>
+			<bounds x="61" y="318" width="112" height="16"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="63" y="320" width="108" height="12">
-			</bounds>
+			<bounds x="63" y="320" width="108" height="12"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="29" y="184" width="42" height="24">
-			</bounds>
+			<bounds x="29" y="184" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="31" y="186" width="38" height="20">
-			</bounds>
+			<bounds x="31" y="186" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="29" y="161" width="42" height="24">
-			</bounds>
+			<bounds x="29" y="161" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="31" y="163" width="38" height="20">
-			</bounds>
+			<bounds x="31" y="163" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="562" y="330" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="330" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="564" y="332" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="332" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="562" y="230" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="230" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="564" y="232" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="232" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="562" y="205" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="205" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="564" y="207" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="207" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="562" y="180" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="180" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="564" y="182" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="182" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="562" y="155" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="155" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="564" y="157" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="157" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="562" y="130" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="130" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="564" y="132" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="132" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="562" y="255" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="255" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="564" y="257" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="257" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="562" y="280" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="280" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="564" y="282" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="282" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="562" y="305" width="122" height="27">
-			</bounds>
+			<bounds x="562" y="305" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="564" y="307" width="118" height="23">
-			</bounds>
+			<bounds x="564" y="307" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="436" y="330" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="330" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="438" y="332" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="332" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="436" y="305" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="305" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="438" y="307" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="307" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="436" y="280" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="280" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="438" y="282" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="282" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="436" y="255" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="255" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="438" y="257" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="257" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="436" y="230" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="230" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="438" y="232" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="232" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="436" y="205" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="205" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="438" y="207" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="207" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="436" y="180" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="180" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="438" y="182" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="182" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="436" y="155" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="155" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="438" y="157" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="157" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="436" y="130" width="122" height="27">
-			</bounds>
+			<bounds x="436" y="130" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="438" y="132" width="118" height="23">
-			</bounds>
+			<bounds x="438" y="132" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="310" y="130" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="130" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="312" y="132" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="132" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="310" y="155" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="155" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="312" y="157" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="157" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="310" y="180" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="180" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="312" y="182" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="182" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="310" y="205" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="205" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="312" y="207" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="207" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="310" y="230" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="230" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="312" y="232" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="232" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="310" y="255" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="255" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="312" y="257" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="257" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="310" y="280" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="280" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="312" y="282" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="282" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="310" y="305" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="305" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="312" y="307" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="307" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="310" y="330" width="122" height="27">
-			</bounds>
+			<bounds x="310" y="330" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="312" y="332" width="118" height="23">
-			</bounds>
+			<bounds x="312" y="332" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="184" y="305" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="305" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="186" y="307" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="307" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="184" y="280" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="280" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="186" y="282" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="282" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="184" y="255" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="255" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="186" y="257" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="257" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="184" y="230" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="230" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="186" y="232" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="232" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="184" y="205" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="205" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="186" y="207" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="207" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="184" y="180" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="180" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="186" y="182" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="182" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="184" y="155" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="155" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="186" y="157" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="157" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="184" y="130" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="130" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="186" y="132" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="132" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="184" y="330" width="122" height="27">
-			</bounds>
+			<bounds x="184" y="330" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="186" y="332" width="118" height="23">
-			</bounds>
+			<bounds x="186" y="332" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="530" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="530" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="532" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="532" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_2_border" state="0">
-			<bounds x="521" y="88" width="12" height="28">
-			</bounds>
+			<bounds x="521" y="88" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_2" state="0">
-			<bounds x="523" y="90" width="8" height="24">
-			</bounds>
+			<bounds x="523" y="90" width="8" height="24"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="484" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="484" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="486" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="486" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_2_border" state="0">
-			<bounds x="480" y="109" width="37" height="19">
-			</bounds>
+			<bounds x="480" y="109" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_2" state="0">
-			<bounds x="482" y="111" width="33" height="15">
-			</bounds>
+			<bounds x="482" y="111" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="446" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="446" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="448" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="448" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_2_border" state="0">
-			<bounds x="437" y="88" width="12" height="28">
-			</bounds>
+			<bounds x="437" y="88" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_2" state="0">
-			<bounds x="439" y="90" width="8" height="24">
-			</bounds>
+			<bounds x="439" y="90" width="8" height="24"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="230" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="230" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="232" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="232" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_2_border" state="0">
-			<bounds x="226" y="109" width="37" height="19">
-			</bounds>
+			<bounds x="226" y="109" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_2" state="0">
-			<bounds x="228" y="111" width="33" height="15">
-			</bounds>
+			<bounds x="228" y="111" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="267" y="88" width="12" height="28">
-			</bounds>
+			<bounds x="267" y="88" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="269" y="90" width="8" height="24">
-			</bounds>
+			<bounds x="269" y="90" width="8" height="24"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="310" y="88" width="12" height="28">
-			</bounds>
+			<bounds x="310" y="88" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="312" y="90" width="8" height="24">
-			</bounds>
+			<bounds x="312" y="90" width="8" height="24"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="353" y="109" width="37" height="19">
-			</bounds>
+			<bounds x="353" y="109" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="355" y="111" width="33" height="15">
-			</bounds>
+			<bounds x="355" y="111" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="394" y="88" width="12" height="28">
-			</bounds>
+			<bounds x="394" y="88" width="12" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="396" y="90" width="8" height="24">
-			</bounds>
+			<bounds x="396" y="90" width="8" height="24"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_2_border" state="0">
-			<bounds x="276" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="276" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_2" state="0">
-			<bounds x="278" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="278" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_2_border" state="0">
-			<bounds x="319" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="319" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_2" state="0">
-			<bounds x="321" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="321" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_2_border" state="0">
-			<bounds x="357" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="357" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_2" state="0">
-			<bounds x="359" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="359" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_2_border" state="0">
-			<bounds x="403" y="93" width="30" height="19">
-			</bounds>
+			<bounds x="403" y="93" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_2" state="0">
-			<bounds x="405" y="95" width="26" height="15">
-			</bounds>
+			<bounds x="405" y="95" width="26" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="78" y="33" width="92" height="92">
-			</bounds>
+			<bounds x="78" y="33" width="92" height="92"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="80" y="35" width="88" height="88">
-			</bounds>
+			<bounds x="80" y="35" width="88" height="88"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="597" y="34" width="27" height="27">
-			</bounds>
+			<bounds x="597" y="34" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="599" y="36" width="23" height="23">
-			</bounds>
+			<bounds x="599" y="36" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="592" y="383" width="19" height="19">
-			</bounds>
+			<bounds x="592" y="383" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="594" y="385" width="15" height="15">
-			</bounds>
+			<bounds x="594" y="385" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="575" y="383" width="19" height="19">
-			</bounds>
+			<bounds x="575" y="383" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="577" y="385" width="15" height="15">
-			</bounds>
+			<bounds x="577" y="385" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="296" y="12" width="47" height="43">
-			</bounds>
+			<bounds x="296" y="12" width="47" height="43"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="298" y="14" width="43" height="39">
-			</bounds>
+			<bounds x="298" y="14" width="43" height="39"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="340" y="12" width="74" height="43">
-			</bounds>
+			<bounds x="340" y="12" width="74" height="43"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="342" y="14" width="70" height="39">
-			</bounds>
+			<bounds x="342" y="14" width="70" height="39"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="411" y="12" width="37" height="43">
-			</bounds>
+			<bounds x="411" y="12" width="37" height="43"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="413" y="14" width="33" height="39">
-			</bounds>
+			<bounds x="413" y="14" width="33" height="39"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="445" y="12" width="87" height="43">
-			</bounds>
+			<bounds x="445" y="12" width="87" height="43"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="447" y="14" width="83" height="39">
-			</bounds>
+			<bounds x="447" y="14" width="83" height="39"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="529" y="12" width="45" height="43">
-			</bounds>
+			<bounds x="529" y="12" width="45" height="43"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="531" y="14" width="41" height="39">
-			</bounds>
+			<bounds x="531" y="14" width="41" height="39"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="583" y="505" width="27" height="27">
-			</bounds>
+			<bounds x="583" y="505" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="585" y="507" width="23" height="23">
-			</bounds>
+			<bounds x="585" y="507" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="667" y="505" width="27" height="27">
-			</bounds>
+			<bounds x="667" y="505" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="669" y="507" width="23" height="23">
-			</bounds>
+			<bounds x="669" y="507" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="639" y="505" width="27" height="27">
-			</bounds>
+			<bounds x="639" y="505" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="641" y="507" width="23" height="23">
-			</bounds>
+			<bounds x="641" y="507" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="607" y="501" width="34" height="34">
-			</bounds>
+			<bounds x="607" y="501" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="609" y="503" width="30" height="30">
-			</bounds>
+			<bounds x="609" y="503" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="579" y="473" width="34" height="34">
-			</bounds>
+			<bounds x="579" y="473" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="581" y="475" width="30" height="30">
-			</bounds>
+			<bounds x="581" y="475" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="663" y="473" width="34" height="34">
-			</bounds>
+			<bounds x="663" y="473" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="665" y="475" width="30" height="30">
-			</bounds>
+			<bounds x="665" y="475" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="635" y="473" width="34" height="34">
-			</bounds>
+			<bounds x="635" y="473" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="637" y="475" width="30" height="30">
-			</bounds>
+			<bounds x="637" y="475" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="611" y="477" width="27" height="27">
-			</bounds>
+			<bounds x="611" y="477" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="613" y="479" width="23" height="23">
-			</bounds>
+			<bounds x="613" y="479" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="663" y="445" width="34" height="34">
-			</bounds>
+			<bounds x="663" y="445" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="665" y="447" width="30" height="30">
-			</bounds>
+			<bounds x="665" y="447" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="635" y="445" width="34" height="34">
-			</bounds>
+			<bounds x="635" y="445" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="637" y="447" width="30" height="30">
-			</bounds>
+			<bounds x="637" y="447" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="579" y="445" width="34" height="34">
-			</bounds>
+			<bounds x="579" y="445" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="581" y="447" width="30" height="30">
-			</bounds>
+			<bounds x="581" y="447" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="611" y="449" width="27" height="27">
-			</bounds>
+			<bounds x="611" y="449" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="613" y="451" width="23" height="23">
-			</bounds>
+			<bounds x="613" y="451" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="583" y="533" width="27" height="27">
-			</bounds>
+			<bounds x="583" y="533" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="585" y="535" width="23" height="23">
-			</bounds>
+			<bounds x="585" y="535" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="663" y="529" width="34" height="34">
-			</bounds>
+			<bounds x="663" y="529" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="665" y="531" width="30" height="30">
-			</bounds>
+			<bounds x="665" y="531" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="635" y="529" width="34" height="34">
-			</bounds>
+			<bounds x="635" y="529" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="637" y="531" width="30" height="30">
-			</bounds>
+			<bounds x="637" y="531" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="607" y="529" width="34" height="34">
-			</bounds>
+			<bounds x="607" y="529" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="609" y="531" width="30" height="30">
-			</bounds>
+			<bounds x="609" y="531" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="522" y="529" width="34" height="34">
-			</bounds>
+			<bounds x="522" y="529" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="524" y="531" width="30" height="30">
-			</bounds>
+			<bounds x="524" y="531" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="522" y="445" width="34" height="34">
-			</bounds>
+			<bounds x="522" y="445" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="524" y="447" width="30" height="30">
-			</bounds>
+			<bounds x="524" y="447" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="522" y="473" width="34" height="34">
-			</bounds>
+			<bounds x="522" y="473" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="524" y="475" width="30" height="30">
-			</bounds>
+			<bounds x="524" y="475" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="522" y="501" width="34" height="34">
-			</bounds>
+			<bounds x="522" y="501" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="524" y="503" width="30" height="30">
-			</bounds>
+			<bounds x="524" y="503" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="555" y="505" width="27" height="27">
-			</bounds>
+			<bounds x="555" y="505" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="557" y="507" width="23" height="23">
-			</bounds>
+			<bounds x="557" y="507" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="555" y="477" width="27" height="27">
-			</bounds>
+			<bounds x="555" y="477" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="557" y="479" width="23" height="23">
-			</bounds>
+			<bounds x="557" y="479" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="551" y="445" width="34" height="34">
-			</bounds>
+			<bounds x="551" y="445" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="553" y="447" width="30" height="30">
-			</bounds>
+			<bounds x="553" y="447" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="551" y="529" width="34" height="34">
-			</bounds>
+			<bounds x="551" y="529" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="553" y="531" width="30" height="30">
-			</bounds>
+			<bounds x="553" y="531" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="colour_button_186_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="430" y="367" width="47" height="47">
-			</bounds>
+			<bounds x="430" y="367" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp250" element="colour_button_186" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="432" y="369" width="43" height="43">
-			</bounds>
+			<bounds x="432" y="369" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_187_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="638" y="16" width="46" height="62">
-			</bounds>
+			<bounds x="638" y="16" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_187" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="640" y="18" width="42" height="58">
-			</bounds>
+			<bounds x="640" y="18" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_188_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="389" y="610" width="66" height="42">
-			</bounds>
+			<bounds x="389" y="610" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_188" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="391" y="612" width="62" height="38">
-			</bounds>
+			<bounds x="391" y="612" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_189_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="259" y="610" width="66" height="42">
-			</bounds>
+			<bounds x="259" y="610" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_189" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="261" y="612" width="62" height="38">
-			</bounds>
+			<bounds x="261" y="612" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_190_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="129" y="610" width="66" height="42">
-			</bounds>
+			<bounds x="129" y="610" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_190" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="131" y="612" width="62" height="38">
-			</bounds>
+			<bounds x="131" y="612" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_191_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="5" y="610" width="66" height="42">
-			</bounds>
+			<bounds x="5" y="610" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_191" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="7" y="612" width="62" height="38">
-			</bounds>
+			<bounds x="7" y="612" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_192_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="670" y="611" width="66" height="42">
-			</bounds>
+			<bounds x="670" y="611" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_192" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="672" y="613" width="62" height="38">
-			</bounds>
+			<bounds x="672" y="613" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_193_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="528" y="611" width="66" height="42">
-			</bounds>
+			<bounds x="528" y="611" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_193" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="530" y="613" width="62" height="38">
-			</bounds>
+			<bounds x="530" y="613" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_196_border" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="681" y="16" width="46" height="62">
-			</bounds>
+			<bounds x="681" y="16" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_196" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="683" y="18" width="42" height="58">
-			</bounds>
+			<bounds x="683" y="18" width="42" height="58"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="119" y="370" width="260" height="26">
-			</bounds>
+			<bounds x="119" y="370" width="260" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="119" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="119" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="135" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="135" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="151" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="151" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="167" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="167" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="183" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="183" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="199" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="199" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="215" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="215" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="231" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="231" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="247" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="247" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="263" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="263" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="279" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="279" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="295" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="295" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="311" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="311" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="327" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="327" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="343" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="343" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="359" y="370" width="16" height="26">
-			</bounds>
+			<bounds x="359" y="370" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="label136" element="label_136">
-			<bounds x="82" y="155" width="8" height="60">
-			</bounds>
+			<bounds x="82" y="155" width="8" height="60"/>
 		</backdrop>
 		<backdrop name="label137" element="label_137">
-			<bounds x="333" y="391" width="47" height="21">
-			</bounds>
+			<bounds x="333" y="391" width="47" height="21"/>
 		</backdrop>
 		<backdrop name="label138" element="label_138">
-			<bounds x="131" y="391" width="41" height="21">
-			</bounds>
+			<bounds x="131" y="391" width="41" height="21"/>
 		</backdrop>
 		<backdrop name="label171" element="label_171">
-			<bounds x="622" y="422" width="129" height="16">
-			</bounds>
+			<bounds x="622" y="422" width="129" height="16"/>
 		</backdrop>
 		<backdrop name="label172" element="label_172">
-			<bounds x="2" y="12" width="72" height="16">
-			</bounds>
+			<bounds x="2" y="12" width="72" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_button" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_button" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1htclb.lay
+++ b/src/mame/layout/m1htclb.lay
@@ -8,11070 +8,7038 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.36" blue="0.05">
-			</color>
+			<color red="0.45" green="0.36" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
+			<color red="0.11" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.91" green="0.72" blue="0.09">
-			</color>
+			<color red="0.91" green="0.72" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.02">
-			</color>
+			<color red="0.22" green="0.18" blue="0.02"/>
 		</rect>
 		<text string="HI-TENSION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.36" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.91" green="0.72" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.18" blue="0.02">
-			</color>
-		</rect>
-		<text string="HI-TENSION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.50" blue="0.29">
-			</color>
+			<color red="0.29" green="0.50" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.12" blue="0.07">
-			</color>
+			<color red="0.07" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.58" green="1.00" blue="0.58">
-			</color>
+			<color red="0.58" green="1.00" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.25" blue="0.15">
-			</color>
+			<color red="0.15" green="0.25" blue="0.15"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.50" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.58" green="1.00" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.25" blue="0.15">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.27" green="0.50" blue="0.27">
-			</color>
+			<color red="0.27" green="0.50" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.12" blue="0.07">
-			</color>
+			<color red="0.07" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.54" green="1.00" blue="0.54">
-			</color>
+			<color red="0.54" green="1.00" blue="0.54"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.27" green="0.50" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.54" green="1.00" blue="0.54">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.23" green="0.50" blue="0.23">
-			</color>
+			<color red="0.23" green="0.50" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
+			<color red="0.05" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="1.00" blue="0.46">
-			</color>
+			<color red="0.46" green="1.00" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.25" blue="0.11">
-			</color>
+			<color red="0.11" green="0.25" blue="0.11"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.23" green="0.50" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="1.00" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.25" blue="0.11">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.50" blue="0.21">
-			</color>
+			<color red="0.21" green="0.50" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
+			<color red="0.05" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="1.00" blue="0.42">
-			</color>
+			<color red="0.42" green="1.00" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.10">
-			</color>
+			<color red="0.10" green="0.25" blue="0.10"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.50" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="1.00" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.10">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.19" green="0.50" blue="0.19">
-			</color>
+			<color red="0.19" green="0.50" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
+			<color red="0.05" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="1.00" blue="0.38">
-			</color>
+			<color red="0.38" green="1.00" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.25" blue="0.09">
-			</color>
+			<color red="0.09" green="0.25" blue="0.09"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.19" green="0.50" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="1.00" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.25" blue="0.09">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
+			<color red="0.16" green="0.50" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
+			<color red="0.04" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
+			<color red="0.33" green="1.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
+			<color red="0.08" green="0.25" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.15" green="0.50" blue="0.15">
-			</color>
+			<color red="0.15" green="0.50" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
+			<color red="0.04" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="1.00" blue="0.29">
-			</color>
+			<color red="0.29" green="1.00" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.25" blue="0.07">
-			</color>
+			<color red="0.07" green="0.25" blue="0.07"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.15" green="0.50" blue="0.15">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="1.00" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.25" blue="0.07">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
+			<color red="0.13" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
+			<color red="0.25" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.10" green="0.50" blue="0.10">
-			</color>
+			<color red="0.10" green="0.50" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
+			<color red="0.02" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="1.00" blue="0.21">
-			</color>
+			<color red="0.21" green="1.00" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.25" blue="0.05">
-			</color>
+			<color red="0.05" green="0.25" blue="0.05"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.10" green="0.50" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="1.00" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.25" blue="0.05">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
+			<color red="0.08" green="0.50" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
+			<color red="0.02" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
+			<color red="0.17" green="1.00" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
+			<color red="0.04" green="0.25" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.50" blue="0.06">
-			</color>
+			<color red="0.06" green="0.50" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
+			<color red="0.02" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="1.00" blue="0.13">
-			</color>
+			<color red="0.13" green="1.00" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.25" blue="0.03">
-			</color>
+			<color red="0.03" green="0.25" blue="0.03"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.50" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="1.00" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.25" blue="0.03">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
+			<color red="0.04" green="0.50" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
+			<color red="0.01" green="0.12" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
+			<color red="0.08" green="1.00" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
+			<color red="0.02" green="0.25" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.50" blue="0.02">
-			</color>
+			<color red="0.02" green="0.50" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="1.00" blue="0.04">
-			</color>
+			<color red="0.04" green="1.00" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.25" blue="0.01">
-			</color>
+			<color red="0.01" green="0.25" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.50" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="1.00" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.25" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.46" blue="0.05">
-			</color>
+			<color red="0.49" green="0.46" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.01">
-			</color>
+			<color red="0.12" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.92" blue="0.09">
-			</color>
+			<color red="0.99" green="0.92" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.02">
-			</color>
+			<color red="0.25" green="0.23" blue="0.02"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.46" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.92" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.02">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.46" blue="0.09">
-			</color>
+			<color red="0.49" green="0.46" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.02">
-			</color>
+			<color red="0.12" green="0.11" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.93" blue="0.18">
-			</color>
+			<color red="0.99" green="0.93" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.04">
-			</color>
+			<color red="0.25" green="0.23" blue="0.04"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.46" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.93" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.04">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.47" blue="0.13">
-			</color>
+			<color red="0.49" green="0.47" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.03">
-			</color>
+			<color red="0.12" green="0.11" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.94" blue="0.26">
-			</color>
+			<color red="0.99" green="0.94" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.06">
-			</color>
+			<color red="0.25" green="0.23" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.47" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.94" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.49" blue="0.33">
-			</color>
+			<color red="0.50" green="0.49" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.08">
-			</color>
+			<color red="0.12" green="0.12" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.97" blue="0.67">
-			</color>
+			<color red="1.00" green="0.97" blue="0.67"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.16">
-			</color>
+			<color red="0.25" green="0.24" blue="0.16"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.49" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.97" blue="0.67">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.16">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.48" blue="0.29">
-			</color>
+			<color red="0.50" green="0.48" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.07">
-			</color>
+			<color red="0.12" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.97" blue="0.59">
-			</color>
+			<color red="1.00" green="0.97" blue="0.59"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.15">
-			</color>
+			<color red="0.25" green="0.24" blue="0.15"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.48" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.97" blue="0.59">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.15">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.47" blue="0.25">
-			</color>
+			<color red="0.49" green="0.47" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.95" blue="0.51">
-			</color>
+			<color red="0.99" green="0.95" blue="0.51"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.13">
-			</color>
+			<color red="0.25" green="0.24" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.47" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.95" blue="0.51">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.47" blue="0.21">
-			</color>
+			<color red="0.49" green="0.47" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.05">
-			</color>
+			<color red="0.12" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.95" blue="0.42">
-			</color>
+			<color red="0.99" green="0.95" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.11">
-			</color>
+			<color red="0.25" green="0.24" blue="0.11"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.47" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.95" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.11">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.47" blue="0.17">
-			</color>
+			<color red="0.49" green="0.47" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.04">
-			</color>
+			<color red="0.12" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.94" blue="0.34">
-			</color>
+			<color red="0.99" green="0.94" blue="0.34"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.08">
-			</color>
+			<color red="0.25" green="0.24" blue="0.08"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.47" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.94" blue="0.34">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.08">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.00">
-			</color>
+			<color red="0.49" green="0.45" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.91" blue="0.01">
-			</color>
+			<color red="0.99" green="0.91" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.00">
-			</color>
+			<color red="0.25" green="0.23" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.45" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.91" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Choose A Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Choose A Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus Numbers">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus Numbers">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
+			<color red="0.49" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
+			<color red="0.99" green="0.79" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
+			<color red="0.25" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="B   O   N   U   S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="B   O   N   U   S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
+			<color red="0.46" green="0.38" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
+			<color red="0.11" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
+			<color red="0.93" green="0.76" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
+			<color red="0.23" green="0.19" blue="0.02"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
+			<color red="0.46" green="0.38" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
+			<color red="0.11" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
+			<color red="0.93" green="0.76" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
+			<color red="0.23" green="0.19" blue="0.02"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.38" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.76" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.19" blue="0.02">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.19" green="0.34" blue="0.50">
-			</color>
+			<color red="0.19" green="0.34" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.12">
-			</color>
+			<color red="0.05" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.69" blue="1.00">
-			</color>
+			<color red="0.38" green="0.69" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.17" blue="0.25">
-			</color>
+			<color red="0.09" green="0.17" blue="0.25"/>
 		</rect>
 		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.19" green="0.34" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.69" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.17" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.33" blue="0.50">
-			</color>
+			<color red="0.16" green="0.33" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
+			<color red="0.04" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.67" blue="1.00">
-			</color>
+			<color red="0.33" green="0.67" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.25">
-			</color>
+			<color red="0.08" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="CASH CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.33" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.67" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.15" green="0.32" blue="0.50">
-			</color>
+			<color red="0.15" green="0.32" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
+			<color red="0.04" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.65" blue="1.00">
-			</color>
+			<color red="0.29" green="0.65" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.16" blue="0.25">
-			</color>
+			<color red="0.07" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="WINSPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.15" green="0.32" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.65" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="WINSPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
+			<color red="0.13" green="0.31" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
+			<color red="0.03" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
+			<color red="0.25" green="0.62" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
+			<color red="0.06" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="FRUIT STEPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="FRUIT STEPPA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.35" green="0.49" blue="0.00">
-			</color>
+			<color red="0.35" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.69" green="0.99" blue="0.01">
-			</color>
+			<color red="0.69" green="0.99" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.17" green="0.25" blue="0.00">
-			</color>
+			<color red="0.17" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.35" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.69" green="0.99" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.17" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.49" blue="0.05">
-			</color>
+			<color red="0.36" green="0.49" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.01">
-			</color>
+			<color red="0.09" green="0.12" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.99" blue="0.09">
-			</color>
+			<color red="0.72" green="0.99" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.25" blue="0.02">
-			</color>
+			<color red="0.18" green="0.25" blue="0.02"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.49" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.99" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.25" blue="0.02">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.37" green="0.49" blue="0.09">
-			</color>
+			<color red="0.37" green="0.49" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.02">
-			</color>
+			<color red="0.09" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.99" blue="0.18">
-			</color>
+			<color red="0.75" green="0.99" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.25" blue="0.04">
-			</color>
+			<color red="0.18" green="0.25" blue="0.04"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.37" green="0.49" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.99" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.25" blue="0.04">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.49" blue="0.13">
-			</color>
+			<color red="0.38" green="0.49" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.03">
-			</color>
+			<color red="0.09" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="0.99" blue="0.26">
-			</color>
+			<color red="0.77" green="0.99" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.06">
-			</color>
+			<color red="0.19" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.49" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="0.99" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.17">
-			</color>
+			<color red="0.40" green="0.49" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.04">
-			</color>
+			<color red="0.10" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.80" green="0.99" blue="0.34">
-			</color>
+			<color red="0.80" green="0.99" blue="0.34"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.08">
-			</color>
+			<color red="0.20" green="0.25" blue="0.08"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.49" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.80" green="0.99" blue="0.34">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.08">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.41" green="0.49" blue="0.21">
-			</color>
+			<color red="0.41" green="0.49" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.05">
-			</color>
+			<color red="0.10" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.82" green="0.99" blue="0.42">
-			</color>
+			<color red="0.82" green="0.99" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.11">
-			</color>
+			<color red="0.20" green="0.25" blue="0.11"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.41" green="0.49" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.82" green="0.99" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.11">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.49" blue="0.25">
-			</color>
+			<color red="0.42" green="0.49" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.06">
-			</color>
+			<color red="0.11" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.99" blue="0.51">
-			</color>
+			<color red="0.85" green="0.99" blue="0.51"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.25" blue="0.13">
-			</color>
+			<color red="0.21" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.49" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.85" green="0.99" blue="0.51">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.29">
-			</color>
+			<color red="0.44" green="0.50" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.07">
-			</color>
+			<color red="0.11" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.59">
-			</color>
+			<color red="0.87" green="1.00" blue="0.59"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.15">
-			</color>
+			<color red="0.22" green="0.25" blue="0.15"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.59">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.15">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.27" blue="0.50">
-			</color>
+			<color red="0.04" green="0.27" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.07" blue="0.12">
-			</color>
+			<color red="0.01" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.54" blue="1.00">
-			</color>
+			<color red="0.08" green="0.54" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.13" blue="0.25">
-			</color>
+			<color red="0.02" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="WIN SPRINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.27" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.54" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIN SPRINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.26" blue="0.50">
-			</color>
+			<color red="0.02" green="0.26" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.52" blue="1.00">
-			</color>
+			<color red="0.04" green="0.52" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.13" blue="0.25">
-			</color>
+			<color red="0.01" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.26" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.52" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.28" blue="0.50">
-			</color>
+			<color red="0.06" green="0.28" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.56" blue="1.00">
-			</color>
+			<color red="0.13" green="0.56" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.14" blue="0.25">
-			</color>
+			<color red="0.03" green="0.14" blue="0.25"/>
 		</rect>
 		<text string="HI LO CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.28" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.56" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.14" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI LO CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
+			<color red="0.08" green="0.29" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
+			<color red="0.17" green="0.58" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
+			<color red="0.04" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="FRUIT STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="FRUIT STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.10" green="0.30" blue="0.50">
-			</color>
+			<color red="0.10" green="0.30" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.60" blue="1.00">
-			</color>
+			<color red="0.21" green="0.60" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.15" blue="0.25">
-			</color>
+			<color red="0.05" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.10" green="0.30" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.60" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="WARNING!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REFILL REQU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="WARNING!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REFILL REQU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.45" green="0.50" blue="0.33">
-			</color>
+			<color red="0.45" green="0.50" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.08">
-			</color>
+			<color red="0.11" green="0.12" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.90" green="1.00" blue="0.67">
-			</color>
+			<color red="0.90" green="1.00" blue="0.67"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.16">
-			</color>
+			<color red="0.22" green="0.25" blue="0.16"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.45" green="0.50" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.90" green="1.00" blue="0.67">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.16">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_135_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_135">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Save">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_141_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_141">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_35">
 		<text string="RESERVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_36">
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_40">
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_49">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_50">
 		<text string="CASH METER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_54">
 		<text string="With thanks to Fruitsim">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_87">
 		<text string="Two cherries = 40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_88">
 		<text string="x3            x4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_89">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_90">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_91">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_92">
 		<text string="WINPLAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_93">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_94">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_95">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_96">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_97">
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_99">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_100">
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_101">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_102">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_103">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_104">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_105">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_106">
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_107">
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_108">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_109">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_110">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_111">
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_121">
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_122">
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_123">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_124">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="v1.1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="734" height="652">
-			</bounds>
+			<bounds x="0" y="0" width="734" height="652"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="4" y="408" width="82" height="134">
-			</bounds>
+			<bounds x="4" y="408" width="82" height="134"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="4" y="408" width="82" height="134">
-			</bounds>
+			<bounds x="4" y="408" width="82" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="88" y="408" width="82" height="134">
-			</bounds>
+			<bounds x="88" y="408" width="82" height="134"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="88" y="408" width="82" height="134">
-			</bounds>
+			<bounds x="88" y="408" width="82" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="172" y="408" width="82" height="134">
-			</bounds>
+			<bounds x="172" y="408" width="82" height="134"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="172" y="408" width="82" height="134">
-			</bounds>
+			<bounds x="172" y="408" width="82" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="256" y="408" width="82" height="134">
-			</bounds>
+			<bounds x="256" y="408" width="82" height="134"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="256" y="408" width="82" height="134">
-			</bounds>
+			<bounds x="256" y="408" width="82" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="130" y="230" width="60" height="60">
-			</bounds>
+			<bounds x="130" y="230" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="130" y="230" width="60" height="60">
-			</bounds>
+			<bounds x="130" y="230" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="18" y="15" width="262" height="52">
-			</bounds>
+			<bounds x="18" y="15" width="262" height="52"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="20" y="17" width="258" height="48">
-			</bounds>
+			<bounds x="20" y="17" width="258" height="48"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="444" y="572" width="47" height="32">
-			</bounds>
+			<bounds x="444" y="572" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="446" y="574" width="43" height="28">
-			</bounds>
+			<bounds x="446" y="574" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="489" y="572" width="47" height="32">
-			</bounds>
+			<bounds x="489" y="572" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="491" y="574" width="43" height="28">
-			</bounds>
+			<bounds x="491" y="574" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="534" y="572" width="47" height="32">
-			</bounds>
+			<bounds x="534" y="572" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="536" y="574" width="43" height="28">
-			</bounds>
+			<bounds x="536" y="574" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="534" y="542" width="47" height="32">
-			</bounds>
+			<bounds x="534" y="542" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="536" y="544" width="43" height="28">
-			</bounds>
+			<bounds x="536" y="544" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="489" y="542" width="47" height="32">
-			</bounds>
+			<bounds x="489" y="542" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="491" y="544" width="43" height="28">
-			</bounds>
+			<bounds x="491" y="544" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="444" y="542" width="47" height="32">
-			</bounds>
+			<bounds x="444" y="542" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="446" y="544" width="43" height="28">
-			</bounds>
+			<bounds x="446" y="544" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="444" y="512" width="47" height="32">
-			</bounds>
+			<bounds x="444" y="512" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="446" y="514" width="43" height="28">
-			</bounds>
+			<bounds x="446" y="514" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="489" y="512" width="47" height="32">
-			</bounds>
+			<bounds x="489" y="512" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="491" y="514" width="43" height="28">
-			</bounds>
+			<bounds x="491" y="514" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="534" y="512" width="47" height="32">
-			</bounds>
+			<bounds x="534" y="512" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="536" y="514" width="43" height="28">
-			</bounds>
+			<bounds x="536" y="514" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="534" y="482" width="47" height="32">
-			</bounds>
+			<bounds x="534" y="482" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="536" y="484" width="43" height="28">
-			</bounds>
+			<bounds x="536" y="484" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="489" y="482" width="47" height="32">
-			</bounds>
+			<bounds x="489" y="482" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="491" y="484" width="43" height="28">
-			</bounds>
+			<bounds x="491" y="484" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="444" y="482" width="47" height="32">
-			</bounds>
+			<bounds x="444" y="482" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="446" y="484" width="43" height="28">
-			</bounds>
+			<bounds x="446" y="484" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="444" y="452" width="69" height="32">
-			</bounds>
+			<bounds x="444" y="452" width="69" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="446" y="454" width="65" height="28">
-			</bounds>
+			<bounds x="446" y="454" width="65" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="511" y="452" width="70" height="32">
-			</bounds>
+			<bounds x="511" y="452" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="513" y="454" width="66" height="28">
-			</bounds>
+			<bounds x="513" y="454" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="444" y="422" width="137" height="32">
-			</bounds>
+			<bounds x="444" y="422" width="137" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="446" y="424" width="133" height="28">
-			</bounds>
+			<bounds x="446" y="424" width="133" height="28"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="394" y="438" width="42" height="26">
-			</bounds>
+			<bounds x="394" y="438" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="396" y="440" width="38" height="22">
-			</bounds>
+			<bounds x="396" y="440" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="394" y="462" width="42" height="25">
-			</bounds>
+			<bounds x="394" y="462" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="396" y="464" width="38" height="21">
-			</bounds>
+			<bounds x="396" y="464" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="394" y="485" width="42" height="24">
-			</bounds>
+			<bounds x="394" y="485" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="396" y="487" width="38" height="20">
-			</bounds>
+			<bounds x="396" y="487" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="394" y="585" width="42" height="19">
-			</bounds>
+			<bounds x="394" y="585" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="396" y="587" width="38" height="15">
-			</bounds>
+			<bounds x="396" y="587" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="394" y="567" width="42" height="20">
-			</bounds>
+			<bounds x="394" y="567" width="42" height="20"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="396" y="569" width="38" height="16">
-			</bounds>
+			<bounds x="396" y="569" width="38" height="16"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="394" y="548" width="42" height="21">
-			</bounds>
+			<bounds x="394" y="548" width="42" height="21"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="396" y="550" width="38" height="17">
-			</bounds>
+			<bounds x="396" y="550" width="38" height="17"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="394" y="528" width="42" height="22">
-			</bounds>
+			<bounds x="394" y="528" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="396" y="530" width="38" height="18">
-			</bounds>
+			<bounds x="396" y="530" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="394" y="507" width="42" height="23">
-			</bounds>
+			<bounds x="394" y="507" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="396" y="509" width="38" height="19">
-			</bounds>
+			<bounds x="396" y="509" width="38" height="19"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="394" y="401" width="42" height="40">
-			</bounds>
+			<bounds x="394" y="401" width="42" height="40"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="396" y="403" width="38" height="36">
-			</bounds>
+			<bounds x="396" y="403" width="38" height="36"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="351" y="418" width="42" height="34">
-			</bounds>
+			<bounds x="351" y="418" width="42" height="34"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="353" y="420" width="38" height="30">
-			</bounds>
+			<bounds x="353" y="420" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="235" y="572" width="62" height="32">
-			</bounds>
+			<bounds x="235" y="572" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="237" y="574" width="58" height="28">
-			</bounds>
+			<bounds x="237" y="574" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="173" y="572" width="62" height="32">
-			</bounds>
+			<bounds x="173" y="572" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="175" y="574" width="58" height="28">
-			</bounds>
+			<bounds x="175" y="574" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="111" y="572" width="62" height="32">
-			</bounds>
+			<bounds x="111" y="572" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="113" y="574" width="58" height="28">
-			</bounds>
+			<bounds x="113" y="574" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="49" y="572" width="62" height="32">
-			</bounds>
+			<bounds x="49" y="572" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="51" y="574" width="58" height="28">
-			</bounds>
+			<bounds x="51" y="574" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="49" y="552" width="248" height="20">
-			</bounds>
+			<bounds x="49" y="552" width="248" height="20"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="51" y="554" width="244" height="16">
-			</bounds>
+			<bounds x="51" y="554" width="244" height="16"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="139" y="198" width="42" height="32">
-			</bounds>
+			<bounds x="139" y="198" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="141" y="200" width="38" height="28">
-			</bounds>
+			<bounds x="141" y="200" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="139" y="290" width="42" height="32">
-			</bounds>
+			<bounds x="139" y="290" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="141" y="292" width="38" height="28">
-			</bounds>
+			<bounds x="141" y="292" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="368" y="370" width="117" height="33">
-			</bounds>
+			<bounds x="368" y="370" width="117" height="33"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="370" y="372" width="113" height="29">
-			</bounds>
+			<bounds x="370" y="372" width="113" height="29"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="366" y="338" width="121" height="34">
-			</bounds>
+			<bounds x="366" y="338" width="121" height="34"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="368" y="340" width="117" height="30">
-			</bounds>
+			<bounds x="368" y="340" width="117" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="364" y="305" width="125" height="35">
-			</bounds>
+			<bounds x="364" y="305" width="125" height="35"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="366" y="307" width="121" height="31">
-			</bounds>
+			<bounds x="366" y="307" width="121" height="31"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="362" y="271" width="129" height="36">
-			</bounds>
+			<bounds x="362" y="271" width="129" height="36"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="364" y="273" width="125" height="32">
-			</bounds>
+			<bounds x="364" y="273" width="125" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="297" y="88" width="56" height="37">
-			</bounds>
+			<bounds x="297" y="88" width="56" height="37"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="299" y="90" width="52" height="33">
-			</bounds>
+			<bounds x="299" y="90" width="52" height="33"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="299" y="127" width="56" height="36">
-			</bounds>
+			<bounds x="299" y="127" width="56" height="36"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="301" y="129" width="52" height="32">
-			</bounds>
+			<bounds x="301" y="129" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="301" y="165" width="56" height="35">
-			</bounds>
+			<bounds x="301" y="165" width="56" height="35"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="303" y="167" width="52" height="31">
-			</bounds>
+			<bounds x="303" y="167" width="52" height="31"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="303" y="202" width="56" height="34">
-			</bounds>
+			<bounds x="303" y="202" width="56" height="34"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="305" y="204" width="52" height="30">
-			</bounds>
+			<bounds x="305" y="204" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="305" y="238" width="56" height="33">
-			</bounds>
+			<bounds x="305" y="238" width="56" height="33"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="307" y="240" width="52" height="29">
-			</bounds>
+			<bounds x="307" y="240" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="307" y="273" width="56" height="32">
-			</bounds>
+			<bounds x="307" y="273" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="309" y="275" width="52" height="28">
-			</bounds>
+			<bounds x="309" y="275" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="309" y="307" width="56" height="31">
-			</bounds>
+			<bounds x="309" y="307" width="56" height="31"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="311" y="309" width="52" height="27">
-			</bounds>
+			<bounds x="311" y="309" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="311" y="340" width="56" height="30">
-			</bounds>
+			<bounds x="311" y="340" width="56" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="313" y="342" width="52" height="26">
-			</bounds>
+			<bounds x="313" y="342" width="52" height="26"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="350" y="46" width="153" height="42">
-			</bounds>
+			<bounds x="350" y="46" width="153" height="42"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="352" y="48" width="149" height="38">
-			</bounds>
+			<bounds x="352" y="48" width="149" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="354" y="125" width="145" height="40">
-			</bounds>
+			<bounds x="354" y="125" width="145" height="40"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="356" y="127" width="141" height="36">
-			</bounds>
+			<bounds x="356" y="127" width="141" height="36"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="352" y="86" width="149" height="41">
-			</bounds>
+			<bounds x="352" y="86" width="149" height="41"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="354" y="88" width="145" height="37">
-			</bounds>
+			<bounds x="354" y="88" width="145" height="37"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="356" y="163" width="141" height="39">
-			</bounds>
+			<bounds x="356" y="163" width="141" height="39"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="358" y="165" width="137" height="35">
-			</bounds>
+			<bounds x="358" y="165" width="137" height="35"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="358" y="200" width="137" height="38">
-			</bounds>
+			<bounds x="358" y="200" width="137" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="360" y="202" width="133" height="34">
-			</bounds>
+			<bounds x="360" y="202" width="133" height="34"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="360" y="236" width="133" height="37">
-			</bounds>
+			<bounds x="360" y="236" width="133" height="37"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="362" y="238" width="129" height="33">
-			</bounds>
+			<bounds x="362" y="238" width="129" height="33"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="375" y="16" width="103" height="26">
-			</bounds>
+			<bounds x="375" y="16" width="103" height="26"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="377" y="18" width="99" height="22">
-			</bounds>
+			<bounds x="377" y="18" width="99" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="313" y="372" width="56" height="29">
-			</bounds>
+			<bounds x="313" y="372" width="56" height="29"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="315" y="374" width="52" height="25">
-			</bounds>
+			<bounds x="315" y="374" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="342" y="461" width="12" height="12">
-			</bounds>
+			<bounds x="342" y="461" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="344" y="463" width="8" height="8">
-			</bounds>
+			<bounds x="344" y="463" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="342" y="471" width="12" height="12">
-			</bounds>
+			<bounds x="342" y="471" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="344" y="473" width="8" height="8">
-			</bounds>
+			<bounds x="344" y="473" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="342" y="481" width="12" height="12">
-			</bounds>
+			<bounds x="342" y="481" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="344" y="483" width="8" height="8">
-			</bounds>
+			<bounds x="344" y="483" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="352" y="461" width="12" height="12">
-			</bounds>
+			<bounds x="352" y="461" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="354" y="463" width="8" height="8">
-			</bounds>
+			<bounds x="354" y="463" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="352" y="471" width="12" height="12">
-			</bounds>
+			<bounds x="352" y="471" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="354" y="473" width="8" height="8">
-			</bounds>
+			<bounds x="354" y="473" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="352" y="481" width="12" height="12">
-			</bounds>
+			<bounds x="352" y="481" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="354" y="483" width="8" height="8">
-			</bounds>
+			<bounds x="354" y="483" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="362" y="461" width="12" height="12">
-			</bounds>
+			<bounds x="362" y="461" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="364" y="463" width="8" height="8">
-			</bounds>
+			<bounds x="364" y="463" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="362" y="471" width="12" height="12">
-			</bounds>
+			<bounds x="362" y="471" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="364" y="473" width="8" height="8">
-			</bounds>
+			<bounds x="364" y="473" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="362" y="481" width="12" height="12">
-			</bounds>
+			<bounds x="362" y="481" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="364" y="483" width="8" height="8">
-			</bounds>
+			<bounds x="364" y="483" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="372" y="461" width="12" height="12">
-			</bounds>
+			<bounds x="372" y="461" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="374" y="463" width="8" height="8">
-			</bounds>
+			<bounds x="374" y="463" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="372" y="471" width="12" height="12">
-			</bounds>
+			<bounds x="372" y="471" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="374" y="473" width="8" height="8">
-			</bounds>
+			<bounds x="374" y="473" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="372" y="481" width="12" height="12">
-			</bounds>
+			<bounds x="372" y="481" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="374" y="483" width="8" height="8">
-			</bounds>
+			<bounds x="374" y="483" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_134_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="19" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="19" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_134" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="21" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="21" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_135_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="101" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="101" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_135" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="103" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="103" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_136_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="183" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="183" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_136" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="185" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="185" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_137_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="265" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="265" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_137" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="267" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="267" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_138_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="370" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="370" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_138" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="372" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="372" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_139_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="458" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="458" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_139" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="460" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="460" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_140_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="548" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="548" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_140" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="550" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="550" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_141_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="632" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="632" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_141" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="634" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="634" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_142_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="522" y="38" width="47" height="62">
-			</bounds>
+			<bounds x="522" y="38" width="47" height="62"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_142" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="524" y="40" width="43" height="58">
-			</bounds>
+			<bounds x="524" y="40" width="43" height="58"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_150_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="370" y="606" width="62" height="46">
-			</bounds>
+			<bounds x="370" y="606" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_150" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="372" y="608" width="58" height="42">
-			</bounds>
+			<bounds x="372" y="608" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="504" y="234" width="26" height="35">
-			</bounds>
+			<bounds x="504" y="234" width="26" height="35"/>
 		</backdrop>
 		<backdrop name="led_off184" element="led_off">
-			<bounds x="507" y="237" width="18" height="3">
-			</bounds>
+			<bounds x="507" y="237" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off185" element="led_off">
-			<bounds x="522" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="522" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off186" element="led_off">
-			<bounds x="522" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="522" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off187" element="led_off">
-			<bounds x="507" y="262" width="18" height="3">
-			</bounds>
+			<bounds x="507" y="262" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off188" element="led_off">
-			<bounds x="507" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="507" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off189" element="led_off">
-			<bounds x="507" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="507" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off190" element="led_off">
-			<bounds x="507" y="249" width="18" height="3">
-			</bounds>
+			<bounds x="507" y="249" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off191" element="led_dot_off">
-			<bounds x="526" y="262" width="3" height="3">
-			</bounds>
+			<bounds x="526" y="262" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="lamp184" element="led_on">
-			<bounds x="507" y="237" width="18" height="3">
-			</bounds>
+			<bounds x="507" y="237" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp185" element="led_on">
-			<bounds x="522" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="522" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp186" element="led_on">
-			<bounds x="522" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="522" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp187" element="led_on">
-			<bounds x="507" y="262" width="18" height="3">
-			</bounds>
+			<bounds x="507" y="262" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp188" element="led_on">
-			<bounds x="507" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="507" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp189" element="led_on">
-			<bounds x="507" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="507" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp190" element="led_on">
-			<bounds x="507" y="249" width="18" height="3">
-			</bounds>
+			<bounds x="507" y="249" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp191" element="led_dot_on">
-			<bounds x="526" y="262" width="3" height="3">
-			</bounds>
+			<bounds x="526" y="262" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="530" y="234" width="26" height="35">
-			</bounds>
+			<bounds x="530" y="234" width="26" height="35"/>
 		</backdrop>
 		<backdrop name="led_off192" element="led_off">
-			<bounds x="533" y="237" width="18" height="3">
-			</bounds>
+			<bounds x="533" y="237" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off193" element="led_off">
-			<bounds x="548" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="548" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off194" element="led_off">
-			<bounds x="548" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="548" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off195" element="led_off">
-			<bounds x="533" y="262" width="18" height="3">
-			</bounds>
+			<bounds x="533" y="262" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off196" element="led_off">
-			<bounds x="533" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="533" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off197" element="led_off">
-			<bounds x="533" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="533" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off198" element="led_off">
-			<bounds x="533" y="249" width="18" height="3">
-			</bounds>
+			<bounds x="533" y="249" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off199" element="led_dot_off">
-			<bounds x="552" y="262" width="3" height="3">
-			</bounds>
+			<bounds x="552" y="262" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="lamp192" element="led_on">
-			<bounds x="533" y="237" width="18" height="3">
-			</bounds>
+			<bounds x="533" y="237" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp193" element="led_on">
-			<bounds x="548" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="548" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp194" element="led_on">
-			<bounds x="548" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="548" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp195" element="led_on">
-			<bounds x="533" y="262" width="18" height="3">
-			</bounds>
+			<bounds x="533" y="262" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp196" element="led_on">
-			<bounds x="533" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="533" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp197" element="led_on">
-			<bounds x="533" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="533" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp198" element="led_on">
-			<bounds x="533" y="249" width="18" height="3">
-			</bounds>
+			<bounds x="533" y="249" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp199" element="led_dot_on">
-			<bounds x="552" y="262" width="3" height="3">
-			</bounds>
+			<bounds x="552" y="262" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="556" y="234" width="26" height="35">
-			</bounds>
+			<bounds x="556" y="234" width="26" height="35"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="559" y="237" width="18" height="3">
-			</bounds>
+			<bounds x="559" y="237" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="574" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="574" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="574" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="574" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="559" y="262" width="18" height="3">
-			</bounds>
+			<bounds x="559" y="262" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="559" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="559" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="559" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="559" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="559" y="249" width="18" height="3">
-			</bounds>
+			<bounds x="559" y="249" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="578" y="262" width="3" height="3">
-			</bounds>
+			<bounds x="578" y="262" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="559" y="237" width="18" height="3">
-			</bounds>
+			<bounds x="559" y="237" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="574" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="574" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="574" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="574" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="559" y="262" width="18" height="3">
-			</bounds>
+			<bounds x="559" y="262" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="559" y="249" width="3" height="15">
-			</bounds>
+			<bounds x="559" y="249" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="559" y="237" width="3" height="15">
-			</bounds>
+			<bounds x="559" y="237" width="3" height="15"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="559" y="249" width="18" height="3">
-			</bounds>
+			<bounds x="559" y="249" width="18" height="3"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="578" y="262" width="3" height="3">
-			</bounds>
+			<bounds x="578" y="262" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="511" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="511" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off208" element="led_off">
-			<bounds x="514" y="155" width="17" height="2">
-			</bounds>
+			<bounds x="514" y="155" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off209" element="led_off">
-			<bounds x="528" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="528" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off210" element="led_off">
-			<bounds x="528" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="528" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off211" element="led_off">
-			<bounds x="514" y="179" width="17" height="2">
-			</bounds>
+			<bounds x="514" y="179" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off212" element="led_off">
-			<bounds x="514" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="514" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off213" element="led_off">
-			<bounds x="514" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="514" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off214" element="led_off">
-			<bounds x="514" y="167" width="17" height="2">
-			</bounds>
+			<bounds x="514" y="167" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off215" element="led_dot_off">
-			<bounds x="531" y="179" width="3" height="2">
-			</bounds>
+			<bounds x="531" y="179" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp208" element="led_on">
-			<bounds x="514" y="155" width="17" height="2">
-			</bounds>
+			<bounds x="514" y="155" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp209" element="led_on">
-			<bounds x="528" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="528" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp210" element="led_on">
-			<bounds x="528" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="528" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp211" element="led_on">
-			<bounds x="514" y="179" width="17" height="2">
-			</bounds>
+			<bounds x="514" y="179" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp212" element="led_on">
-			<bounds x="514" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="514" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp213" element="led_on">
-			<bounds x="514" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="514" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp214" element="led_on">
-			<bounds x="514" y="167" width="17" height="2">
-			</bounds>
+			<bounds x="514" y="167" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp215" element="led_dot_on">
-			<bounds x="531" y="179" width="3" height="2">
-			</bounds>
+			<bounds x="531" y="179" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="534" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="534" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off216" element="led_off">
-			<bounds x="537" y="155" width="17" height="2">
-			</bounds>
+			<bounds x="537" y="155" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off217" element="led_off">
-			<bounds x="551" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="551" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off218" element="led_off">
-			<bounds x="551" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="551" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off219" element="led_off">
-			<bounds x="537" y="179" width="17" height="2">
-			</bounds>
+			<bounds x="537" y="179" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off220" element="led_off">
-			<bounds x="537" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="537" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off221" element="led_off">
-			<bounds x="537" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="537" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off222" element="led_off">
-			<bounds x="537" y="167" width="17" height="2">
-			</bounds>
+			<bounds x="537" y="167" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off223" element="led_dot_off">
-			<bounds x="554" y="179" width="3" height="2">
-			</bounds>
+			<bounds x="554" y="179" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp216" element="led_on">
-			<bounds x="537" y="155" width="17" height="2">
-			</bounds>
+			<bounds x="537" y="155" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp217" element="led_on">
-			<bounds x="551" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="551" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp218" element="led_on">
-			<bounds x="551" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="551" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp219" element="led_on">
-			<bounds x="537" y="179" width="17" height="2">
-			</bounds>
+			<bounds x="537" y="179" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp220" element="led_on">
-			<bounds x="537" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="537" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp221" element="led_on">
-			<bounds x="537" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="537" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp222" element="led_on">
-			<bounds x="537" y="167" width="17" height="2">
-			</bounds>
+			<bounds x="537" y="167" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp223" element="led_dot_on">
-			<bounds x="554" y="179" width="3" height="2">
-			</bounds>
+			<bounds x="554" y="179" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="558" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="558" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="561" y="155" width="17" height="2">
-			</bounds>
+			<bounds x="561" y="155" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="575" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="575" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="575" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="575" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="561" y="179" width="17" height="2">
-			</bounds>
+			<bounds x="561" y="179" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="561" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="561" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="561" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="561" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="561" y="167" width="17" height="2">
-			</bounds>
+			<bounds x="561" y="167" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="578" y="179" width="3" height="2">
-			</bounds>
+			<bounds x="578" y="179" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="561" y="155" width="17" height="2">
-			</bounds>
+			<bounds x="561" y="155" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="575" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="575" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="575" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="575" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="561" y="179" width="17" height="2">
-			</bounds>
+			<bounds x="561" y="179" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="561" y="167" width="3" height="14">
-			</bounds>
+			<bounds x="561" y="167" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="561" y="155" width="3" height="14">
-			</bounds>
+			<bounds x="561" y="155" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="561" y="167" width="17" height="2">
-			</bounds>
+			<bounds x="561" y="167" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="578" y="179" width="3" height="2">
-			</bounds>
+			<bounds x="578" y="179" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="187" y="121" width="44" height="50">
-			</bounds>
+			<bounds x="187" y="121" width="44" height="50"/>
 		</backdrop>
 		<backdrop name="led_off248" element="led_off">
-			<bounds x="193" y="125" width="31" height="4">
-			</bounds>
+			<bounds x="193" y="125" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off249" element="led_off">
-			<bounds x="218" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="218" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off250" element="led_off">
-			<bounds x="218" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="218" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off251" element="led_off">
-			<bounds x="193" y="161" width="31" height="4">
-			</bounds>
+			<bounds x="193" y="161" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off252" element="led_off">
-			<bounds x="193" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="193" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off253" element="led_off">
-			<bounds x="193" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="193" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off254" element="led_off">
-			<bounds x="193" y="143" width="31" height="4">
-			</bounds>
+			<bounds x="193" y="143" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off255" element="led_dot_off">
-			<bounds x="224" y="161" width="6" height="4">
-			</bounds>
+			<bounds x="224" y="161" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="lamp248" element="led_on">
-			<bounds x="193" y="125" width="31" height="4">
-			</bounds>
+			<bounds x="193" y="125" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp249" element="led_on">
-			<bounds x="218" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="218" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="led_on">
-			<bounds x="218" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="218" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp251" element="led_on">
-			<bounds x="193" y="161" width="31" height="4">
-			</bounds>
+			<bounds x="193" y="161" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp252" element="led_on">
-			<bounds x="193" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="193" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp253" element="led_on">
-			<bounds x="193" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="193" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp254" element="led_on">
-			<bounds x="193" y="143" width="31" height="4">
-			</bounds>
+			<bounds x="193" y="143" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp255" element="led_dot_on">
-			<bounds x="224" y="161" width="6" height="4">
-			</bounds>
+			<bounds x="224" y="161" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="99" y="121" width="44" height="50">
-			</bounds>
+			<bounds x="99" y="121" width="44" height="50"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="105" y="125" width="31" height="4">
-			</bounds>
+			<bounds x="105" y="125" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="130" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="130" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="130" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="130" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="105" y="161" width="31" height="4">
-			</bounds>
+			<bounds x="105" y="161" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="105" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="105" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="105" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="105" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="105" y="143" width="31" height="4">
-			</bounds>
+			<bounds x="105" y="143" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="136" y="161" width="6" height="4">
-			</bounds>
+			<bounds x="136" y="161" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="105" y="125" width="31" height="4">
-			</bounds>
+			<bounds x="105" y="125" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="130" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="130" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="130" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="130" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="105" y="161" width="31" height="4">
-			</bounds>
+			<bounds x="105" y="161" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="105" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="105" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="105" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="105" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="105" y="143" width="31" height="4">
-			</bounds>
+			<bounds x="105" y="143" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="136" y="161" width="6" height="4">
-			</bounds>
+			<bounds x="136" y="161" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="143" y="121" width="44" height="50">
-			</bounds>
+			<bounds x="143" y="121" width="44" height="50"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="149" y="125" width="31" height="4">
-			</bounds>
+			<bounds x="149" y="125" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="174" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="174" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="174" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="174" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="149" y="161" width="31" height="4">
-			</bounds>
+			<bounds x="149" y="161" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="149" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="149" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="149" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="149" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="149" y="143" width="31" height="4">
-			</bounds>
+			<bounds x="149" y="143" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="180" y="161" width="6" height="4">
-			</bounds>
+			<bounds x="180" y="161" width="6" height="4"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="149" y="125" width="31" height="4">
-			</bounds>
+			<bounds x="149" y="125" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="174" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="174" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="174" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="174" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="149" y="161" width="31" height="4">
-			</bounds>
+			<bounds x="149" y="161" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="149" y="143" width="6" height="22">
-			</bounds>
+			<bounds x="149" y="143" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="149" y="125" width="6" height="22">
-			</bounds>
+			<bounds x="149" y="125" width="6" height="22"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="149" y="143" width="31" height="4">
-			</bounds>
+			<bounds x="149" y="143" width="31" height="4"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="180" y="161" width="6" height="4">
-			</bounds>
+			<bounds x="180" y="161" width="6" height="4"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="10" y="353" width="272" height="30">
-			</bounds>
+			<bounds x="10" y="353" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="10" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="10" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="27" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="27" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="44" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="44" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="61" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="61" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="78" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="78" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="95" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="95" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="112" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="112" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="129" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="129" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="146" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="146" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="163" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="163" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="180" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="180" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="197" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="197" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="214" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="214" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="231" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="231" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="248" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="248" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="265" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="265" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label35" element="label_35">
-			<bounds x="515" y="123" width="67" height="21">
-			</bounds>
+			<bounds x="515" y="123" width="67" height="21"/>
 		</backdrop>
 		<backdrop name="label36" element="label_36">
-			<bounds x="512" y="135" width="72" height="21">
-			</bounds>
+			<bounds x="512" y="135" width="72" height="21"/>
 		</backdrop>
 		<backdrop name="label40" element="label_40">
-			<bounds x="506" y="215" width="78" height="23">
-			</bounds>
+			<bounds x="506" y="215" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="label49" element="label_49">
-			<bounds x="50" y="96" width="51" height="90">
-			</bounds>
+			<bounds x="50" y="96" width="51" height="90"/>
 		</backdrop>
 		<backdrop name="label50" element="label_50">
-			<bounds x="102" y="98" width="128" height="27">
-			</bounds>
+			<bounds x="102" y="98" width="128" height="27"/>
 		</backdrop>
 		<backdrop name="label54" element="label_54">
-			<bounds x="91" y="388" width="108" height="14">
-			</bounds>
+			<bounds x="91" y="388" width="108" height="14"/>
 		</backdrop>
 		<backdrop name="label87" element="label_87">
-			<bounds x="612" y="582" width="106" height="16">
-			</bounds>
+			<bounds x="612" y="582" width="106" height="16"/>
 		</backdrop>
 		<backdrop name="label88" element="label_88">
-			<bounds x="613" y="19" width="104" height="19">
-			</bounds>
+			<bounds x="613" y="19" width="104" height="19"/>
 		</backdrop>
 		<backdrop name="label89" element="label_89">
-			<bounds x="231" y="334" width="51" height="23">
-			</bounds>
+			<bounds x="231" y="334" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="label90" element="label_90">
-			<bounds x="149" y="334" width="45" height="23">
-			</bounds>
+			<bounds x="149" y="334" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="label91" element="label_91">
-			<bounds x="10" y="334" width="96" height="23">
-			</bounds>
+			<bounds x="10" y="334" width="96" height="23"/>
 		</backdrop>
 		<backdrop name="label92" element="label_92">
-			<bounds x="628" y="2" width="75" height="21">
-			</bounds>
+			<bounds x="628" y="2" width="75" height="21"/>
 		</backdrop>
 		<backdrop name="label93" element="label_93">
-			<bounds x="696" y="255" width="26" height="19">
-			</bounds>
+			<bounds x="696" y="255" width="26" height="19"/>
 		</backdrop>
 		<backdrop name="label94" element="label_94">
-			<bounds x="696" y="213" width="26" height="19">
-			</bounds>
+			<bounds x="696" y="213" width="26" height="19"/>
 		</backdrop>
 		<backdrop name="label95" element="label_95">
-			<bounds x="696" y="173" width="26" height="19">
-			</bounds>
+			<bounds x="696" y="173" width="26" height="19"/>
 		</backdrop>
 		<backdrop name="label96" element="label_96">
-			<bounds x="699" y="546" width="18" height="19">
-			</bounds>
+			<bounds x="699" y="546" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="611" y="546" width="23" height="19">
-			</bounds>
+			<bounds x="611" y="546" width="23" height="19"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="699" y="380" width="18" height="19">
-			</bounds>
+			<bounds x="699" y="380" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label99" element="label_99">
-			<bounds x="598" y="380" width="40" height="19">
-			</bounds>
+			<bounds x="598" y="380" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label100" element="label_100">
-			<bounds x="611" y="504" width="23" height="19">
-			</bounds>
+			<bounds x="611" y="504" width="23" height="19"/>
 		</backdrop>
 		<backdrop name="label101" element="label_101">
-			<bounds x="611" y="465" width="18" height="19">
-			</bounds>
+			<bounds x="611" y="465" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label102" element="label_102">
-			<bounds x="611" y="421" width="18" height="19">
-			</bounds>
+			<bounds x="611" y="421" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label103" element="label_103">
-			<bounds x="598" y="337" width="40" height="19">
-			</bounds>
+			<bounds x="598" y="337" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label104" element="label_104">
-			<bounds x="611" y="295" width="18" height="19">
-			</bounds>
+			<bounds x="611" y="295" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label105" element="label_105">
-			<bounds x="611" y="255" width="18" height="19">
-			</bounds>
+			<bounds x="611" y="255" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label106" element="label_106">
-			<bounds x="611" y="213" width="18" height="19">
-			</bounds>
+			<bounds x="611" y="213" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label107" element="label_107">
-			<bounds x="611" y="173" width="18" height="19">
-			</bounds>
+			<bounds x="611" y="173" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label108" element="label_108">
-			<bounds x="606" y="129" width="26" height="19">
-			</bounds>
+			<bounds x="606" y="129" width="26" height="19"/>
 		</backdrop>
 		<backdrop name="label109" element="label_109">
-			<bounds x="606" y="88" width="26" height="19">
-			</bounds>
+			<bounds x="606" y="88" width="26" height="19"/>
 		</backdrop>
 		<backdrop name="label110" element="label_110">
-			<bounds x="606" y="47" width="26" height="19">
-			</bounds>
+			<bounds x="606" y="47" width="26" height="19"/>
 		</backdrop>
 		<backdrop name="label111" element="label_111">
-			<bounds x="696" y="123" width="31" height="32">
-			</bounds>
+			<bounds x="696" y="123" width="31" height="32"/>
 		</backdrop>
 		<backdrop name="label121" element="label_121">
-			<bounds x="699" y="295" width="18" height="19">
-			</bounds>
+			<bounds x="699" y="295" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label122" element="label_122">
-			<bounds x="699" y="337" width="18" height="19">
-			</bounds>
+			<bounds x="699" y="337" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label123" element="label_123">
-			<bounds x="699" y="421" width="18" height="19">
-			</bounds>
+			<bounds x="699" y="421" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="699" y="465" width="18" height="19">
-			</bounds>
+			<bounds x="699" y="465" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="699" y="504" width="18" height="19">
-			</bounds>
+			<bounds x="699" y="504" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="694" y="47" width="34" height="19">
-			</bounds>
+			<bounds x="694" y="47" width="34" height="19"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="693" y="88" width="34" height="19">
-			</bounds>
+			<bounds x="693" y="88" width="34" height="19"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="712" y="638" width="21" height="13">
-			</bounds>
+			<bounds x="712" y="638" width="21" height="13"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="501" y="359" width="78" height="13">
-			</bounds>
+			<bounds x="501" y="359" width="78" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1imclb.lay
+++ b/src/mame/layout/m1imclb.lay
@@ -8,12932 +8,8018 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.19" blue="0.19">
-			</color>
+			<color red="0.50" green="0.19" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.38" blue="0.38">
-			</color>
+			<color red="1.00" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.09">
-			</color>
+			<color red="0.25" green="0.09" blue="0.09"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.09">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.19" blue="0.19">
-			</color>
+			<color red="0.50" green="0.19" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.38" blue="0.38">
-			</color>
+			<color red="1.00" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.09">
-			</color>
+			<color red="0.25" green="0.09" blue="0.09"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.09">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Feature Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.27" blue="0.50">
-			</color>
+			<color red="0.04" green="0.27" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.07" blue="0.12">
-			</color>
+			<color red="0.01" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.54" blue="1.00">
-			</color>
+			<color red="0.08" green="0.54" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.13" blue="0.25">
-			</color>
+			<color red="0.02" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Scratchc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.27" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.54" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Scratchc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.35" blue="0.50">
-			</color>
+			<color red="0.21" green="0.35" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.09" blue="0.12">
-			</color>
+			<color red="0.05" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.71" blue="1.00">
-			</color>
+			<color red="0.42" green="0.71" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.18" blue="0.25">
-			</color>
+			<color red="0.10" green="0.18" blue="0.25"/>
 		</rect>
 		<text string="Step To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nearest Wi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.35" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.71" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.18" blue="0.25">
-			</color>
-		</rect>
-		<text string="Step To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nearest Wi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
+			<color red="0.50" green="0.02" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
+			<color red="1.00" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
+			<color red="0.25" green="0.01" blue="0.01"/>
 		</rect>
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
-		</rect>
-		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
+			<color red="0.50" green="0.02" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
+			<color red="1.00" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
+			<color red="0.25" green="0.01" blue="0.01"/>
 		</rect>
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
-		</rect>
-		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
+			<color red="0.50" green="0.06" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
+			<color red="1.00" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
+			<color red="0.25" green="0.03" blue="0.03"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
+			<color red="0.50" green="0.06" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
+			<color red="1.00" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
+			<color red="0.25" green="0.03" blue="0.03"/>
 		</rect>
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
-		</rect>
-		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
+			<color red="0.50" green="0.10" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
+			<color red="1.00" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
+			<color red="0.50" green="0.10" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
+			<color red="1.00" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
+			<color red="0.50" green="0.10" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
+			<color red="1.00" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.23">
-			</color>
+			<color red="0.49" green="0.43" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
+			<color red="0.12" green="0.11" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.86" blue="0.47">
-			</color>
+			<color red="0.99" green="0.86" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.11">
-			</color>
+			<color red="0.25" green="0.22" blue="0.11"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.86" blue="0.47">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.11">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.38" blue="0.05">
-			</color>
+			<color red="0.49" green="0.38" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.01">
-			</color>
+			<color red="0.12" green="0.09" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.77" blue="0.09">
-			</color>
+			<color red="0.99" green="0.77" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.02">
-			</color>
+			<color red="0.25" green="0.19" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.38" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.77" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.39" blue="0.09">
-			</color>
+			<color red="0.49" green="0.39" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.02">
-			</color>
+			<color red="0.12" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.18">
-			</color>
+			<color red="0.99" green="0.79" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.04">
-			</color>
+			<color red="0.25" green="0.20" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.39" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.11">
-			</color>
+			<color red="0.49" green="0.40" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.02">
-			</color>
+			<color red="0.12" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.80" blue="0.22">
-			</color>
+			<color red="0.99" green="0.80" blue="0.22"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.05">
-			</color>
+			<color red="0.25" green="0.20" blue="0.05"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.80" blue="0.22">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.05">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.15">
-			</color>
+			<color red="0.49" green="0.41" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
+			<color red="0.12" green="0.10" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.82" blue="0.30">
-			</color>
+			<color red="0.99" green="0.82" blue="0.30"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.07">
-			</color>
+			<color red="0.25" green="0.20" blue="0.07"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.15">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.82" blue="0.30">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.07">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.17">
-			</color>
+			<color red="0.49" green="0.41" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
+			<color red="0.12" green="0.10" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.83" blue="0.34">
-			</color>
+			<color red="0.99" green="0.83" blue="0.34"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.08">
-			</color>
+			<color red="0.25" green="0.20" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.83" blue="0.34">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.42" blue="0.19">
-			</color>
+			<color red="0.49" green="0.42" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.05">
-			</color>
+			<color red="0.12" green="0.10" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.84" blue="0.38">
-			</color>
+			<color red="0.99" green="0.84" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.09">
-			</color>
+			<color red="0.25" green="0.21" blue="0.09"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.42" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.84" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.09">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.42" blue="0.21">
-			</color>
+			<color red="0.49" green="0.42" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
+			<color red="0.12" green="0.11" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.85" blue="0.42">
-			</color>
+			<color red="0.99" green="0.85" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.11">
-			</color>
+			<color red="0.25" green="0.21" blue="0.11"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.42" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.85" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.11">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.13">
-			</color>
+			<color red="0.49" green="0.40" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.03">
-			</color>
+			<color red="0.12" green="0.10" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.81" blue="0.26">
-			</color>
+			<color red="0.99" green="0.81" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.06">
-			</color>
+			<color red="0.25" green="0.20" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.81" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.39" blue="0.07">
-			</color>
+			<color red="0.49" green="0.39" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.02">
-			</color>
+			<color red="0.12" green="0.09" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.78" blue="0.14">
-			</color>
+			<color red="0.99" green="0.78" blue="0.14"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.03">
-			</color>
+			<color red="0.25" green="0.19" blue="0.03"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.39" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.78" blue="0.14">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.03">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.38" blue="0.03">
-			</color>
+			<color red="0.49" green="0.38" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.05">
-			</color>
+			<color red="0.99" green="0.75" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.01">
-			</color>
+			<color red="0.25" green="0.19" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.38" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.26" blue="0.50">
-			</color>
+			<color red="0.02" green="0.26" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.52" blue="1.00">
-			</color>
+			<color red="0.04" green="0.52" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.13" blue="0.25">
-			</color>
+			<color red="0.01" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.26" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.52" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="REFILL REQUIRED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="REFILL REQUIRED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.19" green="0.34" blue="0.50">
-			</color>
+			<color red="0.19" green="0.34" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.12">
-			</color>
+			<color red="0.05" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.69" blue="1.00">
-			</color>
+			<color red="0.38" green="0.69" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.17" blue="0.25">
-			</color>
+			<color red="0.09" green="0.17" blue="0.25"/>
 		</rect>
 		<text string="Nudgepot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.19" green="0.34" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.69" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.17" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudgepot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.33" blue="0.50">
-			</color>
+			<color red="0.16" green="0.33" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
+			<color red="0.04" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.67" blue="1.00">
-			</color>
+			<color red="0.33" green="0.67" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.25">
-			</color>
+			<color red="0.08" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="Scratchcard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.33" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.67" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="Scratchcard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.15" green="0.32" blue="0.50">
-			</color>
+			<color red="0.15" green="0.32" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
+			<color red="0.04" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.65" blue="1.00">
-			</color>
+			<color red="0.29" green="0.65" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.16" blue="0.25">
-			</color>
+			<color red="0.07" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.15" green="0.32" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.65" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
+			<color red="0.13" green="0.31" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
+			<color red="0.03" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
+			<color red="0.25" green="0.62" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
+			<color red="0.06" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="Notation">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="Notation">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.10" green="0.30" blue="0.50">
-			</color>
+			<color red="0.10" green="0.30" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.60" blue="1.00">
-			</color>
+			<color red="0.21" green="0.60" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.15" blue="0.25">
-			</color>
+			<color red="0.05" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="Stop A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.10" green="0.30" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.60" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stop A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
+			<color red="0.08" green="0.29" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
+			<color red="0.17" green="0.58" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
+			<color red="0.04" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="Nudgepot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudgepot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.28" blue="0.50">
-			</color>
+			<color red="0.06" green="0.28" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.56" blue="1.00">
-			</color>
+			<color red="0.13" green="0.56" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.14" blue="0.25">
-			</color>
+			<color red="0.03" green="0.14" blue="0.25"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.28" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.56" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.14" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.23">
-			</color>
+			<color red="0.49" green="0.43" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
+			<color red="0.12" green="0.11" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.86" blue="0.47">
-			</color>
+			<color red="0.99" green="0.86" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.11">
-			</color>
+			<color red="0.25" green="0.22" blue="0.11"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.43" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.86" blue="0.47">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.11">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.35" blue="0.50">
-			</color>
+			<color red="0.21" green="0.35" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.09" blue="0.12">
-			</color>
+			<color red="0.05" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.71" blue="1.00">
-			</color>
+			<color red="0.42" green="0.71" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.18" blue="0.25">
-			</color>
+			<color red="0.10" green="0.18" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.35" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.71" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.18" blue="0.25">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="INS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="INS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="TAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="TAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="MI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="MI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LLI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LLI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="ONA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="ONA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="IRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="IRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_2" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="T ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="T ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_45_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_45_2" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_46_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.00">
-			</color>
+			<color red="0.00" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.84" blue="0.00">
-			</color>
+			<color red="0.00" green="0.84" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.00">
-			</color>
+			<color red="0.00" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="Random Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.84" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.00">
-			</color>
-		</rect>
-		<text string="Random Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.00">
-			</color>
+			<color red="0.00" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.84" blue="0.00">
-			</color>
+			<color red="0.00" green="0.84" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.00">
-			</color>
+			<color red="0.00" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.84" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.00">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.00">
-			</color>
+			<color red="0.00" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.84" blue="0.00">
-			</color>
+			<color red="0.00" green="0.84" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.00">
-			</color>
+			<color red="0.00" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="Skillstop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.84" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skillstop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_202_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_202_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_201_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_201_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_200_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_200_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_206_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_206_2" defstate="0">
 		<disk state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_205_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_205_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_204_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
+			<color red="0.49" green="0.37" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_204_2" defstate="0">
 		<disk state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
+			<color red="0.99" green="0.75" blue="0.01"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.49" green="0.37" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.99" green="0.75" blue="0.01">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_203_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_203_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_152_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_152">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_112">
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_113">
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_114">
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_115">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_116">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_117">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_118">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_120">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_121">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_122">
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_123">
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_124">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="X3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="X4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_140">
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_141">
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_142">
 		<text string="Reserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_144">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_145">
 		<text string="v1.1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_146">
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_147">
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="765" height="651">
-			</bounds>
+			<bounds x="0" y="0" width="765" height="651"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="146" y="463" width="80" height="118">
-			</bounds>
+			<bounds x="146" y="463" width="80" height="118"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="146.0000" y="463.0000" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="146.0000" y="463.0000" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="149.3333" y="464.6389" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="149.3333" y="464.6389" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="152.6667" y="466.2778" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="152.6667" y="466.2778" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="156.0000" y="467.9167" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="156.0000" y="467.9167" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="159.3333" y="469.5555" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="159.3333" y="469.5555" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="162.6667" y="471.1945" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="162.6667" y="471.1945" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="146.0000" y="502.3333" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="146.0000" y="502.3333" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="149.3333" y="503.9722" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="149.3333" y="503.9722" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="152.6667" y="505.6111" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="152.6667" y="505.6111" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="156.0000" y="507.2500" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="156.0000" y="507.2500" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="159.3333" y="508.8889" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="159.3333" y="508.8889" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="162.6667" y="510.5278" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="162.6667" y="510.5278" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="146.0000" y="541.6667" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="146.0000" y="541.6667" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="149.3333" y="543.3056" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="149.3333" y="543.3056" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="152.6667" y="544.9445" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="152.6667" y="544.9445" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="156.0000" y="546.5834" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="156.0000" y="546.5834" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="159.3333" y="548.2222" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="159.3333" y="548.2222" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="162.6667" y="549.8611" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="162.6667" y="549.8611" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="146" y="463" width="80" height="118">
-			</bounds>
+			<bounds x="146" y="463" width="80" height="118"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="228" y="463" width="80" height="118">
-			</bounds>
+			<bounds x="228" y="463" width="80" height="118"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="228.0000" y="463.0000" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="228.0000" y="463.0000" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="231.3333" y="464.6389" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="231.3333" y="464.6389" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="234.6667" y="466.2778" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="234.6667" y="466.2778" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="238.0000" y="467.9167" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="238.0000" y="467.9167" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="241.3333" y="469.5555" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="241.3333" y="469.5555" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="244.6667" y="471.1945" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="244.6667" y="471.1945" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="228.0000" y="502.3333" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="228.0000" y="502.3333" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="231.3333" y="503.9722" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="231.3333" y="503.9722" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="234.6667" y="505.6111" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="234.6667" y="505.6111" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="238.0000" y="507.2500" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="238.0000" y="507.2500" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="241.3333" y="508.8889" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="241.3333" y="508.8889" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="244.6667" y="510.5278" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="244.6667" y="510.5278" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="228.0000" y="541.6667" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="228.0000" y="541.6667" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="231.3333" y="543.3056" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="231.3333" y="543.3056" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="234.6667" y="544.9445" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="234.6667" y="544.9445" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="238.0000" y="546.5834" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="238.0000" y="546.5834" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="241.3333" y="548.2222" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="241.3333" y="548.2222" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="244.6667" y="549.8611" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="244.6667" y="549.8611" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="228" y="463" width="80" height="118">
-			</bounds>
+			<bounds x="228" y="463" width="80" height="118"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="310" y="463" width="80" height="118">
-			</bounds>
+			<bounds x="310" y="463" width="80" height="118"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="310.0000" y="463.0000" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="310.0000" y="463.0000" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="313.3333" y="464.6389" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="313.3333" y="464.6389" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="316.6667" y="466.2778" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="316.6667" y="466.2778" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="320.0000" y="467.9167" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="320.0000" y="467.9167" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.3333" y="469.5555" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="323.3333" y="469.5555" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="326.6667" y="471.1945" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="326.6667" y="471.1945" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="310.0000" y="502.3333" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="310.0000" y="502.3333" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="313.3333" y="503.9722" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="313.3333" y="503.9722" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="316.6667" y="505.6111" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="316.6667" y="505.6111" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="320.0000" y="507.2500" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="320.0000" y="507.2500" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.3333" y="508.8889" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="323.3333" y="508.8889" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="326.6667" y="510.5278" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="326.6667" y="510.5278" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="310.0000" y="541.6667" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="310.0000" y="541.6667" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="313.3333" y="543.3056" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="313.3333" y="543.3056" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="316.6667" y="544.9445" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="316.6667" y="544.9445" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="320.0000" y="546.5834" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="320.0000" y="546.5834" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.3333" y="548.2222" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="323.3333" y="548.2222" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="326.6667" y="549.8611" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="326.6667" y="549.8611" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="310" y="463" width="80" height="118">
-			</bounds>
+			<bounds x="310" y="463" width="80" height="118"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="392" y="463" width="80" height="118">
-			</bounds>
+			<bounds x="392" y="463" width="80" height="118"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="392.0000" y="463.0000" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="392.0000" y="463.0000" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="395.3333" y="464.6389" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="395.3333" y="464.6389" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="398.6667" y="466.2778" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="398.6667" y="466.2778" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="402.0000" y="467.9167" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="402.0000" y="467.9167" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="405.3333" y="469.5555" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="405.3333" y="469.5555" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="408.6667" y="471.1945" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="408.6667" y="471.1945" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="392.0000" y="502.3333" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="392.0000" y="502.3333" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="395.3333" y="503.9722" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="395.3333" y="503.9722" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="398.6667" y="505.6111" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="398.6667" y="505.6111" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="402.0000" y="507.2500" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="402.0000" y="507.2500" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="405.3333" y="508.8889" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="405.3333" y="508.8889" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="408.6667" y="510.5278" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="408.6667" y="510.5278" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="392.0000" y="541.6667" width="80.0000" height="39.3333">
-			</bounds>
+			<bounds x="392.0000" y="541.6667" width="80.0000" height="39.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="395.3333" y="543.3056" width="73.3333" height="36.0556">
-			</bounds>
+			<bounds x="395.3333" y="543.3056" width="73.3333" height="36.0556"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="398.6667" y="544.9445" width="66.6667" height="32.7778">
-			</bounds>
+			<bounds x="398.6667" y="544.9445" width="66.6667" height="32.7778"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="402.0000" y="546.5834" width="60.0000" height="29.5000">
-			</bounds>
+			<bounds x="402.0000" y="546.5834" width="60.0000" height="29.5000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="405.3333" y="548.2222" width="53.3333" height="26.2222">
-			</bounds>
+			<bounds x="405.3333" y="548.2222" width="53.3333" height="26.2222"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="408.6667" y="549.8611" width="46.6667" height="22.9444">
-			</bounds>
+			<bounds x="408.6667" y="549.8611" width="46.6667" height="22.9444"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="392" y="463" width="80" height="118">
-			</bounds>
+			<bounds x="392" y="463" width="80" height="118"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="229" y="325" width="181" height="50">
-			</bounds>
+			<bounds x="229" y="325" width="181" height="50"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="229.0000" y="325.0000" width="181.0000" height="50.0000">
-			</bounds>
+			<bounds x="229.0000" y="325.0000" width="181.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="236.5417" y="327.0833" width="165.9167" height="45.8333">
-			</bounds>
+			<bounds x="236.5417" y="327.0833" width="165.9167" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="244.0833" y="329.1667" width="150.8333" height="41.6667">
-			</bounds>
+			<bounds x="244.0833" y="329.1667" width="150.8333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="251.6250" y="331.2500" width="135.7500" height="37.5000">
-			</bounds>
+			<bounds x="251.6250" y="331.2500" width="135.7500" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="259.1667" y="333.3333" width="120.6667" height="33.3333">
-			</bounds>
+			<bounds x="259.1667" y="333.3333" width="120.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="266.7083" y="335.4167" width="105.5833" height="29.1667">
-			</bounds>
+			<bounds x="266.7083" y="335.4167" width="105.5833" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="229" y="325" width="181" height="50">
-			</bounds>
+			<bounds x="229" y="325" width="181" height="50"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="600" y="435" width="24" height="22">
-			</bounds>
+			<bounds x="600" y="435" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="602" y="437" width="20" height="18">
-			</bounds>
+			<bounds x="602" y="437" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="600" y="456" width="24" height="22">
-			</bounds>
+			<bounds x="600" y="456" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="602" y="458" width="20" height="18">
-			</bounds>
+			<bounds x="602" y="458" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="600" y="477" width="24" height="22">
-			</bounds>
+			<bounds x="600" y="477" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="602" y="479" width="20" height="18">
-			</bounds>
+			<bounds x="602" y="479" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="600" y="498" width="24" height="22">
-			</bounds>
+			<bounds x="600" y="498" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="602" y="500" width="20" height="18">
-			</bounds>
+			<bounds x="602" y="500" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="600" y="519" width="24" height="22">
-			</bounds>
+			<bounds x="600" y="519" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="602" y="521" width="20" height="18">
-			</bounds>
+			<bounds x="602" y="521" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="600" y="540" width="24" height="22">
-			</bounds>
+			<bounds x="600" y="540" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="602" y="542" width="20" height="18">
-			</bounds>
+			<bounds x="602" y="542" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="600" y="561" width="24" height="22">
-			</bounds>
+			<bounds x="600" y="561" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="602" y="563" width="20" height="18">
-			</bounds>
+			<bounds x="602" y="563" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="600" y="582" width="24" height="22">
-			</bounds>
+			<bounds x="600" y="582" width="24" height="22"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="602" y="584" width="20" height="18">
-			</bounds>
+			<bounds x="602" y="584" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="542" y="477" width="46" height="34">
-			</bounds>
+			<bounds x="542" y="477" width="46" height="34"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="544" y="479" width="42" height="30">
-			</bounds>
+			<bounds x="544" y="479" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="481" y="128" width="120" height="35">
-			</bounds>
+			<bounds x="481" y="128" width="120" height="35"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="483" y="130" width="116" height="31">
-			</bounds>
+			<bounds x="483" y="130" width="116" height="31"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="489" y="400" width="112" height="35">
-			</bounds>
+			<bounds x="489" y="400" width="112" height="35"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="491" y="402" width="108" height="31">
-			</bounds>
+			<bounds x="491" y="402" width="108" height="31"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="479" y="60" width="122" height="35">
-			</bounds>
+			<bounds x="479" y="60" width="122" height="35"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="481" y="62" width="118" height="31">
-			</bounds>
+			<bounds x="481" y="62" width="118" height="31"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="600" y="94" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="94" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="602" y="96" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="96" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="600" y="60" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="60" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="602" y="62" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="62" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="600" y="128" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="128" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="602" y="130" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="130" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="600" y="162" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="162" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="602" y="164" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="164" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="600" y="196" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="196" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="602" y="198" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="198" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="600" y="230" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="230" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="602" y="232" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="232" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="600" y="264" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="264" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="602" y="266" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="266" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="600" y="298" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="298" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="602" y="300" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="300" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="600" y="332" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="332" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="602" y="334" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="334" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="600" y="366" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="366" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="602" y="368" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="368" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="600" y="400" width="24" height="35">
-			</bounds>
+			<bounds x="600" y="400" width="24" height="35"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="602" y="402" width="20" height="31">
-			</bounds>
+			<bounds x="602" y="402" width="20" height="31"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="4" y="400" width="146" height="35">
-			</bounds>
+			<bounds x="4" y="400" width="146" height="35"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="6" y="402" width="142" height="31">
-			</bounds>
+			<bounds x="6" y="402" width="142" height="31"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="4" y="94" width="155" height="35">
-			</bounds>
+			<bounds x="4" y="94" width="155" height="35"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="6" y="96" width="151" height="31">
-			</bounds>
+			<bounds x="6" y="96" width="151" height="31"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="4" y="162" width="153" height="35">
-			</bounds>
+			<bounds x="4" y="162" width="153" height="35"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="6" y="164" width="149" height="31">
-			</bounds>
+			<bounds x="6" y="164" width="149" height="31"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="4" y="196" width="152" height="35">
-			</bounds>
+			<bounds x="4" y="196" width="152" height="35"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="6" y="198" width="148" height="31">
-			</bounds>
+			<bounds x="6" y="198" width="148" height="31"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="4" y="264" width="150" height="35">
-			</bounds>
+			<bounds x="4" y="264" width="150" height="35"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="6" y="266" width="146" height="31">
-			</bounds>
+			<bounds x="6" y="266" width="146" height="31"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="4" y="298" width="149" height="35">
-			</bounds>
+			<bounds x="4" y="298" width="149" height="35"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="6" y="300" width="145" height="31">
-			</bounds>
+			<bounds x="6" y="300" width="145" height="31"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="4" y="332" width="148" height="35">
-			</bounds>
+			<bounds x="4" y="332" width="148" height="35"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="6" y="334" width="144" height="31">
-			</bounds>
+			<bounds x="6" y="334" width="144" height="31"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="4" y="366" width="147" height="35">
-			</bounds>
+			<bounds x="4" y="366" width="147" height="35"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="6" y="368" width="143" height="31">
-			</bounds>
+			<bounds x="6" y="368" width="143" height="31"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="4" y="230" width="151" height="35">
-			</bounds>
+			<bounds x="4" y="230" width="151" height="35"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="6" y="232" width="147" height="31">
-			</bounds>
+			<bounds x="6" y="232" width="147" height="31"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="4" y="128" width="154" height="35">
-			</bounds>
+			<bounds x="4" y="128" width="154" height="35"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="6" y="130" width="150" height="31">
-			</bounds>
+			<bounds x="6" y="130" width="150" height="31"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="4" y="26" width="157" height="35">
-			</bounds>
+			<bounds x="4" y="26" width="157" height="35"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="6" y="28" width="153" height="31">
-			</bounds>
+			<bounds x="6" y="28" width="153" height="31"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="4" y="60" width="156" height="35">
-			</bounds>
+			<bounds x="4" y="60" width="156" height="35"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="6" y="62" width="152" height="31">
-			</bounds>
+			<bounds x="6" y="62" width="152" height="31"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="480" y="94" width="121" height="35">
-			</bounds>
+			<bounds x="480" y="94" width="121" height="35"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="482" y="96" width="117" height="31">
-			</bounds>
+			<bounds x="482" y="96" width="117" height="31"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="127" y="513" width="19" height="19">
-			</bounds>
+			<bounds x="127" y="513" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="129" y="515" width="15" height="15">
-			</bounds>
+			<bounds x="129" y="515" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="127" y="473" width="19" height="19">
-			</bounds>
+			<bounds x="127" y="473" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="129" y="475" width="15" height="15">
-			</bounds>
+			<bounds x="129" y="475" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="127" y="552" width="19" height="19">
-			</bounds>
+			<bounds x="127" y="552" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="129" y="554" width="15" height="15">
-			</bounds>
+			<bounds x="129" y="554" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="489" y="14" width="66" height="32">
-			</bounds>
+			<bounds x="489" y="14" width="66" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="491" y="16" width="62" height="28">
-			</bounds>
+			<bounds x="491" y="16" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="488" y="366" width="113" height="35">
-			</bounds>
+			<bounds x="488" y="366" width="113" height="35"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="490" y="368" width="109" height="31">
-			</bounds>
+			<bounds x="490" y="368" width="109" height="31"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="487" y="332" width="114" height="35">
-			</bounds>
+			<bounds x="487" y="332" width="114" height="35"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="489" y="334" width="110" height="31">
-			</bounds>
+			<bounds x="489" y="334" width="110" height="31"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="486" y="298" width="115" height="35">
-			</bounds>
+			<bounds x="486" y="298" width="115" height="35"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="488" y="300" width="111" height="31">
-			</bounds>
+			<bounds x="488" y="300" width="111" height="31"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="485" y="264" width="116" height="35">
-			</bounds>
+			<bounds x="485" y="264" width="116" height="35"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="487" y="266" width="112" height="31">
-			</bounds>
+			<bounds x="487" y="266" width="112" height="31"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="484" y="230" width="117" height="35">
-			</bounds>
+			<bounds x="484" y="230" width="117" height="35"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="486" y="232" width="113" height="31">
-			</bounds>
+			<bounds x="486" y="232" width="113" height="31"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="483" y="196" width="118" height="35">
-			</bounds>
+			<bounds x="483" y="196" width="118" height="35"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="485" y="198" width="114" height="31">
-			</bounds>
+			<bounds x="485" y="198" width="114" height="31"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="482" y="162" width="119" height="35">
-			</bounds>
+			<bounds x="482" y="162" width="119" height="35"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="484" y="164" width="115" height="31">
-			</bounds>
+			<bounds x="484" y="164" width="115" height="31"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="197" y="354" width="32" height="22">
-			</bounds>
+			<bounds x="197" y="354" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="199" y="356" width="28" height="18">
-			</bounds>
+			<bounds x="199" y="356" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="197" y="324" width="32" height="22">
-			</bounds>
+			<bounds x="197" y="324" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="199" y="326" width="28" height="18">
-			</bounds>
+			<bounds x="199" y="326" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="410" y="354" width="32" height="22">
-			</bounds>
+			<bounds x="410" y="354" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="412" y="356" width="28" height="18">
-			</bounds>
+			<bounds x="412" y="356" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="410" y="324" width="32" height="22">
-			</bounds>
+			<bounds x="410" y="324" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="412" y="326" width="28" height="18">
-			</bounds>
+			<bounds x="412" y="326" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="199" y="8" width="42" height="42">
-			</bounds>
+			<bounds x="199" y="8" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="201" y="10" width="38" height="38">
-			</bounds>
+			<bounds x="201" y="10" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="237" y="8" width="46" height="42">
-			</bounds>
+			<bounds x="237" y="8" width="46" height="42"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="239" y="10" width="42" height="38">
-			</bounds>
+			<bounds x="239" y="10" width="42" height="38"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="297" y="8" width="35" height="42">
-			</bounds>
+			<bounds x="297" y="8" width="35" height="42"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="299" y="10" width="31" height="38">
-			</bounds>
+			<bounds x="299" y="10" width="31" height="38"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="329" y="8" width="34" height="42">
-			</bounds>
+			<bounds x="329" y="8" width="34" height="42"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="331" y="10" width="30" height="38">
-			</bounds>
+			<bounds x="331" y="10" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="360" y="8" width="48" height="42">
-			</bounds>
+			<bounds x="360" y="8" width="48" height="42"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="362" y="10" width="44" height="38">
-			</bounds>
+			<bounds x="362" y="10" width="44" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="405" y="8" width="38" height="42">
-			</bounds>
+			<bounds x="405" y="8" width="38" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="407" y="10" width="34" height="38">
-			</bounds>
+			<bounds x="407" y="10" width="34" height="38"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_2_border" state="0">
-			<bounds x="280" y="8" width="20" height="42">
-			</bounds>
+			<bounds x="280" y="8" width="20" height="42"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_2" state="0">
-			<bounds x="282" y="10" width="16" height="38">
-			</bounds>
+			<bounds x="282" y="10" width="16" height="38"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="478" y="524" width="21" height="24">
-			</bounds>
+			<bounds x="478" y="524" width="21" height="24"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="480" y="526" width="17" height="20">
-			</bounds>
+			<bounds x="480" y="526" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_2_border" state="0">
-			<bounds x="472" y="545" width="32" height="28">
-			</bounds>
+			<bounds x="472" y="545" width="32" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_2" state="0">
-			<bounds x="474" y="547" width="28" height="24">
-			</bounds>
+			<bounds x="474" y="547" width="28" height="24"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="472" y="471" width="32" height="28">
-			</bounds>
+			<bounds x="472" y="471" width="32" height="28"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="474" y="473" width="28" height="24">
-			</bounds>
+			<bounds x="474" y="473" width="28" height="24"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_2_border" state="0">
-			<bounds x="478" y="496" width="21" height="24">
-			</bounds>
+			<bounds x="478" y="496" width="21" height="24"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_2" state="0">
-			<bounds x="480" y="498" width="17" height="20">
-			</bounds>
+			<bounds x="480" y="498" width="17" height="20"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="186" y="430" width="42" height="31">
-			</bounds>
+			<bounds x="186" y="430" width="42" height="31"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="188" y="432" width="38" height="27">
-			</bounds>
+			<bounds x="188" y="432" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="336" y="430" width="42" height="31">
-			</bounds>
+			<bounds x="336" y="430" width="42" height="31"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="338" y="432" width="38" height="27">
-			</bounds>
+			<bounds x="338" y="432" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="286" y="430" width="42" height="31">
-			</bounds>
+			<bounds x="286" y="430" width="42" height="31"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="288" y="432" width="38" height="27">
-			</bounds>
+			<bounds x="288" y="432" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="236" y="430" width="42" height="31">
-			</bounds>
+			<bounds x="236" y="430" width="42" height="31"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="238" y="432" width="38" height="27">
-			</bounds>
+			<bounds x="238" y="432" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="386" y="430" width="46" height="17">
-			</bounds>
+			<bounds x="386" y="430" width="46" height="17"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="388" y="432" width="42" height="13">
-			</bounds>
+			<bounds x="388" y="432" width="42" height="13"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="386" y="444" width="46" height="17">
-			</bounds>
+			<bounds x="386" y="444" width="46" height="17"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="388" y="446" width="42" height="13">
-			</bounds>
+			<bounds x="388" y="446" width="42" height="13"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="368" y="584" width="67" height="22">
-			</bounds>
+			<bounds x="368" y="584" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="370" y="586" width="63" height="18">
-			</bounds>
+			<bounds x="370" y="586" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="292" y="584" width="76" height="22">
-			</bounds>
+			<bounds x="292" y="584" width="76" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="294" y="586" width="72" height="18">
-			</bounds>
+			<bounds x="294" y="586" width="72" height="18"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="240" y="584" width="52" height="22">
-			</bounds>
+			<bounds x="240" y="584" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="242" y="586" width="48" height="18">
-			</bounds>
+			<bounds x="242" y="586" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="188" y="584" width="52" height="22">
-			</bounds>
+			<bounds x="188" y="584" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="190" y="586" width="48" height="18">
-			</bounds>
+			<bounds x="190" y="586" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="379" y="261" width="17" height="9">
-			</bounds>
+			<bounds x="379" y="261" width="17" height="9"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="381" y="263" width="13" height="5">
-			</bounds>
+			<bounds x="381" y="263" width="13" height="5"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="379" y="228" width="17" height="9">
-			</bounds>
+			<bounds x="379" y="228" width="17" height="9"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="381" y="230" width="13" height="5">
-			</bounds>
+			<bounds x="381" y="230" width="13" height="5"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="379" y="195" width="17" height="9">
-			</bounds>
+			<bounds x="379" y="195" width="17" height="9"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="381" y="197" width="13" height="5">
-			</bounds>
+			<bounds x="381" y="197" width="13" height="5"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_2_border" state="0">
-			<bounds x="392" y="251" width="29" height="29">
-			</bounds>
+			<bounds x="392" y="251" width="29" height="29"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_2" state="0">
-			<bounds x="394" y="253" width="25" height="25">
-			</bounds>
+			<bounds x="394" y="253" width="25" height="25"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_2_border" state="0">
-			<bounds x="392" y="218" width="29" height="29">
-			</bounds>
+			<bounds x="392" y="218" width="29" height="29"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_2" state="0">
-			<bounds x="394" y="220" width="25" height="25">
-			</bounds>
+			<bounds x="394" y="220" width="25" height="25"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2_border" state="0">
-			<bounds x="392" y="185" width="29" height="29">
-			</bounds>
+			<bounds x="392" y="185" width="29" height="29"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2" state="0">
-			<bounds x="394" y="187" width="25" height="25">
-			</bounds>
+			<bounds x="394" y="187" width="25" height="25"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="355" y="282" width="8" height="17">
-			</bounds>
+			<bounds x="355" y="282" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="357" y="284" width="4" height="13">
-			</bounds>
+			<bounds x="357" y="284" width="4" height="13"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="315" y="282" width="8" height="17">
-			</bounds>
+			<bounds x="315" y="282" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="317" y="284" width="4" height="13">
-			</bounds>
+			<bounds x="317" y="284" width="4" height="13"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="275" y="282" width="8" height="17">
-			</bounds>
+			<bounds x="275" y="282" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="277" y="284" width="4" height="13">
-			</bounds>
+			<bounds x="277" y="284" width="4" height="13"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="235" y="282" width="8" height="17">
-			</bounds>
+			<bounds x="235" y="282" width="8" height="17"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="237" y="284" width="4" height="13">
-			</bounds>
+			<bounds x="237" y="284" width="4" height="13"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_2_border" state="0">
-			<bounds x="227" y="295" width="24" height="24">
-			</bounds>
+			<bounds x="227" y="295" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_2" state="0">
-			<bounds x="229" y="297" width="20" height="20">
-			</bounds>
+			<bounds x="229" y="297" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_2_border" state="0">
-			<bounds x="267" y="295" width="24" height="24">
-			</bounds>
+			<bounds x="267" y="295" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_2" state="0">
-			<bounds x="269" y="297" width="20" height="20">
-			</bounds>
+			<bounds x="269" y="297" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_2_border" state="0">
-			<bounds x="307" y="295" width="24" height="24">
-			</bounds>
+			<bounds x="307" y="295" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_2" state="0">
-			<bounds x="309" y="297" width="20" height="20">
-			</bounds>
+			<bounds x="309" y="297" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_2_border" state="0">
-			<bounds x="347" y="295" width="24" height="24">
-			</bounds>
+			<bounds x="347" y="295" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_2" state="0">
-			<bounds x="349" y="297" width="20" height="20">
-			</bounds>
+			<bounds x="349" y="297" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_150_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="401" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="401" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_150" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="403" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="403" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_151_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="319" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="319" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_151" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="321" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="321" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_152_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="237" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="237" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_152" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="239" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="239" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_153_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="155" y="606" width="62" height="42">
-			</bounds>
+			<bounds x="155" y="606" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_153" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="157" y="608" width="58" height="38">
-			</bounds>
+			<bounds x="157" y="608" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_154_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="42" y="607" width="66" height="42">
-			</bounds>
+			<bounds x="42" y="607" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_154" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="44" y="609" width="62" height="38">
-			</bounds>
+			<bounds x="44" y="609" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_156_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="583" y="607" width="42" height="42">
-			</bounds>
+			<bounds x="583" y="607" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_156" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="585" y="609" width="38" height="38">
-			</bounds>
+			<bounds x="585" y="609" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_157_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="543" y="607" width="42" height="42">
-			</bounds>
+			<bounds x="543" y="607" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_157" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="545" y="609" width="38" height="38">
-			</bounds>
+			<bounds x="545" y="609" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_158_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="470" y="607" width="72" height="42">
-			</bounds>
+			<bounds x="470" y="607" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_158" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="472" y="609" width="68" height="38">
-			</bounds>
+			<bounds x="472" y="609" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp62" element="colour_button_159_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="572" y="6" width="47" height="47">
-			</bounds>
+			<bounds x="572" y="6" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp62" element="colour_button_159" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="574" y="8" width="43" height="43">
-			</bounds>
+			<bounds x="574" y="8" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_167_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="42" y="607" width="66" height="42">
-			</bounds>
+			<bounds x="42" y="607" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_167" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="44" y="609" width="62" height="38">
-			</bounds>
+			<bounds x="44" y="609" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="184" y="119" width="24" height="32">
-			</bounds>
+			<bounds x="184" y="119" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="187" y="121" width="17" height="2">
-			</bounds>
+			<bounds x="187" y="121" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="201" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="201" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="201" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="201" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="187" y="145" width="17" height="2">
-			</bounds>
+			<bounds x="187" y="145" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="187" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="187" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="187" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="187" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="187" y="133" width="17" height="2">
-			</bounds>
+			<bounds x="187" y="133" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="204" y="145" width="3" height="2">
-			</bounds>
+			<bounds x="204" y="145" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="187" y="121" width="17" height="2">
-			</bounds>
+			<bounds x="187" y="121" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="201" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="201" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="201" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="201" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="187" y="145" width="17" height="2">
-			</bounds>
+			<bounds x="187" y="145" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="187" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="187" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="187" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="187" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="187" y="133" width="17" height="2">
-			</bounds>
+			<bounds x="187" y="133" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="204" y="145" width="3" height="2">
-			</bounds>
+			<bounds x="204" y="145" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="208" y="119" width="24" height="32">
-			</bounds>
+			<bounds x="208" y="119" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="211" y="121" width="17" height="2">
-			</bounds>
+			<bounds x="211" y="121" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="225" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="225" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="225" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="225" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="211" y="145" width="17" height="2">
-			</bounds>
+			<bounds x="211" y="145" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="211" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="211" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="211" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="211" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="211" y="133" width="17" height="2">
-			</bounds>
+			<bounds x="211" y="133" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="228" y="145" width="3" height="2">
-			</bounds>
+			<bounds x="228" y="145" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="211" y="121" width="17" height="2">
-			</bounds>
+			<bounds x="211" y="121" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="225" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="225" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="225" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="225" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="211" y="145" width="17" height="2">
-			</bounds>
+			<bounds x="211" y="145" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="211" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="211" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="211" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="211" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="211" y="133" width="17" height="2">
-			</bounds>
+			<bounds x="211" y="133" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="228" y="145" width="3" height="2">
-			</bounds>
+			<bounds x="228" y="145" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="232" y="119" width="24" height="32">
-			</bounds>
+			<bounds x="232" y="119" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="235" y="121" width="17" height="2">
-			</bounds>
+			<bounds x="235" y="121" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="249" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="249" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="249" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="249" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="235" y="145" width="17" height="2">
-			</bounds>
+			<bounds x="235" y="145" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="235" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="235" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="235" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="235" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="235" y="133" width="17" height="2">
-			</bounds>
+			<bounds x="235" y="133" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="252" y="145" width="3" height="2">
-			</bounds>
+			<bounds x="252" y="145" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="235" y="121" width="17" height="2">
-			</bounds>
+			<bounds x="235" y="121" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="249" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="249" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="249" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="249" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="235" y="145" width="17" height="2">
-			</bounds>
+			<bounds x="235" y="145" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="235" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="235" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="235" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="235" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="235" y="133" width="17" height="2">
-			</bounds>
+			<bounds x="235" y="133" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="252" y="145" width="3" height="2">
-			</bounds>
+			<bounds x="252" y="145" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="256" y="119" width="24" height="32">
-			</bounds>
+			<bounds x="256" y="119" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="259" y="121" width="17" height="2">
-			</bounds>
+			<bounds x="259" y="121" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="273" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="273" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="273" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="273" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="259" y="145" width="17" height="2">
-			</bounds>
+			<bounds x="259" y="145" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="259" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="259" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="259" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="259" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="259" y="133" width="17" height="2">
-			</bounds>
+			<bounds x="259" y="133" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="276" y="145" width="3" height="2">
-			</bounds>
+			<bounds x="276" y="145" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="259" y="121" width="17" height="2">
-			</bounds>
+			<bounds x="259" y="121" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="273" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="273" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="273" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="273" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="259" y="145" width="17" height="2">
-			</bounds>
+			<bounds x="259" y="145" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="259" y="133" width="3" height="14">
-			</bounds>
+			<bounds x="259" y="133" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="259" y="121" width="3" height="14">
-			</bounds>
+			<bounds x="259" y="121" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="259" y="133" width="17" height="2">
-			</bounds>
+			<bounds x="259" y="133" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="276" y="145" width="3" height="2">
-			</bounds>
+			<bounds x="276" y="145" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="188" y="73" width="21" height="28">
-			</bounds>
+			<bounds x="188" y="73" width="21" height="28"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="191" y="75" width="14" height="2">
-			</bounds>
+			<bounds x="191" y="75" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="203" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="203" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="203" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="203" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="191" y="95" width="14" height="2">
-			</bounds>
+			<bounds x="191" y="95" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="191" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="191" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="191" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="191" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="191" y="85" width="14" height="2">
-			</bounds>
+			<bounds x="191" y="85" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="206" y="95" width="3" height="2">
-			</bounds>
+			<bounds x="206" y="95" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="191" y="75" width="14" height="2">
-			</bounds>
+			<bounds x="191" y="75" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="203" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="203" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="203" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="203" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="191" y="95" width="14" height="2">
-			</bounds>
+			<bounds x="191" y="95" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="191" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="191" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="191" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="191" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="191" y="85" width="14" height="2">
-			</bounds>
+			<bounds x="191" y="85" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="206" y="95" width="3" height="2">
-			</bounds>
+			<bounds x="206" y="95" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="209" y="73" width="21" height="28">
-			</bounds>
+			<bounds x="209" y="73" width="21" height="28"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="212" y="75" width="14" height="2">
-			</bounds>
+			<bounds x="212" y="75" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="224" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="224" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="224" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="224" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="212" y="95" width="14" height="2">
-			</bounds>
+			<bounds x="212" y="95" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="212" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="212" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="212" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="212" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="212" y="85" width="14" height="2">
-			</bounds>
+			<bounds x="212" y="85" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="227" y="95" width="3" height="2">
-			</bounds>
+			<bounds x="227" y="95" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="212" y="75" width="14" height="2">
-			</bounds>
+			<bounds x="212" y="75" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="224" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="224" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="224" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="224" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="212" y="95" width="14" height="2">
-			</bounds>
+			<bounds x="212" y="95" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="212" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="212" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="212" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="212" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="212" y="85" width="14" height="2">
-			</bounds>
+			<bounds x="212" y="85" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="227" y="95" width="3" height="2">
-			</bounds>
+			<bounds x="227" y="95" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="230" y="73" width="21" height="28">
-			</bounds>
+			<bounds x="230" y="73" width="21" height="28"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="233" y="75" width="14" height="2">
-			</bounds>
+			<bounds x="233" y="75" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="245" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="245" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="245" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="245" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="233" y="95" width="14" height="2">
-			</bounds>
+			<bounds x="233" y="95" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="233" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="233" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="233" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="233" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="233" y="85" width="14" height="2">
-			</bounds>
+			<bounds x="233" y="85" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="248" y="95" width="3" height="2">
-			</bounds>
+			<bounds x="248" y="95" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="233" y="75" width="14" height="2">
-			</bounds>
+			<bounds x="233" y="75" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="245" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="245" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="245" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="245" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="233" y="95" width="14" height="2">
-			</bounds>
+			<bounds x="233" y="95" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="233" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="233" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="233" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="233" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="233" y="85" width="14" height="2">
-			</bounds>
+			<bounds x="233" y="85" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="248" y="95" width="3" height="2">
-			</bounds>
+			<bounds x="248" y="95" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="251" y="73" width="21" height="28">
-			</bounds>
+			<bounds x="251" y="73" width="21" height="28"/>
 		</backdrop>
 		<backdrop name="led_off248" element="led_off">
-			<bounds x="254" y="75" width="14" height="2">
-			</bounds>
+			<bounds x="254" y="75" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off249" element="led_off">
-			<bounds x="266" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="266" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off250" element="led_off">
-			<bounds x="266" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="266" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off251" element="led_off">
-			<bounds x="254" y="95" width="14" height="2">
-			</bounds>
+			<bounds x="254" y="95" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off252" element="led_off">
-			<bounds x="254" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="254" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off253" element="led_off">
-			<bounds x="254" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="254" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off254" element="led_off">
-			<bounds x="254" y="85" width="14" height="2">
-			</bounds>
+			<bounds x="254" y="85" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off255" element="led_dot_off">
-			<bounds x="269" y="95" width="3" height="2">
-			</bounds>
+			<bounds x="269" y="95" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp248" element="led_on">
-			<bounds x="254" y="75" width="14" height="2">
-			</bounds>
+			<bounds x="254" y="75" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp249" element="led_on">
-			<bounds x="266" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="266" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp250" element="led_on">
-			<bounds x="266" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="266" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp251" element="led_on">
-			<bounds x="254" y="95" width="14" height="2">
-			</bounds>
+			<bounds x="254" y="95" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp252" element="led_on">
-			<bounds x="254" y="85" width="3" height="12">
-			</bounds>
+			<bounds x="254" y="85" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp253" element="led_on">
-			<bounds x="254" y="75" width="3" height="12">
-			</bounds>
+			<bounds x="254" y="75" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp254" element="led_on">
-			<bounds x="254" y="85" width="14" height="2">
-			</bounds>
+			<bounds x="254" y="85" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp255" element="led_dot_on">
-			<bounds x="269" y="95" width="3" height="2">
-			</bounds>
+			<bounds x="269" y="95" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="404" y="97" width="21" height="28">
-			</bounds>
+			<bounds x="404" y="97" width="21" height="28"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="407" y="99" width="14" height="2">
-			</bounds>
+			<bounds x="407" y="99" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="419" y="99" width="3" height="12">
-			</bounds>
+			<bounds x="419" y="99" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="419" y="109" width="3" height="12">
-			</bounds>
+			<bounds x="419" y="109" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="407" y="119" width="14" height="2">
-			</bounds>
+			<bounds x="407" y="119" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="407" y="109" width="3" height="12">
-			</bounds>
+			<bounds x="407" y="109" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="407" y="99" width="3" height="12">
-			</bounds>
+			<bounds x="407" y="99" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="407" y="109" width="14" height="2">
-			</bounds>
+			<bounds x="407" y="109" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="422" y="119" width="3" height="2">
-			</bounds>
+			<bounds x="422" y="119" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="407" y="99" width="14" height="2">
-			</bounds>
+			<bounds x="407" y="99" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="419" y="99" width="3" height="12">
-			</bounds>
+			<bounds x="419" y="99" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="419" y="109" width="3" height="12">
-			</bounds>
+			<bounds x="419" y="109" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="407" y="119" width="14" height="2">
-			</bounds>
+			<bounds x="407" y="119" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="407" y="109" width="3" height="12">
-			</bounds>
+			<bounds x="407" y="109" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="407" y="99" width="3" height="12">
-			</bounds>
+			<bounds x="407" y="99" width="3" height="12"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="407" y="109" width="14" height="2">
-			</bounds>
+			<bounds x="407" y="109" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="422" y="119" width="3" height="2">
-			</bounds>
+			<bounds x="422" y="119" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="425" y="97" width="20" height="28">
-			</bounds>
+			<bounds x="425" y="97" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="427" y="99" width="14" height="2">
-			</bounds>
+			<bounds x="427" y="99" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="439" y="99" width="2" height="12">
-			</bounds>
+			<bounds x="439" y="99" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="439" y="109" width="2" height="12">
-			</bounds>
+			<bounds x="439" y="109" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="427" y="119" width="14" height="2">
-			</bounds>
+			<bounds x="427" y="119" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="427" y="109" width="2" height="12">
-			</bounds>
+			<bounds x="427" y="109" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="427" y="99" width="2" height="12">
-			</bounds>
+			<bounds x="427" y="99" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="427" y="109" width="14" height="2">
-			</bounds>
+			<bounds x="427" y="109" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="442" y="119" width="2" height="2">
-			</bounds>
+			<bounds x="442" y="119" width="2" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="427" y="99" width="14" height="2">
-			</bounds>
+			<bounds x="427" y="99" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="439" y="99" width="2" height="12">
-			</bounds>
+			<bounds x="439" y="99" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="439" y="109" width="2" height="12">
-			</bounds>
+			<bounds x="439" y="109" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="427" y="119" width="14" height="2">
-			</bounds>
+			<bounds x="427" y="119" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="427" y="109" width="2" height="12">
-			</bounds>
+			<bounds x="427" y="109" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="427" y="99" width="2" height="12">
-			</bounds>
+			<bounds x="427" y="99" width="2" height="12"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="427" y="109" width="14" height="2">
-			</bounds>
+			<bounds x="427" y="109" width="14" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="442" y="119" width="2" height="2">
-			</bounds>
+			<bounds x="442" y="119" width="2" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="187" y="398" width="264" height="26">
-			</bounds>
+			<bounds x="187" y="398" width="264" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="187" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="187" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="204" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="204" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="221" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="221" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="238" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="238" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="255" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="255" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="272" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="272" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="289" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="289" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="306" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="306" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="323" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="323" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="340" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="340" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="357" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="357" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="374" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="374" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="391" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="391" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="408" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="408" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="425" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="425" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="442" y="398" width="17" height="26">
-			</bounds>
+			<bounds x="442" y="398" width="17" height="26"/>
 		</backdrop>
 		<backdrop name="label112" element="label_112">
-			<bounds x="664" y="55" width="51" height="27">
-			</bounds>
+			<bounds x="664" y="55" width="51" height="27"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="664" y="70" width="51" height="27">
-			</bounds>
+			<bounds x="664" y="70" width="51" height="27"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="723" y="132" width="27" height="27">
-			</bounds>
+			<bounds x="723" y="132" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="label115" element="label_115">
-			<bounds x="723" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="723" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="label116" element="label_116">
-			<bounds x="725" y="200" width="27" height="27">
-			</bounds>
+			<bounds x="725" y="200" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="label117" element="label_117">
-			<bounds x="723" y="234" width="27" height="27">
-			</bounds>
+			<bounds x="723" y="234" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="label118" element="label_118">
-			<bounds x="723" y="268" width="27" height="27">
-			</bounds>
+			<bounds x="723" y="268" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="723" y="302" width="27" height="27">
-			</bounds>
+			<bounds x="723" y="302" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="label120" element="label_120">
-			<bounds x="723" y="64" width="39" height="27">
-			</bounds>
+			<bounds x="723" y="64" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label121" element="label_121">
-			<bounds x="723" y="98" width="39" height="27">
-			</bounds>
+			<bounds x="723" y="98" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label122" element="label_122">
-			<bounds x="664" y="89" width="43" height="27">
-			</bounds>
+			<bounds x="664" y="89" width="43" height="27"/>
 		</backdrop>
 		<backdrop name="label123" element="label_123">
-			<bounds x="671" y="104" width="29" height="27">
-			</bounds>
+			<bounds x="671" y="104" width="29" height="27"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="664" y="132" width="39" height="27">
-			</bounds>
+			<bounds x="664" y="132" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="664" y="166" width="39" height="27">
-			</bounds>
+			<bounds x="664" y="166" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="664" y="200" width="39" height="27">
-			</bounds>
+			<bounds x="664" y="200" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="664" y="234" width="39" height="27">
-			</bounds>
+			<bounds x="664" y="234" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="664" y="268" width="39" height="27">
-			</bounds>
+			<bounds x="664" y="268" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="664" y="302" width="27" height="27">
-			</bounds>
+			<bounds x="664" y="302" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="731" y="38" width="26" height="27">
-			</bounds>
+			<bounds x="731" y="38" width="26" height="27"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="677" y="38" width="26" height="27">
-			</bounds>
+			<bounds x="677" y="38" width="26" height="27"/>
 		</backdrop>
 		<backdrop name="label140" element="label_140">
-			<bounds x="200" y="57" width="63" height="19">
-			</bounds>
+			<bounds x="200" y="57" width="63" height="19"/>
 		</backdrop>
 		<backdrop name="label141" element="label_141">
-			<bounds x="191" y="100" width="78" height="23">
-			</bounds>
+			<bounds x="191" y="100" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="label142" element="label_142">
-			<bounds x="211" y="55" width="43" height="11">
-			</bounds>
+			<bounds x="211" y="55" width="43" height="11"/>
 		</backdrop>
 		<backdrop name="label144" element="label_144">
-			<bounds x="645" y="540" width="115" height="14">
-			</bounds>
+			<bounds x="645" y="540" width="115" height="14"/>
 		</backdrop>
 		<backdrop name="label145" element="label_145">
-			<bounds x="741" y="636" width="21" height="13">
-			</bounds>
+			<bounds x="741" y="636" width="21" height="13"/>
 		</backdrop>
 		<backdrop name="label146" element="label_146">
-			<bounds x="414" y="121" width="23" height="16">
-			</bounds>
+			<bounds x="414" y="121" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label147" element="label_147">
-			<bounds x="405" y="83" width="39" height="16">
-			</bounds>
+			<bounds x="405" y="83" width="39" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_reel" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_button" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1infern.lay
+++ b/src/mame/layout/m1infern.lay
@@ -8,15532 +8,8677 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Red Sevens &#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Red Sevens &#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Win Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Win Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Super Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Run For It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Run For It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Stop N Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stop N Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="BIG Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="BIG Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.20">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.20"/>
 		</text>
 		<text string="to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.30" width="0.80" height="0.20">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.30" width="0.80" height="0.20"/>
 		</text>
 		<text string="Nearest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.20">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.20"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.70" width="0.80" height="0.20">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.20">
-			</bounds>
-		</text>
-		<text string="to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.30" width="0.80" height="0.20">
-			</bounds>
-		</text>
-		<text string="Nearest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.20">
-			</bounds>
-		</text>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.70" width="0.80" height="0.20">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.70" width="0.80" height="0.20"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.13"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.18" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.18" width="0.90" height="0.13"/>
 		</text>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.31" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.31" width="0.90" height="0.13"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.44" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.44" width="0.90" height="0.13"/>
 		</text>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.56" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.56" width="0.90" height="0.13"/>
 		</text>
 		<text string="v">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.69" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.69" width="0.90" height="0.13"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.82" width="0.90" height="0.13">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.18" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.31" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.44" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.56" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="v">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.69" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.82" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.82" width="0.90" height="0.13"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.13"/>
 		</text>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.18" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.18" width="0.90" height="0.13"/>
 		</text>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.31" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.31" width="0.90" height="0.13"/>
 		</text>
 		<text string="h">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.44" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.44" width="0.90" height="0.13"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.56" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.56" width="0.90" height="0.13"/>
 		</text>
 		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.69" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.69" width="0.90" height="0.13"/>
 		</text>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.82" width="0.90" height="0.13">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.18" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.31" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="h">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.44" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.56" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.69" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.82" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.82" width="0.90" height="0.13"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="12 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="12 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="10 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="10 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="8 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="8 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="6 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="6 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Burnt Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Burnt Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Secret Passage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="99 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="99 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Choose a Matrix">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Choose a Matrix">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Matrix Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Matrix Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Hi-Lo Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Hi-Lo Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bonus Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Burnt Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Burnt Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Run Wild">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Run Wild">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Free Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Free Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Advance Hi-Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Advance Hi-Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.48" blue="0.00">
-			</color>
+			<color red="0.00" green="0.48" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.96" blue="0.00">
-			</color>
+			<color red="0.00" green="0.96" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
+			<color red="0.00" green="0.24" blue="0.00"/>
 		</disk>
 		<text string="Double Bars &#xA3;3.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.48" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.96" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
-		</disk>
-		<text string="Double Bars &#xA3;3.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.46" blue="0.00">
-			</color>
+			<color red="0.00" green="0.46" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.11" blue="0.00">
-			</color>
+			<color red="0.00" green="0.11" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.92" blue="0.00">
-			</color>
+			<color red="0.00" green="0.92" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.23" blue="0.00">
-			</color>
+			<color red="0.00" green="0.23" blue="0.00"/>
 		</disk>
 		<text string="Single Bars &#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.46" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.11" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.92" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.23" blue="0.00">
-			</color>
-		</disk>
-		<text string="Single Bars &#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.44" blue="0.00">
-			</color>
+			<color red="0.00" green="0.44" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.11" blue="0.00">
-			</color>
+			<color red="0.00" green="0.11" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.88" blue="0.00">
-			</color>
+			<color red="0.00" green="0.88" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.22" blue="0.00">
-			</color>
+			<color red="0.00" green="0.22" blue="0.00"/>
 		</disk>
 		<text string="Bells &#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.44" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.11" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.88" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.22" blue="0.00">
-			</color>
-		</disk>
-		<text string="Bells &#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.42" blue="0.00">
-			</color>
+			<color red="0.00" green="0.42" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.84" blue="0.00">
-			</color>
+			<color red="0.00" green="0.84" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.21" blue="0.00">
-			</color>
+			<color red="0.00" green="0.21" blue="0.00"/>
 		</disk>
 		<text string="Melons &#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.42" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.84" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.21" blue="0.00">
-			</color>
-		</disk>
-		<text string="Melons &#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
+			<color red="0.00" green="0.80" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</disk>
 		<text string="Mixed Bars &#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</disk>
-		<text string="Mixed Bars &#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.38" blue="0.00">
-			</color>
+			<color red="0.00" green="0.38" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
+			<color red="0.00" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.76" blue="0.00">
-			</color>
+			<color red="0.00" green="0.76" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.19" blue="0.00">
-			</color>
+			<color red="0.00" green="0.19" blue="0.00"/>
 		</disk>
 		<text string="Cherries &#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.38" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.76" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.19" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cherries &#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cash Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Feature Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Feature Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Cash Accumulator">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Insert Quid">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Hold / Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Hold/Nudge/Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Hold/Nudge/Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_170_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_170">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_171_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_171">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_172_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_172">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_141">
 		<text string="Any Line to Play Inferno">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_143">
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1016" height="689">
-			</bounds>
+			<bounds x="0" y="0" width="1016" height="689"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="131" y="489" width="80" height="140">
-			</bounds>
+			<bounds x="131" y="489" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="131.0000" y="489.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="131.0000" y="489.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="134.3333" y="490.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="134.3333" y="490.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="137.6667" y="492.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="137.6667" y="492.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="141.0000" y="494.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="141.0000" y="494.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="144.3333" y="496.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="144.3333" y="496.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="147.6667" y="498.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="147.6667" y="498.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="131.0000" y="535.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="131.0000" y="535.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="134.3333" y="537.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="134.3333" y="537.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="137.6667" y="539.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="137.6667" y="539.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="141.0000" y="541.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="141.0000" y="541.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="144.3333" y="543.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="144.3333" y="543.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="147.6667" y="545.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="147.6667" y="545.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="131.0000" y="582.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="131.0000" y="582.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="134.3333" y="584.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="134.3333" y="584.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="137.6667" y="586.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="137.6667" y="586.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="141.0000" y="588.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="141.0000" y="588.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="144.3333" y="590.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="144.3333" y="590.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="147.6667" y="592.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="147.6667" y="592.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="131" y="489" width="80" height="140">
-			</bounds>
+			<bounds x="131" y="489" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="235" y="489" width="80" height="140">
-			</bounds>
+			<bounds x="235" y="489" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="235.0000" y="489.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="235.0000" y="489.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="238.3333" y="490.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="238.3333" y="490.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="241.6667" y="492.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="241.6667" y="492.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="245.0000" y="494.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="245.0000" y="494.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="248.3333" y="496.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="248.3333" y="496.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="251.6667" y="498.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="251.6667" y="498.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="235.0000" y="535.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="235.0000" y="535.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="238.3333" y="537.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="238.3333" y="537.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="241.6667" y="539.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="241.6667" y="539.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="245.0000" y="541.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="245.0000" y="541.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="248.3333" y="543.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="248.3333" y="543.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="251.6667" y="545.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="251.6667" y="545.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="235.0000" y="582.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="235.0000" y="582.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="238.3333" y="584.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="238.3333" y="584.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="241.6667" y="586.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="241.6667" y="586.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="245.0000" y="588.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="245.0000" y="588.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="248.3333" y="590.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="248.3333" y="590.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="251.6667" y="592.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="251.6667" y="592.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="235" y="489" width="80" height="140">
-			</bounds>
+			<bounds x="235" y="489" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="339" y="489" width="80" height="140">
-			</bounds>
+			<bounds x="339" y="489" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="339.0000" y="489.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="339.0000" y="489.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.3333" y="490.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="342.3333" y="490.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.6667" y="492.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="345.6667" y="492.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.0000" y="494.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="349.0000" y="494.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.3333" y="496.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="352.3333" y="496.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6667" y="498.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="355.6667" y="498.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="339.0000" y="535.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="339.0000" y="535.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.3333" y="537.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="342.3333" y="537.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.6667" y="539.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="345.6667" y="539.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.0000" y="541.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="349.0000" y="541.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.3333" y="543.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="352.3333" y="543.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6667" y="545.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="355.6667" y="545.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="339.0000" y="582.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="339.0000" y="582.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.3333" y="584.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="342.3333" y="584.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.6667" y="586.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="345.6667" y="586.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.0000" y="588.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="349.0000" y="588.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.3333" y="590.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="352.3333" y="590.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6667" y="592.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="355.6667" y="592.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="339" y="489" width="80" height="140">
-			</bounds>
+			<bounds x="339" y="489" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="567" y="203" width="80" height="80">
-			</bounds>
+			<bounds x="567" y="203" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="567" y="203" width="80" height="80">
-			</bounds>
+			<bounds x="567" y="203" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="643" y="486" width="122" height="27">
-			</bounds>
+			<bounds x="643" y="486" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="645" y="488" width="118" height="23">
-			</bounds>
+			<bounds x="645" y="488" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="666" y="427" width="66" height="34">
-			</bounds>
+			<bounds x="666" y="427" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="668" y="429" width="62" height="30">
-			</bounds>
+			<bounds x="668" y="429" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="594" y="427" width="66" height="34">
-			</bounds>
+			<bounds x="594" y="427" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="596" y="429" width="62" height="30">
-			</bounds>
+			<bounds x="596" y="429" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="378" y="347" width="66" height="34">
-			</bounds>
+			<bounds x="378" y="347" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="380" y="349" width="62" height="30">
-			</bounds>
+			<bounds x="380" y="349" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="42" y="427" width="66" height="34">
-			</bounds>
+			<bounds x="42" y="427" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="44" y="429" width="62" height="30">
-			</bounds>
+			<bounds x="44" y="429" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="450" y="107" width="66" height="34">
-			</bounds>
+			<bounds x="450" y="107" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="452" y="109" width="62" height="30">
-			</bounds>
+			<bounds x="452" y="109" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="226" y="11" width="102" height="72">
-			</bounds>
+			<bounds x="226" y="11" width="102" height="72"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="228" y="13" width="98" height="68">
-			</bounds>
+			<bounds x="228" y="13" width="98" height="68"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="242" y="91" width="72" height="72">
-			</bounds>
+			<bounds x="242" y="91" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="244" y="93" width="68" height="68">
-			</bounds>
+			<bounds x="244" y="93" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="242" y="171" width="72" height="72">
-			</bounds>
+			<bounds x="242" y="171" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="244" y="173" width="68" height="68">
-			</bounds>
+			<bounds x="244" y="173" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="242" y="251" width="72" height="72">
-			</bounds>
+			<bounds x="242" y="251" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="244" y="253" width="68" height="68">
-			</bounds>
+			<bounds x="244" y="253" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="242" y="331" width="72" height="72">
-			</bounds>
+			<bounds x="242" y="331" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="244" y="333" width="68" height="68">
-			</bounds>
+			<bounds x="244" y="333" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="242" y="411" width="72" height="72">
-			</bounds>
+			<bounds x="242" y="411" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="244" y="413" width="68" height="68">
-			</bounds>
+			<bounds x="244" y="413" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="970" y="107" width="35" height="35">
-			</bounds>
+			<bounds x="970" y="107" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="972" y="109" width="31" height="31">
-			</bounds>
+			<bounds x="972" y="109" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="938" y="107" width="35" height="35">
-			</bounds>
+			<bounds x="938" y="107" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="940" y="109" width="31" height="31">
-			</bounds>
+			<bounds x="940" y="109" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="906" y="107" width="35" height="35">
-			</bounds>
+			<bounds x="906" y="107" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="908" y="109" width="31" height="31">
-			</bounds>
+			<bounds x="908" y="109" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="874" y="107" width="35" height="35">
-			</bounds>
+			<bounds x="874" y="107" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="876" y="109" width="31" height="31">
-			</bounds>
+			<bounds x="876" y="109" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="842" y="107" width="35" height="35">
-			</bounds>
+			<bounds x="842" y="107" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="844" y="109" width="31" height="31">
-			</bounds>
+			<bounds x="844" y="109" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="970" y="139" width="35" height="35">
-			</bounds>
+			<bounds x="970" y="139" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="972" y="141" width="31" height="31">
-			</bounds>
+			<bounds x="972" y="141" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="938" y="139" width="35" height="35">
-			</bounds>
+			<bounds x="938" y="139" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="940" y="141" width="31" height="31">
-			</bounds>
+			<bounds x="940" y="141" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="906" y="139" width="35" height="35">
-			</bounds>
+			<bounds x="906" y="139" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="908" y="141" width="31" height="31">
-			</bounds>
+			<bounds x="908" y="141" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="874" y="139" width="35" height="35">
-			</bounds>
+			<bounds x="874" y="139" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="876" y="141" width="31" height="31">
-			</bounds>
+			<bounds x="876" y="141" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="906" y="171" width="35" height="35">
-			</bounds>
+			<bounds x="906" y="171" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="908" y="173" width="31" height="31">
-			</bounds>
+			<bounds x="908" y="173" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="874" y="171" width="35" height="35">
-			</bounds>
+			<bounds x="874" y="171" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="876" y="173" width="31" height="31">
-			</bounds>
+			<bounds x="876" y="173" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="842" y="171" width="35" height="35">
-			</bounds>
+			<bounds x="842" y="171" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="844" y="173" width="31" height="31">
-			</bounds>
+			<bounds x="844" y="173" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="938" y="171" width="35" height="35">
-			</bounds>
+			<bounds x="938" y="171" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="940" y="173" width="31" height="31">
-			</bounds>
+			<bounds x="940" y="173" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="970" y="171" width="35" height="35">
-			</bounds>
+			<bounds x="970" y="171" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="972" y="173" width="31" height="31">
-			</bounds>
+			<bounds x="972" y="173" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="842" y="139" width="35" height="35">
-			</bounds>
+			<bounds x="842" y="139" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="844" y="141" width="31" height="31">
-			</bounds>
+			<bounds x="844" y="141" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="818" y="219" width="19" height="101">
-			</bounds>
+			<bounds x="818" y="219" width="19" height="101"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="820" y="221" width="15" height="97">
-			</bounds>
+			<bounds x="820" y="221" width="15" height="97"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="842" y="219" width="35" height="35">
-			</bounds>
+			<bounds x="842" y="219" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="844" y="221" width="31" height="31">
-			</bounds>
+			<bounds x="844" y="221" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="938" y="219" width="35" height="35">
-			</bounds>
+			<bounds x="938" y="219" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="940" y="221" width="31" height="31">
-			</bounds>
+			<bounds x="940" y="221" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="874" y="219" width="35" height="35">
-			</bounds>
+			<bounds x="874" y="219" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="876" y="221" width="31" height="31">
-			</bounds>
+			<bounds x="876" y="221" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="906" y="219" width="35" height="35">
-			</bounds>
+			<bounds x="906" y="219" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="908" y="221" width="31" height="31">
-			</bounds>
+			<bounds x="908" y="221" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="970" y="219" width="35" height="35">
-			</bounds>
+			<bounds x="970" y="219" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="972" y="221" width="31" height="31">
-			</bounds>
+			<bounds x="972" y="221" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="970" y="251" width="35" height="35">
-			</bounds>
+			<bounds x="970" y="251" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="972" y="253" width="31" height="31">
-			</bounds>
+			<bounds x="972" y="253" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="938" y="251" width="35" height="35">
-			</bounds>
+			<bounds x="938" y="251" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="940" y="253" width="31" height="31">
-			</bounds>
+			<bounds x="940" y="253" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="906" y="251" width="35" height="35">
-			</bounds>
+			<bounds x="906" y="251" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="908" y="253" width="31" height="31">
-			</bounds>
+			<bounds x="908" y="253" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="874" y="251" width="35" height="35">
-			</bounds>
+			<bounds x="874" y="251" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="876" y="253" width="31" height="31">
-			</bounds>
+			<bounds x="876" y="253" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="906" y="283" width="35" height="35">
-			</bounds>
+			<bounds x="906" y="283" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="908" y="285" width="31" height="31">
-			</bounds>
+			<bounds x="908" y="285" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="874" y="283" width="35" height="35">
-			</bounds>
+			<bounds x="874" y="283" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="876" y="285" width="31" height="31">
-			</bounds>
+			<bounds x="876" y="285" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="842" y="283" width="35" height="35">
-			</bounds>
+			<bounds x="842" y="283" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="844" y="285" width="31" height="31">
-			</bounds>
+			<bounds x="844" y="285" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="842" y="251" width="35" height="35">
-			</bounds>
+			<bounds x="842" y="251" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="844" y="253" width="31" height="31">
-			</bounds>
+			<bounds x="844" y="253" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="970" y="283" width="35" height="35">
-			</bounds>
+			<bounds x="970" y="283" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="972" y="285" width="31" height="31">
-			</bounds>
+			<bounds x="972" y="285" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="938" y="283" width="35" height="35">
-			</bounds>
+			<bounds x="938" y="283" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="940" y="285" width="31" height="31">
-			</bounds>
+			<bounds x="940" y="285" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="42" y="267" width="66" height="34">
-			</bounds>
+			<bounds x="42" y="267" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="44" y="269" width="62" height="30">
-			</bounds>
+			<bounds x="44" y="269" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="378" y="187" width="66" height="34">
-			</bounds>
+			<bounds x="378" y="187" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="380" y="189" width="62" height="30">
-			</bounds>
+			<bounds x="380" y="189" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="450" y="347" width="66" height="34">
-			</bounds>
+			<bounds x="450" y="347" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="452" y="349" width="62" height="30">
-			</bounds>
+			<bounds x="452" y="349" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="42" y="347" width="66" height="34">
-			</bounds>
+			<bounds x="42" y="347" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="44" y="349" width="62" height="30">
-			</bounds>
+			<bounds x="44" y="349" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="378" y="427" width="66" height="34">
-			</bounds>
+			<bounds x="378" y="427" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="380" y="429" width="62" height="30">
-			</bounds>
+			<bounds x="380" y="429" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="474" y="387" width="42" height="34">
-			</bounds>
+			<bounds x="474" y="387" width="42" height="34"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="476" y="389" width="38" height="30">
-			</bounds>
+			<bounds x="476" y="389" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="418" y="387" width="58" height="32">
-			</bounds>
+			<bounds x="418" y="387" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="420" y="389" width="54" height="28">
-			</bounds>
+			<bounds x="420" y="389" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="378" y="387" width="42" height="34">
-			</bounds>
+			<bounds x="378" y="387" width="42" height="34"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="380" y="389" width="38" height="30">
-			</bounds>
+			<bounds x="380" y="389" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="818" y="107" width="19" height="101">
-			</bounds>
+			<bounds x="818" y="107" width="19" height="101"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="820" y="109" width="15" height="97">
-			</bounds>
+			<bounds x="820" y="109" width="15" height="97"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="738" y="427" width="66" height="34">
-			</bounds>
+			<bounds x="738" y="427" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="740" y="429" width="62" height="30">
-			</bounds>
+			<bounds x="740" y="429" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="114" y="107" width="66" height="34">
-			</bounds>
+			<bounds x="114" y="107" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="116" y="109" width="62" height="30">
-			</bounds>
+			<bounds x="116" y="109" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="378" y="107" width="66" height="34">
-			</bounds>
+			<bounds x="378" y="107" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="380" y="109" width="62" height="30">
-			</bounds>
+			<bounds x="380" y="109" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="186" y="187" width="66" height="34">
-			</bounds>
+			<bounds x="186" y="187" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="188" y="189" width="62" height="30">
-			</bounds>
+			<bounds x="188" y="189" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="306" y="267" width="66" height="34">
-			</bounds>
+			<bounds x="306" y="267" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="308" y="269" width="62" height="30">
-			</bounds>
+			<bounds x="308" y="269" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="114" y="347" width="66" height="34">
-			</bounds>
+			<bounds x="114" y="347" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="116" y="349" width="62" height="30">
-			</bounds>
+			<bounds x="116" y="349" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="450" y="427" width="66" height="34">
-			</bounds>
+			<bounds x="450" y="427" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="452" y="429" width="62" height="30">
-			</bounds>
+			<bounds x="452" y="429" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="482" y="307" width="66" height="34">
-			</bounds>
+			<bounds x="482" y="307" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="484" y="309" width="62" height="30">
-			</bounds>
+			<bounds x="484" y="309" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="442" y="179" width="66" height="66">
-			</bounds>
+			<bounds x="442" y="179" width="66" height="66"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="444" y="181" width="62" height="62">
-			</bounds>
+			<bounds x="444" y="181" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="442" y="243" width="66" height="66">
-			</bounds>
+			<bounds x="442" y="243" width="66" height="66"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="444" y="245" width="62" height="62">
-			</bounds>
+			<bounds x="444" y="245" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="482" y="147" width="66" height="34">
-			</bounds>
+			<bounds x="482" y="147" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="484" y="149" width="62" height="30">
-			</bounds>
+			<bounds x="484" y="149" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="114" y="251" width="66" height="66">
-			</bounds>
+			<bounds x="114" y="251" width="66" height="66"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="116" y="253" width="62" height="62">
-			</bounds>
+			<bounds x="116" y="253" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="522" y="411" width="66" height="66">
-			</bounds>
+			<bounds x="522" y="411" width="66" height="66"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="524" y="413" width="62" height="62">
-			</bounds>
+			<bounds x="524" y="413" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="114" y="411" width="66" height="66">
-			</bounds>
+			<bounds x="114" y="411" width="66" height="66"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="116" y="413" width="62" height="62">
-			</bounds>
+			<bounds x="116" y="413" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="306" y="107" width="66" height="34">
-			</bounds>
+			<bounds x="306" y="107" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="308" y="109" width="62" height="30">
-			</bounds>
+			<bounds x="308" y="109" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="306" y="187" width="66" height="34">
-			</bounds>
+			<bounds x="306" y="187" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="308" y="189" width="62" height="30">
-			</bounds>
+			<bounds x="308" y="189" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="114" y="187" width="66" height="34">
-			</bounds>
+			<bounds x="114" y="187" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="116" y="189" width="62" height="30">
-			</bounds>
+			<bounds x="116" y="189" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="10" y="227" width="66" height="34">
-			</bounds>
+			<bounds x="10" y="227" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="12" y="229" width="62" height="30">
-			</bounds>
+			<bounds x="12" y="229" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="186" y="267" width="66" height="34">
-			</bounds>
+			<bounds x="186" y="267" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="188" y="269" width="62" height="30">
-			</bounds>
+			<bounds x="188" y="269" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="306" y="347" width="66" height="34">
-			</bounds>
+			<bounds x="306" y="347" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="308" y="349" width="62" height="30">
-			</bounds>
+			<bounds x="308" y="349" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="186" y="347" width="66" height="34">
-			</bounds>
+			<bounds x="186" y="347" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="188" y="349" width="62" height="30">
-			</bounds>
+			<bounds x="188" y="349" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="10" y="387" width="66" height="34">
-			</bounds>
+			<bounds x="10" y="387" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="12" y="389" width="62" height="30">
-			</bounds>
+			<bounds x="12" y="389" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="39" y="163" width="72" height="58">
-			</bounds>
+			<bounds x="39" y="163" width="72" height="58"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="41" y="165" width="68" height="54">
-			</bounds>
+			<bounds x="41" y="165" width="68" height="54"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="186" y="427" width="66" height="34">
-			</bounds>
+			<bounds x="186" y="427" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="188" y="429" width="62" height="30">
-			</bounds>
+			<bounds x="188" y="429" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="302" y="411" width="72" height="58">
-			</bounds>
+			<bounds x="302" y="411" width="72" height="58"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="304" y="413" width="68" height="54">
-			</bounds>
+			<bounds x="304" y="413" width="68" height="54"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="375" y="259" width="72" height="58">
-			</bounds>
+			<bounds x="375" y="259" width="72" height="58"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="377" y="261" width="68" height="54">
-			</bounds>
+			<bounds x="377" y="261" width="68" height="54"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="183" y="91" width="72" height="58">
-			</bounds>
+			<bounds x="183" y="91" width="72" height="58"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="185" y="93" width="68" height="54">
-			</bounds>
+			<bounds x="185" y="93" width="68" height="54"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="42" y="107" width="66" height="34">
-			</bounds>
+			<bounds x="42" y="107" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="44" y="109" width="62" height="30">
-			</bounds>
+			<bounds x="44" y="109" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="10" y="67" width="66" height="34">
-			</bounds>
+			<bounds x="10" y="67" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="12" y="69" width="62" height="30">
-			</bounds>
+			<bounds x="12" y="69" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="18" y="3" width="66" height="66">
-			</bounds>
+			<bounds x="18" y="3" width="66" height="66"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="20" y="5" width="62" height="62">
-			</bounds>
+			<bounds x="20" y="5" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="154" y="27" width="66" height="34">
-			</bounds>
+			<bounds x="154" y="27" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="156" y="29" width="62" height="30">
-			</bounds>
+			<bounds x="156" y="29" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="82" y="27" width="66" height="34">
-			</bounds>
+			<bounds x="82" y="27" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="84" y="29" width="62" height="30">
-			</bounds>
+			<bounds x="84" y="29" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="810" y="427" width="66" height="34">
-			</bounds>
+			<bounds x="810" y="427" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="812" y="429" width="62" height="30">
-			</bounds>
+			<bounds x="812" y="429" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="10" y="504" width="92" height="18">
-			</bounds>
+			<bounds x="10" y="504" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="12" y="506" width="88" height="14">
-			</bounds>
+			<bounds x="12" y="506" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="10" y="520" width="92" height="18">
-			</bounds>
+			<bounds x="10" y="520" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="12" y="522" width="88" height="14">
-			</bounds>
+			<bounds x="12" y="522" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="10" y="536" width="92" height="18">
-			</bounds>
+			<bounds x="10" y="536" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="12" y="538" width="88" height="14">
-			</bounds>
+			<bounds x="12" y="538" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="10" y="552" width="92" height="18">
-			</bounds>
+			<bounds x="10" y="552" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="12" y="554" width="88" height="14">
-			</bounds>
+			<bounds x="12" y="554" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="10" y="568" width="92" height="18">
-			</bounds>
+			<bounds x="10" y="568" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="12" y="570" width="88" height="14">
-			</bounds>
+			<bounds x="12" y="570" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="10" y="584" width="92" height="18">
-			</bounds>
+			<bounds x="10" y="584" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="12" y="586" width="88" height="14">
-			</bounds>
+			<bounds x="12" y="586" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="10" y="600" width="92" height="18">
-			</bounds>
+			<bounds x="10" y="600" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="12" y="602" width="88" height="14">
-			</bounds>
+			<bounds x="12" y="602" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="914" y="568" width="92" height="18">
-			</bounds>
+			<bounds x="914" y="568" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="916" y="570" width="88" height="14">
-			</bounds>
+			<bounds x="916" y="570" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="914" y="552" width="92" height="18">
-			</bounds>
+			<bounds x="914" y="552" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="916" y="554" width="88" height="14">
-			</bounds>
+			<bounds x="916" y="554" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="914" y="536" width="92" height="18">
-			</bounds>
+			<bounds x="914" y="536" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="916" y="538" width="88" height="14">
-			</bounds>
+			<bounds x="916" y="538" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="914" y="520" width="92" height="18">
-			</bounds>
+			<bounds x="914" y="520" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="916" y="522" width="88" height="14">
-			</bounds>
+			<bounds x="916" y="522" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="914" y="504" width="92" height="18">
-			</bounds>
+			<bounds x="914" y="504" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="916" y="506" width="88" height="14">
-			</bounds>
+			<bounds x="916" y="506" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="914" y="584" width="92" height="18">
-			</bounds>
+			<bounds x="914" y="584" width="92" height="18"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="916" y="586" width="88" height="14">
-			</bounds>
+			<bounds x="916" y="586" width="88" height="14"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="772" y="501" width="122" height="27">
-			</bounds>
+			<bounds x="772" y="501" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="774" y="503" width="118" height="23">
-			</bounds>
+			<bounds x="774" y="503" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="643" y="521" width="122" height="27">
-			</bounds>
+			<bounds x="643" y="521" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="645" y="523" width="118" height="23">
-			</bounds>
+			<bounds x="645" y="523" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="772" y="538" width="122" height="27">
-			</bounds>
+			<bounds x="772" y="538" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="774" y="540" width="118" height="23">
-			</bounds>
+			<bounds x="774" y="540" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="642" y="556" width="122" height="27">
-			</bounds>
+			<bounds x="642" y="556" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="644" y="558" width="118" height="23">
-			</bounds>
+			<bounds x="644" y="558" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="771" y="574" width="122" height="27">
-			</bounds>
+			<bounds x="771" y="574" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="773" y="576" width="118" height="23">
-			</bounds>
+			<bounds x="773" y="576" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="641" y="591" width="122" height="27">
-			</bounds>
+			<bounds x="641" y="591" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="643" y="593" width="118" height="23">
-			</bounds>
+			<bounds x="643" y="593" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="679" y="105" width="102" height="22">
-			</bounds>
+			<bounds x="679" y="105" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="681" y="107" width="98" height="18">
-			</bounds>
+			<bounds x="681" y="107" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="723" y="124" width="53" height="53">
-			</bounds>
+			<bounds x="723" y="124" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="725" y="126" width="49" height="49">
-			</bounds>
+			<bounds x="725" y="126" width="49" height="49"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="730" y="254" width="41" height="41">
-			</bounds>
+			<bounds x="730" y="254" width="41" height="41"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="732" y="256" width="37" height="37">
-			</bounds>
+			<bounds x="732" y="256" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="709" y="310" width="35" height="35">
-			</bounds>
+			<bounds x="709" y="310" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="711" y="312" width="31" height="31">
-			</bounds>
+			<bounds x="711" y="312" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="704" y="274" width="39" height="39">
-			</bounds>
+			<bounds x="704" y="274" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="706" y="276" width="35" height="35">
-			</bounds>
+			<bounds x="706" y="276" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="698" y="236" width="43" height="43">
-			</bounds>
+			<bounds x="698" y="236" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="700" y="238" width="39" height="39">
-			</bounds>
+			<bounds x="700" y="238" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="728" y="214" width="45" height="45">
-			</bounds>
+			<bounds x="728" y="214" width="45" height="45"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="730" y="216" width="41" height="41">
-			</bounds>
+			<bounds x="730" y="216" width="41" height="41"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="690" y="194" width="47" height="47">
-			</bounds>
+			<bounds x="690" y="194" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="692" y="196" width="43" height="43">
-			</bounds>
+			<bounds x="692" y="196" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="724" y="170" width="49" height="49">
-			</bounds>
+			<bounds x="724" y="170" width="49" height="49"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="726" y="172" width="45" height="45">
-			</bounds>
+			<bounds x="726" y="172" width="45" height="45"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="681" y="148" width="51" height="51">
-			</bounds>
+			<bounds x="681" y="148" width="51" height="51"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="683" y="150" width="47" height="47">
-			</bounds>
+			<bounds x="683" y="150" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="731" y="292" width="37" height="37">
-			</bounds>
+			<bounds x="731" y="292" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="733" y="294" width="33" height="33">
-			</bounds>
+			<bounds x="733" y="294" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="583" y="31" width="42" height="47">
-			</bounds>
+			<bounds x="583" y="31" width="42" height="47"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="585" y="33" width="38" height="43">
-			</bounds>
+			<bounds x="585" y="33" width="38" height="43"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="623" y="31" width="42" height="47">
-			</bounds>
+			<bounds x="623" y="31" width="42" height="47"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="625" y="33" width="38" height="43">
-			</bounds>
+			<bounds x="625" y="33" width="38" height="43"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="663" y="31" width="42" height="47">
-			</bounds>
+			<bounds x="663" y="31" width="42" height="47"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="665" y="33" width="38" height="43">
-			</bounds>
+			<bounds x="665" y="33" width="38" height="43"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="703" y="31" width="42" height="47">
-			</bounds>
+			<bounds x="703" y="31" width="42" height="47"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="705" y="33" width="38" height="43">
-			</bounds>
+			<bounds x="705" y="33" width="38" height="43"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="743" y="31" width="42" height="47">
-			</bounds>
+			<bounds x="743" y="31" width="42" height="47"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="745" y="33" width="38" height="43">
-			</bounds>
+			<bounds x="745" y="33" width="38" height="43"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="783" y="31" width="42" height="47">
-			</bounds>
+			<bounds x="783" y="31" width="42" height="47"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="785" y="33" width="38" height="43">
-			</bounds>
+			<bounds x="785" y="33" width="38" height="43"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="823" y="31" width="42" height="47">
-			</bounds>
+			<bounds x="823" y="31" width="42" height="47"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="825" y="33" width="38" height="43">
-			</bounds>
+			<bounds x="825" y="33" width="38" height="43"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="468" y="532" width="42" height="42">
-			</bounds>
+			<bounds x="468" y="532" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="470" y="534" width="38" height="38">
-			</bounds>
+			<bounds x="470" y="534" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="508" y="532" width="42" height="42">
-			</bounds>
+			<bounds x="508" y="532" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="510" y="534" width="38" height="38">
-			</bounds>
+			<bounds x="510" y="534" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="548" y="532" width="42" height="42">
-			</bounds>
+			<bounds x="548" y="532" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="550" y="534" width="38" height="38">
-			</bounds>
+			<bounds x="550" y="534" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="548" y="572" width="42" height="42">
-			</bounds>
+			<bounds x="548" y="572" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="550" y="574" width="38" height="38">
-			</bounds>
+			<bounds x="550" y="574" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="508" y="572" width="42" height="42">
-			</bounds>
+			<bounds x="508" y="572" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="510" y="574" width="38" height="38">
-			</bounds>
+			<bounds x="510" y="574" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="468" y="572" width="42" height="42">
-			</bounds>
+			<bounds x="468" y="572" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="470" y="574" width="38" height="38">
-			</bounds>
+			<bounds x="470" y="574" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="508" y="612" width="42" height="42">
-			</bounds>
+			<bounds x="508" y="612" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="510" y="614" width="38" height="38">
-			</bounds>
+			<bounds x="510" y="614" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="468" y="612" width="42" height="42">
-			</bounds>
+			<bounds x="468" y="612" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="470" y="614" width="38" height="38">
-			</bounds>
+			<bounds x="470" y="614" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="548" y="612" width="42" height="42">
-			</bounds>
+			<bounds x="548" y="612" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="550" y="614" width="38" height="38">
-			</bounds>
+			<bounds x="550" y="614" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="460" y="481" width="134" height="22">
-			</bounds>
+			<bounds x="460" y="481" width="134" height="22"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="462" y="483" width="130" height="18">
-			</bounds>
+			<bounds x="462" y="483" width="130" height="18"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="960" y="397" width="38" height="19">
-			</bounds>
+			<bounds x="960" y="397" width="38" height="19"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="962" y="399" width="34" height="15">
-			</bounds>
+			<bounds x="962" y="399" width="34" height="15"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="920" y="360" width="78" height="34">
-			</bounds>
+			<bounds x="920" y="360" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="922" y="362" width="74" height="30">
-			</bounds>
+			<bounds x="922" y="362" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="920" y="397" width="38" height="19">
-			</bounds>
+			<bounds x="920" y="397" width="38" height="19"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="922" y="399" width="34" height="15">
-			</bounds>
+			<bounds x="922" y="399" width="34" height="15"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="960" y="421" width="38" height="19">
-			</bounds>
+			<bounds x="960" y="421" width="38" height="19"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="962" y="423" width="34" height="15">
-			</bounds>
+			<bounds x="962" y="423" width="34" height="15"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="920" y="421" width="38" height="19">
-			</bounds>
+			<bounds x="920" y="421" width="38" height="19"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="922" y="423" width="34" height="15">
-			</bounds>
+			<bounds x="922" y="423" width="34" height="15"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="487" y="12" width="72" height="72">
-			</bounds>
+			<bounds x="487" y="12" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="489" y="14" width="68" height="68">
-			</bounds>
+			<bounds x="489" y="14" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="455" y="11" width="32" height="72">
-			</bounds>
+			<bounds x="455" y="11" width="32" height="72"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="457" y="13" width="28" height="68">
-			</bounds>
+			<bounds x="457" y="13" width="28" height="68"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="383" y="11" width="72" height="72">
-			</bounds>
+			<bounds x="383" y="11" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="385" y="13" width="68" height="68">
-			</bounds>
+			<bounds x="385" y="13" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="322" y="574" width="19" height="19">
-			</bounds>
+			<bounds x="322" y="574" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="324" y="576" width="15" height="15">
-			</bounds>
+			<bounds x="324" y="576" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="322" y="550" width="19" height="19">
-			</bounds>
+			<bounds x="322" y="550" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="324" y="552" width="15" height="15">
-			</bounds>
+			<bounds x="324" y="552" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="322" y="526" width="19" height="19">
-			</bounds>
+			<bounds x="322" y="526" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="324" y="528" width="15" height="15">
-			</bounds>
+			<bounds x="324" y="528" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="218" y="526" width="19" height="19">
-			</bounds>
+			<bounds x="218" y="526" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="220" y="528" width="15" height="15">
-			</bounds>
+			<bounds x="220" y="528" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1_border" state="0">
-			<bounds x="218" y="550" width="19" height="19">
-			</bounds>
+			<bounds x="218" y="550" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1" state="0">
-			<bounds x="220" y="552" width="15" height="15">
-			</bounds>
+			<bounds x="220" y="552" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0">
-			<bounds x="218" y="574" width="19" height="19">
-			</bounds>
+			<bounds x="218" y="574" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0">
-			<bounds x="220" y="576" width="15" height="15">
-			</bounds>
+			<bounds x="220" y="576" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="114" y="574" width="19" height="19">
-			</bounds>
+			<bounds x="114" y="574" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="116" y="576" width="15" height="15">
-			</bounds>
+			<bounds x="116" y="576" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="114" y="526" width="19" height="19">
-			</bounds>
+			<bounds x="114" y="526" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="116" y="528" width="15" height="15">
-			</bounds>
+			<bounds x="116" y="528" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="114" y="550" width="19" height="19">
-			</bounds>
+			<bounds x="114" y="550" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="116" y="552" width="15" height="15">
-			</bounds>
+			<bounds x="116" y="552" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_165_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="890" y="34" width="92" height="32">
-			</bounds>
+			<bounds x="890" y="34" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_165" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="892" y="36" width="88" height="28">
-			</bounds>
+			<bounds x="892" y="36" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_166_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="10" y="632" width="92" height="32">
-			</bounds>
+			<bounds x="10" y="632" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_166" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="12" y="634" width="88" height="28">
-			</bounds>
+			<bounds x="12" y="634" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_167_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="124" y="632" width="92" height="32">
-			</bounds>
+			<bounds x="124" y="632" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_167" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="126" y="634" width="88" height="28">
-			</bounds>
+			<bounds x="126" y="634" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_168_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="226" y="632" width="92" height="32">
-			</bounds>
+			<bounds x="226" y="632" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_168" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="228" y="634" width="88" height="28">
-			</bounds>
+			<bounds x="228" y="634" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_169_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="332" y="632" width="92" height="32">
-			</bounds>
+			<bounds x="332" y="632" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_169" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="334" y="634" width="88" height="28">
-			</bounds>
+			<bounds x="334" y="634" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_170_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="657" y="630" width="92" height="32">
-			</bounds>
+			<bounds x="657" y="630" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_170" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="659" y="632" width="88" height="28">
-			</bounds>
+			<bounds x="659" y="632" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_171_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="914" y="631" width="92" height="32">
-			</bounds>
+			<bounds x="914" y="631" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_171" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="916" y="633" width="88" height="28">
-			</bounds>
+			<bounds x="916" y="633" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_172_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="784" y="631" width="92" height="32">
-			</bounds>
+			<bounds x="784" y="631" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_172" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="786" y="633" width="88" height="28">
-			</bounds>
+			<bounds x="786" y="633" width="88" height="28"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="602" y="373" width="272" height="30">
-			</bounds>
+			<bounds x="602" y="373" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="602" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="602" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="619" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="619" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="636" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="636" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="653" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="653" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="670" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="670" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="687" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="687" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="704" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="704" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="721" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="721" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="738" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="738" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="755" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="755" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="772" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="772" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="789" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="789" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="806" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="806" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="823" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="823" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="840" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="840" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="857" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="857" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label141" element="label_141">
-			<bounds x="463" y="505" width="130" height="14">
-			</bounds>
+			<bounds x="463" y="505" width="130" height="14"/>
 		</backdrop>
 		<backdrop name="label143" element="label_143">
-			<bounds x="957" y="490" width="6" height="14">
-			</bounds>
+			<bounds x="957" y="490" width="6" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1inwinc.lay
+++ b/src/mame/layout/m1inwinc.lay
@@ -8,13408 +8,8181 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Winnings">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Winnings">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Trail ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Instant">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Instant">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Random Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Random Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Skill Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Skill Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</disk>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</disk>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
-		</disk>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</disk>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</disk>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
-		</disk>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_189_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_189_3" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_189_4" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_188_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_188_3" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_188_4" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_5_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_188_5" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_6_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_188_6" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_5_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_189_5" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_6_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_189_6" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Scratch Card">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Scratch Card">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Step to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.27"/>
 		</text>
 		<text string="Nearest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Step to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="Nearest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Lucky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Dip">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Lucky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Dip">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Instant Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Instant Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Number Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Number Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Can U ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="MT me">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Can U ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="MT me">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Cash Cracker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Cash Cracker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_255_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_255_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystic Mog">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_130_border">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_130">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_133_border">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_133">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_135_border">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_135">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_28">
 		<text string="Instant Win V1.4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="By bennyboy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_41">
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_42">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_56">
 		<text string="Credits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="758" height="659">
-			</bounds>
+			<bounds x="0" y="0" width="758" height="659"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="106" y="431" width="80" height="140">
-			</bounds>
+			<bounds x="106" y="431" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="106.0000" y="431.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="106.0000" y="431.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="109.3333" y="432.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="109.3333" y="432.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="112.6667" y="434.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="112.6667" y="434.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="116.0000" y="436.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="116.0000" y="436.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="119.3333" y="438.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="119.3333" y="438.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="122.6667" y="440.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="122.6667" y="440.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="106.0000" y="477.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="106.0000" y="477.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="109.3333" y="479.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="109.3333" y="479.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="112.6667" y="481.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="112.6667" y="481.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="116.0000" y="483.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="116.0000" y="483.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="119.3333" y="485.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="119.3333" y="485.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="122.6667" y="487.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="122.6667" y="487.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="106.0000" y="524.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="106.0000" y="524.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="109.3333" y="526.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="109.3333" y="526.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="112.6667" y="528.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="112.6667" y="528.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="116.0000" y="530.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="116.0000" y="530.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="119.3333" y="532.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="119.3333" y="532.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="122.6667" y="534.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="122.6667" y="534.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="106" y="431" width="80" height="140">
-			</bounds>
+			<bounds x="106" y="431" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="214" y="432" width="80" height="140">
-			</bounds>
+			<bounds x="214" y="432" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="214.0000" y="432.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="214.0000" y="432.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="217.3333" y="433.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="217.3333" y="433.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="220.6667" y="435.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="220.6667" y="435.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="224.0000" y="437.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="224.0000" y="437.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="227.3333" y="439.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="227.3333" y="439.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="230.6667" y="441.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="230.6667" y="441.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="214.0000" y="478.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="214.0000" y="478.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="217.3333" y="480.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="217.3333" y="480.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="220.6667" y="482.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="220.6667" y="482.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="224.0000" y="484.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="224.0000" y="484.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="227.3333" y="486.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="227.3333" y="486.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="230.6667" y="488.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="230.6667" y="488.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="214.0000" y="525.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="214.0000" y="525.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="217.3333" y="527.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="217.3333" y="527.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="220.6667" y="529.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="220.6667" y="529.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="224.0000" y="531.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="224.0000" y="531.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="227.3333" y="533.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="227.3333" y="533.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="230.6667" y="535.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="230.6667" y="535.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="214" y="432" width="80" height="140">
-			</bounds>
+			<bounds x="214" y="432" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="322" y="433" width="80" height="140">
-			</bounds>
+			<bounds x="322" y="433" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="433.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="433.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="434.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="434.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="436.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="436.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="438.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="438.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="440.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="440.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="442.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="442.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="479.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="479.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="481.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="481.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="483.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="483.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="485.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="485.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="487.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="487.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="489.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="489.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="526.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="526.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="528.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="528.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="530.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="530.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="532.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="532.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="534.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="534.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="536.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="536.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="322" y="433" width="80" height="140">
-			</bounds>
+			<bounds x="322" y="433" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="79" y="172" width="60" height="70">
-			</bounds>
+			<bounds x="79" y="172" width="60" height="70"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="79.0000" y="172.0000" width="60.0000" height="70.0000">
-			</bounds>
+			<bounds x="79.0000" y="172.0000" width="60.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="81.5000" y="174.9167" width="55.0000" height="64.1667">
-			</bounds>
+			<bounds x="81.5000" y="174.9167" width="55.0000" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="84.0000" y="177.8333" width="50.0000" height="58.3333">
-			</bounds>
+			<bounds x="84.0000" y="177.8333" width="50.0000" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="86.5000" y="180.7500" width="45.0000" height="52.5000">
-			</bounds>
+			<bounds x="86.5000" y="180.7500" width="45.0000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="89.0000" y="183.6667" width="40.0000" height="46.6667">
-			</bounds>
+			<bounds x="89.0000" y="183.6667" width="40.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="91.5000" y="186.5833" width="35.0000" height="40.8333">
-			</bounds>
+			<bounds x="91.5000" y="186.5833" width="35.0000" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="79" y="172" width="60" height="70">
-			</bounds>
+			<bounds x="79" y="172" width="60" height="70"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="25" y="89" width="73" height="22">
-			</bounds>
+			<bounds x="25" y="89" width="73" height="22"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="27" y="91" width="69" height="18">
-			</bounds>
+			<bounds x="27" y="91" width="69" height="18"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="20" y="25" width="82" height="27">
-			</bounds>
+			<bounds x="20" y="25" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="22" y="27" width="78" height="23">
-			</bounds>
+			<bounds x="22" y="27" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="20" y="52" width="82" height="27">
-			</bounds>
+			<bounds x="20" y="52" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="22" y="54" width="78" height="23">
-			</bounds>
+			<bounds x="22" y="54" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="629" y="350" width="52" height="37">
-			</bounds>
+			<bounds x="629" y="350" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="631" y="352" width="48" height="33">
-			</bounds>
+			<bounds x="631" y="352" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="162" y="344" width="52" height="37">
-			</bounds>
+			<bounds x="162" y="344" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="164" y="346" width="48" height="33">
-			</bounds>
+			<bounds x="164" y="346" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="525" y="325" width="52" height="47">
-			</bounds>
+			<bounds x="525" y="325" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="527" y="327" width="48" height="43">
-			</bounds>
+			<bounds x="527" y="327" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="577" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="577" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="579" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="579" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="473" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="473" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="475" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="475" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="421" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="421" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="423" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="423" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="369" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="369" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="371" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="371" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="265" y="331" width="52" height="37">
-			</bounds>
+			<bounds x="265" y="331" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="267" y="333" width="48" height="33">
-			</bounds>
+			<bounds x="267" y="333" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="525" y="371" width="52" height="47">
-			</bounds>
+			<bounds x="525" y="371" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="527" y="373" width="48" height="43">
-			</bounds>
+			<bounds x="527" y="373" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="577" y="375" width="52" height="37">
-			</bounds>
+			<bounds x="577" y="375" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="579" y="377" width="48" height="33">
-			</bounds>
+			<bounds x="579" y="377" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="473" y="375" width="52" height="37">
-			</bounds>
+			<bounds x="473" y="375" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="475" y="377" width="48" height="33">
-			</bounds>
+			<bounds x="475" y="377" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="421" y="375" width="52" height="37">
-			</bounds>
+			<bounds x="421" y="375" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="423" y="377" width="48" height="33">
-			</bounds>
+			<bounds x="423" y="377" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="369" y="375" width="52" height="37">
-			</bounds>
+			<bounds x="369" y="375" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="371" y="377" width="48" height="33">
-			</bounds>
+			<bounds x="371" y="377" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="265" y="375" width="52" height="37">
-			</bounds>
+			<bounds x="265" y="375" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="267" y="377" width="48" height="33">
-			</bounds>
+			<bounds x="267" y="377" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="213" y="375" width="52" height="37">
-			</bounds>
+			<bounds x="213" y="375" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="215" y="377" width="48" height="33">
-			</bounds>
+			<bounds x="215" y="377" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="577" y="52" width="52" height="37">
-			</bounds>
+			<bounds x="577" y="52" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="579" y="54" width="48" height="33">
-			</bounds>
+			<bounds x="579" y="54" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="139" y="581" width="38" height="27">
-			</bounds>
+			<bounds x="139" y="581" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="141" y="583" width="34" height="23">
-			</bounds>
+			<bounds x="141" y="583" width="34" height="23"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="228" y="581" width="38" height="27">
-			</bounds>
+			<bounds x="228" y="581" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="230" y="583" width="34" height="23">
-			</bounds>
+			<bounds x="230" y="583" width="34" height="23"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="318" y="581" width="38" height="27">
-			</bounds>
+			<bounds x="318" y="581" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="320" y="583" width="34" height="23">
-			</bounds>
+			<bounds x="320" y="583" width="34" height="23"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="408" y="581" width="38" height="27">
-			</bounds>
+			<bounds x="408" y="581" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="410" y="583" width="34" height="23">
-			</bounds>
+			<bounds x="410" y="583" width="34" height="23"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="498" y="581" width="38" height="27">
-			</bounds>
+			<bounds x="498" y="581" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="500" y="583" width="34" height="23">
-			</bounds>
+			<bounds x="500" y="583" width="34" height="23"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="588" y="581" width="38" height="27">
-			</bounds>
+			<bounds x="588" y="581" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="590" y="583" width="34" height="23">
-			</bounds>
+			<bounds x="590" y="583" width="34" height="23"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="488" y="456" width="77" height="37">
-			</bounds>
+			<bounds x="488" y="456" width="77" height="37"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="490" y="458" width="73" height="33">
-			</bounds>
+			<bounds x="490" y="458" width="73" height="33"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="488" y="505" width="77" height="37">
-			</bounds>
+			<bounds x="488" y="505" width="77" height="37"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="490" y="507" width="73" height="33">
-			</bounds>
+			<bounds x="490" y="507" width="73" height="33"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="54" y="364" width="52" height="32">
-			</bounds>
+			<bounds x="54" y="364" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="56" y="366" width="48" height="28">
-			</bounds>
+			<bounds x="56" y="366" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="106" y="333" width="52" height="32">
-			</bounds>
+			<bounds x="106" y="333" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="108" y="335" width="48" height="28">
-			</bounds>
+			<bounds x="108" y="335" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="106" y="364" width="52" height="32">
-			</bounds>
+			<bounds x="106" y="364" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="108" y="366" width="48" height="28">
-			</bounds>
+			<bounds x="108" y="366" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="54" y="333" width="52" height="32">
-			</bounds>
+			<bounds x="54" y="333" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="56" y="335" width="48" height="28">
-			</bounds>
+			<bounds x="56" y="335" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="48" y="211" width="27" height="32">
-			</bounds>
+			<bounds x="48" y="211" width="27" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="50" y="213" width="23" height="28">
-			</bounds>
+			<bounds x="50" y="213" width="23" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="48" y="171" width="27" height="32">
-			</bounds>
+			<bounds x="48" y="171" width="27" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="50" y="173" width="23" height="28">
-			</bounds>
+			<bounds x="50" y="173" width="23" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="41" y="554" width="46" height="46">
-			</bounds>
+			<bounds x="41" y="554" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="43" y="556" width="42" height="42">
-			</bounds>
+			<bounds x="43" y="556" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="409" y="527" width="39" height="39">
-			</bounds>
+			<bounds x="409" y="527" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="411" y="529" width="35" height="35">
-			</bounds>
+			<bounds x="411" y="529" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="409" y="441" width="39" height="39">
-			</bounds>
+			<bounds x="409" y="441" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="411" y="443" width="35" height="35">
-			</bounds>
+			<bounds x="411" y="443" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="48" y="523" width="32" height="32">
-			</bounds>
+			<bounds x="48" y="523" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="50" y="525" width="28" height="28">
-			</bounds>
+			<bounds x="50" y="525" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="48" y="492" width="32" height="32">
-			</bounds>
+			<bounds x="48" y="492" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="50" y="494" width="28" height="28">
-			</bounds>
+			<bounds x="50" y="494" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="48" y="461" width="32" height="32">
-			</bounds>
+			<bounds x="48" y="461" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="50" y="463" width="28" height="28">
-			</bounds>
+			<bounds x="50" y="463" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="48" y="430" width="32" height="32">
-			</bounds>
+			<bounds x="48" y="430" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="50" y="432" width="28" height="28">
-			</bounds>
+			<bounds x="50" y="432" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="138" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="138" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="140" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="140" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="138" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="138" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="140" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="140" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="138" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="138" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="140" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="140" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_2_border" state="0">
-			<bounds x="138" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="138" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_2" state="0">
-			<bounds x="140" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="140" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="172" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="172" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="174" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="174" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_3_border" state="0">
-			<bounds x="172" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="172" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_3" state="0">
-			<bounds x="174" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="174" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="209" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="209" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="211" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="211" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_4_border" state="0">
-			<bounds x="209" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="209" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_4" state="0">
-			<bounds x="211" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="211" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="243" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="243" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="245" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="245" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="243" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="243" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="245" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="245" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="280" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="280" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="282" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="282" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_2_border" state="0">
-			<bounds x="280" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="280" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_2" state="0">
-			<bounds x="282" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="282" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="314" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="314" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="316" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="316" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_3_border" state="0">
-			<bounds x="314" y="64" width="37" height="25">
-			</bounds>
+			<bounds x="314" y="64" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_3" state="0">
-			<bounds x="316" y="66" width="33" height="21">
-			</bounds>
+			<bounds x="316" y="66" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="314" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="314" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="316" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="316" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_4_border" state="0">
-			<bounds x="314" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="314" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_4" state="0">
-			<bounds x="316" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="316" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="280" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="280" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="282" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="282" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_5_border" state="0">
-			<bounds x="280" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="280" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_5" state="0">
-			<bounds x="282" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="282" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="243" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="243" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="245" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="245" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_6_border" state="0">
-			<bounds x="243" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="243" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_6" state="0">
-			<bounds x="245" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="245" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="209" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="209" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="211" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="211" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_5_border" state="0">
-			<bounds x="209" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="209" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_5" state="0">
-			<bounds x="211" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="211" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="172" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="172" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="174" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="174" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_6_border" state="0">
-			<bounds x="172" y="42" width="37" height="25">
-			</bounds>
+			<bounds x="172" y="42" width="37" height="25"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_6" state="0">
-			<bounds x="174" y="44" width="33" height="21">
-			</bounds>
+			<bounds x="174" y="44" width="33" height="21"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="463" y="42" width="112" height="47">
-			</bounds>
+			<bounds x="463" y="42" width="112" height="47"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="465" y="44" width="108" height="43">
-			</bounds>
+			<bounds x="465" y="44" width="108" height="43"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="352" y="42" width="112" height="47">
-			</bounds>
+			<bounds x="352" y="42" width="112" height="47"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="354" y="44" width="108" height="43">
-			</bounds>
+			<bounds x="354" y="44" width="108" height="43"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="317" y="371" width="52" height="47">
-			</bounds>
+			<bounds x="317" y="371" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="319" y="373" width="48" height="43">
-			</bounds>
+			<bounds x="319" y="373" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="317" y="325" width="52" height="47">
-			</bounds>
+			<bounds x="317" y="325" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="319" y="327" width="48" height="43">
-			</bounds>
+			<bounds x="319" y="327" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="577" y="284" width="52" height="37">
-			</bounds>
+			<bounds x="577" y="284" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="579" y="286" width="48" height="33">
-			</bounds>
+			<bounds x="579" y="286" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="525" y="279" width="52" height="47">
-			</bounds>
+			<bounds x="525" y="279" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="527" y="281" width="48" height="43">
-			</bounds>
+			<bounds x="527" y="281" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="473" y="284" width="52" height="37">
-			</bounds>
+			<bounds x="473" y="284" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="475" y="286" width="48" height="33">
-			</bounds>
+			<bounds x="475" y="286" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="421" y="284" width="52" height="37">
-			</bounds>
+			<bounds x="421" y="284" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="423" y="286" width="48" height="33">
-			</bounds>
+			<bounds x="423" y="286" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="369" y="284" width="52" height="37">
-			</bounds>
+			<bounds x="369" y="284" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="371" y="286" width="48" height="33">
-			</bounds>
+			<bounds x="371" y="286" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="317" y="279" width="52" height="47">
-			</bounds>
+			<bounds x="317" y="279" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="319" y="281" width="48" height="43">
-			</bounds>
+			<bounds x="319" y="281" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="265" y="284" width="52" height="37">
-			</bounds>
+			<bounds x="265" y="284" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="267" y="286" width="48" height="33">
-			</bounds>
+			<bounds x="267" y="286" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="577" y="240" width="52" height="37">
-			</bounds>
+			<bounds x="577" y="240" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="579" y="242" width="48" height="33">
-			</bounds>
+			<bounds x="579" y="242" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="525" y="233" width="52" height="47">
-			</bounds>
+			<bounds x="525" y="233" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="527" y="235" width="48" height="43">
-			</bounds>
+			<bounds x="527" y="235" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="473" y="240" width="52" height="37">
-			</bounds>
+			<bounds x="473" y="240" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="475" y="242" width="48" height="33">
-			</bounds>
+			<bounds x="475" y="242" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="421" y="240" width="52" height="37">
-			</bounds>
+			<bounds x="421" y="240" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="423" y="242" width="48" height="33">
-			</bounds>
+			<bounds x="423" y="242" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="369" y="240" width="52" height="37">
-			</bounds>
+			<bounds x="369" y="240" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="371" y="242" width="48" height="33">
-			</bounds>
+			<bounds x="371" y="242" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="317" y="233" width="52" height="47">
-			</bounds>
+			<bounds x="317" y="233" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="319" y="235" width="48" height="43">
-			</bounds>
+			<bounds x="319" y="235" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="265" y="240" width="52" height="37">
-			</bounds>
+			<bounds x="265" y="240" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="267" y="242" width="48" height="33">
-			</bounds>
+			<bounds x="267" y="242" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="577" y="193" width="52" height="37">
-			</bounds>
+			<bounds x="577" y="193" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="579" y="195" width="48" height="33">
-			</bounds>
+			<bounds x="579" y="195" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="525" y="187" width="52" height="47">
-			</bounds>
+			<bounds x="525" y="187" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="527" y="189" width="48" height="43">
-			</bounds>
+			<bounds x="527" y="189" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="473" y="193" width="52" height="37">
-			</bounds>
+			<bounds x="473" y="193" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="475" y="195" width="48" height="33">
-			</bounds>
+			<bounds x="475" y="195" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="421" y="193" width="52" height="37">
-			</bounds>
+			<bounds x="421" y="193" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="423" y="195" width="48" height="33">
-			</bounds>
+			<bounds x="423" y="195" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="369" y="193" width="52" height="37">
-			</bounds>
+			<bounds x="369" y="193" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="371" y="195" width="48" height="33">
-			</bounds>
+			<bounds x="371" y="195" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="317" y="187" width="52" height="47">
-			</bounds>
+			<bounds x="317" y="187" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="319" y="189" width="48" height="43">
-			</bounds>
+			<bounds x="319" y="189" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="265" y="193" width="52" height="37">
-			</bounds>
+			<bounds x="265" y="193" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="267" y="195" width="48" height="33">
-			</bounds>
+			<bounds x="267" y="195" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="577" y="147" width="52" height="37">
-			</bounds>
+			<bounds x="577" y="147" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="579" y="149" width="48" height="33">
-			</bounds>
+			<bounds x="579" y="149" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="525" y="141" width="52" height="47">
-			</bounds>
+			<bounds x="525" y="141" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="527" y="143" width="48" height="43">
-			</bounds>
+			<bounds x="527" y="143" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="421" y="146" width="52" height="37">
-			</bounds>
+			<bounds x="421" y="146" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="423" y="148" width="48" height="33">
-			</bounds>
+			<bounds x="423" y="148" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="473" y="146" width="52" height="37">
-			</bounds>
+			<bounds x="473" y="146" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="475" y="148" width="48" height="33">
-			</bounds>
+			<bounds x="475" y="148" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="369" y="146" width="52" height="37">
-			</bounds>
+			<bounds x="369" y="146" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="371" y="148" width="48" height="33">
-			</bounds>
+			<bounds x="371" y="148" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="317" y="140" width="52" height="47">
-			</bounds>
+			<bounds x="317" y="140" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="319" y="142" width="48" height="43">
-			</bounds>
+			<bounds x="319" y="142" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="265" y="146" width="52" height="37">
-			</bounds>
+			<bounds x="265" y="146" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="267" y="148" width="48" height="33">
-			</bounds>
+			<bounds x="267" y="148" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="577" y="99" width="52" height="37">
-			</bounds>
+			<bounds x="577" y="99" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="579" y="101" width="48" height="33">
-			</bounds>
+			<bounds x="579" y="101" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="525" y="94" width="52" height="47">
-			</bounds>
+			<bounds x="525" y="94" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="527" y="96" width="48" height="43">
-			</bounds>
+			<bounds x="527" y="96" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="473" y="99" width="52" height="37">
-			</bounds>
+			<bounds x="473" y="99" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="475" y="101" width="48" height="33">
-			</bounds>
+			<bounds x="475" y="101" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="421" y="99" width="52" height="37">
-			</bounds>
+			<bounds x="421" y="99" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="423" y="101" width="48" height="33">
-			</bounds>
+			<bounds x="423" y="101" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="369" y="99" width="52" height="37">
-			</bounds>
+			<bounds x="369" y="99" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="371" y="101" width="48" height="33">
-			</bounds>
+			<bounds x="371" y="101" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="317" y="94" width="52" height="47">
-			</bounds>
+			<bounds x="317" y="94" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="319" y="96" width="48" height="43">
-			</bounds>
+			<bounds x="319" y="96" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="265" y="96" width="52" height="37">
-			</bounds>
+			<bounds x="265" y="96" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="267" y="98" width="48" height="33">
-			</bounds>
+			<bounds x="267" y="98" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="213" y="305" width="52" height="37">
-			</bounds>
+			<bounds x="213" y="305" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="215" y="307" width="48" height="33">
-			</bounds>
+			<bounds x="215" y="307" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="213" y="219" width="52" height="37">
-			</bounds>
+			<bounds x="213" y="219" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="215" y="221" width="48" height="33">
-			</bounds>
+			<bounds x="215" y="221" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="213" y="120" width="52" height="37">
-			</bounds>
+			<bounds x="213" y="120" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="215" y="122" width="48" height="33">
-			</bounds>
+			<bounds x="215" y="122" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="629" y="263" width="52" height="37">
-			</bounds>
+			<bounds x="629" y="263" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="631" y="265" width="48" height="33">
-			</bounds>
+			<bounds x="631" y="265" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="629" y="170" width="52" height="37">
-			</bounds>
+			<bounds x="629" y="170" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="631" y="172" width="48" height="33">
-			</bounds>
+			<bounds x="631" y="172" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="629" y="78" width="52" height="37">
-			</bounds>
+			<bounds x="629" y="78" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="631" y="80" width="48" height="33">
-			</bounds>
+			<bounds x="631" y="80" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="62" y="315" width="19" height="19">
-			</bounds>
+			<bounds x="62" y="315" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="64" y="317" width="15" height="15">
-			</bounds>
+			<bounds x="64" y="317" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="131" y="315" width="19" height="19">
-			</bounds>
+			<bounds x="131" y="315" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="133" y="317" width="15" height="15">
-			</bounds>
+			<bounds x="133" y="317" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="62" y="277" width="19" height="19">
-			</bounds>
+			<bounds x="62" y="277" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="64" y="279" width="15" height="15">
-			</bounds>
+			<bounds x="64" y="279" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1_border" state="0">
-			<bounds x="131" y="278" width="19" height="19">
-			</bounds>
+			<bounds x="131" y="278" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1" state="0">
-			<bounds x="133" y="280" width="15" height="15">
-			</bounds>
+			<bounds x="133" y="280" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="80" y="280" width="52" height="52">
-			</bounds>
+			<bounds x="80" y="280" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="82" y="282" width="48" height="48">
-			</bounds>
+			<bounds x="82" y="282" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_130_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="5" y="615" width="78" height="42">
-			</bounds>
+			<bounds x="5" y="615" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_130" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="7" y="617" width="74" height="38">
-			</bounds>
+			<bounds x="7" y="617" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_133_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="106" y="615" width="78" height="42">
-			</bounds>
+			<bounds x="106" y="615" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_133" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="108" y="617" width="74" height="38">
-			</bounds>
+			<bounds x="108" y="617" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_134_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="214" y="615" width="78" height="42">
-			</bounds>
+			<bounds x="214" y="615" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_134" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="216" y="617" width="74" height="38">
-			</bounds>
+			<bounds x="216" y="617" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_135_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="324" y="615" width="78" height="42">
-			</bounds>
+			<bounds x="324" y="615" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_135" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="326" y="617" width="74" height="38">
-			</bounds>
+			<bounds x="326" y="617" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_136_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="428" y="615" width="78" height="42">
-			</bounds>
+			<bounds x="428" y="615" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_136" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="430" y="617" width="74" height="38">
-			</bounds>
+			<bounds x="430" y="617" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_137_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="524" y="615" width="80" height="42">
-			</bounds>
+			<bounds x="524" y="615" width="80" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_137" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="526" y="617" width="76" height="38">
-			</bounds>
+			<bounds x="526" y="617" width="76" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_138_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="620" y="615" width="78" height="42">
-			</bounds>
+			<bounds x="620" y="615" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_138" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="622" y="617" width="74" height="38">
-			</bounds>
+			<bounds x="622" y="617" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_139_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="691" y="27" width="52" height="27">
-			</bounds>
+			<bounds x="691" y="27" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_139" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="693" y="29" width="48" height="23">
-			</bounds>
+			<bounds x="693" y="29" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_140_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="691" y="1" width="52" height="27">
-			</bounds>
+			<bounds x="691" y="1" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_140" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="693" y="3" width="48" height="23">
-			</bounds>
+			<bounds x="693" y="3" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="73" y="111" width="24" height="32">
-			</bounds>
+			<bounds x="73" y="111" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="76" y="113" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="113" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="90" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="90" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="90" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="90" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="76" y="137" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="137" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="76" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="76" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="76" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="76" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="76" y="125" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="125" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="93" y="137" width="3" height="2">
-			</bounds>
+			<bounds x="93" y="137" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="76" y="113" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="113" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="90" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="90" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="90" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="90" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="76" y="137" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="137" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="76" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="76" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="76" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="76" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="76" y="125" width="17" height="2">
-			</bounds>
+			<bounds x="76" y="125" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="93" y="137" width="3" height="2">
-			</bounds>
+			<bounds x="93" y="137" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="49" y="111" width="24" height="32">
-			</bounds>
+			<bounds x="49" y="111" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="52" y="113" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="113" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="66" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="66" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="66" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="66" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="52" y="137" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="137" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="52" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="52" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="52" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="52" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="52" y="125" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="125" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="69" y="137" width="3" height="2">
-			</bounds>
+			<bounds x="69" y="137" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="52" y="113" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="113" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="66" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="66" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="66" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="66" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="52" y="137" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="137" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="52" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="52" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="52" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="52" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="52" y="125" width="17" height="2">
-			</bounds>
+			<bounds x="52" y="125" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="69" y="137" width="3" height="2">
-			</bounds>
+			<bounds x="69" y="137" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="25" y="111" width="24" height="32">
-			</bounds>
+			<bounds x="25" y="111" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="28" y="113" width="17" height="2">
-			</bounds>
+			<bounds x="28" y="113" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="42" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="42" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="42" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="42" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="28" y="137" width="17" height="2">
-			</bounds>
+			<bounds x="28" y="137" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="28" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="28" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="28" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="28" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="28" y="125" width="17" height="2">
-			</bounds>
+			<bounds x="28" y="125" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="45" y="137" width="3" height="2">
-			</bounds>
+			<bounds x="45" y="137" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="28" y="113" width="17" height="2">
-			</bounds>
+			<bounds x="28" y="113" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="42" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="42" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="42" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="42" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="28" y="137" width="17" height="2">
-			</bounds>
+			<bounds x="28" y="137" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="28" y="125" width="3" height="14">
-			</bounds>
+			<bounds x="28" y="125" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="28" y="113" width="3" height="14">
-			</bounds>
+			<bounds x="28" y="113" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="28" y="125" width="17" height="2">
-			</bounds>
+			<bounds x="28" y="125" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="45" y="137" width="3" height="2">
-			</bounds>
+			<bounds x="45" y="137" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="671" y="576" width="24" height="32">
-			</bounds>
+			<bounds x="671" y="576" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="674" y="578" width="17" height="2">
-			</bounds>
+			<bounds x="674" y="578" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="688" y="578" width="3" height="14">
-			</bounds>
+			<bounds x="688" y="578" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="688" y="590" width="3" height="14">
-			</bounds>
+			<bounds x="688" y="590" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="674" y="602" width="17" height="2">
-			</bounds>
+			<bounds x="674" y="602" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="674" y="590" width="3" height="14">
-			</bounds>
+			<bounds x="674" y="590" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="674" y="578" width="3" height="14">
-			</bounds>
+			<bounds x="674" y="578" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="674" y="590" width="17" height="2">
-			</bounds>
+			<bounds x="674" y="590" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="691" y="602" width="3" height="2">
-			</bounds>
+			<bounds x="691" y="602" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="674" y="578" width="17" height="2">
-			</bounds>
+			<bounds x="674" y="578" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="688" y="578" width="3" height="14">
-			</bounds>
+			<bounds x="688" y="578" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="688" y="590" width="3" height="14">
-			</bounds>
+			<bounds x="688" y="590" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="674" y="602" width="17" height="2">
-			</bounds>
+			<bounds x="674" y="602" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="674" y="590" width="3" height="14">
-			</bounds>
+			<bounds x="674" y="590" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="674" y="578" width="3" height="14">
-			</bounds>
+			<bounds x="674" y="578" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="674" y="590" width="17" height="2">
-			</bounds>
+			<bounds x="674" y="590" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="691" y="602" width="3" height="2">
-			</bounds>
+			<bounds x="691" y="602" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="647" y="576" width="24" height="32">
-			</bounds>
+			<bounds x="647" y="576" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="650" y="578" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="578" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="664" y="578" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="578" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="664" y="590" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="590" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="650" y="602" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="602" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="650" y="590" width="3" height="14">
-			</bounds>
+			<bounds x="650" y="590" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="650" y="578" width="3" height="14">
-			</bounds>
+			<bounds x="650" y="578" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="650" y="590" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="590" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="667" y="602" width="3" height="2">
-			</bounds>
+			<bounds x="667" y="602" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="650" y="578" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="578" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="664" y="578" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="578" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="664" y="590" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="590" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="650" y="602" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="602" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="650" y="590" width="3" height="14">
-			</bounds>
+			<bounds x="650" y="590" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="650" y="578" width="3" height="14">
-			</bounds>
+			<bounds x="650" y="578" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="650" y="590" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="590" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="667" y="602" width="3" height="2">
-			</bounds>
+			<bounds x="667" y="602" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label28" element="label_28">
-			<bounds x="646" y="468" width="46" height="52">
-			</bounds>
+			<bounds x="646" y="468" width="46" height="52"/>
 		</backdrop>
 		<backdrop name="label41" element="label_41">
-			<bounds x="295" y="496" width="25" height="13">
-			</bounds>
+			<bounds x="295" y="496" width="25" height="13"/>
 		</backdrop>
 		<backdrop name="label42" element="label_42">
-			<bounds x="189" y="496" width="23" height="13">
-			</bounds>
+			<bounds x="189" y="496" width="23" height="13"/>
 		</backdrop>
 		<backdrop name="label56" element="label_56">
-			<bounds x="655" y="561" width="32" height="13">
-			</bounds>
+			<bounds x="655" y="561" width="32" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1itjobc.lay
+++ b/src/mame/layout/m1itjobc.lay
@@ -8,14202 +8,8219 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Blocking">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Device">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Blocking">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Device">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Scooter">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Scooter">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Spray Paint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Spray Paint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mini">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mini">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Overalls">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Overalls">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Aston Martin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Aston Martin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Coach">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Coach">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Super Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Big Win Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Big Win Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mini">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mini">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Film">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Film">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Multiply">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Multiply">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Breakout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Breakout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Even">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Break">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Even">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Break">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Mafia">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Mafia">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bridg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bridg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Trans.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Trans.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Caught">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Caught">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Trans.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Trans.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Equip.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Equip.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bridg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bridg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Short">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cut">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Short">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cut">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="All">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="All">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Equip.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Equip.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Caught">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Caught">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bridg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bridg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Caught">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Caught">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Mafia">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Mafia">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bridg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mr">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bridg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Heaven's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Above">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Heaven's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Above">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Italia">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Italia">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mini">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Madness">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mini">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Madness">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Up Against">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Up Against">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bid For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Freedom">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bid For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Freedom">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Look">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Around">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Look">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Around">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Follow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Me">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Follow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Me">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Cash Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cash Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Hi - Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Hi - Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Super Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Supporters Club">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Supporters Club">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Any 3 Mini's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Any 3 Mini's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Starts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Starts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Short">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cut">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Short">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cut">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Decoy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Decoy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Transport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Transport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Crashed">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Mini">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Crashed">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Mini">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Caught">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Caught">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mr. Bridger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mr. Bridger">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Equipment">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Equipment">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Make Or">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Break">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Make Or">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Break">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD    LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD    HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_170_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_170">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_171_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_171">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string=" START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_172_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_172">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_173_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_173">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_174_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_174">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_124">
 		<text string="1 - 12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_139">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_140">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_155">
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="646">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="646"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="253" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="253" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="253.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="253.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="256.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="256.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="259.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="259.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="263.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="263.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="266.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="266.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="269.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="269.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="253.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="253.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="256.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="256.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="259.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="259.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="263.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="263.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="266.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="266.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="269.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="269.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="253.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="253.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="256.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="256.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="259.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="259.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="263.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="263.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="266.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="266.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="269.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="269.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="253" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="253" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="335" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="335" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="335.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="338.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="341.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="345.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="348.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="351.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="335.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="338.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="341.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="345.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="348.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="351.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="335.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="338.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="341.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="345.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="348.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="351.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="335" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="335" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="417" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="417" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="417.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="417.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="420.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="420.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="423.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="423.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="427.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="427.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="430.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="430.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="433.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="433.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="417.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="417.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="420.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="420.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="423.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="423.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="427.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="427.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="430.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="430.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="433.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="433.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="417.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="417.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="420.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="420.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="423.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="423.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="427.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="427.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="430.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="430.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="433.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="433.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="417" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="417" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="370" y="129" width="70" height="70">
-			</bounds>
+			<bounds x="370" y="129" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="370.0000" y="129.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="370.0000" y="129.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="372.9167" y="131.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="372.9167" y="131.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="375.8333" y="134.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="375.8333" y="134.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="378.7500" y="137.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="378.7500" y="137.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="381.6667" y="140.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="381.6667" y="140.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="384.5833" y="143.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="384.5833" y="143.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="370" y="129" width="70" height="70">
-			</bounds>
+			<bounds x="370" y="129" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="6" y="6" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="6" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="8" y="8" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="8" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="6" y="54" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="54" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="8" y="56" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="56" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="6" y="102" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="102" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="8" y="104" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="104" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="6" y="150" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="150" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="8" y="152" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="152" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="6" y="198" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="198" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="8" y="200" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="200" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="6" y="246" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="246" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="8" y="248" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="248" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="6" y="294" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="294" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="8" y="296" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="296" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="6" y="342" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="342" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="8" y="344" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="344" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="6" y="390" width="62" height="26">
-			</bounds>
+			<bounds x="6" y="390" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="8" y="392" width="58" height="22">
-			</bounds>
+			<bounds x="8" y="392" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="6" y="438" width="68" height="26">
-			</bounds>
+			<bounds x="6" y="438" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="8" y="440" width="64" height="22">
-			</bounds>
+			<bounds x="8" y="440" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="603" y="72" width="58" height="32">
-			</bounds>
+			<bounds x="603" y="72" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="605" y="74" width="54" height="28">
-			</bounds>
+			<bounds x="605" y="74" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="727" y="104" width="58" height="32">
-			</bounds>
+			<bounds x="727" y="104" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="729" y="106" width="54" height="28">
-			</bounds>
+			<bounds x="729" y="106" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="603" y="104" width="58" height="32">
-			</bounds>
+			<bounds x="603" y="104" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="605" y="106" width="54" height="28">
-			</bounds>
+			<bounds x="605" y="106" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="727" y="136" width="58" height="32">
-			</bounds>
+			<bounds x="727" y="136" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="729" y="138" width="54" height="28">
-			</bounds>
+			<bounds x="729" y="138" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="603" y="136" width="58" height="32">
-			</bounds>
+			<bounds x="603" y="136" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="605" y="138" width="54" height="28">
-			</bounds>
+			<bounds x="605" y="138" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="727" y="168" width="58" height="32">
-			</bounds>
+			<bounds x="727" y="168" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="729" y="170" width="54" height="28">
-			</bounds>
+			<bounds x="729" y="170" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="603" y="168" width="58" height="32">
-			</bounds>
+			<bounds x="603" y="168" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="605" y="170" width="54" height="28">
-			</bounds>
+			<bounds x="605" y="170" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="727" y="72" width="58" height="32">
-			</bounds>
+			<bounds x="727" y="72" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="729" y="74" width="54" height="28">
-			</bounds>
+			<bounds x="729" y="74" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="661" y="72" width="66" height="32">
-			</bounds>
+			<bounds x="661" y="72" width="66" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="663" y="74" width="62" height="28">
-			</bounds>
+			<bounds x="663" y="74" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="661" y="104" width="66" height="32">
-			</bounds>
+			<bounds x="661" y="104" width="66" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="663" y="106" width="62" height="28">
-			</bounds>
+			<bounds x="663" y="106" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="661" y="136" width="66" height="32">
-			</bounds>
+			<bounds x="661" y="136" width="66" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="663" y="138" width="62" height="28">
-			</bounds>
+			<bounds x="663" y="138" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="661" y="168" width="66" height="32">
-			</bounds>
+			<bounds x="661" y="168" width="66" height="32"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="663" y="170" width="62" height="28">
-			</bounds>
+			<bounds x="663" y="170" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="727" y="200" width="58" height="32">
-			</bounds>
+			<bounds x="727" y="200" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="729" y="202" width="54" height="28">
-			</bounds>
+			<bounds x="729" y="202" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="661" y="200" width="66" height="32">
-			</bounds>
+			<bounds x="661" y="200" width="66" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="663" y="202" width="62" height="28">
-			</bounds>
+			<bounds x="663" y="202" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="603" y="200" width="58" height="32">
-			</bounds>
+			<bounds x="603" y="200" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="605" y="202" width="54" height="28">
-			</bounds>
+			<bounds x="605" y="202" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="619" y="19" width="152" height="28">
-			</bounds>
+			<bounds x="619" y="19" width="152" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="621" y="21" width="148" height="24">
-			</bounds>
+			<bounds x="621" y="21" width="148" height="24"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="224" y="130" width="70" height="32">
-			</bounds>
+			<bounds x="224" y="130" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="226" y="132" width="66" height="28">
-			</bounds>
+			<bounds x="226" y="132" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="341" y="227" width="70" height="32">
-			</bounds>
+			<bounds x="341" y="227" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="343" y="229" width="66" height="28">
-			</bounds>
+			<bounds x="343" y="229" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="411" y="227" width="70" height="32">
-			</bounds>
+			<bounds x="411" y="227" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="413" y="229" width="66" height="28">
-			</bounds>
+			<bounds x="413" y="229" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="129" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="129" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="131" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="131" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="181" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="181" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="183" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="183" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="233" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="233" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="235" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="235" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="285" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="285" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="287" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="287" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="337" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="337" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="339" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="339" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="389" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="389" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="391" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="391" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="441" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="441" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="443" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="443" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="493" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="493" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="495" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="495" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="77" y="259" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="259" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="79" y="261" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="261" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="77" y="227" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="227" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="79" y="229" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="229" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="77" y="195" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="195" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="79" y="197" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="197" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="77" y="163" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="163" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="79" y="165" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="165" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="77" y="131" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="131" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="79" y="133" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="133" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="77" y="99" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="99" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="79" y="101" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="101" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="77" y="67" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="67" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="79" y="69" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="69" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="77" y="35" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="35" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="79" y="37" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="37" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="77" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="79" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="545" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="547" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="493" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="493" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="495" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="495" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="441" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="441" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="443" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="443" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="389" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="389" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="391" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="391" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="337" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="337" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="339" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="339" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="285" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="285" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="287" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="287" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="233" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="233" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="235" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="235" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="181" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="181" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="183" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="183" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="129" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="129" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="131" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="131" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="77" y="291" width="52" height="32">
-			</bounds>
+			<bounds x="77" y="291" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="79" y="293" width="48" height="28">
-			</bounds>
+			<bounds x="79" y="293" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="545" y="3" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="3" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="547" y="5" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="5" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="545" y="35" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="35" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="547" y="37" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="37" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="545" y="67" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="67" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="547" y="69" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="69" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="545" y="99" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="99" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="547" y="101" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="101" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="545" y="131" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="131" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="547" y="133" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="133" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="545" y="163" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="163" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="547" y="165" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="165" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="545" y="195" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="195" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="547" y="197" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="197" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="545" y="227" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="227" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="547" y="229" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="229" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="545" y="259" width="52" height="32">
-			</bounds>
+			<bounds x="545" y="259" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="547" y="261" width="48" height="28">
-			</bounds>
+			<bounds x="547" y="261" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="454" y="259" width="70" height="32">
-			</bounds>
+			<bounds x="454" y="259" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="456" y="261" width="66" height="28">
-			</bounds>
+			<bounds x="456" y="261" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="481" y="204" width="58" height="32">
-			</bounds>
+			<bounds x="481" y="204" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="483" y="206" width="54" height="28">
-			</bounds>
+			<bounds x="483" y="206" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="483" y="172" width="52" height="32">
-			</bounds>
+			<bounds x="483" y="172" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="485" y="174" width="48" height="28">
-			</bounds>
+			<bounds x="485" y="174" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="292" y="44" width="48" height="32">
-			</bounds>
+			<bounds x="292" y="44" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="294" y="46" width="44" height="28">
-			</bounds>
+			<bounds x="294" y="46" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="340" y="44" width="48" height="32">
-			</bounds>
+			<bounds x="340" y="44" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="342" y="46" width="44" height="28">
-			</bounds>
+			<bounds x="342" y="46" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="388" y="44" width="48" height="32">
-			</bounds>
+			<bounds x="388" y="44" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="390" y="46" width="44" height="28">
-			</bounds>
+			<bounds x="390" y="46" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="436" y="44" width="48" height="32">
-			</bounds>
+			<bounds x="436" y="44" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="438" y="46" width="44" height="28">
-			</bounds>
+			<bounds x="438" y="46" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="484" y="44" width="48" height="32">
-			</bounds>
+			<bounds x="484" y="44" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="486" y="46" width="44" height="28">
-			</bounds>
+			<bounds x="486" y="46" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="484" y="76" width="48" height="32">
-			</bounds>
+			<bounds x="484" y="76" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="486" y="78" width="44" height="28">
-			</bounds>
+			<bounds x="486" y="78" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="484" y="108" width="48" height="32">
-			</bounds>
+			<bounds x="484" y="108" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="486" y="110" width="44" height="28">
-			</bounds>
+			<bounds x="486" y="110" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="484" y="140" width="48" height="32">
-			</bounds>
+			<bounds x="484" y="140" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="486" y="142" width="44" height="28">
-			</bounds>
+			<bounds x="486" y="142" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="130" y="36" width="82" height="50">
-			</bounds>
+			<bounds x="130" y="36" width="82" height="50"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="132" y="38" width="78" height="46">
-			</bounds>
+			<bounds x="132" y="38" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="130" y="36" width="82" height="50">
-			</bounds>
+			<bounds x="130" y="36" width="82" height="50"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="132" y="38" width="78" height="46">
-			</bounds>
+			<bounds x="132" y="38" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="167" y="323" width="50" height="32">
-			</bounds>
+			<bounds x="167" y="323" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="169" y="325" width="46" height="28">
-			</bounds>
+			<bounds x="169" y="325" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="483" y="323" width="70" height="32">
-			</bounds>
+			<bounds x="483" y="323" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="485" y="325" width="66" height="28">
-			</bounds>
+			<bounds x="485" y="325" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="553" y="334" width="70" height="32">
-			</bounds>
+			<bounds x="553" y="334" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="555" y="336" width="66" height="28">
-			</bounds>
+			<bounds x="555" y="336" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="156" y="258" width="50" height="32">
-			</bounds>
+			<bounds x="156" y="258" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="158" y="260" width="46" height="28">
-			</bounds>
+			<bounds x="158" y="260" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="153" y="226" width="50" height="32">
-			</bounds>
+			<bounds x="153" y="226" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="155" y="228" width="46" height="28">
-			</bounds>
+			<bounds x="155" y="228" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="150" y="194" width="50" height="32">
-			</bounds>
+			<bounds x="150" y="194" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="152" y="196" width="46" height="28">
-			</bounds>
+			<bounds x="152" y="196" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="147" y="162" width="50" height="32">
-			</bounds>
+			<bounds x="147" y="162" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="149" y="164" width="46" height="28">
-			</bounds>
+			<bounds x="149" y="164" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="144" y="130" width="50" height="32">
-			</bounds>
+			<bounds x="144" y="130" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="146" y="132" width="46" height="28">
-			</bounds>
+			<bounds x="146" y="132" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="271" y="226" width="70" height="32">
-			</bounds>
+			<bounds x="271" y="226" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="273" y="228" width="66" height="28">
-			</bounds>
+			<bounds x="273" y="228" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="240" y="162" width="70" height="32">
-			</bounds>
+			<bounds x="240" y="162" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="242" y="164" width="66" height="28">
-			</bounds>
+			<bounds x="242" y="164" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="256" y="194" width="70" height="32">
-			</bounds>
+			<bounds x="256" y="194" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="258" y="196" width="66" height="28">
-			</bounds>
+			<bounds x="258" y="196" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="394" y="95" width="52" height="32">
-			</bounds>
+			<bounds x="394" y="95" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="396" y="97" width="48" height="28">
-			</bounds>
+			<bounds x="396" y="97" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="366" y="96" width="52" height="32">
-			</bounds>
+			<bounds x="366" y="96" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="368" y="98" width="48" height="28">
-			</bounds>
+			<bounds x="368" y="98" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="148" y="396" width="62" height="32">
-			</bounds>
+			<bounds x="148" y="396" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="150" y="398" width="58" height="28">
-			</bounds>
+			<bounds x="150" y="398" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="148" y="428" width="62" height="32">
-			</bounds>
+			<bounds x="148" y="428" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="150" y="430" width="58" height="28">
-			</bounds>
+			<bounds x="150" y="430" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="148" y="460" width="62" height="32">
-			</bounds>
+			<bounds x="148" y="460" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="150" y="462" width="58" height="28">
-			</bounds>
+			<bounds x="150" y="462" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="86" y="460" width="62" height="32">
-			</bounds>
+			<bounds x="86" y="460" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="88" y="462" width="58" height="28">
-			</bounds>
+			<bounds x="88" y="462" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="86" y="428" width="62" height="32">
-			</bounds>
+			<bounds x="86" y="428" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="88" y="430" width="58" height="28">
-			</bounds>
+			<bounds x="88" y="430" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="86" y="396" width="62" height="32">
-			</bounds>
+			<bounds x="86" y="396" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="88" y="398" width="58" height="28">
-			</bounds>
+			<bounds x="88" y="398" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="87" y="374" width="122" height="22">
-			</bounds>
+			<bounds x="87" y="374" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="89" y="376" width="118" height="18">
-			</bounds>
+			<bounds x="89" y="376" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="623" y="340" width="70" height="32">
-			</bounds>
+			<bounds x="623" y="340" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="625" y="342" width="66" height="28">
-			</bounds>
+			<bounds x="625" y="342" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="613" y="271" width="110" height="42">
-			</bounds>
+			<bounds x="613" y="271" width="110" height="42"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="615" y="273" width="106" height="38">
-			</bounds>
+			<bounds x="615" y="273" width="106" height="38"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="724" y="271" width="52" height="42">
-			</bounds>
+			<bounds x="724" y="271" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="726" y="273" width="48" height="38">
-			</bounds>
+			<bounds x="726" y="273" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="217" y="338" width="50" height="32">
-			</bounds>
+			<bounds x="217" y="338" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="219" y="340" width="46" height="28">
-			</bounds>
+			<bounds x="219" y="340" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="267" y="338" width="50" height="32">
-			</bounds>
+			<bounds x="267" y="338" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="269" y="340" width="46" height="28">
-			</bounds>
+			<bounds x="269" y="340" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="317" y="338" width="50" height="32">
-			</bounds>
+			<bounds x="317" y="338" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="319" y="340" width="46" height="28">
-			</bounds>
+			<bounds x="319" y="340" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="367" y="338" width="50" height="32">
-			</bounds>
+			<bounds x="367" y="338" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="369" y="340" width="46" height="28">
-			</bounds>
+			<bounds x="369" y="340" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="417" y="338" width="50" height="32">
-			</bounds>
+			<bounds x="417" y="338" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="419" y="340" width="46" height="28">
-			</bounds>
+			<bounds x="419" y="340" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="656" y="479" width="68" height="32">
-			</bounds>
+			<bounds x="656" y="479" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="658" y="481" width="64" height="28">
-			</bounds>
+			<bounds x="658" y="481" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="588" y="479" width="68" height="32">
-			</bounds>
+			<bounds x="588" y="479" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="590" y="481" width="64" height="28">
-			</bounds>
+			<bounds x="590" y="481" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="656" y="415" width="68" height="32">
-			</bounds>
+			<bounds x="656" y="415" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="658" y="417" width="64" height="28">
-			</bounds>
+			<bounds x="658" y="417" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="588" y="415" width="68" height="32">
-			</bounds>
+			<bounds x="588" y="415" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="590" y="417" width="64" height="28">
-			</bounds>
+			<bounds x="590" y="417" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="621" y="447" width="68" height="32">
-			</bounds>
+			<bounds x="621" y="447" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="623" y="449" width="64" height="28">
-			</bounds>
+			<bounds x="623" y="449" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="595" y="393" width="122" height="22">
-			</bounds>
+			<bounds x="595" y="393" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="597" y="395" width="118" height="18">
-			</bounds>
+			<bounds x="597" y="395" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="553" y="447" width="68" height="32">
-			</bounds>
+			<bounds x="553" y="447" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="555" y="449" width="64" height="28">
-			</bounds>
+			<bounds x="555" y="449" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="689" y="447" width="68" height="32">
-			</bounds>
+			<bounds x="689" y="447" width="68" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="691" y="449" width="64" height="28">
-			</bounds>
+			<bounds x="691" y="449" width="64" height="28"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="625" y="48" width="42" height="22">
-			</bounds>
+			<bounds x="625" y="48" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="627" y="50" width="38" height="18">
-			</bounds>
+			<bounds x="627" y="50" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="724" y="48" width="42" height="22">
-			</bounds>
+			<bounds x="724" y="48" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="726" y="50" width="38" height="18">
-			</bounds>
+			<bounds x="726" y="50" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_163_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="722" y="554" width="42" height="27">
-			</bounds>
+			<bounds x="722" y="554" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_163" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="724" y="556" width="38" height="23">
-			</bounds>
+			<bounds x="724" y="556" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp140" element="colour_button_164_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="213" y="87" width="78" height="38">
-			</bounds>
+			<bounds x="213" y="87" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp140" element="colour_button_164" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="215" y="89" width="74" height="34">
-			</bounds>
+			<bounds x="215" y="89" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp151" element="colour_button_165_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="213" y="42" width="78" height="38">
-			</bounds>
+			<bounds x="213" y="42" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="colour_button_165" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="215" y="44" width="74" height="34">
-			</bounds>
+			<bounds x="215" y="44" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp128" element="colour_button_166_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="133" y="87" width="78" height="38">
-			</bounds>
+			<bounds x="133" y="87" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp128" element="colour_button_166" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="135" y="89" width="74" height="34">
-			</bounds>
+			<bounds x="135" y="89" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_168_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="416" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="416" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_168" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="418" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="418" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_169_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="334" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="334" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_169" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="336" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="336" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_170_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="253" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="253" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_170" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="255" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="255" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_171_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="676" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="676" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_171" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="678" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="678" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_172_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="504" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="504" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_172" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="506" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="506" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_173_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="590" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="590" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_173" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="592" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="592" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_174_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="168" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="168" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_174" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="170" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="170" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="240" y="380" width="272" height="30">
-			</bounds>
+			<bounds x="240" y="380" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="240" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="240" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="257" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="257" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="274" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="274" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="291" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="291" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="308" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="308" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="325" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="325" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="342" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="342" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="359" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="359" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="376" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="376" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="393" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="393" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="410" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="410" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="427" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="427" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="444" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="444" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="461" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="461" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="478" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="478" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="495" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="495" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="382" y="198" width="49" height="22">
-			</bounds>
+			<bounds x="382" y="198" width="49" height="22"/>
 		</backdrop>
 		<backdrop name="label139" element="label_139">
-			<bounds x="226" y="494" width="25" height="26">
-			</bounds>
+			<bounds x="226" y="494" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label140" element="label_140">
-			<bounds x="499" y="494" width="25" height="26">
-			</bounds>
+			<bounds x="499" y="494" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label155" element="label_155">
-			<bounds x="668" y="49" width="45" height="16">
-			</bounds>
+			<bounds x="668" y="49" width="45" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_button" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_button" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_button" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1itskob.lay
+++ b/src/mame/layout/m1itskob.lay
@@ -8,14258 +8,8543 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WARNING:">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.18"/>
 		</text>
 		<text string="THIS MACHINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.23" width="0.90" height="0.18"/>
 		</text>
 		<text string="PAYS OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.41" width="0.90" height="0.18"/>
 		</text>
 		<text string="AUTOMATICALLY AT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.59" width="0.90" height="0.18"/>
 		</text>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WARNING:">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="THIS MACHINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="PAYS OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="AUTOMATICALLY AT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.77" width="0.90" height="0.18"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3; 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3; 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="DISQUAL-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="IFIED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="DISQUAL-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="IFIED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="6 0 P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="6 0 P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MINI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MARATHO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="MINI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MARATHO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3; 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3; 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BALLOON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BURST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BALLOON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BURST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3; 1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3; 1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BUNGEE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BUNGEE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3; 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3; 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3; 2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3; 2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3; 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3; 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3; 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3; 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3; 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3; 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FLOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FLOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mixed 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mixed 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Single Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Single Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Double Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Double Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Triple Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Triple Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3; 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3; 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Blue 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Blue 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3; 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Choose a Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Choose a Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Skillstop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skillstop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Eddie's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Eddie's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red Sevens">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red Sevens">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8 JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8 JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Replay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Replay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Double">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Double">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SCOREBOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SCOREBOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3; 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="80 P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="80 P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60 P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60 P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40 P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40 P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="It's a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="It's a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FINALE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FINALE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GRAND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GRAND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_4_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_4_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="` - CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.10"/>
 		</text>
 		<text string="1 - REEL 1 HOLD/NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.15" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.15" width="0.90" height="0.10"/>
 		</text>
 		<text string="2 - REEL 2 HOLD/NUDGE/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.25" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.25" width="0.90" height="0.10"/>
 		</text>
 		<text string="3 - REEL 3 HOLD/NUDGE/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.10"/>
 		</text>
 		<text string="C - STOP/COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.45" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.45" width="0.90" height="0.10"/>
 		</text>
 		<text string="E - EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.55" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.55" width="0.90" height="0.10"/>
 		</text>
 		<text string="SPACE - START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.10"/>
 		</text>
 		<text string="J - PLAY JOKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.75" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.75" width="0.90" height="0.10"/>
 		</text>
 		<text string="T - COLLECT WATER TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.85" width="0.90" height="0.10">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="` - CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.10">
-			</bounds>
-		</text>
-		<text string="1 - REEL 1 HOLD/NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.15" width="0.90" height="0.10">
-			</bounds>
-		</text>
-		<text string="2 - REEL 2 HOLD/NUDGE/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.25" width="0.90" height="0.10">
-			</bounds>
-		</text>
-		<text string="3 - REEL 3 HOLD/NUDGE/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.10">
-			</bounds>
-		</text>
-		<text string="C - STOP/COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.45" width="0.90" height="0.10">
-			</bounds>
-		</text>
-		<text string="E - EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.55" width="0.90" height="0.10">
-			</bounds>
-		</text>
-		<text string="SPACE - START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.10">
-			</bounds>
-		</text>
-		<text string="J - PLAY JOKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.75" width="0.90" height="0.10">
-			</bounds>
-		</text>
-		<text string="T - COLLECT WATER TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.85" width="0.90" height="0.10">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.85" width="0.90" height="0.10"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_126_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_126">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JOKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_127_border">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_127">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_128_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_128">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_129_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_129">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_130_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_130">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_131_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_131">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_132_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_132">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_133_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_133">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="TANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1016" height="689">
-			</bounds>
+			<bounds x="0" y="0" width="1016" height="689"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="187" y="422" width="80" height="140">
-			</bounds>
+			<bounds x="187" y="422" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="187.0000" y="422.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="187.0000" y="422.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="190.3333" y="423.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="190.3333" y="423.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="193.6667" y="425.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="193.6667" y="425.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.0000" y="427.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="197.0000" y="427.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.3333" y="429.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="200.3333" y="429.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6667" y="431.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="203.6667" y="431.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="187.0000" y="468.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="187.0000" y="468.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="190.3333" y="470.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="190.3333" y="470.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="193.6667" y="472.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="193.6667" y="472.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.0000" y="474.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="197.0000" y="474.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.3333" y="476.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="200.3333" y="476.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6667" y="478.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="203.6667" y="478.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="187.0000" y="515.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="187.0000" y="515.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="190.3333" y="517.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="190.3333" y="517.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="193.6667" y="519.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="193.6667" y="519.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.0000" y="521.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="197.0000" y="521.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.3333" y="523.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="200.3333" y="523.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6667" y="525.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="203.6667" y="525.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="187" y="422" width="80" height="140">
-			</bounds>
+			<bounds x="187" y="422" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="303" y="422" width="80" height="140">
-			</bounds>
+			<bounds x="303" y="422" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="422.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="422.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="423.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="423.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="425.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="425.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="427.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="427.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="429.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="429.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="431.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="431.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="468.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="468.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="470.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="470.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="472.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="472.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="474.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="474.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="476.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="476.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="478.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="478.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="515.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="515.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="517.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="517.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="519.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="519.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="521.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="521.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="523.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="523.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="525.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="525.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="303" y="422" width="80" height="140">
-			</bounds>
+			<bounds x="303" y="422" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="422" y="423" width="80" height="140">
-			</bounds>
+			<bounds x="422" y="423" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="422.0000" y="423.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="422.0000" y="423.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="425.3333" y="424.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="425.3333" y="424.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="428.6667" y="426.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="428.6667" y="426.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="432.0000" y="428.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="432.0000" y="428.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="435.3333" y="430.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="435.3333" y="430.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="438.6667" y="432.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="438.6667" y="432.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="422.0000" y="469.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="422.0000" y="469.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="425.3333" y="471.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="425.3333" y="471.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="428.6667" y="473.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="428.6667" y="473.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="432.0000" y="475.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="432.0000" y="475.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="435.3333" y="477.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="435.3333" y="477.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="438.6667" y="479.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="438.6667" y="479.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="422.0000" y="516.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="422.0000" y="516.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="425.3333" y="518.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="425.3333" y="518.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="428.6667" y="520.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="428.6667" y="520.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="432.0000" y="522.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="432.0000" y="522.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="435.3333" y="524.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="435.3333" y="524.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="438.6667" y="526.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="438.6667" y="526.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="422" y="423" width="80" height="140">
-			</bounds>
+			<bounds x="422" y="423" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="219" y="157" width="60" height="60">
-			</bounds>
+			<bounds x="219" y="157" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="219.0000" y="157.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="219.0000" y="157.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="221.5000" y="159.5000" width="55.0000" height="55.0000">
-			</bounds>
+			<bounds x="221.5000" y="159.5000" width="55.0000" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="224.0000" y="162.0000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="224.0000" y="162.0000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="226.5000" y="164.5000" width="45.0000" height="45.0000">
-			</bounds>
+			<bounds x="226.5000" y="164.5000" width="45.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="229.0000" y="167.0000" width="40.0000" height="40.0000">
-			</bounds>
+			<bounds x="229.0000" y="167.0000" width="40.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="231.5000" y="169.5000" width="35.0000" height="35.0000">
-			</bounds>
+			<bounds x="231.5000" y="169.5000" width="35.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="219" y="157" width="60" height="60">
-			</bounds>
+			<bounds x="219" y="157" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="518" y="373" width="62" height="37">
-			</bounds>
+			<bounds x="518" y="373" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="520" y="375" width="58" height="33">
-			</bounds>
+			<bounds x="520" y="375" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="39" y="495" width="72" height="37">
-			</bounds>
+			<bounds x="39" y="495" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="41" y="497" width="68" height="33">
-			</bounds>
+			<bounds x="41" y="497" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="39" y="458" width="72" height="37">
-			</bounds>
+			<bounds x="39" y="458" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="41" y="460" width="68" height="33">
-			</bounds>
+			<bounds x="41" y="460" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="39" y="421" width="72" height="37">
-			</bounds>
+			<bounds x="39" y="421" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="41" y="423" width="68" height="33">
-			</bounds>
+			<bounds x="41" y="423" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="39" y="532" width="72" height="37">
-			</bounds>
+			<bounds x="39" y="532" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="41" y="534" width="68" height="33">
-			</bounds>
+			<bounds x="41" y="534" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="39" y="569" width="72" height="37">
-			</bounds>
+			<bounds x="39" y="569" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="41" y="571" width="68" height="33">
-			</bounds>
+			<bounds x="41" y="571" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="522" y="247" width="122" height="82">
-			</bounds>
+			<bounds x="522" y="247" width="122" height="82"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="524" y="249" width="118" height="78">
-			</bounds>
+			<bounds x="524" y="249" width="118" height="78"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="194" y="84" width="52" height="32">
-			</bounds>
+			<bounds x="194" y="84" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="196" y="86" width="48" height="28">
-			</bounds>
+			<bounds x="196" y="86" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="190" y="37" width="52" height="32">
-			</bounds>
+			<bounds x="190" y="37" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="192" y="39" width="48" height="28">
-			</bounds>
+			<bounds x="192" y="39" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="254" y="13" width="62" height="32">
-			</bounds>
+			<bounds x="254" y="13" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="256" y="15" width="58" height="28">
-			</bounds>
+			<bounds x="256" y="15" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="323" y="112" width="52" height="32">
-			</bounds>
+			<bounds x="323" y="112" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="325" y="114" width="48" height="28">
-			</bounds>
+			<bounds x="325" y="114" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="258" y="103" width="52" height="32">
-			</bounds>
+			<bounds x="258" y="103" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="260" y="105" width="48" height="28">
-			</bounds>
+			<bounds x="260" y="105" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="840" y="330" width="52" height="32">
-			</bounds>
+			<bounds x="840" y="330" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="842" y="332" width="48" height="28">
-			</bounds>
+			<bounds x="842" y="332" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="761" y="330" width="52" height="32">
-			</bounds>
+			<bounds x="761" y="330" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="763" y="332" width="48" height="28">
-			</bounds>
+			<bounds x="763" y="332" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="676" y="329" width="72" height="32">
-			</bounds>
+			<bounds x="676" y="329" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="678" y="331" width="68" height="28">
-			</bounds>
+			<bounds x="678" y="331" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="610" y="332" width="52" height="32">
-			</bounds>
+			<bounds x="610" y="332" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="612" y="334" width="48" height="28">
-			</bounds>
+			<bounds x="612" y="334" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="538" y="332" width="52" height="32">
-			</bounds>
+			<bounds x="538" y="332" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="540" y="334" width="48" height="28">
-			</bounds>
+			<bounds x="540" y="334" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="473" y="333" width="52" height="32">
-			</bounds>
+			<bounds x="473" y="333" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="475" y="335" width="48" height="28">
-			</bounds>
+			<bounds x="475" y="335" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="399" y="333" width="52" height="32">
-			</bounds>
+			<bounds x="399" y="333" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="401" y="335" width="48" height="28">
-			</bounds>
+			<bounds x="401" y="335" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="328" y="332" width="62" height="32">
-			</bounds>
+			<bounds x="328" y="332" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="330" y="334" width="58" height="28">
-			</bounds>
+			<bounds x="330" y="334" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="258" y="317" width="52" height="32">
-			</bounds>
+			<bounds x="258" y="317" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="260" y="319" width="48" height="28">
-			</bounds>
+			<bounds x="260" y="319" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="235" y="277" width="52" height="32">
-			</bounds>
+			<bounds x="235" y="277" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="237" y="279" width="48" height="28">
-			</bounds>
+			<bounds x="237" y="279" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="266" y="231" width="52" height="32">
-			</bounds>
+			<bounds x="266" y="231" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="268" y="233" width="48" height="28">
-			</bounds>
+			<bounds x="268" y="233" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="323" y="202" width="52" height="32">
-			</bounds>
+			<bounds x="323" y="202" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="325" y="204" width="48" height="28">
-			</bounds>
+			<bounds x="325" y="204" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="388" y="202" width="52" height="32">
-			</bounds>
+			<bounds x="388" y="202" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="390" y="204" width="48" height="28">
-			</bounds>
+			<bounds x="390" y="204" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="460" y="204" width="52" height="32">
-			</bounds>
+			<bounds x="460" y="204" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="462" y="206" width="48" height="28">
-			</bounds>
+			<bounds x="462" y="206" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="539" y="207" width="52" height="32">
-			</bounds>
+			<bounds x="539" y="207" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="541" y="209" width="48" height="28">
-			</bounds>
+			<bounds x="541" y="209" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="630" y="209" width="52" height="32">
-			</bounds>
+			<bounds x="630" y="209" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="632" y="211" width="48" height="28">
-			</bounds>
+			<bounds x="632" y="211" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="701" y="223" width="52" height="32">
-			</bounds>
+			<bounds x="701" y="223" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="703" y="225" width="48" height="28">
-			</bounds>
+			<bounds x="703" y="225" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="399" y="114" width="52" height="32">
-			</bounds>
+			<bounds x="399" y="114" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="401" y="116" width="48" height="28">
-			</bounds>
+			<bounds x="401" y="116" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="475" y="113" width="52" height="32">
-			</bounds>
+			<bounds x="475" y="113" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="477" y="115" width="48" height="28">
-			</bounds>
+			<bounds x="477" y="115" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="557" y="111" width="52" height="32">
-			</bounds>
+			<bounds x="557" y="111" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="559" y="113" width="48" height="28">
-			</bounds>
+			<bounds x="559" y="113" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="637" y="108" width="52" height="32">
-			</bounds>
+			<bounds x="637" y="108" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="639" y="110" width="48" height="28">
-			</bounds>
+			<bounds x="639" y="110" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="719" y="93" width="52" height="32">
-			</bounds>
+			<bounds x="719" y="93" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="721" y="95" width="48" height="28">
-			</bounds>
+			<bounds x="721" y="95" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="801" y="90" width="52" height="32">
-			</bounds>
+			<bounds x="801" y="90" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="803" y="92" width="48" height="28">
-			</bounds>
+			<bounds x="803" y="92" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="894" y="114" width="52" height="32">
-			</bounds>
+			<bounds x="894" y="114" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="896" y="116" width="48" height="28">
-			</bounds>
+			<bounds x="896" y="116" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="932" y="161" width="52" height="32">
-			</bounds>
+			<bounds x="932" y="161" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="934" y="163" width="48" height="28">
-			</bounds>
+			<bounds x="934" y="163" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="871" y="221" width="52" height="32">
-			</bounds>
+			<bounds x="871" y="221" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="873" y="223" width="48" height="28">
-			</bounds>
+			<bounds x="873" y="223" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="792" y="226" width="52" height="32">
-			</bounds>
+			<bounds x="792" y="226" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="794" y="228" width="48" height="28">
-			</bounds>
+			<bounds x="794" y="228" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="900" y="352" width="52" height="32">
-			</bounds>
+			<bounds x="900" y="352" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="902" y="354" width="48" height="28">
-			</bounds>
+			<bounds x="902" y="354" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="582" y="146" width="27" height="52">
-			</bounds>
+			<bounds x="582" y="146" width="27" height="52"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="584" y="148" width="23" height="48">
-			</bounds>
+			<bounds x="584" y="148" width="23" height="48"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="609" y="158" width="27" height="27">
-			</bounds>
+			<bounds x="609" y="158" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="611" y="160" width="23" height="23">
-			</bounds>
+			<bounds x="611" y="160" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="456" y="146" width="27" height="52">
-			</bounds>
+			<bounds x="456" y="146" width="27" height="52"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="458" y="148" width="23" height="48">
-			</bounds>
+			<bounds x="458" y="148" width="23" height="48"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="485" y="152" width="24" height="42">
-			</bounds>
+			<bounds x="485" y="152" width="24" height="42"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="487" y="154" width="20" height="38">
-			</bounds>
+			<bounds x="487" y="154" width="20" height="38"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="511" y="161" width="22" height="22">
-			</bounds>
+			<bounds x="511" y="161" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="513" y="163" width="18" height="18">
-			</bounds>
+			<bounds x="513" y="163" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="532" y="161" width="22" height="22">
-			</bounds>
+			<bounds x="532" y="161" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="534" y="163" width="18" height="18">
-			</bounds>
+			<bounds x="534" y="163" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="555" y="152" width="24" height="42">
-			</bounds>
+			<bounds x="555" y="152" width="24" height="42"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="557" y="154" width="20" height="38">
-			</bounds>
+			<bounds x="557" y="154" width="20" height="38"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="402" y="261" width="42" height="42">
-			</bounds>
+			<bounds x="402" y="261" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="404" y="263" width="38" height="38">
-			</bounds>
+			<bounds x="404" y="263" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="438" y="237" width="42" height="42">
-			</bounds>
+			<bounds x="438" y="237" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="440" y="239" width="38" height="38">
-			</bounds>
+			<bounds x="440" y="239" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="366" y="289" width="42" height="42">
-			</bounds>
+			<bounds x="366" y="289" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="368" y="291" width="38" height="38">
-			</bounds>
+			<bounds x="368" y="291" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="337" y="245" width="52" height="52">
-			</bounds>
+			<bounds x="337" y="245" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="339" y="247" width="48" height="48">
-			</bounds>
+			<bounds x="339" y="247" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="437" y="282" width="52" height="52">
-			</bounds>
+			<bounds x="437" y="282" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="439" y="284" width="48" height="48">
-			</bounds>
+			<bounds x="439" y="284" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="307" y="279" width="37" height="37">
-			</bounds>
+			<bounds x="307" y="279" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="309" y="281" width="33" height="33">
-			</bounds>
+			<bounds x="309" y="281" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="146" y="566" width="102" height="19">
-			</bounds>
+			<bounds x="146" y="566" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="148" y="568" width="98" height="15">
-			</bounds>
+			<bounds x="148" y="568" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="146" y="581" width="102" height="35">
-			</bounds>
+			<bounds x="146" y="581" width="102" height="35"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="148" y="583" width="98" height="31">
-			</bounds>
+			<bounds x="148" y="583" width="98" height="31"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="316" y="564" width="102" height="19">
-			</bounds>
+			<bounds x="316" y="564" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="318" y="566" width="98" height="15">
-			</bounds>
+			<bounds x="318" y="566" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="316" y="580" width="102" height="35">
-			</bounds>
+			<bounds x="316" y="580" width="102" height="35"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="318" y="582" width="98" height="31">
-			</bounds>
+			<bounds x="318" y="582" width="98" height="31"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="488" y="580" width="102" height="35">
-			</bounds>
+			<bounds x="488" y="580" width="102" height="35"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="490" y="582" width="98" height="31">
-			</bounds>
+			<bounds x="490" y="582" width="98" height="31"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="488" y="565" width="102" height="19">
-			</bounds>
+			<bounds x="488" y="565" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="490" y="567" width="98" height="15">
-			</bounds>
+			<bounds x="490" y="567" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="670" y="566" width="102" height="19">
-			</bounds>
+			<bounds x="670" y="566" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="672" y="568" width="98" height="15">
-			</bounds>
+			<bounds x="672" y="568" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="670" y="582" width="102" height="35">
-			</bounds>
+			<bounds x="670" y="582" width="102" height="35"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="672" y="584" width="98" height="31">
-			</bounds>
+			<bounds x="672" y="584" width="98" height="31"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="848" y="563" width="102" height="19">
-			</bounds>
+			<bounds x="848" y="563" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="850" y="565" width="98" height="15">
-			</bounds>
+			<bounds x="850" y="565" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="848" y="579" width="102" height="35">
-			</bounds>
+			<bounds x="848" y="579" width="102" height="35"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="850" y="581" width="98" height="31">
-			</bounds>
+			<bounds x="850" y="581" width="98" height="31"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="590" y="541" width="102" height="22">
-			</bounds>
+			<bounds x="590" y="541" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="592" y="543" width="98" height="18">
-			</bounds>
+			<bounds x="592" y="543" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="590" y="519" width="102" height="22">
-			</bounds>
+			<bounds x="590" y="519" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="592" y="521" width="98" height="18">
-			</bounds>
+			<bounds x="592" y="521" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="590" y="497" width="102" height="22">
-			</bounds>
+			<bounds x="590" y="497" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="592" y="499" width="98" height="18">
-			</bounds>
+			<bounds x="592" y="499" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="590" y="475" width="102" height="22">
-			</bounds>
+			<bounds x="590" y="475" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="592" y="477" width="98" height="18">
-			</bounds>
+			<bounds x="592" y="477" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="590" y="453" width="102" height="22">
-			</bounds>
+			<bounds x="590" y="453" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="592" y="455" width="98" height="18">
-			</bounds>
+			<bounds x="592" y="455" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="590" y="418" width="52" height="32">
-			</bounds>
+			<bounds x="590" y="418" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="592" y="420" width="48" height="28">
-			</bounds>
+			<bounds x="592" y="420" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="639" y="418" width="52" height="32">
-			</bounds>
+			<bounds x="639" y="418" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="641" y="420" width="48" height="28">
-			</bounds>
+			<bounds x="641" y="420" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="784" y="418" width="202" height="36">
-			</bounds>
+			<bounds x="784" y="418" width="202" height="36"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="786" y="420" width="198" height="32">
-			</bounds>
+			<bounds x="786" y="420" width="198" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="784" y="451" width="202" height="68">
-			</bounds>
+			<bounds x="784" y="451" width="202" height="68"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="786" y="453" width="198" height="64">
-			</bounds>
+			<bounds x="786" y="453" width="198" height="64"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="745" y="128" width="72" height="19">
-			</bounds>
+			<bounds x="745" y="128" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="747" y="130" width="68" height="15">
-			</bounds>
+			<bounds x="747" y="130" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="745" y="147" width="72" height="19">
-			</bounds>
+			<bounds x="745" y="147" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="747" y="149" width="68" height="15">
-			</bounds>
+			<bounds x="747" y="149" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="745" y="166" width="72" height="19">
-			</bounds>
+			<bounds x="745" y="166" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="747" y="168" width="68" height="15">
-			</bounds>
+			<bounds x="747" y="168" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="745" y="185" width="72" height="19">
-			</bounds>
+			<bounds x="745" y="185" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="747" y="187" width="68" height="15">
-			</bounds>
+			<bounds x="747" y="187" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="745" y="204" width="72" height="19">
-			</bounds>
+			<bounds x="745" y="204" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="747" y="206" width="68" height="15">
-			</bounds>
+			<bounds x="747" y="206" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="51" y="29" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="29" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="53" y="31" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="31" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="51" y="29" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="29" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="53" y="31" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="31" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="218" y="140" width="92" height="19">
-			</bounds>
+			<bounds x="218" y="140" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="220" y="142" width="88" height="15">
-			</bounds>
+			<bounds x="220" y="142" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="278" y="156" width="32" height="32">
-			</bounds>
+			<bounds x="278" y="156" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="280" y="158" width="28" height="28">
-			</bounds>
+			<bounds x="280" y="158" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="278" y="186" width="32" height="32">
-			</bounds>
+			<bounds x="278" y="186" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="280" y="188" width="28" height="28">
-			</bounds>
+			<bounds x="280" y="188" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="51" y="53" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="53" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="53" y="55" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="55" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="51" y="53" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="53" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="53" y="55" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="55" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="51" y="77" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="77" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="53" y="79" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="79" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="51" y="77" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="77" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="53" y="79" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="79" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="51" y="101" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="101" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="53" y="103" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="103" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="51" y="101" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="101" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="53" y="103" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="103" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="51" y="125" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="125" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="53" y="127" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="127" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="51" y="125" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="125" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="53" y="127" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="127" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="51" y="149" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="149" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="53" y="151" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="151" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="51" y="149" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="149" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="53" y="151" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="151" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="51" y="173" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="173" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="53" y="175" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="175" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="51" y="173" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="173" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="53" y="175" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="175" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="51" y="197" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="197" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="53" y="199" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="199" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="51" y="197" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="197" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="53" y="199" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="199" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="51" y="221" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="221" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="53" y="223" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="223" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="51" y="221" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="221" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="53" y="223" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="223" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="51" y="245" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="245" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="53" y="247" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="247" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="51" y="245" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="245" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="53" y="247" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="247" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="51" y="269" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="269" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="53" y="271" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="271" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="51" y="269" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="269" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="53" y="271" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="271" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="51" y="293" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="293" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="53" y="295" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="295" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="51" y="293" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="293" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="53" y="295" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="295" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="51" y="317" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="317" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="53" y="319" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="319" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="51" y="317" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="317" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="53" y="319" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="319" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="51" y="341" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="341" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="53" y="343" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="343" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="51" y="341" width="62" height="27">
-			</bounds>
+			<bounds x="51" y="341" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="53" y="343" width="58" height="23">
-			</bounds>
+			<bounds x="53" y="343" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="106" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="106" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="108" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="108" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="150" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="150" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="152" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="152" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="458" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="458" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="460" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="460" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="414" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="414" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="416" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="416" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="370" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="370" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="372" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="372" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="326" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="326" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="328" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="328" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="282" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="282" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="284" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="284" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="238" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="238" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="240" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="240" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="194" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="194" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="196" y="372" width="38" height="38">
-			</bounds>
+			<bounds x="196" y="372" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="527" y="5" width="82" height="32">
-			</bounds>
+			<bounds x="527" y="5" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="529" y="7" width="78" height="28">
-			</bounds>
+			<bounds x="529" y="7" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="388" y="5" width="82" height="32">
-			</bounds>
+			<bounds x="388" y="5" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="390" y="7" width="78" height="28">
-			</bounds>
+			<bounds x="390" y="7" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="32" y="8" width="52" height="19">
-			</bounds>
+			<bounds x="32" y="8" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="34" y="10" width="48" height="15">
-			</bounds>
+			<bounds x="34" y="10" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="81" y="8" width="52" height="19">
-			</bounds>
+			<bounds x="81" y="8" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="83" y="10" width="48" height="15">
-			</bounds>
+			<bounds x="83" y="10" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1_border" state="0">
-			<bounds x="730" y="3" width="122" height="82">
-			</bounds>
+			<bounds x="730" y="3" width="122" height="82"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1" state="0">
-			<bounds x="732" y="5" width="118" height="78">
-			</bounds>
+			<bounds x="732" y="5" width="118" height="78"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="603" y="36" width="32" height="32">
-			</bounds>
+			<bounds x="603" y="36" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="605" y="38" width="28" height="28">
-			</bounds>
+			<bounds x="605" y="38" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="555" y="36" width="32" height="32">
-			</bounds>
+			<bounds x="555" y="36" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="557" y="38" width="28" height="28">
-			</bounds>
+			<bounds x="557" y="38" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="555" y="67" width="32" height="32">
-			</bounds>
+			<bounds x="555" y="67" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="557" y="69" width="28" height="28">
-			</bounds>
+			<bounds x="557" y="69" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="603" y="67" width="32" height="32">
-			</bounds>
+			<bounds x="603" y="67" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="605" y="69" width="28" height="28">
-			</bounds>
+			<bounds x="605" y="69" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="334" y="67" width="32" height="32">
-			</bounds>
+			<bounds x="334" y="67" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="336" y="69" width="28" height="28">
-			</bounds>
+			<bounds x="336" y="69" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="442" y="67" width="32" height="32">
-			</bounds>
+			<bounds x="442" y="67" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="444" y="69" width="28" height="28">
-			</bounds>
+			<bounds x="444" y="69" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="486" y="67" width="32" height="32">
-			</bounds>
+			<bounds x="486" y="67" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="488" y="69" width="28" height="28">
-			</bounds>
+			<bounds x="488" y="69" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="385" y="67" width="32" height="32">
-			</bounds>
+			<bounds x="385" y="67" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="387" y="69" width="28" height="28">
-			</bounds>
+			<bounds x="387" y="69" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="385" y="36" width="32" height="32">
-			</bounds>
+			<bounds x="385" y="36" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="387" y="38" width="28" height="28">
-			</bounds>
+			<bounds x="387" y="38" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="486" y="36" width="32" height="32">
-			</bounds>
+			<bounds x="486" y="36" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="488" y="38" width="28" height="28">
-			</bounds>
+			<bounds x="488" y="38" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="442" y="36" width="32" height="32">
-			</bounds>
+			<bounds x="442" y="36" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="444" y="38" width="28" height="28">
-			</bounds>
+			<bounds x="444" y="38" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="334" y="36" width="32" height="32">
-			</bounds>
+			<bounds x="334" y="36" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="336" y="38" width="28" height="28">
-			</bounds>
+			<bounds x="336" y="38" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp251" element="colour_button_126_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="834" y="152" width="52" height="52">
-			</bounds>
+			<bounds x="834" y="152" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp251" element="colour_button_126" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="836" y="154" width="48" height="48">
-			</bounds>
+			<bounds x="836" y="154" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_127_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="753" y="622" width="92" height="37">
-			</bounds>
+			<bounds x="753" y="622" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_127" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="755" y="624" width="88" height="33">
-			</bounds>
+			<bounds x="755" y="624" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_128_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="572" y="622" width="92" height="37">
-			</bounds>
+			<bounds x="572" y="622" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_128" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="574" y="624" width="88" height="33">
-			</bounds>
+			<bounds x="574" y="624" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_129_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="416" y="622" width="92" height="37">
-			</bounds>
+			<bounds x="416" y="622" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_129" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="418" y="624" width="88" height="33">
-			</bounds>
+			<bounds x="418" y="624" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_130_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="293" y="622" width="92" height="37">
-			</bounds>
+			<bounds x="293" y="622" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_130" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="295" y="624" width="88" height="33">
-			</bounds>
+			<bounds x="295" y="624" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_131_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="176" y="622" width="92" height="37">
-			</bounds>
+			<bounds x="176" y="622" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_131" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="178" y="624" width="88" height="33">
-			</bounds>
+			<bounds x="178" y="624" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_132_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="27" y="622" width="92" height="37">
-			</bounds>
+			<bounds x="27" y="622" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_132" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="29" y="624" width="88" height="33">
-			</bounds>
+			<bounds x="29" y="624" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_133_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="912" y="622" width="92" height="37">
-			</bounds>
+			<bounds x="912" y="622" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_133" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="914" y="624" width="88" height="33">
-			</bounds>
+			<bounds x="914" y="624" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp252" element="colour_button_134_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="140" y="214" width="67" height="67">
-			</bounds>
+			<bounds x="140" y="214" width="67" height="67"/>
 		</backdrop>
 		<backdrop name="lamp252" element="colour_button_134" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="142" y="216" width="63" height="63">
-			</bounds>
+			<bounds x="142" y="216" width="63" height="63"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_138_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="933" y="8" width="52" height="52">
-			</bounds>
+			<bounds x="933" y="8" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_138" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="935" y="10" width="48" height="48">
-			</bounds>
+			<bounds x="935" y="10" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_139_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="870" y="8" width="52" height="52">
-			</bounds>
+			<bounds x="870" y="8" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_139" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="872" y="10" width="48" height="48">
-			</bounds>
+			<bounds x="872" y="10" width="48" height="48"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="648" y="290" width="272" height="30">
-			</bounds>
+			<bounds x="648" y="290" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="648" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="648" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="665" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="665" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="682" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="682" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="699" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="699" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="716" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="716" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="733" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="733" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="750" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="750" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="767" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="767" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="784" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="784" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="801" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="801" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="818" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="818" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="835" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="835" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="852" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="852" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="869" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="869" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="886" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="886" y="290" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="903" y="290" width="17" height="30">
-			</bounds>
+			<bounds x="903" y="290" width="17" height="30"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_button" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_button" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1jpmult.lay
+++ b/src/mame/layout/m1jpmult.lay
@@ -8,8532 +8,5696 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
+			<color red="0.47" green="0.42" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
+			<color red="0.94" green="0.84" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
+			<color red="0.24" green="0.21" blue="0.01"/>
 		</rect>
 		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.42" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.84" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.21" blue="0.01">
-			</color>
-		</rect>
-		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="PO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="PO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="AC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="AC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_70_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_70">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_78_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_78">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_79_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_79">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Tk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_81_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_81">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_82_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_82">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_83_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_83">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_84_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_84">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_85_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_85">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_86_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_86">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_11">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_13">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_14">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_54">
 		<text string="20P PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_60">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_64">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_65">
 		<text string="v1.3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="653" height="630">
-			</bounds>
+			<bounds x="0" y="0" width="653" height="630"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="96" y="349" width="80" height="140">
-			</bounds>
+			<bounds x="96" y="349" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="96" y="349" width="80" height="140">
-			</bounds>
+			<bounds x="96" y="349" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="246" y="349" width="80" height="140">
-			</bounds>
+			<bounds x="246" y="349" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="246" y="349" width="80" height="140">
-			</bounds>
+			<bounds x="246" y="349" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="396" y="349" width="80" height="140">
-			</bounds>
+			<bounds x="396" y="349" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="396" y="349" width="80" height="140">
-			</bounds>
+			<bounds x="396" y="349" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="221" y="527" width="56" height="43">
-			</bounds>
+			<bounds x="221" y="527" width="56" height="43"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="223" y="529" width="52" height="39">
-			</bounds>
+			<bounds x="223" y="529" width="52" height="39"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="326" y="423" width="10" height="10">
-			</bounds>
+			<bounds x="326" y="423" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="328" y="425" width="6" height="6">
-			</bounds>
+			<bounds x="328" y="425" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="326" y="414" width="10" height="10">
-			</bounds>
+			<bounds x="326" y="414" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="328" y="416" width="6" height="6">
-			</bounds>
+			<bounds x="328" y="416" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="326" y="405" width="10" height="10">
-			</bounds>
+			<bounds x="326" y="405" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="328" y="407" width="6" height="6">
-			</bounds>
+			<bounds x="328" y="407" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="176" y="423" width="10" height="10">
-			</bounds>
+			<bounds x="176" y="423" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="178" y="425" width="6" height="6">
-			</bounds>
+			<bounds x="178" y="425" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="176" y="414" width="10" height="10">
-			</bounds>
+			<bounds x="176" y="414" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="178" y="416" width="6" height="6">
-			</bounds>
+			<bounds x="178" y="416" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="176" y="405" width="10" height="10">
-			</bounds>
+			<bounds x="176" y="405" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="178" y="407" width="6" height="6">
-			</bounds>
+			<bounds x="178" y="407" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="476" y="405" width="10" height="10">
-			</bounds>
+			<bounds x="476" y="405" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="478" y="407" width="6" height="6">
-			</bounds>
+			<bounds x="478" y="407" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="476" y="414" width="10" height="10">
-			</bounds>
+			<bounds x="476" y="414" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="478" y="416" width="6" height="6">
-			</bounds>
+			<bounds x="478" y="416" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="476" y="423" width="10" height="10">
-			</bounds>
+			<bounds x="476" y="423" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="478" y="425" width="6" height="6">
-			</bounds>
+			<bounds x="478" y="425" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="121" y="26" width="32" height="32">
-			</bounds>
+			<bounds x="121" y="26" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="123" y="28" width="28" height="28">
-			</bounds>
+			<bounds x="123" y="28" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="241" y="133" width="56" height="43">
-			</bounds>
+			<bounds x="241" y="133" width="56" height="43"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="243" y="135" width="52" height="39">
-			</bounds>
+			<bounds x="243" y="135" width="52" height="39"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="241" y="190" width="56" height="43">
-			</bounds>
+			<bounds x="241" y="190" width="56" height="43"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="243" y="192" width="52" height="39">
-			</bounds>
+			<bounds x="243" y="192" width="52" height="39"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="241" y="247" width="56" height="43">
-			</bounds>
+			<bounds x="241" y="247" width="56" height="43"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="243" y="249" width="52" height="39">
-			</bounds>
+			<bounds x="243" y="249" width="52" height="39"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="506" y="247" width="56" height="43">
-			</bounds>
+			<bounds x="506" y="247" width="56" height="43"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="508" y="249" width="52" height="39">
-			</bounds>
+			<bounds x="508" y="249" width="52" height="39"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="506" y="190" width="56" height="43">
-			</bounds>
+			<bounds x="506" y="190" width="56" height="43"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="508" y="192" width="52" height="39">
-			</bounds>
+			<bounds x="508" y="192" width="52" height="39"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="506" y="133" width="56" height="43">
-			</bounds>
+			<bounds x="506" y="133" width="56" height="43"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="508" y="135" width="52" height="39">
-			</bounds>
+			<bounds x="508" y="135" width="52" height="39"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="452" y="59" width="36" height="50">
-			</bounds>
+			<bounds x="452" y="59" width="36" height="50"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="454" y="61" width="32" height="46">
-			</bounds>
+			<bounds x="454" y="61" width="32" height="46"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="273" y="59" width="40" height="50">
-			</bounds>
+			<bounds x="273" y="59" width="40" height="50"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="275" y="61" width="36" height="46">
-			</bounds>
+			<bounds x="275" y="61" width="36" height="46"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="310" y="59" width="30" height="50">
-			</bounds>
+			<bounds x="310" y="59" width="30" height="50"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="312" y="61" width="26" height="46">
-			</bounds>
+			<bounds x="312" y="61" width="26" height="46"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="337" y="59" width="30" height="50">
-			</bounds>
+			<bounds x="337" y="59" width="30" height="50"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="339" y="61" width="26" height="46">
-			</bounds>
+			<bounds x="339" y="61" width="26" height="46"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="364" y="59" width="32" height="50">
-			</bounds>
+			<bounds x="364" y="59" width="32" height="50"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="366" y="61" width="28" height="46">
-			</bounds>
+			<bounds x="366" y="61" width="28" height="46"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="393" y="59" width="30" height="50">
-			</bounds>
+			<bounds x="393" y="59" width="30" height="50"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="395" y="61" width="26" height="46">
-			</bounds>
+			<bounds x="395" y="61" width="26" height="46"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="420" y="59" width="35" height="50">
-			</bounds>
+			<bounds x="420" y="59" width="35" height="50"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="422" y="61" width="31" height="46">
-			</bounds>
+			<bounds x="422" y="61" width="31" height="46"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="205" y="59" width="42" height="50">
-			</bounds>
+			<bounds x="205" y="59" width="42" height="50"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="207" y="61" width="38" height="46">
-			</bounds>
+			<bounds x="207" y="61" width="38" height="46"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="244" y="59" width="32" height="50">
-			</bounds>
+			<bounds x="244" y="59" width="32" height="50"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="246" y="61" width="28" height="46">
-			</bounds>
+			<bounds x="246" y="61" width="28" height="46"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="166" y="59" width="42" height="50">
-			</bounds>
+			<bounds x="166" y="59" width="42" height="50"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="168" y="61" width="38" height="46">
-			</bounds>
+			<bounds x="168" y="61" width="38" height="46"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="310" y="9" width="32" height="52">
-			</bounds>
+			<bounds x="310" y="9" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="312" y="11" width="28" height="48">
-			</bounds>
+			<bounds x="312" y="11" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="339" y="9" width="68" height="52">
-			</bounds>
+			<bounds x="339" y="9" width="68" height="52"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="341" y="11" width="64" height="48">
-			</bounds>
+			<bounds x="341" y="11" width="64" height="48"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="245" y="9" width="68" height="52">
-			</bounds>
+			<bounds x="245" y="9" width="68" height="52"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="247" y="11" width="64" height="48">
-			</bounds>
+			<bounds x="247" y="11" width="64" height="48"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="210" y="9" width="38" height="52">
-			</bounds>
+			<bounds x="210" y="9" width="38" height="52"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="212" y="11" width="34" height="48">
-			</bounds>
+			<bounds x="212" y="11" width="34" height="48"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="404" y="9" width="40" height="52">
-			</bounds>
+			<bounds x="404" y="9" width="40" height="52"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="406" y="11" width="36" height="48">
-			</bounds>
+			<bounds x="406" y="11" width="36" height="48"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="13" y="528" width="52" height="40">
-			</bounds>
+			<bounds x="13" y="528" width="52" height="40"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="15" y="530" width="48" height="36">
-			</bounds>
+			<bounds x="15" y="530" width="48" height="36"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="18" y="349" width="42" height="42">
-			</bounds>
+			<bounds x="18" y="349" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="20" y="351" width="38" height="38">
-			</bounds>
+			<bounds x="20" y="351" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="18" y="406" width="42" height="42">
-			</bounds>
+			<bounds x="18" y="406" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="20" y="408" width="38" height="38">
-			</bounds>
+			<bounds x="20" y="408" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="18" y="463" width="42" height="42">
-			</bounds>
+			<bounds x="18" y="463" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="20" y="465" width="38" height="38">
-			</bounds>
+			<bounds x="20" y="465" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_70_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="6" y="585" width="66" height="42">
-			</bounds>
+			<bounds x="6" y="585" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_70" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="8" y="587" width="62" height="38">
-			</bounds>
+			<bounds x="8" y="587" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_78_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="590" y="35" width="50" height="52">
-			</bounds>
+			<bounds x="590" y="35" width="50" height="52"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_78" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="592" y="37" width="46" height="48">
-			</bounds>
+			<bounds x="592" y="37" width="46" height="48"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_79_border" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="540" y="35" width="50" height="52">
-			</bounds>
+			<bounds x="540" y="35" width="50" height="52"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_79" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="542" y="37" width="46" height="48">
-			</bounds>
+			<bounds x="542" y="37" width="46" height="48"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_81_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="584" y="585" width="66" height="42">
-			</bounds>
+			<bounds x="584" y="585" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_81" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="586" y="587" width="62" height="38">
-			</bounds>
+			<bounds x="586" y="587" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_82_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="505" y="585" width="66" height="42">
-			</bounds>
+			<bounds x="505" y="585" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_82" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="507" y="587" width="62" height="38">
-			</bounds>
+			<bounds x="507" y="587" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_83_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="403" y="585" width="66" height="42">
-			</bounds>
+			<bounds x="403" y="585" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_83" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="405" y="587" width="62" height="38">
-			</bounds>
+			<bounds x="405" y="587" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_84_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="253" y="585" width="66" height="42">
-			</bounds>
+			<bounds x="253" y="585" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_84" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="255" y="587" width="62" height="38">
-			</bounds>
+			<bounds x="255" y="587" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_85_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="103" y="585" width="66" height="42">
-			</bounds>
+			<bounds x="103" y="585" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_85" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="105" y="587" width="62" height="38">
-			</bounds>
+			<bounds x="105" y="587" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_86_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="6" y="585" width="66" height="42">
-			</bounds>
+			<bounds x="6" y="585" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_86" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="8" y="587" width="62" height="38">
-			</bounds>
+			<bounds x="8" y="587" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="528" y="400" width="30" height="40">
-			</bounds>
+			<bounds x="528" y="400" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off152" element="led_off">
-			<bounds x="532" y="403" width="21" height="3">
-			</bounds>
+			<bounds x="532" y="403" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off153" element="led_off">
-			<bounds x="549" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="549" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off154" element="led_off">
-			<bounds x="549" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="549" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off155" element="led_off">
-			<bounds x="532" y="432" width="21" height="3">
-			</bounds>
+			<bounds x="532" y="432" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off156" element="led_off">
-			<bounds x="532" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="532" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off157" element="led_off">
-			<bounds x="532" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="532" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off158" element="led_off">
-			<bounds x="532" y="418" width="21" height="3">
-			</bounds>
+			<bounds x="532" y="418" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off159" element="led_dot_off">
-			<bounds x="553" y="432" width="4" height="3">
-			</bounds>
+			<bounds x="553" y="432" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp152" element="led_on">
-			<bounds x="532" y="403" width="21" height="3">
-			</bounds>
+			<bounds x="532" y="403" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp153" element="led_on">
-			<bounds x="549" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="549" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp154" element="led_on">
-			<bounds x="549" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="549" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="led_on">
-			<bounds x="532" y="432" width="21" height="3">
-			</bounds>
+			<bounds x="532" y="432" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp156" element="led_on">
-			<bounds x="532" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="532" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp157" element="led_on">
-			<bounds x="532" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="532" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp158" element="led_on">
-			<bounds x="532" y="418" width="21" height="3">
-			</bounds>
+			<bounds x="532" y="418" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp159" element="led_dot_on">
-			<bounds x="553" y="432" width="4" height="3">
-			</bounds>
+			<bounds x="553" y="432" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="558" y="400" width="30" height="40">
-			</bounds>
+			<bounds x="558" y="400" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off160" element="led_off">
-			<bounds x="562" y="403" width="21" height="3">
-			</bounds>
+			<bounds x="562" y="403" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off161" element="led_off">
-			<bounds x="579" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="579" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off162" element="led_off">
-			<bounds x="579" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="579" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off163" element="led_off">
-			<bounds x="562" y="432" width="21" height="3">
-			</bounds>
+			<bounds x="562" y="432" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off164" element="led_off">
-			<bounds x="562" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="562" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off165" element="led_off">
-			<bounds x="562" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="562" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off166" element="led_off">
-			<bounds x="562" y="418" width="21" height="3">
-			</bounds>
+			<bounds x="562" y="418" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off167" element="led_dot_off">
-			<bounds x="583" y="432" width="4" height="3">
-			</bounds>
+			<bounds x="583" y="432" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp160" element="led_on">
-			<bounds x="562" y="403" width="21" height="3">
-			</bounds>
+			<bounds x="562" y="403" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp161" element="led_on">
-			<bounds x="579" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="579" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp162" element="led_on">
-			<bounds x="579" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="579" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp163" element="led_on">
-			<bounds x="562" y="432" width="21" height="3">
-			</bounds>
+			<bounds x="562" y="432" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp164" element="led_on">
-			<bounds x="562" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="562" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp165" element="led_on">
-			<bounds x="562" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="562" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp166" element="led_on">
-			<bounds x="562" y="418" width="21" height="3">
-			</bounds>
+			<bounds x="562" y="418" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp167" element="led_dot_on">
-			<bounds x="583" y="432" width="4" height="3">
-			</bounds>
+			<bounds x="583" y="432" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="588" y="400" width="30" height="40">
-			</bounds>
+			<bounds x="588" y="400" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off168" element="led_off">
-			<bounds x="592" y="403" width="21" height="3">
-			</bounds>
+			<bounds x="592" y="403" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off169" element="led_off">
-			<bounds x="609" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="609" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off170" element="led_off">
-			<bounds x="609" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="609" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off171" element="led_off">
-			<bounds x="592" y="432" width="21" height="3">
-			</bounds>
+			<bounds x="592" y="432" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off172" element="led_off">
-			<bounds x="592" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="592" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off173" element="led_off">
-			<bounds x="592" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="592" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off174" element="led_off">
-			<bounds x="592" y="418" width="21" height="3">
-			</bounds>
+			<bounds x="592" y="418" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off175" element="led_dot_off">
-			<bounds x="613" y="432" width="4" height="3">
-			</bounds>
+			<bounds x="613" y="432" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp168" element="led_on">
-			<bounds x="592" y="403" width="21" height="3">
-			</bounds>
+			<bounds x="592" y="403" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp169" element="led_on">
-			<bounds x="609" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="609" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp170" element="led_on">
-			<bounds x="609" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="609" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="led_on">
-			<bounds x="592" y="432" width="21" height="3">
-			</bounds>
+			<bounds x="592" y="432" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp172" element="led_on">
-			<bounds x="592" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="592" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp173" element="led_on">
-			<bounds x="592" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="592" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp174" element="led_on">
-			<bounds x="592" y="418" width="21" height="3">
-			</bounds>
+			<bounds x="592" y="418" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp175" element="led_dot_on">
-			<bounds x="613" y="432" width="4" height="3">
-			</bounds>
+			<bounds x="613" y="432" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="618" y="400" width="30" height="40">
-			</bounds>
+			<bounds x="618" y="400" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off176" element="led_off">
-			<bounds x="622" y="403" width="21" height="3">
-			</bounds>
+			<bounds x="622" y="403" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off177" element="led_off">
-			<bounds x="639" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="639" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off178" element="led_off">
-			<bounds x="639" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="639" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off179" element="led_off">
-			<bounds x="622" y="432" width="21" height="3">
-			</bounds>
+			<bounds x="622" y="432" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off180" element="led_off">
-			<bounds x="622" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="622" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off181" element="led_off">
-			<bounds x="622" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="622" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off182" element="led_off">
-			<bounds x="622" y="418" width="21" height="3">
-			</bounds>
+			<bounds x="622" y="418" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off183" element="led_dot_off">
-			<bounds x="643" y="432" width="4" height="3">
-			</bounds>
+			<bounds x="643" y="432" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp176" element="led_on">
-			<bounds x="622" y="403" width="21" height="3">
-			</bounds>
+			<bounds x="622" y="403" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp177" element="led_on">
-			<bounds x="639" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="639" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp178" element="led_on">
-			<bounds x="639" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="639" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp179" element="led_on">
-			<bounds x="622" y="432" width="21" height="3">
-			</bounds>
+			<bounds x="622" y="432" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp180" element="led_on">
-			<bounds x="622" y="418" width="4" height="18">
-			</bounds>
+			<bounds x="622" y="418" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp181" element="led_on">
-			<bounds x="622" y="403" width="4" height="18">
-			</bounds>
+			<bounds x="622" y="403" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp182" element="led_on">
-			<bounds x="622" y="418" width="21" height="3">
-			</bounds>
+			<bounds x="622" y="418" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp183" element="led_dot_on">
-			<bounds x="643" y="432" width="4" height="3">
-			</bounds>
+			<bounds x="643" y="432" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="557" y="528" width="30" height="40">
-			</bounds>
+			<bounds x="557" y="528" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="561" y="531" width="21" height="3">
-			</bounds>
+			<bounds x="561" y="531" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="578" y="531" width="4" height="18">
-			</bounds>
+			<bounds x="578" y="531" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="578" y="546" width="4" height="18">
-			</bounds>
+			<bounds x="578" y="546" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="561" y="560" width="21" height="3">
-			</bounds>
+			<bounds x="561" y="560" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="561" y="546" width="4" height="18">
-			</bounds>
+			<bounds x="561" y="546" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="561" y="531" width="4" height="18">
-			</bounds>
+			<bounds x="561" y="531" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="561" y="546" width="21" height="3">
-			</bounds>
+			<bounds x="561" y="546" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="582" y="560" width="4" height="3">
-			</bounds>
+			<bounds x="582" y="560" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="561" y="531" width="21" height="3">
-			</bounds>
+			<bounds x="561" y="531" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="578" y="531" width="4" height="18">
-			</bounds>
+			<bounds x="578" y="531" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="578" y="546" width="4" height="18">
-			</bounds>
+			<bounds x="578" y="546" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="561" y="560" width="21" height="3">
-			</bounds>
+			<bounds x="561" y="560" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="561" y="546" width="4" height="18">
-			</bounds>
+			<bounds x="561" y="546" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="561" y="531" width="4" height="18">
-			</bounds>
+			<bounds x="561" y="531" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="561" y="546" width="21" height="3">
-			</bounds>
+			<bounds x="561" y="546" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="582" y="560" width="4" height="3">
-			</bounds>
+			<bounds x="582" y="560" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="587" y="528" width="30" height="40">
-			</bounds>
+			<bounds x="587" y="528" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="591" y="531" width="21" height="3">
-			</bounds>
+			<bounds x="591" y="531" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="608" y="531" width="4" height="18">
-			</bounds>
+			<bounds x="608" y="531" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="608" y="546" width="4" height="18">
-			</bounds>
+			<bounds x="608" y="546" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="591" y="560" width="21" height="3">
-			</bounds>
+			<bounds x="591" y="560" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="591" y="546" width="4" height="18">
-			</bounds>
+			<bounds x="591" y="546" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="591" y="531" width="4" height="18">
-			</bounds>
+			<bounds x="591" y="531" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="591" y="546" width="21" height="3">
-			</bounds>
+			<bounds x="591" y="546" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="612" y="560" width="4" height="3">
-			</bounds>
+			<bounds x="612" y="560" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="591" y="531" width="21" height="3">
-			</bounds>
+			<bounds x="591" y="531" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="608" y="531" width="4" height="18">
-			</bounds>
+			<bounds x="608" y="531" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="608" y="546" width="4" height="18">
-			</bounds>
+			<bounds x="608" y="546" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="591" y="560" width="21" height="3">
-			</bounds>
+			<bounds x="591" y="560" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="591" y="546" width="4" height="18">
-			</bounds>
+			<bounds x="591" y="546" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="591" y="531" width="4" height="18">
-			</bounds>
+			<bounds x="591" y="531" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="591" y="546" width="21" height="3">
-			</bounds>
+			<bounds x="591" y="546" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="612" y="560" width="4" height="3">
-			</bounds>
+			<bounds x="612" y="560" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="351" y="403" width="28" height="32">
-			</bounds>
+			<bounds x="351" y="403" width="28" height="32"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="201" y="403" width="28" height="32">
-			</bounds>
+			<bounds x="201" y="403" width="28" height="32"/>
 		</backdrop>
 		<backdrop name="label13" element="label_13">
-			<bounds x="492" y="384" width="38" height="67">
-			</bounds>
+			<bounds x="492" y="384" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label14" element="label_14">
-			<bounds x="541" y="380" width="96" height="23">
-			</bounds>
+			<bounds x="541" y="380" width="96" height="23"/>
 		</backdrop>
 		<backdrop name="label54" element="label_54">
-			<bounds x="552" y="84" width="76" height="23">
-			</bounds>
+			<bounds x="552" y="84" width="76" height="23"/>
 		</backdrop>
 		<backdrop name="label60" element="label_60">
-			<bounds x="562" y="508" width="51" height="23">
-			</bounds>
+			<bounds x="562" y="508" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="label64" element="label_64">
-			<bounds x="4" y="75" width="102" height="12">
-			</bounds>
+			<bounds x="4" y="75" width="102" height="12"/>
 		</backdrop>
 		<backdrop name="label65" element="label_65">
-			<bounds x="632" y="3" width="19" height="12">
-			</bounds>
+			<bounds x="632" y="3" width="19" height="12"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_button" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1lucknon.lay
+++ b/src/mame/layout/m1lucknon.lay
@@ -8,8810 +8,5810 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="PICK A BUTTON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="PICK A BUTTON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="nudge now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="nudge now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string=" &#xA3; &#xA3; &#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.27"/>
 		</text>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="blue card">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string=" &#xA3; &#xA3; &#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="blue card">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="  &#xA3; &#xA3; &#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.27"/>
 		</text>
 		<text string="jackpot  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="red card">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="  &#xA3; &#xA3; &#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="jackpot  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="red card">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="  &#xA3; &#xA3; &#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.27"/>
 		</text>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="mixed card">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="  &#xA3; &#xA3; &#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="mixed card">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LUCKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LUCKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="colour_button_120_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_120">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_152_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_152">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_60">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_61">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_65">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_66">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_67">
 		<text string="27 WAYS TO WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="664" height="754">
-			</bounds>
+			<bounds x="0" y="0" width="664" height="754"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="162" y="509" width="80" height="140">
-			</bounds>
+			<bounds x="162" y="509" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="162.0000" y="509.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="162.0000" y="509.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="165.3333" y="510.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="165.3333" y="510.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="168.6667" y="512.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="168.6667" y="512.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="172.0000" y="514.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="172.0000" y="514.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="175.3333" y="516.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="175.3333" y="516.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="178.6667" y="518.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="178.6667" y="518.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="162.0000" y="555.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="162.0000" y="555.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="165.3333" y="557.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="165.3333" y="557.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="168.6667" y="559.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="168.6667" y="559.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="172.0000" y="561.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="172.0000" y="561.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="175.3333" y="563.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="175.3333" y="563.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="178.6667" y="565.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="178.6667" y="565.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="162.0000" y="602.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="162.0000" y="602.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="165.3333" y="604.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="165.3333" y="604.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="168.6667" y="606.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="168.6667" y="606.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="172.0000" y="608.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="172.0000" y="608.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="175.3333" y="610.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="175.3333" y="610.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="178.6667" y="612.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="178.6667" y="612.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="162" y="509" width="80" height="140">
-			</bounds>
+			<bounds x="162" y="509" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="246" y="509" width="80" height="140">
-			</bounds>
+			<bounds x="246" y="509" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="246.0000" y="509.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="246.0000" y="509.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="249.3333" y="510.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="249.3333" y="510.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="252.6667" y="512.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="252.6667" y="512.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="256.0000" y="514.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="256.0000" y="514.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="259.3333" y="516.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="259.3333" y="516.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="262.6667" y="518.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="262.6667" y="518.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="246.0000" y="555.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="246.0000" y="555.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="249.3333" y="557.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="249.3333" y="557.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="252.6667" y="559.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="252.6667" y="559.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="256.0000" y="561.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="256.0000" y="561.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="259.3333" y="563.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="259.3333" y="563.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="262.6667" y="565.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="262.6667" y="565.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="246.0000" y="602.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="246.0000" y="602.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="249.3333" y="604.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="249.3333" y="604.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="252.6667" y="606.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="252.6667" y="606.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="256.0000" y="608.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="256.0000" y="608.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="259.3333" y="610.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="259.3333" y="610.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="262.6667" y="612.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="262.6667" y="612.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="246" y="509" width="80" height="140">
-			</bounds>
+			<bounds x="246" y="509" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="330" y="509" width="80" height="140">
-			</bounds>
+			<bounds x="330" y="509" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="509.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="509.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="510.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="510.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="512.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="512.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="514.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="514.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="516.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="516.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="518.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="518.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="555.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="555.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="557.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="557.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="559.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="559.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="561.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="561.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="563.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="563.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="565.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="565.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="602.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="602.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="604.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="604.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="606.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="606.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="608.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="608.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="610.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="610.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="612.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="612.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="330" y="509" width="80" height="140">
-			</bounds>
+			<bounds x="330" y="509" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="169" y="356" width="70" height="70">
-			</bounds>
+			<bounds x="169" y="356" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="171" y="358" width="66" height="66">
-			</bounds>
+			<bounds x="171" y="358" width="66" height="66"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="87" y="630" width="48" height="36">
-			</bounds>
+			<bounds x="87" y="630" width="48" height="36"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="89" y="632" width="44" height="32">
-			</bounds>
+			<bounds x="89" y="632" width="44" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="186" y="657" width="36" height="24">
-			</bounds>
+			<bounds x="186" y="657" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="188" y="659" width="32" height="20">
-			</bounds>
+			<bounds x="188" y="659" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="247" y="657" width="36" height="24">
-			</bounds>
+			<bounds x="247" y="657" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="249" y="659" width="32" height="20">
-			</bounds>
+			<bounds x="249" y="659" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="305" y="657" width="36" height="24">
-			</bounds>
+			<bounds x="305" y="657" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="307" y="659" width="32" height="20">
-			</bounds>
+			<bounds x="307" y="659" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="365" y="657" width="36" height="24">
-			</bounds>
+			<bounds x="365" y="657" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="367" y="659" width="32" height="20">
-			</bounds>
+			<bounds x="367" y="659" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="126" y="191" width="140" height="48">
-			</bounds>
+			<bounds x="126" y="191" width="140" height="48"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="128" y="193" width="136" height="44">
-			</bounds>
+			<bounds x="128" y="193" width="136" height="44"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="126" y="87" width="140" height="48">
-			</bounds>
+			<bounds x="126" y="87" width="140" height="48"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="128" y="89" width="136" height="44">
-			</bounds>
+			<bounds x="128" y="89" width="136" height="44"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="126" y="281" width="140" height="48">
-			</bounds>
+			<bounds x="126" y="281" width="140" height="48"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="128" y="283" width="136" height="44">
-			</bounds>
+			<bounds x="128" y="283" width="136" height="44"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="591" y="473" width="36" height="42">
-			</bounds>
+			<bounds x="591" y="473" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="593" y="475" width="32" height="38">
-			</bounds>
+			<bounds x="593" y="475" width="32" height="38"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="591" y="515" width="36" height="42">
-			</bounds>
+			<bounds x="591" y="515" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="593" y="517" width="32" height="38">
-			</bounds>
+			<bounds x="593" y="517" width="32" height="38"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="591" y="557" width="36" height="42">
-			</bounds>
+			<bounds x="591" y="557" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="593" y="559" width="32" height="38">
-			</bounds>
+			<bounds x="593" y="559" width="32" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="316" y="50" width="162" height="47">
-			</bounds>
+			<bounds x="316" y="50" width="162" height="47"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="318" y="52" width="158" height="43">
-			</bounds>
+			<bounds x="318" y="52" width="158" height="43"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="323" y="3" width="142" height="48">
-			</bounds>
+			<bounds x="323" y="3" width="142" height="48"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="325" y="5" width="138" height="44">
-			</bounds>
+			<bounds x="325" y="5" width="138" height="44"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="591" y="640" width="36" height="42">
-			</bounds>
+			<bounds x="591" y="640" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="593" y="642" width="32" height="38">
-			</bounds>
+			<bounds x="593" y="642" width="32" height="38"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="591" y="599" width="36" height="42">
-			</bounds>
+			<bounds x="591" y="599" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="593" y="601" width="32" height="38">
-			</bounds>
+			<bounds x="593" y="601" width="32" height="38"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="571" y="431" width="82" height="36">
-			</bounds>
+			<bounds x="571" y="431" width="82" height="36"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="573" y="433" width="78" height="32">
-			</bounds>
+			<bounds x="573" y="433" width="78" height="32"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="45" y="335" width="24" height="88">
-			</bounds>
+			<bounds x="45" y="335" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="47" y="337" width="20" height="84">
-			</bounds>
+			<bounds x="47" y="337" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="21" y="335" width="24" height="88">
-			</bounds>
+			<bounds x="21" y="335" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="23" y="337" width="20" height="84">
-			</bounds>
+			<bounds x="23" y="337" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="45" y="247" width="24" height="88">
-			</bounds>
+			<bounds x="45" y="247" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="47" y="249" width="20" height="84">
-			</bounds>
+			<bounds x="47" y="249" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="21" y="247" width="24" height="88">
-			</bounds>
+			<bounds x="21" y="247" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="23" y="249" width="20" height="84">
-			</bounds>
+			<bounds x="23" y="249" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="45" y="159" width="24" height="88">
-			</bounds>
+			<bounds x="45" y="159" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="47" y="161" width="20" height="84">
-			</bounds>
+			<bounds x="47" y="161" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="21" y="159" width="24" height="88">
-			</bounds>
+			<bounds x="21" y="159" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="23" y="161" width="20" height="84">
-			</bounds>
+			<bounds x="23" y="161" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="333" y="159" width="24" height="88">
-			</bounds>
+			<bounds x="333" y="159" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="335" y="161" width="20" height="84">
-			</bounds>
+			<bounds x="335" y="161" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="309" y="159" width="24" height="88">
-			</bounds>
+			<bounds x="309" y="159" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="311" y="161" width="20" height="84">
-			</bounds>
+			<bounds x="311" y="161" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="333" y="247" width="24" height="88">
-			</bounds>
+			<bounds x="333" y="247" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="335" y="249" width="20" height="84">
-			</bounds>
+			<bounds x="335" y="249" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="333" y="335" width="24" height="88">
-			</bounds>
+			<bounds x="333" y="335" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="335" y="337" width="20" height="84">
-			</bounds>
+			<bounds x="335" y="337" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="309" y="247" width="24" height="88">
-			</bounds>
+			<bounds x="309" y="247" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="311" y="249" width="20" height="84">
-			</bounds>
+			<bounds x="311" y="249" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="309" y="335" width="24" height="88">
-			</bounds>
+			<bounds x="309" y="335" width="24" height="88"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="311" y="337" width="20" height="84">
-			</bounds>
+			<bounds x="311" y="337" width="20" height="84"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_120_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="623" y="2" width="36" height="46">
-			</bounds>
+			<bounds x="623" y="2" width="36" height="46"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_120" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="625" y="4" width="32" height="42">
-			</bounds>
+			<bounds x="625" y="4" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp220" element="colour_button_147_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="255" y="369" width="46" height="46">
-			</bounds>
+			<bounds x="255" y="369" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp220" element="colour_button_147" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="257" y="371" width="42" height="42">
-			</bounds>
+			<bounds x="257" y="371" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp219" element="colour_button_148_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="90" y="368" width="46" height="46">
-			</bounds>
+			<bounds x="90" y="368" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp219" element="colour_button_148" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="92" y="370" width="42" height="42">
-			</bounds>
+			<bounds x="92" y="370" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_151_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="438" y="695" width="75" height="37">
-			</bounds>
+			<bounds x="438" y="695" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_151" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="440" y="697" width="71" height="33">
-			</bounds>
+			<bounds x="440" y="697" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_152_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="336" y="695" width="75" height="37">
-			</bounds>
+			<bounds x="336" y="695" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_152" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="338" y="697" width="71" height="33">
-			</bounds>
+			<bounds x="338" y="697" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_153_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="251" y="695" width="75" height="37">
-			</bounds>
+			<bounds x="251" y="695" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_153" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="253" y="697" width="71" height="33">
-			</bounds>
+			<bounds x="253" y="697" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_154_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="166" y="695" width="75" height="37">
-			</bounds>
+			<bounds x="166" y="695" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_154" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="168" y="697" width="71" height="33">
-			</bounds>
+			<bounds x="168" y="697" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_155_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="3" y="695" width="75" height="37">
-			</bounds>
+			<bounds x="3" y="695" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_155" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="5" y="697" width="71" height="33">
-			</bounds>
+			<bounds x="5" y="697" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_156_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="82" y="695" width="75" height="37">
-			</bounds>
+			<bounds x="82" y="695" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_156" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="84" y="697" width="71" height="33">
-			</bounds>
+			<bounds x="84" y="697" width="71" height="33"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="149" y="472" width="272" height="30">
-			</bounds>
+			<bounds x="149" y="472" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="149" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="149" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="166" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="166" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="183" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="183" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="200" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="200" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="217" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="217" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="234" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="234" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="251" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="251" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="268" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="268" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="285" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="285" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="302" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="302" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="319" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="319" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="336" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="336" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="353" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="353" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="370" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="370" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="387" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="387" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="404" y="472" width="17" height="30">
-			</bounds>
+			<bounds x="404" y="472" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label60" element="label_60">
-			<bounds x="525" y="238" width="19" height="34">
-			</bounds>
+			<bounds x="525" y="238" width="19" height="34"/>
 		</backdrop>
 		<backdrop name="label61" element="label_61">
-			<bounds x="583" y="238" width="19" height="34">
-			</bounds>
+			<bounds x="583" y="238" width="19" height="34"/>
 		</backdrop>
 		<backdrop name="label65" element="label_65">
-			<bounds x="583" y="302" width="19" height="34">
-			</bounds>
+			<bounds x="583" y="302" width="19" height="34"/>
 		</backdrop>
 		<backdrop name="label66" element="label_66">
-			<bounds x="525" y="302" width="19" height="34">
-			</bounds>
+			<bounds x="525" y="302" width="19" height="34"/>
 		</backdrop>
 		<backdrop name="label67" element="label_67">
-			<bounds x="543" y="376" width="66" height="28">
-			</bounds>
+			<bounds x="543" y="376" width="66" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_button" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_button" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1luxorb.lay
+++ b/src/mame/layout/m1luxorb.lay
@@ -8,14212 +8,8190 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string=" 6 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string=" 6 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string=" 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string=" 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string=" 8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string=" 8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string=" 9 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string=" 9 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="10 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pyramid">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Payout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pyramid">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Payout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="16 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="16 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pharoahs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fortune">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pharoahs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fortune">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Luxor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Luxor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Sphinx">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Sphinx">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Luxor Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Luxor Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Serpents ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Serpents ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Choose ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Choose ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Secret Chamber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Secret Chamber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Luxor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Luxor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mummys">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mummys">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Tomb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Raider">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Tomb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Raider">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="  6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="  6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="gamble ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="gamble ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
 		<text string=" Mo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string=" Mo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red Gamble 0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red Gamble 0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Blue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Blue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Gamble ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Advanc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Advanc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Advanc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Advanc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Blue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Blue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gold Gamble 0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gold Gamble 0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gold ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble 0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gold ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Gamble 0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
 		<text string="Mov">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Mov">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Luxor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Luxor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Move Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Move Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Stopper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stopper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Lucky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lucky">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_246_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_246">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_270_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_270">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_271_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_271">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_272_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_272">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_273_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_273">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold/Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_274_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_274">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold/Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_275_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_275">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Auto Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_276_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_276">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_277_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_277">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_293_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_293">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_294_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_294">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_233">
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_234">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_235">
 		<text string="THANKS TO CRAZY SQUID AND LAUNTON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="899" height="735">
-			</bounds>
+			<bounds x="0" y="0" width="899" height="735"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="237" y="488" width="80" height="140">
-			</bounds>
+			<bounds x="237" y="488" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="237.0000" y="488.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="237.0000" y="488.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="240.3333" y="489.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="240.3333" y="489.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="243.6667" y="491.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="243.6667" y="491.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="247.0000" y="493.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="247.0000" y="493.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="250.3333" y="495.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="250.3333" y="495.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="253.6667" y="497.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="253.6667" y="497.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="237.0000" y="534.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="237.0000" y="534.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="240.3333" y="536.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="240.3333" y="536.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="243.6667" y="538.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="243.6667" y="538.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="247.0000" y="540.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="247.0000" y="540.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="250.3333" y="542.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="250.3333" y="542.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="253.6667" y="544.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="253.6667" y="544.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="237.0000" y="581.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="237.0000" y="581.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="240.3333" y="583.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="240.3333" y="583.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="243.6667" y="585.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="243.6667" y="585.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="247.0000" y="587.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="247.0000" y="587.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="250.3333" y="589.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="250.3333" y="589.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="253.6667" y="591.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="253.6667" y="591.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="237" y="488" width="80" height="140">
-			</bounds>
+			<bounds x="237" y="488" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="319" y="488" width="80" height="140">
-			</bounds>
+			<bounds x="319" y="488" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="319.0000" y="488.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="319.0000" y="488.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="322.3333" y="489.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="322.3333" y="489.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="325.6667" y="491.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="325.6667" y="491.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="329.0000" y="493.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="329.0000" y="493.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="332.3333" y="495.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="332.3333" y="495.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="335.6667" y="497.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="335.6667" y="497.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="319.0000" y="534.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="319.0000" y="534.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="322.3333" y="536.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="322.3333" y="536.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="325.6667" y="538.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="325.6667" y="538.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="329.0000" y="540.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="329.0000" y="540.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="332.3333" y="542.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="332.3333" y="542.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="335.6667" y="544.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="335.6667" y="544.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="319.0000" y="581.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="319.0000" y="581.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="322.3333" y="583.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="322.3333" y="583.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="325.6667" y="585.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="325.6667" y="585.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="329.0000" y="587.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="329.0000" y="587.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="332.3333" y="589.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="332.3333" y="589.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="335.6667" y="591.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="335.6667" y="591.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="319" y="488" width="80" height="140">
-			</bounds>
+			<bounds x="319" y="488" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="401" y="489" width="80" height="140">
-			</bounds>
+			<bounds x="401" y="489" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="401.0000" y="489.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="401.0000" y="489.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="404.3333" y="490.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="404.3333" y="490.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="407.6667" y="492.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="407.6667" y="492.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="411.0000" y="494.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="411.0000" y="494.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="414.3333" y="496.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="414.3333" y="496.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="417.6667" y="498.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="417.6667" y="498.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="401.0000" y="535.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="401.0000" y="535.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="404.3333" y="537.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="404.3333" y="537.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="407.6667" y="539.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="407.6667" y="539.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="411.0000" y="541.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="411.0000" y="541.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="414.3333" y="543.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="414.3333" y="543.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="417.6667" y="545.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="417.6667" y="545.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="401.0000" y="582.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="401.0000" y="582.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="404.3333" y="584.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="404.3333" y="584.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="407.6667" y="586.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="407.6667" y="586.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="411.0000" y="588.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="411.0000" y="588.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="414.3333" y="590.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="414.3333" y="590.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="417.6667" y="592.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="417.6667" y="592.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="401" y="489" width="80" height="140">
-			</bounds>
+			<bounds x="401" y="489" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="34" y="244" width="80" height="80">
-			</bounds>
+			<bounds x="34" y="244" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="34.0000" y="244.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="34.0000" y="244.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="37.3333" y="247.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="37.3333" y="247.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="40.6667" y="250.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="40.6667" y="250.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="44.0000" y="254.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="44.0000" y="254.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="47.3333" y="257.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="47.3333" y="257.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="50.6667" y="260.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="50.6667" y="260.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="34" y="244" width="80" height="80">
-			</bounds>
+			<bounds x="34" y="244" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="6" y="316" width="26" height="26">
-			</bounds>
+			<bounds x="6" y="316" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="8" y="318" width="22" height="22">
-			</bounds>
+			<bounds x="8" y="318" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="7" y="221" width="26" height="26">
-			</bounds>
+			<bounds x="7" y="221" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="9" y="223" width="22" height="22">
-			</bounds>
+			<bounds x="9" y="223" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="546" y="1" width="58" height="58">
-			</bounds>
+			<bounds x="546" y="1" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="548" y="3" width="54" height="54">
-			</bounds>
+			<bounds x="548" y="3" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="470" y="647" width="47" height="24">
-			</bounds>
+			<bounds x="470" y="647" width="47" height="24"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="472" y="649" width="43" height="20">
-			</bounds>
+			<bounds x="472" y="649" width="43" height="20"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="20" y="599" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="599" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="22" y="601" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="601" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="20" y="573" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="573" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="22" y="575" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="575" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="20" y="547" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="547" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="22" y="549" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="549" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="20" y="521" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="521" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="22" y="523" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="523" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="20" y="495" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="495" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="22" y="497" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="497" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="20" y="469" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="469" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="22" y="471" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="471" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="20" y="443" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="443" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="22" y="445" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="445" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="20" y="417" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="417" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="22" y="419" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="419" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="20" y="391" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="391" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="22" y="393" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="393" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="20" y="365" width="58" height="26">
-			</bounds>
+			<bounds x="20" y="365" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="22" y="367" width="54" height="22">
-			</bounds>
+			<bounds x="22" y="367" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="123" y="647" width="36" height="36">
-			</bounds>
+			<bounds x="123" y="647" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="125" y="649" width="32" height="32">
-			</bounds>
+			<bounds x="125" y="649" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="356" y="647" width="36" height="36">
-			</bounds>
+			<bounds x="356" y="647" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="358" y="649" width="32" height="32">
-			</bounds>
+			<bounds x="358" y="649" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="318" y="647" width="36" height="36">
-			</bounds>
+			<bounds x="318" y="647" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="320" y="649" width="32" height="32">
-			</bounds>
+			<bounds x="320" y="649" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="282" y="647" width="36" height="36">
-			</bounds>
+			<bounds x="282" y="647" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="284" y="649" width="32" height="32">
-			</bounds>
+			<bounds x="284" y="649" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="233" y="647" width="52" height="36">
-			</bounds>
+			<bounds x="233" y="647" width="52" height="36"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="235" y="649" width="48" height="32">
-			</bounds>
+			<bounds x="235" y="649" width="48" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="195" y="647" width="36" height="36">
-			</bounds>
+			<bounds x="195" y="647" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="197" y="649" width="32" height="32">
-			</bounds>
+			<bounds x="197" y="649" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="160" y="647" width="36" height="36">
-			</bounds>
+			<bounds x="160" y="647" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="162" y="649" width="32" height="32">
-			</bounds>
+			<bounds x="162" y="649" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="393" y="630" width="62" height="68">
-			</bounds>
+			<bounds x="393" y="630" width="62" height="68"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="395" y="632" width="58" height="64">
-			</bounds>
+			<bounds x="395" y="632" width="58" height="64"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="505" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="505" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="507" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="507" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="331" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="331" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="333" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="333" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="447" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="447" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="449" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="449" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="389" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="389" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="391" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="391" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="621" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="621" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="623" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="623" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="679" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="679" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="681" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="681" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="737" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="737" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="739" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="739" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="795" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="795" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="797" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="797" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="563" y="283" width="58" height="36">
-			</bounds>
+			<bounds x="563" y="283" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="565" y="285" width="54" height="32">
-			</bounds>
+			<bounds x="565" y="285" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="795" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="795" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="797" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="797" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="737" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="737" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="739" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="739" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="679" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="679" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="681" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="681" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="621" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="621" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="623" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="623" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="505" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="505" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="507" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="507" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="563" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="563" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="565" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="565" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="447" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="447" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="449" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="449" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="331" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="331" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="333" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="333" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="389" y="374" width="58" height="36">
-			</bounds>
+			<bounds x="389" y="374" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="391" y="376" width="54" height="32">
-			</bounds>
+			<bounds x="391" y="376" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="795" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="795" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="797" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="797" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="737" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="737" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="739" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="739" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="679" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="679" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="681" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="681" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="621" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="621" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="623" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="623" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="563" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="563" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="565" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="565" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="447" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="447" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="449" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="449" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="505" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="505" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="507" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="507" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="331" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="331" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="333" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="333" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="389" y="326" width="58" height="36">
-			</bounds>
+			<bounds x="389" y="326" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="391" y="328" width="54" height="32">
-			</bounds>
+			<bounds x="391" y="328" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="787" y="207" width="48" height="26">
-			</bounds>
+			<bounds x="787" y="207" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="789" y="209" width="44" height="22">
-			</bounds>
+			<bounds x="789" y="209" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="623" y="27" width="58" height="36">
-			</bounds>
+			<bounds x="623" y="27" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="625" y="29" width="54" height="32">
-			</bounds>
+			<bounds x="625" y="29" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="537" y="193" width="78" height="36">
-			</bounds>
+			<bounds x="537" y="193" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="539" y="195" width="74" height="32">
-			</bounds>
+			<bounds x="539" y="195" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="461" y="196" width="58" height="36">
-			</bounds>
+			<bounds x="461" y="196" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="463" y="198" width="54" height="32">
-			</bounds>
+			<bounds x="463" y="198" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="568" y="237" width="58" height="36">
-			</bounds>
+			<bounds x="568" y="237" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="570" y="239" width="54" height="32">
-			</bounds>
+			<bounds x="570" y="239" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="408" y="239" width="58" height="36">
-			</bounds>
+			<bounds x="408" y="239" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="410" y="241" width="54" height="32">
-			</bounds>
+			<bounds x="410" y="241" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="499" y="237" width="58" height="36">
-			</bounds>
+			<bounds x="499" y="237" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="501" y="239" width="54" height="32">
-			</bounds>
+			<bounds x="501" y="239" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="546" y="146" width="58" height="36">
-			</bounds>
+			<bounds x="546" y="146" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="548" y="148" width="54" height="32">
-			</bounds>
+			<bounds x="548" y="148" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="705" y="198" width="58" height="36">
-			</bounds>
+			<bounds x="705" y="198" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="707" y="200" width="54" height="32">
-			</bounds>
+			<bounds x="707" y="200" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="441" y="146" width="62" height="36">
-			</bounds>
+			<bounds x="441" y="146" width="62" height="36"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="443" y="148" width="58" height="32">
-			</bounds>
+			<bounds x="443" y="148" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="652" y="146" width="58" height="36">
-			</bounds>
+			<bounds x="652" y="146" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="654" y="148" width="54" height="32">
-			</bounds>
+			<bounds x="654" y="148" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="634" y="238" width="58" height="36">
-			</bounds>
+			<bounds x="634" y="238" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="636" y="240" width="54" height="32">
-			</bounds>
+			<bounds x="636" y="240" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="625" y="103" width="58" height="36">
-			</bounds>
+			<bounds x="625" y="103" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="627" y="105" width="54" height="32">
-			</bounds>
+			<bounds x="627" y="105" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="390" y="196" width="62" height="36">
-			</bounds>
+			<bounds x="390" y="196" width="62" height="36"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="392" y="198" width="58" height="32">
-			</bounds>
+			<bounds x="392" y="198" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="538" y="102" width="78" height="36">
-			</bounds>
+			<bounds x="538" y="102" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="540" y="104" width="74" height="32">
-			</bounds>
+			<bounds x="540" y="104" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="469" y="103" width="58" height="36">
-			</bounds>
+			<bounds x="469" y="103" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="471" y="105" width="54" height="32">
-			</bounds>
+			<bounds x="471" y="105" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="550" y="63" width="58" height="36">
-			</bounds>
+			<bounds x="550" y="63" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="552" y="65" width="54" height="32">
-			</bounds>
+			<bounds x="552" y="65" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="479" y="28" width="58" height="36">
-			</bounds>
+			<bounds x="479" y="28" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="481" y="30" width="54" height="32">
-			</bounds>
+			<bounds x="481" y="30" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="629" y="198" width="58" height="36">
-			</bounds>
+			<bounds x="629" y="198" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="631" y="200" width="54" height="32">
-			</bounds>
+			<bounds x="631" y="200" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="230" y="396" width="24" height="24">
-			</bounds>
+			<bounds x="230" y="396" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="232" y="398" width="20" height="20">
-			</bounds>
+			<bounds x="232" y="398" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="206" y="396" width="24" height="24">
-			</bounds>
+			<bounds x="206" y="396" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="208" y="398" width="20" height="20">
-			</bounds>
+			<bounds x="208" y="398" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="182" y="396" width="24" height="24">
-			</bounds>
+			<bounds x="182" y="396" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="184" y="398" width="20" height="20">
-			</bounds>
+			<bounds x="184" y="398" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="182" y="371" width="24" height="24">
-			</bounds>
+			<bounds x="182" y="371" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="184" y="373" width="20" height="20">
-			</bounds>
+			<bounds x="184" y="373" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="206" y="371" width="24" height="24">
-			</bounds>
+			<bounds x="206" y="371" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="208" y="373" width="20" height="20">
-			</bounds>
+			<bounds x="208" y="373" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="230" y="371" width="24" height="24">
-			</bounds>
+			<bounds x="230" y="371" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="232" y="373" width="20" height="20">
-			</bounds>
+			<bounds x="232" y="373" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="183" y="345" width="24" height="24">
-			</bounds>
+			<bounds x="183" y="345" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="185" y="347" width="20" height="20">
-			</bounds>
+			<bounds x="185" y="347" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="207" y="345" width="24" height="24">
-			</bounds>
+			<bounds x="207" y="345" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="209" y="347" width="20" height="20">
-			</bounds>
+			<bounds x="209" y="347" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="231" y="345" width="24" height="24">
-			</bounds>
+			<bounds x="231" y="345" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="233" y="347" width="20" height="20">
-			</bounds>
+			<bounds x="233" y="347" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="183" y="320" width="24" height="24">
-			</bounds>
+			<bounds x="183" y="320" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="185" y="322" width="20" height="20">
-			</bounds>
+			<bounds x="185" y="322" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="207" y="320" width="24" height="24">
-			</bounds>
+			<bounds x="207" y="320" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="209" y="322" width="20" height="20">
-			</bounds>
+			<bounds x="209" y="322" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="231" y="320" width="24" height="24">
-			</bounds>
+			<bounds x="231" y="320" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="233" y="322" width="20" height="20">
-			</bounds>
+			<bounds x="233" y="322" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="183" y="269" width="24" height="24">
-			</bounds>
+			<bounds x="183" y="269" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="185" y="271" width="20" height="20">
-			</bounds>
+			<bounds x="185" y="271" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="183" y="294" width="24" height="24">
-			</bounds>
+			<bounds x="183" y="294" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="185" y="296" width="20" height="20">
-			</bounds>
+			<bounds x="185" y="296" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="231" y="294" width="24" height="24">
-			</bounds>
+			<bounds x="231" y="294" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="233" y="296" width="20" height="20">
-			</bounds>
+			<bounds x="233" y="296" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="207" y="294" width="24" height="24">
-			</bounds>
+			<bounds x="207" y="294" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="209" y="296" width="20" height="20">
-			</bounds>
+			<bounds x="209" y="296" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="207" y="269" width="24" height="24">
-			</bounds>
+			<bounds x="207" y="269" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="209" y="271" width="20" height="20">
-			</bounds>
+			<bounds x="209" y="271" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="231" y="269" width="24" height="24">
-			</bounds>
+			<bounds x="231" y="269" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="233" y="271" width="20" height="20">
-			</bounds>
+			<bounds x="233" y="271" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="784" y="641" width="58" height="24">
-			</bounds>
+			<bounds x="784" y="641" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="786" y="643" width="54" height="20">
-			</bounds>
+			<bounds x="786" y="643" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="784" y="464" width="58" height="24">
-			</bounds>
+			<bounds x="784" y="464" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="786" y="466" width="54" height="20">
-			</bounds>
+			<bounds x="786" y="466" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="784" y="534" width="58" height="24">
-			</bounds>
+			<bounds x="784" y="534" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="786" y="536" width="54" height="20">
-			</bounds>
+			<bounds x="786" y="536" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="784" y="605" width="58" height="24">
-			</bounds>
+			<bounds x="784" y="605" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="786" y="607" width="54" height="20">
-			</bounds>
+			<bounds x="786" y="607" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="784" y="571" width="58" height="24">
-			</bounds>
+			<bounds x="784" y="571" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="786" y="573" width="54" height="20">
-			</bounds>
+			<bounds x="786" y="573" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="784" y="500" width="58" height="24">
-			</bounds>
+			<bounds x="784" y="500" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="786" y="502" width="54" height="20">
-			</bounds>
+			<bounds x="786" y="502" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="746" y="491" width="36" height="36">
-			</bounds>
+			<bounds x="746" y="491" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="748" y="493" width="32" height="32">
-			</bounds>
+			<bounds x="748" y="493" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="746" y="527" width="36" height="36">
-			</bounds>
+			<bounds x="746" y="527" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="748" y="529" width="32" height="32">
-			</bounds>
+			<bounds x="748" y="529" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="746" y="563" width="36" height="36">
-			</bounds>
+			<bounds x="746" y="563" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="748" y="565" width="32" height="32">
-			</bounds>
+			<bounds x="748" y="565" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="746" y="599" width="36" height="36">
-			</bounds>
+			<bounds x="746" y="599" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="748" y="601" width="32" height="32">
-			</bounds>
+			<bounds x="748" y="601" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="746" y="635" width="36" height="36">
-			</bounds>
+			<bounds x="746" y="635" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="748" y="637" width="32" height="32">
-			</bounds>
+			<bounds x="748" y="637" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="746" y="455" width="36" height="36">
-			</bounds>
+			<bounds x="746" y="455" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="748" y="457" width="32" height="32">
-			</bounds>
+			<bounds x="748" y="457" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="746" y="419" width="36" height="36">
-			</bounds>
+			<bounds x="746" y="419" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="748" y="421" width="32" height="32">
-			</bounds>
+			<bounds x="748" y="421" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="91" y="39" width="36" height="26">
-			</bounds>
+			<bounds x="91" y="39" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="93" y="41" width="32" height="22">
-			</bounds>
+			<bounds x="93" y="41" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="127" y="39" width="36" height="26">
-			</bounds>
+			<bounds x="127" y="39" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="129" y="41" width="32" height="22">
-			</bounds>
+			<bounds x="129" y="41" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="235" y="39" width="36" height="26">
-			</bounds>
+			<bounds x="235" y="39" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="237" y="41" width="32" height="22">
-			</bounds>
+			<bounds x="237" y="41" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="271" y="39" width="36" height="26">
-			</bounds>
+			<bounds x="271" y="39" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="273" y="41" width="32" height="22">
-			</bounds>
+			<bounds x="273" y="41" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="199" y="39" width="36" height="26">
-			</bounds>
+			<bounds x="199" y="39" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="201" y="41" width="32" height="22">
-			</bounds>
+			<bounds x="201" y="41" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="163" y="39" width="36" height="26">
-			</bounds>
+			<bounds x="163" y="39" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="165" y="41" width="32" height="22">
-			</bounds>
+			<bounds x="165" y="41" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="107" y="12" width="36" height="26">
-			</bounds>
+			<bounds x="107" y="12" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="109" y="14" width="32" height="22">
-			</bounds>
+			<bounds x="109" y="14" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="143" y="12" width="36" height="26">
-			</bounds>
+			<bounds x="143" y="12" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="145" y="14" width="32" height="22">
-			</bounds>
+			<bounds x="145" y="14" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="179" y="12" width="36" height="26">
-			</bounds>
+			<bounds x="179" y="12" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="181" y="14" width="32" height="22">
-			</bounds>
+			<bounds x="181" y="14" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="215" y="12" width="36" height="26">
-			</bounds>
+			<bounds x="215" y="12" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="217" y="14" width="32" height="22">
-			</bounds>
+			<bounds x="217" y="14" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="251" y="12" width="36" height="26">
-			</bounds>
+			<bounds x="251" y="12" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="253" y="14" width="32" height="22">
-			</bounds>
+			<bounds x="253" y="14" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="214" y="209" width="58" height="26">
-			</bounds>
+			<bounds x="214" y="209" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="216" y="211" width="54" height="22">
-			</bounds>
+			<bounds x="216" y="211" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="257" y="154" width="68" height="19">
-			</bounds>
+			<bounds x="257" y="154" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="259" y="156" width="64" height="15">
-			</bounds>
+			<bounds x="259" y="156" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="243" y="116" width="46" height="24">
-			</bounds>
+			<bounds x="243" y="116" width="46" height="24"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="245" y="118" width="42" height="20">
-			</bounds>
+			<bounds x="245" y="118" width="42" height="20"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="195" y="116" width="50" height="24">
-			</bounds>
+			<bounds x="195" y="116" width="50" height="24"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="197" y="118" width="46" height="20">
-			</bounds>
+			<bounds x="197" y="118" width="46" height="20"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="199" y="150" width="58" height="26">
-			</bounds>
+			<bounds x="199" y="150" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="201" y="152" width="54" height="22">
-			</bounds>
+			<bounds x="201" y="152" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="65" y="130" width="68" height="24">
-			</bounds>
+			<bounds x="65" y="130" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="67" y="132" width="64" height="20">
-			</bounds>
+			<bounds x="67" y="132" width="64" height="20"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="229" y="183" width="57" height="19">
-			</bounds>
+			<bounds x="229" y="183" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="231" y="185" width="53" height="15">
-			</bounds>
+			<bounds x="231" y="185" width="53" height="15"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="72" y="158" width="68" height="19">
-			</bounds>
+			<bounds x="72" y="158" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="74" y="160" width="64" height="15">
-			</bounds>
+			<bounds x="74" y="160" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="119" y="187" width="58" height="24">
-			</bounds>
+			<bounds x="119" y="187" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="121" y="189" width="54" height="20">
-			</bounds>
+			<bounds x="121" y="189" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="62" y="187" width="58" height="24">
-			</bounds>
+			<bounds x="62" y="187" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="64" y="189" width="54" height="20">
-			</bounds>
+			<bounds x="64" y="189" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_246_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="853" y="1" width="46" height="36">
-			</bounds>
+			<bounds x="853" y="1" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_246" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="855" y="3" width="42" height="32">
-			</bounds>
+			<bounds x="855" y="3" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="colour_button_270_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="257" y="289" width="75" height="27">
-			</bounds>
+			<bounds x="257" y="289" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp136" element="colour_button_270" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="259" y="291" width="71" height="23">
-			</bounds>
+			<bounds x="259" y="291" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_271_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="156" y="698" width="75" height="27">
-			</bounds>
+			<bounds x="156" y="698" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_271" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="158" y="700" width="71" height="23">
-			</bounds>
+			<bounds x="158" y="700" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_272_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="236" y="697" width="75" height="27">
-			</bounds>
+			<bounds x="236" y="697" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_272" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="238" y="699" width="71" height="23">
-			</bounds>
+			<bounds x="238" y="699" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_273_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="320" y="698" width="75" height="27">
-			</bounds>
+			<bounds x="320" y="698" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_273" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="322" y="700" width="71" height="23">
-			</bounds>
+			<bounds x="322" y="700" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_274_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="404" y="698" width="75" height="27">
-			</bounds>
+			<bounds x="404" y="698" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_274" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="406" y="700" width="71" height="23">
-			</bounds>
+			<bounds x="406" y="700" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_275_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="494" y="688" width="80" height="39">
-			</bounds>
+			<bounds x="494" y="688" width="80" height="39"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_275" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="496" y="690" width="76" height="35">
-			</bounds>
+			<bounds x="496" y="690" width="76" height="35"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_276_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="590" y="698" width="75" height="27">
-			</bounds>
+			<bounds x="590" y="698" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_276" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="592" y="700" width="71" height="23">
-			</bounds>
+			<bounds x="592" y="700" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_277_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="677" y="698" width="75" height="27">
-			</bounds>
+			<bounds x="677" y="698" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_277" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="679" y="700" width="71" height="23">
-			</bounds>
+			<bounds x="679" y="700" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="colour_button_293_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="257" y="377" width="75" height="27">
-			</bounds>
+			<bounds x="257" y="377" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="colour_button_293" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="259" y="379" width="71" height="23">
-			</bounds>
+			<bounds x="259" y="379" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="colour_button_294_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="257" y="331" width="75" height="27">
-			</bounds>
+			<bounds x="257" y="331" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp135" element="colour_button_294" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="259" y="333" width="71" height="23">
-			</bounds>
+			<bounds x="259" y="333" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="92" y="76" width="272" height="30">
-			</bounds>
+			<bounds x="92" y="76" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="92" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="92" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="109" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="109" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="126" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="126" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="143" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="143" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="160" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="160" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="177" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="177" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="194" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="194" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="211" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="211" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="228" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="228" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="245" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="245" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="262" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="262" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="279" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="279" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="296" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="296" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="313" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="313" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="330" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="330" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="347" y="76" width="17" height="30">
-			</bounds>
+			<bounds x="347" y="76" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label233" element="label_233">
-			<bounds x="205" y="552" width="30" height="32">
-			</bounds>
+			<bounds x="205" y="552" width="30" height="32"/>
 		</backdrop>
 		<backdrop name="label234" element="label_234">
-			<bounds x="483" y="552" width="34" height="16">
-			</bounds>
+			<bounds x="483" y="552" width="34" height="16"/>
 		</backdrop>
 		<backdrop name="label235" element="label_235">
-			<bounds x="751" y="5" width="83" height="120">
-			</bounds>
+			<bounds x="751" y="5" width="83" height="120"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_button" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_button" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_button" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1manhat.lay
+++ b/src/mame/layout/m1manhat.lay
@@ -8,12648 +8,7838 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.33">
-			</color>
+			<color red="0.33" green="0.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.08">
-			</color>
+			<color red="0.08" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.66" green="0.00" blue="0.66">
-			</color>
+			<color red="0.66" green="0.00" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.00" blue="0.16">
-			</color>
+			<color red="0.16" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.66" green="0.00" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
+			<color red="0.12" green="0.50" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
+			<color red="0.24" green="1.00" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
+			<color red="0.12" green="0.50" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
+			<color red="0.24" green="1.00" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="NUMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="NUMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
+			<color red="0.12" green="0.50" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
+			<color red="0.24" green="1.00" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="HI-LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="HI-LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
+			<color red="0.12" green="0.50" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
+			<color red="0.24" green="1.00" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="SCORCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="SCORCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
+			<color red="0.12" green="0.50" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
+			<color red="0.24" green="1.00" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="FREE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="FREE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GAME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.33">
-			</color>
+			<color red="0.33" green="0.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.08">
-			</color>
+			<color red="0.08" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.66" green="0.00" blue="0.66">
-			</color>
+			<color red="0.66" green="0.00" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.00" blue="0.16">
-			</color>
+			<color red="0.16" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.66" green="0.00" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.00">
-			</color>
+			<color red="0.49" green="0.16" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.32" blue="0.00">
-			</color>
+			<color red="0.99" green="0.32" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.00">
-			</color>
+			<color red="0.25" green="0.08" blue="0.00"/>
 		</rect>
 		<text string="T CHANCE  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.32" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.00">
-			</color>
-		</rect>
-		<text string="T CHANCE  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.00">
-			</color>
+			<color red="0.49" green="0.16" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.32" blue="0.00">
-			</color>
+			<color red="0.99" green="0.32" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.00">
-			</color>
+			<color red="0.25" green="0.08" blue="0.00"/>
 		</rect>
 		<text string="   &#xA3;2.40 + RP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.32" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.00">
-			</color>
-		</rect>
-		<text string="   &#xA3;2.40 + RP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="       REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="       REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SKILL     ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SKILL     ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.13">
-			</color>
+			<color red="0.50" green="0.31" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
+			<color red="0.12" green="0.07" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.25">
-			</color>
+			<color red="1.00" green="0.62" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
+			<color red="0.25" green="0.15" blue="0.06"/>
 		</rect>
 		<text string="  CASH A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
-		</rect>
-		<text string="  CASH A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.13">
-			</color>
+			<color red="0.50" green="0.31" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
+			<color red="0.12" green="0.07" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.25">
-			</color>
+			<color red="1.00" green="0.62" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
+			<color red="0.25" green="0.15" blue="0.06"/>
 		</rect>
 		<text string="CCOUNT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
-		</rect>
-		<text string="CCOUNT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="      NUMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="      NUMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ER RUN     ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ER RUN     ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S       ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S       ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="UDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="UDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="       N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="       N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.04">
-			</color>
+			<color red="0.50" green="0.27" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.01">
-			</color>
+			<color red="0.12" green="0.07" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.08">
-			</color>
+			<color red="1.00" green="0.54" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.02">
-			</color>
+			<color red="0.25" green="0.13" blue="0.02"/>
 		</rect>
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.02">
-			</color>
-		</rect>
-		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.08">
-			</color>
+			<color red="0.50" green="0.29" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.17">
-			</color>
+			<color red="1.00" green="0.58" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.04">
-			</color>
+			<color red="0.25" green="0.15" blue="0.04"/>
 		</rect>
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.04">
-			</color>
-		</rect>
-		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.08">
-			</color>
+			<color red="0.50" green="0.29" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.17">
-			</color>
+			<color red="1.00" green="0.58" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.04">
-			</color>
+			<color red="0.25" green="0.15" blue="0.04"/>
 		</rect>
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.04">
-			</color>
-		</rect>
-		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.13">
-			</color>
+			<color red="0.50" green="0.31" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
+			<color red="0.12" green="0.07" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.25">
-			</color>
+			<color red="1.00" green="0.62" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
+			<color red="0.25" green="0.15" blue="0.06"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.16">
-			</color>
+			<color red="0.50" green="0.33" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.04">
-			</color>
+			<color red="0.12" green="0.08" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.33">
-			</color>
+			<color red="1.00" green="0.67" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.08">
-			</color>
+			<color red="0.25" green="0.16" blue="0.08"/>
 		</rect>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.08">
-			</color>
-		</rect>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.04">
-			</color>
+			<color red="0.50" green="0.27" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.01">
-			</color>
+			<color red="0.12" green="0.07" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.08">
-			</color>
+			<color red="1.00" green="0.54" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.02">
-			</color>
+			<color red="0.25" green="0.13" blue="0.02"/>
 		</rect>
 		<text string="WINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.02">
-			</color>
-		</rect>
-		<text string="WINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.04">
-			</color>
+			<color red="0.50" green="0.27" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.01">
-			</color>
+			<color red="0.12" green="0.07" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.08">
-			</color>
+			<color red="1.00" green="0.54" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.02">
-			</color>
+			<color red="0.25" green="0.13" blue="0.02"/>
 		</rect>
 		<text string="UNLIM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.02">
-			</color>
-		</rect>
-		<text string="UNLIM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.04">
-			</color>
+			<color red="0.50" green="0.27" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.01">
-			</color>
+			<color red="0.12" green="0.07" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.08">
-			</color>
+			<color red="1.00" green="0.54" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.02">
-			</color>
+			<color red="0.25" green="0.13" blue="0.02"/>
 		</rect>
 		<text string="ITED  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.02">
-			</color>
-		</rect>
-		<text string="ITED  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.00">
-			</color>
+			<color red="0.49" green="0.16" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.32" blue="0.00">
-			</color>
+			<color red="0.99" green="0.32" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.00">
-			</color>
+			<color red="0.25" green="0.08" blue="0.00"/>
 		</rect>
 		<text string="ONEY    ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.32" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.00">
-			</color>
-		</rect>
-		<text string="ONEY    ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.00">
-			</color>
+			<color red="0.49" green="0.16" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.32" blue="0.00">
-			</color>
+			<color red="0.99" green="0.32" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.00">
-			</color>
+			<color red="0.25" green="0.08" blue="0.00"/>
 		</rect>
 		<text string="    BIG M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.32" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.00">
-			</color>
-		</rect>
-		<text string="    BIG M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="     NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="     NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GES     ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GES     ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.35" blue="0.00">
-			</color>
+			<color red="0.00" green="0.35" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
+			<color red="0.00" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.70" blue="0.00">
-			</color>
+			<color red="0.00" green="0.70" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.00">
-			</color>
+			<color red="0.00" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.35" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.70" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.35" blue="0.00">
-			</color>
+			<color red="0.00" green="0.35" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
+			<color red="0.00" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.70" blue="0.00">
-			</color>
+			<color red="0.00" green="0.70" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.00">
-			</color>
+			<color red="0.00" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.35" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.70" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.35" blue="0.00">
-			</color>
+			<color red="0.00" green="0.35" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
+			<color red="0.00" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.70" blue="0.00">
-			</color>
+			<color red="0.00" green="0.70" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.00">
-			</color>
+			<color red="0.00" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.35" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.70" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.35" blue="0.00">
-			</color>
+			<color red="0.00" green="0.35" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
+			<color red="0.00" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.70" blue="0.00">
-			</color>
+			<color red="0.00" green="0.70" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.00">
-			</color>
+			<color red="0.00" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.35" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.70" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
+			<color red="0.00" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
+			<color red="0.00" green="0.94" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
+			<color red="0.00" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
+			<color red="0.00" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
+			<color red="0.00" green="0.94" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
+			<color red="0.00" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
+			<color red="0.00" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
+			<color red="0.00" green="0.94" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
+			<color red="0.00" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
+			<color red="0.00" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
+			<color red="0.00" green="0.94" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
+			<color red="0.00" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
+			<color red="0.00" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
+			<color red="0.00" green="0.94" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
+			<color red="0.00" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
+			<color red="0.00" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
+			<color red="0.00" green="0.94" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
+			<color red="0.00" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.94" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
+			<color red="0.00" green="0.79" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
+			<color red="0.00" green="0.79" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
+			<color red="0.00" green="0.79" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
+			<color red="0.00" green="0.79" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
+			<color red="0.00" green="0.79" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="90p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="90p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
+			<color red="0.00" green="0.79" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.79" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
+			<color red="0.00" green="0.65" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
+			<color red="0.00" green="0.65" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
+			<color red="0.00" green="0.65" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
+			<color red="0.00" green="0.65" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
+			<color red="0.00" green="0.65" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
+			<color red="0.00" green="0.65" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="70p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="70p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="1.00" blue="0.51">
-			</color>
+			<color red="0.51" green="1.00" blue="0.51"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="1.00" blue="0.51">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.49" blue="0.00">
-			</color>
+			<color red="0.00" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.99" blue="0.00">
-			</color>
+			<color red="0.00" green="0.99" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+ rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.99" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+ rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.49" blue="0.00">
-			</color>
+			<color red="0.00" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.99" blue="0.00">
-			</color>
+			<color red="0.00" green="0.99" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.99" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.49" blue="0.00">
-			</color>
+			<color red="0.00" green="0.49" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.99" blue="0.00">
-			</color>
+			<color red="0.00" green="0.99" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.49" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.99" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
+			<color red="0.12" green="0.50" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
+			<color red="0.24" green="1.00" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
+			<color red="0.12" green="0.50" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
+			<color red="0.24" green="1.00" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.12" green="0.50" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.24" green="1.00" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="WITH 50/50 HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="WITH 50/50 HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="BANK SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="BANK SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="        H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string=" SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="        H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SCORE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LD       ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SCORE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LD       ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_257_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.29" green="0.00" blue="0.00">
-			</color>
+			<color red="0.29" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.07" green="0.00" blue="0.00">
-			</color>
+			<color red="0.07" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_257_1" defstate="0">
 		<disk state="1">
-			<color red="0.59" green="0.00" blue="0.00">
-			</color>
+			<color red="0.59" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.15" green="0.00" blue="0.00">
-			</color>
+			<color red="0.15" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.29" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.07" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.59" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.15" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
+			<color red="0.00" green="0.65" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.65" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="SUPER HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="SUPER HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_206_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_206">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_207_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_207">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_208_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_208">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_209_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_209">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BANK ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_210_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_210">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_211_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_211">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_212_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_212">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_213_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_213">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_214_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_214">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_215_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_215">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_216_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_216">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_11">
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_14">
 		<text string="NO PRIZE GREATER IN VALUE THAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="FOUR POUNDS AND EIGHTY PENCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="CAN BE WON FROM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="THIS MACHINE IN ANY ONE GAME.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="label_86">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="CASH ACCOUNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_135">
 		<text string="v2.1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_162">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_164">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_172">
 		<text string="SUPERSCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="821" height="662">
-			</bounds>
+			<bounds x="0" y="0" width="821" height="662"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="116" y="387" width="80" height="168">
-			</bounds>
+			<bounds x="116" y="387" width="80" height="168"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="387.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="116.0000" y="387.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="119.3333" y="389.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="119.3333" y="389.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="122.6667" y="391.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="122.6667" y="391.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="126.0000" y="394.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="126.0000" y="394.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="129.3333" y="396.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="129.3333" y="396.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="132.6667" y="398.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="132.6667" y="398.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="443.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="116.0000" y="443.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="119.3333" y="445.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="119.3333" y="445.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="122.6667" y="447.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="122.6667" y="447.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="126.0000" y="450.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="126.0000" y="450.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="129.3333" y="452.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="129.3333" y="452.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="132.6667" y="454.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="132.6667" y="454.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="499.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="116.0000" y="499.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="119.3333" y="501.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="119.3333" y="501.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="122.6667" y="503.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="122.6667" y="503.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="126.0000" y="506.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="126.0000" y="506.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="129.3333" y="508.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="129.3333" y="508.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="132.6667" y="510.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="132.6667" y="510.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="116" y="387" width="80" height="168">
-			</bounds>
+			<bounds x="116" y="387" width="80" height="168"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="198" y="387" width="80" height="168">
-			</bounds>
+			<bounds x="198" y="387" width="80" height="168"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="387.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="198.0000" y="387.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="201.3333" y="389.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="201.3333" y="389.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="204.6667" y="391.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="204.6667" y="391.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="208.0000" y="394.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="208.0000" y="394.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="211.3333" y="396.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="211.3333" y="396.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="214.6667" y="398.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="214.6667" y="398.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="443.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="198.0000" y="443.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="201.3333" y="445.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="201.3333" y="445.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="204.6667" y="447.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="204.6667" y="447.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="208.0000" y="450.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="208.0000" y="450.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="211.3333" y="452.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="211.3333" y="452.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="214.6667" y="454.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="214.6667" y="454.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="499.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="198.0000" y="499.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="201.3333" y="501.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="201.3333" y="501.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="204.6667" y="503.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="204.6667" y="503.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="208.0000" y="506.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="208.0000" y="506.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="211.3333" y="508.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="211.3333" y="508.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="214.6667" y="510.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="214.6667" y="510.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="198" y="387" width="80" height="168">
-			</bounds>
+			<bounds x="198" y="387" width="80" height="168"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="280" y="387" width="80" height="168">
-			</bounds>
+			<bounds x="280" y="387" width="80" height="168"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="280.0000" y="387.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="280.0000" y="387.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="283.3333" y="389.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="283.3333" y="389.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="286.6667" y="391.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="286.6667" y="391.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="290.0000" y="394.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="290.0000" y="394.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="293.3333" y="396.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="293.3333" y="396.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="296.6667" y="398.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="296.6667" y="398.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="280.0000" y="443.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="280.0000" y="443.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="283.3333" y="445.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="283.3333" y="445.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="286.6667" y="447.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="286.6667" y="447.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="290.0000" y="450.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="290.0000" y="450.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="293.3333" y="452.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="293.3333" y="452.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="296.6667" y="454.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="296.6667" y="454.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="280.0000" y="499.0000" width="80.0000" height="56.0000">
-			</bounds>
+			<bounds x="280.0000" y="499.0000" width="80.0000" height="56.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="283.3333" y="501.3333" width="73.3333" height="51.3333">
-			</bounds>
+			<bounds x="283.3333" y="501.3333" width="73.3333" height="51.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="286.6667" y="503.6667" width="66.6667" height="46.6667">
-			</bounds>
+			<bounds x="286.6667" y="503.6667" width="66.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="290.0000" y="506.0000" width="60.0000" height="42.0000">
-			</bounds>
+			<bounds x="290.0000" y="506.0000" width="60.0000" height="42.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="293.3333" y="508.3333" width="53.3333" height="37.3333">
-			</bounds>
+			<bounds x="293.3333" y="508.3333" width="53.3333" height="37.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="296.6667" y="510.6667" width="46.6667" height="32.6667">
-			</bounds>
+			<bounds x="296.6667" y="510.6667" width="46.6667" height="32.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="280" y="387" width="80" height="168">
-			</bounds>
+			<bounds x="280" y="387" width="80" height="168"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="380" y="158" width="70" height="70">
-			</bounds>
+			<bounds x="380" y="158" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="380.0000" y="158.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="380.0000" y="158.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="382.9167" y="160.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="382.9167" y="160.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="385.8333" y="163.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="385.8333" y="163.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="388.7500" y="166.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="388.7500" y="166.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="391.6667" y="169.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="391.6667" y="169.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="394.5833" y="172.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="394.5833" y="172.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="380" y="158" width="70" height="70">
-			</bounds>
+			<bounds x="380" y="158" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="1" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="1" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="3" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="3" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="756" y="96" width="60" height="30">
-			</bounds>
+			<bounds x="756" y="96" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="758" y="98" width="56" height="26">
-			</bounds>
+			<bounds x="758" y="98" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="756" y="126" width="60" height="30">
-			</bounds>
+			<bounds x="756" y="126" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="758" y="128" width="56" height="26">
-			</bounds>
+			<bounds x="758" y="128" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="756" y="156" width="60" height="30">
-			</bounds>
+			<bounds x="756" y="156" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="758" y="158" width="56" height="26">
-			</bounds>
+			<bounds x="758" y="158" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="756" y="186" width="60" height="30">
-			</bounds>
+			<bounds x="756" y="186" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="758" y="188" width="56" height="26">
-			</bounds>
+			<bounds x="758" y="188" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="756" y="216" width="60" height="30">
-			</bounds>
+			<bounds x="756" y="216" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="758" y="218" width="56" height="26">
-			</bounds>
+			<bounds x="758" y="218" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="756" y="246" width="60" height="30">
-			</bounds>
+			<bounds x="756" y="246" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="758" y="248" width="56" height="26">
-			</bounds>
+			<bounds x="758" y="248" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="756" y="276" width="60" height="30">
-			</bounds>
+			<bounds x="756" y="276" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="758" y="278" width="56" height="26">
-			</bounds>
+			<bounds x="758" y="278" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="459" y="194" width="37" height="37">
-			</bounds>
+			<bounds x="459" y="194" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="461" y="196" width="33" height="33">
-			</bounds>
+			<bounds x="461" y="196" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="459" y="156" width="37" height="37">
-			</bounds>
+			<bounds x="459" y="156" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="461" y="158" width="33" height="33">
-			</bounds>
+			<bounds x="461" y="158" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="337" y="7" width="27" height="19">
-			</bounds>
+			<bounds x="337" y="7" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="339" y="9" width="23" height="15">
-			</bounds>
+			<bounds x="339" y="9" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="337" y="27" width="27" height="19">
-			</bounds>
+			<bounds x="337" y="27" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="339" y="29" width="23" height="15">
-			</bounds>
+			<bounds x="339" y="29" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="265" y="29" width="65" height="18">
-			</bounds>
+			<bounds x="265" y="29" width="65" height="18"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="267" y="31" width="61" height="14">
-			</bounds>
+			<bounds x="267" y="31" width="61" height="14"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="204" y="29" width="64" height="18">
-			</bounds>
+			<bounds x="204" y="29" width="64" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="206" y="31" width="60" height="14">
-			</bounds>
+			<bounds x="206" y="31" width="60" height="14"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="204" y="125" width="56" height="36">
-			</bounds>
+			<bounds x="204" y="125" width="56" height="36"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="206" y="127" width="52" height="32">
-			</bounds>
+			<bounds x="206" y="127" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="257" y="125" width="56" height="36">
-			</bounds>
+			<bounds x="257" y="125" width="56" height="36"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="259" y="127" width="52" height="32">
-			</bounds>
+			<bounds x="259" y="127" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="204" y="161" width="52" height="34">
-			</bounds>
+			<bounds x="204" y="161" width="52" height="34"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="206" y="163" width="48" height="30">
-			</bounds>
+			<bounds x="206" y="163" width="48" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="253" y="161" width="56" height="34">
-			</bounds>
+			<bounds x="253" y="161" width="56" height="34"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="255" y="163" width="52" height="30">
-			</bounds>
+			<bounds x="255" y="163" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="204" y="195" width="51" height="32">
-			</bounds>
+			<bounds x="204" y="195" width="51" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="206" y="197" width="47" height="28">
-			</bounds>
+			<bounds x="206" y="197" width="47" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="252" y="195" width="53" height="32">
-			</bounds>
+			<bounds x="252" y="195" width="53" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="254" y="197" width="49" height="28">
-			</bounds>
+			<bounds x="254" y="197" width="49" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="276" y="87" width="41" height="38">
-			</bounds>
+			<bounds x="276" y="87" width="41" height="38"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="278" y="89" width="37" height="34">
-			</bounds>
+			<bounds x="278" y="89" width="37" height="34"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="240" y="87" width="39" height="38">
-			</bounds>
+			<bounds x="240" y="87" width="39" height="38"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="242" y="89" width="35" height="34">
-			</bounds>
+			<bounds x="242" y="89" width="35" height="34"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="204" y="87" width="39" height="38">
-			</bounds>
+			<bounds x="204" y="87" width="39" height="38"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="206" y="89" width="35" height="34">
-			</bounds>
+			<bounds x="206" y="89" width="35" height="34"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="161" y="47" width="40" height="40">
-			</bounds>
+			<bounds x="161" y="47" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="163" y="49" width="36" height="36">
-			</bounds>
+			<bounds x="163" y="49" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="163" y="87" width="38" height="38">
-			</bounds>
+			<bounds x="163" y="87" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="165" y="89" width="34" height="34">
-			</bounds>
+			<bounds x="165" y="89" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="165" y="125" width="36" height="36">
-			</bounds>
+			<bounds x="165" y="125" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="167" y="127" width="32" height="32">
-			</bounds>
+			<bounds x="167" y="127" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="167" y="161" width="34" height="34">
-			</bounds>
+			<bounds x="167" y="161" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="169" y="163" width="30" height="30">
-			</bounds>
+			<bounds x="169" y="163" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="169" y="195" width="32" height="32">
-			</bounds>
+			<bounds x="169" y="195" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="171" y="197" width="28" height="28">
-			</bounds>
+			<bounds x="171" y="197" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="159" y="5" width="42" height="42">
-			</bounds>
+			<bounds x="159" y="5" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="161" y="7" width="38" height="38">
-			</bounds>
+			<bounds x="161" y="7" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="204" y="47" width="44" height="40">
-			</bounds>
+			<bounds x="204" y="47" width="44" height="40"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="206" y="49" width="40" height="36">
-			</bounds>
+			<bounds x="206" y="49" width="40" height="36"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="245" y="47" width="42" height="40">
-			</bounds>
+			<bounds x="245" y="47" width="42" height="40"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="247" y="49" width="38" height="36">
-			</bounds>
+			<bounds x="247" y="49" width="38" height="36"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="284" y="47" width="40" height="40">
-			</bounds>
+			<bounds x="284" y="47" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="286" y="49" width="36" height="36">
-			</bounds>
+			<bounds x="286" y="49" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="265" y="5" width="65" height="27">
-			</bounds>
+			<bounds x="265" y="5" width="65" height="27"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="267" y="7" width="61" height="23">
-			</bounds>
+			<bounds x="267" y="7" width="61" height="23"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="204" y="5" width="65" height="27">
-			</bounds>
+			<bounds x="204" y="5" width="65" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="206" y="7" width="61" height="23">
-			</bounds>
+			<bounds x="206" y="7" width="61" height="23"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="27" y="6" width="42" height="27">
-			</bounds>
+			<bounds x="27" y="6" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="29" y="8" width="38" height="23">
-			</bounds>
+			<bounds x="29" y="8" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="66" y="6" width="42" height="27">
-			</bounds>
+			<bounds x="66" y="6" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="68" y="8" width="38" height="23">
-			</bounds>
+			<bounds x="68" y="8" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="69" y="47" width="32" height="32">
-			</bounds>
+			<bounds x="69" y="47" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="71" y="49" width="28" height="28">
-			</bounds>
+			<bounds x="71" y="49" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="69" y="80" width="32" height="32">
-			</bounds>
+			<bounds x="69" y="80" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="71" y="82" width="28" height="28">
-			</bounds>
+			<bounds x="71" y="82" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="69" y="113" width="32" height="32">
-			</bounds>
+			<bounds x="69" y="113" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="71" y="115" width="28" height="28">
-			</bounds>
+			<bounds x="71" y="115" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="69" y="146" width="32" height="32">
-			</bounds>
+			<bounds x="69" y="146" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="71" y="148" width="28" height="28">
-			</bounds>
+			<bounds x="71" y="148" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="36" y="134" width="32" height="32">
-			</bounds>
+			<bounds x="36" y="134" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="38" y="136" width="28" height="28">
-			</bounds>
+			<bounds x="38" y="136" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="36" y="101" width="32" height="32">
-			</bounds>
+			<bounds x="36" y="101" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="38" y="103" width="28" height="28">
-			</bounds>
+			<bounds x="38" y="103" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="36" y="68" width="32" height="32">
-			</bounds>
+			<bounds x="36" y="68" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="38" y="70" width="28" height="28">
-			</bounds>
+			<bounds x="38" y="70" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="36" y="35" width="32" height="32">
-			</bounds>
+			<bounds x="36" y="35" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="38" y="37" width="28" height="28">
-			</bounds>
+			<bounds x="38" y="37" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="368" y="18" width="47" height="19">
-			</bounds>
+			<bounds x="368" y="18" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="370" y="20" width="43" height="15">
-			</bounds>
+			<bounds x="370" y="20" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="619" y="446" width="42" height="32">
-			</bounds>
+			<bounds x="619" y="446" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="621" y="448" width="38" height="28">
-			</bounds>
+			<bounds x="621" y="448" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="577" y="446" width="42" height="32">
-			</bounds>
+			<bounds x="577" y="446" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="579" y="448" width="38" height="28">
-			</bounds>
+			<bounds x="579" y="448" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="535" y="446" width="42" height="32">
-			</bounds>
+			<bounds x="535" y="446" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="537" y="448" width="38" height="28">
-			</bounds>
+			<bounds x="537" y="448" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="493" y="446" width="42" height="32">
-			</bounds>
+			<bounds x="493" y="446" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="495" y="448" width="38" height="28">
-			</bounds>
+			<bounds x="495" y="448" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="451" y="446" width="42" height="32">
-			</bounds>
+			<bounds x="451" y="446" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="453" y="448" width="38" height="28">
-			</bounds>
+			<bounds x="453" y="448" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="409" y="446" width="42" height="32">
-			</bounds>
+			<bounds x="409" y="446" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="411" y="448" width="38" height="28">
-			</bounds>
+			<bounds x="411" y="448" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="409" y="478" width="42" height="32">
-			</bounds>
+			<bounds x="409" y="478" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="411" y="480" width="38" height="28">
-			</bounds>
+			<bounds x="411" y="480" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="451" y="478" width="42" height="32">
-			</bounds>
+			<bounds x="451" y="478" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="453" y="480" width="38" height="28">
-			</bounds>
+			<bounds x="453" y="480" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="493" y="478" width="42" height="32">
-			</bounds>
+			<bounds x="493" y="478" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="495" y="480" width="38" height="28">
-			</bounds>
+			<bounds x="495" y="480" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="535" y="478" width="42" height="32">
-			</bounds>
+			<bounds x="535" y="478" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="537" y="480" width="38" height="28">
-			</bounds>
+			<bounds x="537" y="480" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="577" y="478" width="42" height="32">
-			</bounds>
+			<bounds x="577" y="478" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="579" y="480" width="38" height="28">
-			</bounds>
+			<bounds x="579" y="480" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="619" y="478" width="42" height="32">
-			</bounds>
+			<bounds x="619" y="478" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="621" y="480" width="38" height="28">
-			</bounds>
+			<bounds x="621" y="480" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="577" y="510" width="42" height="32">
-			</bounds>
+			<bounds x="577" y="510" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="579" y="512" width="38" height="28">
-			</bounds>
+			<bounds x="579" y="512" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="535" y="510" width="42" height="32">
-			</bounds>
+			<bounds x="535" y="510" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="537" y="512" width="38" height="28">
-			</bounds>
+			<bounds x="537" y="512" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="493" y="510" width="42" height="32">
-			</bounds>
+			<bounds x="493" y="510" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="495" y="512" width="38" height="28">
-			</bounds>
+			<bounds x="495" y="512" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="451" y="510" width="42" height="32">
-			</bounds>
+			<bounds x="451" y="510" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="453" y="512" width="38" height="28">
-			</bounds>
+			<bounds x="453" y="512" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="409" y="510" width="42" height="32">
-			</bounds>
+			<bounds x="409" y="510" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="411" y="512" width="38" height="28">
-			</bounds>
+			<bounds x="411" y="512" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="619" y="510" width="42" height="32">
-			</bounds>
+			<bounds x="619" y="510" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="621" y="512" width="38" height="28">
-			</bounds>
+			<bounds x="621" y="512" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="514" y="351" width="42" height="32">
-			</bounds>
+			<bounds x="514" y="351" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="516" y="353" width="38" height="28">
-			</bounds>
+			<bounds x="516" y="353" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="438" y="414" width="42" height="32">
-			</bounds>
+			<bounds x="438" y="414" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="440" y="416" width="38" height="28">
-			</bounds>
+			<bounds x="440" y="416" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="514" y="414" width="42" height="32">
-			</bounds>
+			<bounds x="514" y="414" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="516" y="416" width="38" height="28">
-			</bounds>
+			<bounds x="516" y="416" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="589" y="414" width="42" height="32">
-			</bounds>
+			<bounds x="589" y="414" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="591" y="416" width="38" height="28">
-			</bounds>
+			<bounds x="591" y="416" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="554" y="382" width="42" height="32">
-			</bounds>
+			<bounds x="554" y="382" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="556" y="384" width="38" height="28">
-			</bounds>
+			<bounds x="556" y="384" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="474" y="382" width="42" height="32">
-			</bounds>
+			<bounds x="474" y="382" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="476" y="384" width="38" height="28">
-			</bounds>
+			<bounds x="476" y="384" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="20" y="302" width="102" height="19">
-			</bounds>
+			<bounds x="20" y="302" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="22" y="304" width="98" height="15">
-			</bounds>
+			<bounds x="22" y="304" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="20" y="287" width="102" height="19">
-			</bounds>
+			<bounds x="20" y="287" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="22" y="289" width="98" height="15">
-			</bounds>
+			<bounds x="22" y="289" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="21" y="253" width="52" height="32">
-			</bounds>
+			<bounds x="21" y="253" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="23" y="255" width="48" height="28">
-			</bounds>
+			<bounds x="23" y="255" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="70" y="253" width="52" height="32">
-			</bounds>
+			<bounds x="70" y="253" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="72" y="255" width="48" height="28">
-			</bounds>
+			<bounds x="72" y="255" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp257" element="lamp_257_1_border" state="0">
-			<bounds x="199" y="227" width="82" height="27">
-			</bounds>
+			<bounds x="199" y="227" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp257" element="lamp_257_1" state="0">
-			<bounds x="201" y="229" width="78" height="23">
-			</bounds>
+			<bounds x="201" y="229" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="409" y="549" width="37" height="19">
-			</bounds>
+			<bounds x="409" y="549" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="411" y="551" width="33" height="15">
-			</bounds>
+			<bounds x="411" y="551" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="361" y="507" width="19" height="19">
-			</bounds>
+			<bounds x="361" y="507" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="363" y="509" width="15" height="15">
-			</bounds>
+			<bounds x="363" y="509" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="95" y="507" width="19" height="19">
-			</bounds>
+			<bounds x="95" y="507" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="97" y="509" width="15" height="15">
-			</bounds>
+			<bounds x="97" y="509" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="361" y="462" width="19" height="19">
-			</bounds>
+			<bounds x="361" y="462" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="363" y="464" width="15" height="15">
-			</bounds>
+			<bounds x="363" y="464" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="95" y="462" width="19" height="19">
-			</bounds>
+			<bounds x="95" y="462" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="97" y="464" width="15" height="15">
-			</bounds>
+			<bounds x="97" y="464" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="95" y="414" width="19" height="19">
-			</bounds>
+			<bounds x="95" y="414" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="97" y="416" width="15" height="15">
-			</bounds>
+			<bounds x="97" y="416" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="361" y="414" width="19" height="19">
-			</bounds>
+			<bounds x="361" y="414" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="363" y="416" width="15" height="15">
-			</bounds>
+			<bounds x="363" y="416" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="348" y="370" width="42" height="19">
-			</bounds>
+			<bounds x="348" y="370" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="350" y="372" width="38" height="15">
-			</bounds>
+			<bounds x="350" y="372" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="87" y="370" width="42" height="19">
-			</bounds>
+			<bounds x="87" y="370" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="89" y="372" width="38" height="15">
-			</bounds>
+			<bounds x="89" y="372" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="198" y="560" width="77" height="17">
-			</bounds>
+			<bounds x="198" y="560" width="77" height="17"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="200" y="562" width="73" height="13">
-			</bounds>
+			<bounds x="200" y="562" width="73" height="13"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="87" y="554" width="42" height="19">
-			</bounds>
+			<bounds x="87" y="554" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="89" y="556" width="38" height="15">
-			</bounds>
+			<bounds x="89" y="556" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="348" y="554" width="42" height="19">
-			</bounds>
+			<bounds x="348" y="554" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="350" y="556" width="38" height="15">
-			</bounds>
+			<bounds x="350" y="556" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_193_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="24" y="625" width="75" height="32">
-			</bounds>
+			<bounds x="24" y="625" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_193" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="26" y="627" width="71" height="28">
-			</bounds>
+			<bounds x="26" y="627" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_206_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="437" y="1" width="42" height="42">
-			</bounds>
+			<bounds x="437" y="1" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_206" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="439" y="3" width="38" height="38">
-			</bounds>
+			<bounds x="439" y="3" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_207_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="167" y="330" width="75" height="34">
-			</bounds>
+			<bounds x="167" y="330" width="75" height="34"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_207" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="169" y="332" width="71" height="30">
-			</bounds>
+			<bounds x="169" y="332" width="71" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_208_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="246" y="330" width="75" height="34">
-			</bounds>
+			<bounds x="246" y="330" width="75" height="34"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_208" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="248" y="332" width="71" height="30">
-			</bounds>
+			<bounds x="248" y="332" width="71" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="colour_button_209_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="36" y="329" width="75" height="34">
-			</bounds>
+			<bounds x="36" y="329" width="75" height="34"/>
 		</backdrop>
 		<backdrop name="lamp8" element="colour_button_209" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="38" y="331" width="71" height="30">
-			</bounds>
+			<bounds x="38" y="331" width="71" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_210_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="281" y="625" width="75" height="32">
-			</bounds>
+			<bounds x="281" y="625" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_210" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="283" y="627" width="71" height="28">
-			</bounds>
+			<bounds x="283" y="627" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_211_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="201" y="625" width="75" height="32">
-			</bounds>
+			<bounds x="201" y="625" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_211" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="203" y="627" width="71" height="28">
-			</bounds>
+			<bounds x="203" y="627" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_212_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="121" y="625" width="75" height="32">
-			</bounds>
+			<bounds x="121" y="625" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_212" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="123" y="627" width="71" height="28">
-			</bounds>
+			<bounds x="123" y="627" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_213_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="24" y="625" width="75" height="32">
-			</bounds>
+			<bounds x="24" y="625" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_213" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="26" y="627" width="71" height="28">
-			</bounds>
+			<bounds x="26" y="627" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_214_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="640" y="626" width="75" height="32">
-			</bounds>
+			<bounds x="640" y="626" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_214" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="642" y="628" width="71" height="28">
-			</bounds>
+			<bounds x="642" y="628" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_215_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="551" y="626" width="75" height="32">
-			</bounds>
+			<bounds x="551" y="626" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_215" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="553" y="628" width="71" height="28">
-			</bounds>
+			<bounds x="553" y="628" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_216_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="460" y="626" width="75" height="32">
-			</bounds>
+			<bounds x="460" y="626" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_216" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="462" y="628" width="71" height="28">
-			</bounds>
+			<bounds x="462" y="628" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="36" y="205" width="24" height="32">
-			</bounds>
+			<bounds x="36" y="205" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="39" y="207" width="17" height="2">
-			</bounds>
+			<bounds x="39" y="207" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="53" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="53" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="53" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="53" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="39" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="39" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="39" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="39" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="39" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="39" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="39" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="39" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="56" y="231" width="3" height="2">
-			</bounds>
+			<bounds x="56" y="231" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="39" y="207" width="17" height="2">
-			</bounds>
+			<bounds x="39" y="207" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="53" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="53" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="53" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="53" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="39" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="39" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="39" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="39" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="39" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="39" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="39" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="39" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="56" y="231" width="3" height="2">
-			</bounds>
+			<bounds x="56" y="231" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="60" y="205" width="24" height="32">
-			</bounds>
+			<bounds x="60" y="205" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="63" y="207" width="17" height="2">
-			</bounds>
+			<bounds x="63" y="207" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="77" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="77" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="77" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="77" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="63" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="63" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="63" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="63" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="63" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="63" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="63" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="63" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="80" y="231" width="3" height="2">
-			</bounds>
+			<bounds x="80" y="231" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="63" y="207" width="17" height="2">
-			</bounds>
+			<bounds x="63" y="207" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="77" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="77" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="77" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="77" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="63" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="63" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="63" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="63" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="63" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="63" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="63" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="63" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="80" y="231" width="3" height="2">
-			</bounds>
+			<bounds x="80" y="231" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="84" y="205" width="24" height="32">
-			</bounds>
+			<bounds x="84" y="205" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off112" element="led_off">
-			<bounds x="87" y="207" width="17" height="2">
-			</bounds>
+			<bounds x="87" y="207" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off113" element="led_off">
-			<bounds x="101" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="101" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off114" element="led_off">
-			<bounds x="101" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="101" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off115" element="led_off">
-			<bounds x="87" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="87" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off116" element="led_off">
-			<bounds x="87" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="87" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off117" element="led_off">
-			<bounds x="87" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="87" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off118" element="led_off">
-			<bounds x="87" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="87" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off119" element="led_dot_off">
-			<bounds x="104" y="231" width="3" height="2">
-			</bounds>
+			<bounds x="104" y="231" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp112" element="led_on">
-			<bounds x="87" y="207" width="17" height="2">
-			</bounds>
+			<bounds x="87" y="207" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp113" element="led_on">
-			<bounds x="101" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="101" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp114" element="led_on">
-			<bounds x="101" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="101" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp115" element="led_on">
-			<bounds x="87" y="231" width="17" height="2">
-			</bounds>
+			<bounds x="87" y="231" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp116" element="led_on">
-			<bounds x="87" y="219" width="3" height="14">
-			</bounds>
+			<bounds x="87" y="219" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp117" element="led_on">
-			<bounds x="87" y="207" width="3" height="14">
-			</bounds>
+			<bounds x="87" y="207" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp118" element="led_on">
-			<bounds x="87" y="219" width="17" height="2">
-			</bounds>
+			<bounds x="87" y="219" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp119" element="led_dot_on">
-			<bounds x="104" y="231" width="3" height="2">
-			</bounds>
+			<bounds x="104" y="231" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="412" y="62" width="60" height="80">
-			</bounds>
+			<bounds x="412" y="62" width="60" height="80"/>
 		</backdrop>
 		<backdrop name="led_off192" element="led_off">
-			<bounds x="420" y="69" width="42" height="7">
-			</bounds>
+			<bounds x="420" y="69" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off193" element="led_off">
-			<bounds x="454" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="454" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off194" element="led_off">
-			<bounds x="454" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="454" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off195" element="led_off">
-			<bounds x="420" y="127" width="42" height="7">
-			</bounds>
+			<bounds x="420" y="127" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off196" element="led_off">
-			<bounds x="420" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="420" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off197" element="led_off">
-			<bounds x="420" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="420" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off198" element="led_off">
-			<bounds x="420" y="98" width="42" height="7">
-			</bounds>
+			<bounds x="420" y="98" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off199" element="led_dot_off">
-			<bounds x="463" y="127" width="8" height="7">
-			</bounds>
+			<bounds x="463" y="127" width="8" height="7"/>
 		</backdrop>
 		<backdrop name="lamp192" element="led_on">
-			<bounds x="420" y="69" width="42" height="7">
-			</bounds>
+			<bounds x="420" y="69" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp193" element="led_on">
-			<bounds x="454" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="454" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp194" element="led_on">
-			<bounds x="454" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="454" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp195" element="led_on">
-			<bounds x="420" y="127" width="42" height="7">
-			</bounds>
+			<bounds x="420" y="127" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp196" element="led_on">
-			<bounds x="420" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="420" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp197" element="led_on">
-			<bounds x="420" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="420" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp198" element="led_on">
-			<bounds x="420" y="98" width="42" height="7">
-			</bounds>
+			<bounds x="420" y="98" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp199" element="led_dot_on">
-			<bounds x="463" y="127" width="8" height="7">
-			</bounds>
+			<bounds x="463" y="127" width="8" height="7"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="592" y="62" width="60" height="80">
-			</bounds>
+			<bounds x="592" y="62" width="60" height="80"/>
 		</backdrop>
 		<backdrop name="led_off216" element="led_off">
-			<bounds x="600" y="69" width="42" height="7">
-			</bounds>
+			<bounds x="600" y="69" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off217" element="led_off">
-			<bounds x="634" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="634" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off218" element="led_off">
-			<bounds x="634" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="634" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off219" element="led_off">
-			<bounds x="600" y="127" width="42" height="7">
-			</bounds>
+			<bounds x="600" y="127" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off220" element="led_off">
-			<bounds x="600" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="600" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off221" element="led_off">
-			<bounds x="600" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="600" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off222" element="led_off">
-			<bounds x="600" y="98" width="42" height="7">
-			</bounds>
+			<bounds x="600" y="98" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off223" element="led_dot_off">
-			<bounds x="643" y="127" width="8" height="7">
-			</bounds>
+			<bounds x="643" y="127" width="8" height="7"/>
 		</backdrop>
 		<backdrop name="lamp216" element="led_on">
-			<bounds x="600" y="69" width="42" height="7">
-			</bounds>
+			<bounds x="600" y="69" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp217" element="led_on">
-			<bounds x="634" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="634" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp218" element="led_on">
-			<bounds x="634" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="634" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp219" element="led_on">
-			<bounds x="600" y="127" width="42" height="7">
-			</bounds>
+			<bounds x="600" y="127" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp220" element="led_on">
-			<bounds x="600" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="600" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp221" element="led_on">
-			<bounds x="600" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="600" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp222" element="led_on">
-			<bounds x="600" y="98" width="42" height="7">
-			</bounds>
+			<bounds x="600" y="98" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp223" element="led_dot_on">
-			<bounds x="643" y="127" width="8" height="7">
-			</bounds>
+			<bounds x="643" y="127" width="8" height="7"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="532" y="62" width="60" height="80">
-			</bounds>
+			<bounds x="532" y="62" width="60" height="80"/>
 		</backdrop>
 		<backdrop name="led_off208" element="led_off">
-			<bounds x="540" y="69" width="42" height="7">
-			</bounds>
+			<bounds x="540" y="69" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off209" element="led_off">
-			<bounds x="574" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="574" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off210" element="led_off">
-			<bounds x="574" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="574" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off211" element="led_off">
-			<bounds x="540" y="127" width="42" height="7">
-			</bounds>
+			<bounds x="540" y="127" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off212" element="led_off">
-			<bounds x="540" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="540" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off213" element="led_off">
-			<bounds x="540" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="540" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off214" element="led_off">
-			<bounds x="540" y="98" width="42" height="7">
-			</bounds>
+			<bounds x="540" y="98" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off215" element="led_dot_off">
-			<bounds x="583" y="127" width="8" height="7">
-			</bounds>
+			<bounds x="583" y="127" width="8" height="7"/>
 		</backdrop>
 		<backdrop name="lamp208" element="led_on">
-			<bounds x="540" y="69" width="42" height="7">
-			</bounds>
+			<bounds x="540" y="69" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp209" element="led_on">
-			<bounds x="574" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="574" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp210" element="led_on">
-			<bounds x="574" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="574" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp211" element="led_on">
-			<bounds x="540" y="127" width="42" height="7">
-			</bounds>
+			<bounds x="540" y="127" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp212" element="led_on">
-			<bounds x="540" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="540" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp213" element="led_on">
-			<bounds x="540" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="540" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp214" element="led_on">
-			<bounds x="540" y="98" width="42" height="7">
-			</bounds>
+			<bounds x="540" y="98" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp215" element="led_dot_on">
-			<bounds x="583" y="127" width="8" height="7">
-			</bounds>
+			<bounds x="583" y="127" width="8" height="7"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="472" y="62" width="60" height="80">
-			</bounds>
+			<bounds x="472" y="62" width="60" height="80"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="480" y="69" width="42" height="7">
-			</bounds>
+			<bounds x="480" y="69" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="514" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="514" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="514" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="514" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="480" y="127" width="42" height="7">
-			</bounds>
+			<bounds x="480" y="127" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="480" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="480" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="480" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="480" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="480" y="98" width="42" height="7">
-			</bounds>
+			<bounds x="480" y="98" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="523" y="127" width="8" height="7">
-			</bounds>
+			<bounds x="523" y="127" width="8" height="7"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="480" y="69" width="42" height="7">
-			</bounds>
+			<bounds x="480" y="69" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="514" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="514" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="514" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="514" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="480" y="127" width="42" height="7">
-			</bounds>
+			<bounds x="480" y="127" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="480" y="98" width="8" height="36">
-			</bounds>
+			<bounds x="480" y="98" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="480" y="69" width="8" height="36">
-			</bounds>
+			<bounds x="480" y="69" width="8" height="36"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="480" y="98" width="42" height="7">
-			</bounds>
+			<bounds x="480" y="98" width="42" height="7"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="523" y="127" width="8" height="7">
-			</bounds>
+			<bounds x="523" y="127" width="8" height="7"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="714" y="490" width="24" height="32">
-			</bounds>
+			<bounds x="714" y="490" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="717" y="492" width="17" height="2">
-			</bounds>
+			<bounds x="717" y="492" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="731" y="492" width="3" height="14">
-			</bounds>
+			<bounds x="731" y="492" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="731" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="731" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="717" y="516" width="17" height="2">
-			</bounds>
+			<bounds x="717" y="516" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="717" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="717" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="717" y="492" width="3" height="14">
-			</bounds>
+			<bounds x="717" y="492" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="717" y="504" width="17" height="2">
-			</bounds>
+			<bounds x="717" y="504" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="734" y="516" width="3" height="2">
-			</bounds>
+			<bounds x="734" y="516" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="717" y="492" width="17" height="2">
-			</bounds>
+			<bounds x="717" y="492" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="731" y="492" width="3" height="14">
-			</bounds>
+			<bounds x="731" y="492" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="731" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="731" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="717" y="516" width="17" height="2">
-			</bounds>
+			<bounds x="717" y="516" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="717" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="717" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="717" y="492" width="3" height="14">
-			</bounds>
+			<bounds x="717" y="492" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="717" y="504" width="17" height="2">
-			</bounds>
+			<bounds x="717" y="504" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="734" y="516" width="3" height="2">
-			</bounds>
+			<bounds x="734" y="516" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="738" y="490" width="24" height="32">
-			</bounds>
+			<bounds x="738" y="490" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="741" y="492" width="17" height="2">
-			</bounds>
+			<bounds x="741" y="492" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="755" y="492" width="3" height="14">
-			</bounds>
+			<bounds x="755" y="492" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="755" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="755" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="741" y="516" width="17" height="2">
-			</bounds>
+			<bounds x="741" y="516" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="741" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="741" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="741" y="492" width="3" height="14">
-			</bounds>
+			<bounds x="741" y="492" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="741" y="504" width="17" height="2">
-			</bounds>
+			<bounds x="741" y="504" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="758" y="516" width="3" height="2">
-			</bounds>
+			<bounds x="758" y="516" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="741" y="492" width="17" height="2">
-			</bounds>
+			<bounds x="741" y="492" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="755" y="492" width="3" height="14">
-			</bounds>
+			<bounds x="755" y="492" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="755" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="755" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="741" y="516" width="17" height="2">
-			</bounds>
+			<bounds x="741" y="516" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="741" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="741" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="741" y="492" width="3" height="14">
-			</bounds>
+			<bounds x="741" y="492" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="741" y="504" width="17" height="2">
-			</bounds>
+			<bounds x="741" y="504" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="758" y="516" width="3" height="2">
-			</bounds>
+			<bounds x="758" y="516" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="265" y="256" width="50" height="50">
-			</bounds>
+			<bounds x="265" y="256" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="272" y="260" width="35" height="4">
-			</bounds>
+			<bounds x="272" y="260" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="300" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="300" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="300" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="300" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="272" y="296" width="35" height="4">
-			</bounds>
+			<bounds x="272" y="296" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="272" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="272" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="272" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="272" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="272" y="278" width="35" height="4">
-			</bounds>
+			<bounds x="272" y="278" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="307" y="296" width="7" height="4">
-			</bounds>
+			<bounds x="307" y="296" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="272" y="260" width="35" height="4">
-			</bounds>
+			<bounds x="272" y="260" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="300" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="300" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="300" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="300" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="272" y="296" width="35" height="4">
-			</bounds>
+			<bounds x="272" y="296" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="272" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="272" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="272" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="272" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="272" y="278" width="35" height="4">
-			</bounds>
+			<bounds x="272" y="278" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="307" y="296" width="7" height="4">
-			</bounds>
+			<bounds x="307" y="296" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="215" y="256" width="50" height="50">
-			</bounds>
+			<bounds x="215" y="256" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="222" y="260" width="35" height="4">
-			</bounds>
+			<bounds x="222" y="260" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="250" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="250" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="250" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="250" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="222" y="296" width="35" height="4">
-			</bounds>
+			<bounds x="222" y="296" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="222" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="222" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="222" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="222" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="222" y="278" width="35" height="4">
-			</bounds>
+			<bounds x="222" y="278" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="257" y="296" width="7" height="4">
-			</bounds>
+			<bounds x="257" y="296" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="222" y="260" width="35" height="4">
-			</bounds>
+			<bounds x="222" y="260" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="250" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="250" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="250" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="250" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="222" y="296" width="35" height="4">
-			</bounds>
+			<bounds x="222" y="296" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="222" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="222" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="222" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="222" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="222" y="278" width="35" height="4">
-			</bounds>
+			<bounds x="222" y="278" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="257" y="296" width="7" height="4">
-			</bounds>
+			<bounds x="257" y="296" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="165" y="256" width="50" height="50">
-			</bounds>
+			<bounds x="165" y="256" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="172" y="260" width="35" height="4">
-			</bounds>
+			<bounds x="172" y="260" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="200" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="200" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="200" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="200" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="172" y="296" width="35" height="4">
-			</bounds>
+			<bounds x="172" y="296" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="172" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="172" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="172" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="172" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="172" y="278" width="35" height="4">
-			</bounds>
+			<bounds x="172" y="278" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="207" y="296" width="7" height="4">
-			</bounds>
+			<bounds x="207" y="296" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="172" y="260" width="35" height="4">
-			</bounds>
+			<bounds x="172" y="260" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="200" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="200" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="200" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="200" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="172" y="296" width="35" height="4">
-			</bounds>
+			<bounds x="172" y="296" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="172" y="278" width="7" height="22">
-			</bounds>
+			<bounds x="172" y="278" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="172" y="260" width="7" height="22">
-			</bounds>
+			<bounds x="172" y="260" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="172" y="278" width="35" height="4">
-			</bounds>
+			<bounds x="172" y="278" width="35" height="4"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="207" y="296" width="7" height="4">
-			</bounds>
+			<bounds x="207" y="296" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="505" y="9" width="22" height="16">
-			</bounds>
+			<bounds x="505" y="9" width="22" height="16"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="530" y="9" width="33" height="16">
-			</bounds>
+			<bounds x="530" y="9" width="33" height="16"/>
 		</backdrop>
 		<backdrop name="label14" element="label_14">
-			<bounds x="650" y="5" width="166" height="48">
-			</bounds>
+			<bounds x="650" y="5" width="166" height="48"/>
 		</backdrop>
 		<backdrop name="label86" element="label_86">
-			<bounds x="349" y="48" width="53" height="111">
-			</bounds>
+			<bounds x="349" y="48" width="53" height="111"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="29" y="191" width="86" height="14">
-			</bounds>
+			<bounds x="29" y="191" width="86" height="14"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="485" y="39" width="105" height="24">
-			</bounds>
+			<bounds x="485" y="39" width="105" height="24"/>
 		</backdrop>
 		<backdrop name="label135" element="label_135">
-			<bounds x="797" y="645" width="19" height="12">
-			</bounds>
+			<bounds x="797" y="645" width="19" height="12"/>
 		</backdrop>
 		<backdrop name="label162" element="label_162">
-			<bounds x="722" y="523" width="35" height="14">
-			</bounds>
+			<bounds x="722" y="523" width="35" height="14"/>
 		</backdrop>
 		<backdrop name="label164" element="label_164">
-			<bounds x="690" y="459" width="102" height="12">
-			</bounds>
+			<bounds x="690" y="459" width="102" height="12"/>
 		</backdrop>
 		<backdrop name="label172" element="label_172">
-			<bounds x="194" y="309" width="89" height="16">
-			</bounds>
+			<bounds x="194" y="309" width="89" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_button" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_button" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_button" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1monclb.lay
+++ b/src/mame/layout/m1monclb.lay
@@ -6,19070 +6,10300 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png">
-		</image>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="P'ville">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="P'ville">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="In">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="In">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Visiting">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Visiting">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Pall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Mall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Mall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Electric Co.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Electric Co.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="W'hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="W'hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="N'land">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Avenue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="N'land">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Avenue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Euston">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Euston">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="M'rough">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="M'rough">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="M'bone">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="M'bone">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Angel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Islington">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Angel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Islington">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="King's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="King's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Go">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Go">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Old Kent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Old Kent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Comm.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Comm.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="W'chapel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="W'chapel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Income">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Income">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Park Lane">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Park Lane">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Liverpool Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Liverpool Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bond">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bond">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Oxford Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Oxford Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Regent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Regent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Vine">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Vine">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Parking">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Parking">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Strand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Strand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Trafalgar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Trafalgar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Fenchu'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Fenchu'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Leicester">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Leicester">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Conventry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Conventry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Water">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="Works">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Water">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="Works">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Go To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Go To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Fleet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fleet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="u">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="u">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_150_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_152_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_153_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_155_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_156_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_158_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_137_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_137_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_136_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_136_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_147_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_148_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_148_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_145_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_145_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_143_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_143_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_142_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_142_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_140_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_140_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_134_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_134_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_131_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_129_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_166_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_166_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_160_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_161_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_163_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_168_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Next Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Next Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Crossword">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Competition">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Crossword">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Competition">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="House Repairs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="House Repairs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="House">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Multipli">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="House">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Multipli">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Back To Old Kent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Back To Old Kent">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Go To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Go To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Throw 8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Or More">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Throw 8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Or More">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Get Out Of Jail Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Get Out Of Jail Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Advance To Pall Mall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Advance To Pall Mall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Double Or Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Double Or Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_209_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bond">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bond">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Regent Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Regent Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Oxford Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Oxford Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_199_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Coventry Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Coventry Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Leicester Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Leicester Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_207_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Trafalgar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Trafalgar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_191_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Strand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Strand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Fleet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fleet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="M'rough">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="M'rough">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Vine">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Vine">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_206_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_190_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_190_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_197_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_197_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_205_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="N'land">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Avenue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="N'land">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Avenue">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Pall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Mall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Mall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="W'hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="W'hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_195_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Euston">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Euston">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Angel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Islingto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Angel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Islingto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_188_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="P'ville Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="P'ville Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_204_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_203_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="W'chapel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="W'chapel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Old Kent Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Old Kent Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Park">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lane">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Park">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Lane">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Stop A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Stop A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Choose A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Choose A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Notation">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Notation">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Monopoly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Monopoly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Hi / Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Hi / Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Choose A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Choose A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Station Repairs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Station Repairs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Nudge Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Nudge Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_239_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_239_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="King's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="King's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_238_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_238_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="M'bone">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="M'bone">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_237_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_237_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Fenchu'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fenchu'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_236_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_236_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Liverpool Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Liverpool Street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_183_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="x10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="x10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_186_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="x4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="x4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="x3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="x3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_184_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="x5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="x5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;250.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;250.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;50.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;50.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;40.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;40.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;30.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;30.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;25.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;25.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;100.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;100.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;75.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;75.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;200.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;200.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="When Lit Press Stop For Winning Shuffle After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="When Lit Press Stop For Winning Shuffle After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_300_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_300">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Collect Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_301_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_301">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_302_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_302">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_303_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_303">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_304_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_304">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_305_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_305">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_306_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_306">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_307_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_307">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_308_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_308">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_309_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_309">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_310_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_310">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_5">
 		<text string="V1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_139">
 		<text string="CASH POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_150">
 		<text string="Awards Cash Track">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_157">
 		<text string="Awards Monopoly Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_182">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_183">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_198">
 		<text string="Nudge Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
-			<bounds x="0" y="0" width="1013" height="660">
-			</bounds>
+		<backdrop element="backdrop_colour">
+			<bounds x="0" y="0" width="1013" height="660"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="145" y="400" width="80" height="140">
-			</bounds>
+			<bounds x="145" y="400" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="145.0000" y="400.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="145.0000" y="400.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="148.3333" y="401.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="148.3333" y="401.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="151.6667" y="403.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="151.6667" y="403.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="155.0000" y="405.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="155.0000" y="405.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="158.3333" y="407.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="158.3333" y="407.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="161.6667" y="409.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="161.6667" y="409.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="145.0000" y="446.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="145.0000" y="446.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="148.3333" y="448.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="148.3333" y="448.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="151.6667" y="450.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="151.6667" y="450.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="155.0000" y="452.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="155.0000" y="452.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="158.3333" y="454.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="158.3333" y="454.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="161.6667" y="456.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="161.6667" y="456.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="145.0000" y="493.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="145.0000" y="493.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="148.3333" y="495.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="148.3333" y="495.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="151.6667" y="497.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="151.6667" y="497.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="155.0000" y="499.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="155.0000" y="499.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="158.3333" y="501.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="158.3333" y="501.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="161.6667" y="503.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="161.6667" y="503.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="145" y="400" width="80" height="140">
-			</bounds>
+			<bounds x="145" y="400" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="235" y="400" width="80" height="140">
-			</bounds>
+			<bounds x="235" y="400" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="235.0000" y="400.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="235.0000" y="400.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="238.3333" y="401.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="238.3333" y="401.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="241.6667" y="403.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="241.6667" y="403.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="245.0000" y="405.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="245.0000" y="405.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="248.3333" y="407.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="248.3333" y="407.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="251.6667" y="409.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="251.6667" y="409.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="235.0000" y="446.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="235.0000" y="446.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="238.3333" y="448.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="238.3333" y="448.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="241.6667" y="450.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="241.6667" y="450.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="245.0000" y="452.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="245.0000" y="452.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="248.3333" y="454.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="248.3333" y="454.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="251.6667" y="456.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="251.6667" y="456.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="235.0000" y="493.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="235.0000" y="493.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="238.3333" y="495.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="238.3333" y="495.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="241.6667" y="497.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="241.6667" y="497.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="245.0000" y="499.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="245.0000" y="499.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="248.3333" y="501.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="248.3333" y="501.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="251.6667" y="503.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="251.6667" y="503.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="235" y="400" width="80" height="140">
-			</bounds>
+			<bounds x="235" y="400" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="325" y="400" width="80" height="140">
-			</bounds>
+			<bounds x="325" y="400" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="325.0000" y="400.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="325.0000" y="400.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="328.3333" y="401.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="328.3333" y="401.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="331.6667" y="403.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="331.6667" y="403.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="335.0000" y="405.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="335.0000" y="405.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="338.3333" y="407.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="338.3333" y="407.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="341.6667" y="409.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="341.6667" y="409.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="325.0000" y="446.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="325.0000" y="446.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="328.3333" y="448.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="328.3333" y="448.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="331.6667" y="450.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="331.6667" y="450.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="335.0000" y="452.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="335.0000" y="452.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="338.3333" y="454.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="338.3333" y="454.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="341.6667" y="456.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="341.6667" y="456.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="325.0000" y="493.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="325.0000" y="493.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="328.3333" y="495.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="328.3333" y="495.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="331.6667" y="497.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="331.6667" y="497.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="335.0000" y="499.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="335.0000" y="499.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="338.3333" y="501.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="338.3333" y="501.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="341.6667" y="503.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="341.6667" y="503.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="325" y="400" width="80" height="140">
-			</bounds>
+			<bounds x="325" y="400" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="415" y="400" width="80" height="140">
-			</bounds>
+			<bounds x="415" y="400" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="415.0000" y="400.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="415.0000" y="400.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="418.3333" y="401.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="418.3333" y="401.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="421.6667" y="403.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="421.6667" y="403.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="425.0000" y="405.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="425.0000" y="405.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="428.3333" y="407.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="428.3333" y="407.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="431.6667" y="409.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="431.6667" y="409.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="415.0000" y="446.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="415.0000" y="446.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="418.3333" y="448.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="418.3333" y="448.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="421.6667" y="450.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="421.6667" y="450.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="425.0000" y="452.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="425.0000" y="452.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="428.3333" y="454.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="428.3333" y="454.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="431.6667" y="456.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="431.6667" y="456.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="415.0000" y="493.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="415.0000" y="493.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="418.3333" y="495.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="418.3333" y="495.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="421.6667" y="497.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="421.6667" y="497.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="425.0000" y="499.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="425.0000" y="499.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="428.3333" y="501.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="428.3333" y="501.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="431.6667" y="503.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="431.6667" y="503.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="415" y="400" width="80" height="140">
-			</bounds>
+			<bounds x="415" y="400" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="300" y="250" width="75" height="60">
-			</bounds>
+			<bounds x="300" y="250" width="75" height="60"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="300.0000" y="250.0000" width="75.0000" height="60.0000">
-			</bounds>
+			<bounds x="300.0000" y="250.0000" width="75.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="303.1250" y="252.5000" width="68.7500" height="55.0000">
-			</bounds>
+			<bounds x="303.1250" y="252.5000" width="68.7500" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="306.2500" y="255.0000" width="62.5000" height="50.0000">
-			</bounds>
+			<bounds x="306.2500" y="255.0000" width="62.5000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="309.3750" y="257.5000" width="56.2500" height="45.0000">
-			</bounds>
+			<bounds x="309.3750" y="257.5000" width="56.2500" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="312.5000" y="260.0000" width="50.0000" height="40.0000">
-			</bounds>
+			<bounds x="312.5000" y="260.0000" width="50.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="315.6250" y="262.5000" width="43.7500" height="35.0000">
-			</bounds>
+			<bounds x="315.6250" y="262.5000" width="43.7500" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="300" y="250" width="75" height="60">
-			</bounds>
+			<bounds x="300" y="250" width="75" height="60"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="76" y="567" width="62" height="42">
-			</bounds>
+			<bounds x="76" y="567" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="78" y="569" width="58" height="38">
-			</bounds>
+			<bounds x="78" y="569" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="36" y="547" width="42" height="42">
-			</bounds>
+			<bounds x="36" y="547" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="38" y="549" width="38" height="38">
-			</bounds>
+			<bounds x="38" y="549" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="36" y="587" width="42" height="22">
-			</bounds>
+			<bounds x="36" y="587" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="38" y="589" width="38" height="18">
-			</bounds>
+			<bounds x="38" y="589" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="16" y="487" width="42" height="62">
-			</bounds>
+			<bounds x="16" y="487" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="18" y="489" width="38" height="58">
-			</bounds>
+			<bounds x="18" y="489" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="16" y="447" width="62" height="42">
-			</bounds>
+			<bounds x="16" y="447" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="18" y="449" width="58" height="38">
-			</bounds>
+			<bounds x="18" y="449" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="16" y="387" width="42" height="62">
-			</bounds>
+			<bounds x="16" y="387" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="18" y="389" width="38" height="58">
-			</bounds>
+			<bounds x="18" y="389" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="16" y="327" width="42" height="62">
-			</bounds>
+			<bounds x="16" y="327" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="18" y="329" width="38" height="58">
-			</bounds>
+			<bounds x="18" y="329" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="136" y="567" width="62" height="42">
-			</bounds>
+			<bounds x="136" y="567" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="138" y="569" width="58" height="38">
-			</bounds>
+			<bounds x="138" y="569" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="16" y="127" width="42" height="62">
-			</bounds>
+			<bounds x="16" y="127" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="18" y="129" width="38" height="58">
-			</bounds>
+			<bounds x="18" y="129" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="16" y="187" width="62" height="42">
-			</bounds>
+			<bounds x="16" y="187" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="18" y="189" width="58" height="38">
-			</bounds>
+			<bounds x="18" y="189" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="16" y="227" width="42" height="62">
-			</bounds>
+			<bounds x="16" y="227" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="18" y="229" width="38" height="58">
-			</bounds>
+			<bounds x="18" y="229" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="16" y="287" width="62" height="42">
-			</bounds>
+			<bounds x="16" y="287" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="18" y="289" width="58" height="38">
-			</bounds>
+			<bounds x="18" y="289" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="236" y="567" width="62" height="42">
-			</bounds>
+			<bounds x="236" y="567" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="238" y="569" width="58" height="38">
-			</bounds>
+			<bounds x="238" y="569" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="296" y="547" width="42" height="62">
-			</bounds>
+			<bounds x="296" y="547" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="298" y="549" width="38" height="58">
-			</bounds>
+			<bounds x="298" y="549" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="196" y="547" width="42" height="62">
-			</bounds>
+			<bounds x="196" y="547" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="198" y="549" width="38" height="58">
-			</bounds>
+			<bounds x="198" y="549" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="556" y="547" width="62" height="62">
-			</bounds>
+			<bounds x="556" y="547" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="558" y="549" width="58" height="58">
-			</bounds>
+			<bounds x="558" y="549" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="496" y="567" width="62" height="42">
-			</bounds>
+			<bounds x="496" y="567" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="498" y="569" width="58" height="38">
-			</bounds>
+			<bounds x="498" y="569" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="456" y="547" width="42" height="62">
-			</bounds>
+			<bounds x="456" y="547" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="458" y="549" width="38" height="58">
-			</bounds>
+			<bounds x="458" y="549" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="396" y="567" width="62" height="42">
-			</bounds>
+			<bounds x="396" y="567" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="398" y="569" width="58" height="38">
-			</bounds>
+			<bounds x="398" y="569" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="336" y="547" width="62" height="62">
-			</bounds>
+			<bounds x="336" y="547" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="338" y="549" width="58" height="58">
-			</bounds>
+			<bounds x="338" y="549" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="576" y="367" width="42" height="62">
-			</bounds>
+			<bounds x="576" y="367" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="578" y="369" width="38" height="58">
-			</bounds>
+			<bounds x="578" y="369" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="556" y="327" width="62" height="42">
-			</bounds>
+			<bounds x="556" y="327" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="558" y="329" width="58" height="38">
-			</bounds>
+			<bounds x="558" y="329" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="556" y="287" width="62" height="42">
-			</bounds>
+			<bounds x="556" y="287" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="558" y="289" width="58" height="38">
-			</bounds>
+			<bounds x="558" y="289" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="576" y="227" width="42" height="62">
-			</bounds>
+			<bounds x="576" y="227" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="578" y="229" width="38" height="58">
-			</bounds>
+			<bounds x="578" y="229" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="556" y="187" width="62" height="42">
-			</bounds>
+			<bounds x="556" y="187" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="558" y="189" width="58" height="38">
-			</bounds>
+			<bounds x="558" y="189" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="576" y="127" width="42" height="62">
-			</bounds>
+			<bounds x="576" y="127" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="578" y="129" width="38" height="58">
-			</bounds>
+			<bounds x="578" y="129" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="576" y="67" width="42" height="62">
-			</bounds>
+			<bounds x="576" y="67" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="578" y="69" width="38" height="58">
-			</bounds>
+			<bounds x="578" y="69" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="136" y="7" width="42" height="62">
-			</bounds>
+			<bounds x="136" y="7" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="138" y="9" width="38" height="58">
-			</bounds>
+			<bounds x="138" y="9" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="16" y="67" width="42" height="62">
-			</bounds>
+			<bounds x="16" y="67" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="18" y="69" width="38" height="58">
-			</bounds>
+			<bounds x="18" y="69" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="16" y="7" width="62" height="62">
-			</bounds>
+			<bounds x="16" y="7" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="18" y="9" width="58" height="58">
-			</bounds>
+			<bounds x="18" y="9" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="76" y="7" width="62" height="42">
-			</bounds>
+			<bounds x="76" y="7" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="78" y="9" width="58" height="38">
-			</bounds>
+			<bounds x="78" y="9" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="556" y="427" width="62" height="62">
-			</bounds>
+			<bounds x="556" y="427" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="558" y="429" width="58" height="58">
-			</bounds>
+			<bounds x="558" y="429" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="236" y="7" width="62" height="42">
-			</bounds>
+			<bounds x="236" y="7" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="238" y="9" width="58" height="38">
-			</bounds>
+			<bounds x="238" y="9" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="296" y="7" width="42" height="62">
-			</bounds>
+			<bounds x="296" y="7" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="298" y="9" width="38" height="58">
-			</bounds>
+			<bounds x="298" y="9" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="336" y="7" width="62" height="42">
-			</bounds>
+			<bounds x="336" y="7" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="338" y="9" width="58" height="38">
-			</bounds>
+			<bounds x="338" y="9" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="396" y="7" width="62" height="42">
-			</bounds>
+			<bounds x="396" y="7" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="398" y="9" width="58" height="38">
-			</bounds>
+			<bounds x="398" y="9" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="456" y="7" width="42" height="62">
-			</bounds>
+			<bounds x="456" y="7" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="458" y="9" width="38" height="58">
-			</bounds>
+			<bounds x="458" y="9" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="496" y="7" width="62" height="42">
-			</bounds>
+			<bounds x="496" y="7" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="498" y="9" width="58" height="38">
-			</bounds>
+			<bounds x="498" y="9" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="556" y="7" width="62" height="62">
-			</bounds>
+			<bounds x="556" y="7" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="558" y="9" width="58" height="58">
-			</bounds>
+			<bounds x="558" y="9" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="176" y="7" width="62" height="42">
-			</bounds>
+			<bounds x="176" y="7" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="178" y="9" width="58" height="38">
-			</bounds>
+			<bounds x="178" y="9" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="576" y="487" width="42" height="62">
-			</bounds>
+			<bounds x="576" y="487" width="42" height="62"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="578" y="489" width="38" height="58">
-			</bounds>
+			<bounds x="578" y="489" width="38" height="58"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_2_border" state="0">
-			<bounds x="16" y="547" width="22" height="62">
-			</bounds>
+			<bounds x="16" y="547" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_2" state="0">
-			<bounds x="18" y="549" width="18" height="58">
-			</bounds>
+			<bounds x="18" y="549" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_2_border" state="0">
-			<bounds x="76" y="47" width="62" height="22">
-			</bounds>
+			<bounds x="76" y="47" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_2" state="0">
-			<bounds x="78" y="49" width="58" height="18">
-			</bounds>
+			<bounds x="78" y="49" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_2_border" state="0">
-			<bounds x="176" y="47" width="62" height="22">
-			</bounds>
+			<bounds x="176" y="47" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_2" state="0">
-			<bounds x="178" y="49" width="58" height="18">
-			</bounds>
+			<bounds x="178" y="49" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_2_border" state="0">
-			<bounds x="236" y="47" width="62" height="22">
-			</bounds>
+			<bounds x="236" y="47" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_2" state="0">
-			<bounds x="238" y="49" width="58" height="18">
-			</bounds>
+			<bounds x="238" y="49" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2_border" state="0">
-			<bounds x="336" y="47" width="62" height="22">
-			</bounds>
+			<bounds x="336" y="47" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2" state="0">
-			<bounds x="338" y="49" width="58" height="18">
-			</bounds>
+			<bounds x="338" y="49" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_2_border" state="0">
-			<bounds x="396" y="47" width="62" height="22">
-			</bounds>
+			<bounds x="396" y="47" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_2" state="0">
-			<bounds x="398" y="49" width="58" height="18">
-			</bounds>
+			<bounds x="398" y="49" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_2_border" state="0">
-			<bounds x="496" y="47" width="62" height="22">
-			</bounds>
+			<bounds x="496" y="47" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_2" state="0">
-			<bounds x="498" y="49" width="58" height="18">
-			</bounds>
+			<bounds x="498" y="49" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_2_border" state="0">
-			<bounds x="76" y="547" width="62" height="22">
-			</bounds>
+			<bounds x="76" y="547" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_2" state="0">
-			<bounds x="78" y="549" width="58" height="18">
-			</bounds>
+			<bounds x="78" y="549" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_2_border" state="0">
-			<bounds x="136" y="547" width="62" height="22">
-			</bounds>
+			<bounds x="136" y="547" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_2" state="0">
-			<bounds x="138" y="549" width="58" height="18">
-			</bounds>
+			<bounds x="138" y="549" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_2_border" state="0">
-			<bounds x="56" y="127" width="22" height="62">
-			</bounds>
+			<bounds x="56" y="127" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_2" state="0">
-			<bounds x="58" y="129" width="18" height="58">
-			</bounds>
+			<bounds x="58" y="129" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_2_border" state="0">
-			<bounds x="56" y="67" width="22" height="62">
-			</bounds>
+			<bounds x="56" y="67" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_2" state="0">
-			<bounds x="58" y="69" width="18" height="58">
-			</bounds>
+			<bounds x="58" y="69" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_2_border" state="0">
-			<bounds x="56" y="227" width="22" height="62">
-			</bounds>
+			<bounds x="56" y="227" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_2" state="0">
-			<bounds x="58" y="229" width="18" height="58">
-			</bounds>
+			<bounds x="58" y="229" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2_border" state="0">
-			<bounds x="56" y="327" width="22" height="62">
-			</bounds>
+			<bounds x="56" y="327" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2" state="0">
-			<bounds x="58" y="329" width="18" height="58">
-			</bounds>
+			<bounds x="58" y="329" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_2_border" state="0">
-			<bounds x="56" y="387" width="22" height="62">
-			</bounds>
+			<bounds x="56" y="387" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_2" state="0">
-			<bounds x="58" y="389" width="18" height="58">
-			</bounds>
+			<bounds x="58" y="389" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_2_border" state="0">
-			<bounds x="56" y="487" width="22" height="62">
-			</bounds>
+			<bounds x="56" y="487" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_2" state="0">
-			<bounds x="58" y="489" width="18" height="58">
-			</bounds>
+			<bounds x="58" y="489" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_2_border" state="0">
-			<bounds x="236" y="547" width="62" height="22">
-			</bounds>
+			<bounds x="236" y="547" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_2" state="0">
-			<bounds x="238" y="549" width="58" height="18">
-			</bounds>
+			<bounds x="238" y="549" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_2_border" state="0">
-			<bounds x="396" y="547" width="62" height="22">
-			</bounds>
+			<bounds x="396" y="547" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_2" state="0">
-			<bounds x="398" y="549" width="58" height="18">
-			</bounds>
+			<bounds x="398" y="549" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_2_border" state="0">
-			<bounds x="496" y="547" width="62" height="22">
-			</bounds>
+			<bounds x="496" y="547" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_2" state="0">
-			<bounds x="498" y="549" width="58" height="18">
-			</bounds>
+			<bounds x="498" y="549" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_2_border" state="0">
-			<bounds x="556" y="367" width="22" height="62">
-			</bounds>
+			<bounds x="556" y="367" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_2" state="0">
-			<bounds x="558" y="369" width="18" height="58">
-			</bounds>
+			<bounds x="558" y="369" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2_border" state="0">
-			<bounds x="556" y="67" width="22" height="62">
-			</bounds>
+			<bounds x="556" y="67" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2" state="0">
-			<bounds x="558" y="69" width="18" height="58">
-			</bounds>
+			<bounds x="558" y="69" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_2_border" state="0">
-			<bounds x="556" y="127" width="22" height="62">
-			</bounds>
+			<bounds x="556" y="127" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_2" state="0">
-			<bounds x="558" y="129" width="18" height="58">
-			</bounds>
+			<bounds x="558" y="129" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_2_border" state="0">
-			<bounds x="556" y="227" width="22" height="62">
-			</bounds>
+			<bounds x="556" y="227" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_2" state="0">
-			<bounds x="558" y="229" width="18" height="58">
-			</bounds>
+			<bounds x="558" y="229" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_2_border" state="0">
-			<bounds x="556" y="487" width="22" height="62">
-			</bounds>
+			<bounds x="556" y="487" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_2" state="0">
-			<bounds x="558" y="489" width="18" height="58">
-			</bounds>
+			<bounds x="558" y="489" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="81" y="254" width="59" height="32">
-			</bounds>
+			<bounds x="81" y="254" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="83" y="256" width="55" height="28">
-			</bounds>
+			<bounds x="83" y="256" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="494" y="254" width="59" height="32">
-			</bounds>
+			<bounds x="494" y="254" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="496" y="256" width="55" height="28">
-			</bounds>
+			<bounds x="496" y="256" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="494" y="219" width="59" height="32">
-			</bounds>
+			<bounds x="494" y="219" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="496" y="221" width="55" height="28">
-			</bounds>
+			<bounds x="496" y="221" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="494" y="184" width="59" height="32">
-			</bounds>
+			<bounds x="494" y="184" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="496" y="186" width="55" height="28">
-			</bounds>
+			<bounds x="496" y="186" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="494" y="149" width="59" height="32">
-			</bounds>
+			<bounds x="494" y="149" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="496" y="151" width="55" height="28">
-			</bounds>
+			<bounds x="496" y="151" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="494" y="114" width="59" height="32">
-			</bounds>
+			<bounds x="494" y="114" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="496" y="116" width="55" height="28">
-			</bounds>
+			<bounds x="496" y="116" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="494" y="79" width="59" height="32">
-			</bounds>
+			<bounds x="494" y="79" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="496" y="81" width="55" height="28">
-			</bounds>
+			<bounds x="496" y="81" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="81" y="79" width="59" height="32">
-			</bounds>
+			<bounds x="81" y="79" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="83" y="81" width="55" height="28">
-			</bounds>
+			<bounds x="83" y="81" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="81" y="114" width="59" height="32">
-			</bounds>
+			<bounds x="81" y="114" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="83" y="116" width="55" height="28">
-			</bounds>
+			<bounds x="83" y="116" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="81" y="149" width="59" height="32">
-			</bounds>
+			<bounds x="81" y="149" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="83" y="151" width="55" height="28">
-			</bounds>
+			<bounds x="83" y="151" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="81" y="184" width="59" height="32">
-			</bounds>
+			<bounds x="81" y="184" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="83" y="186" width="55" height="28">
-			</bounds>
+			<bounds x="83" y="186" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="81" y="219" width="59" height="32">
-			</bounds>
+			<bounds x="81" y="219" width="59" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="83" y="221" width="55" height="28">
-			</bounds>
+			<bounds x="83" y="221" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="734" y="79" width="52" height="12">
-			</bounds>
+			<bounds x="734" y="79" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="736" y="81" width="48" height="8">
-			</bounds>
+			<bounds x="736" y="81" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="684" y="79" width="52" height="12">
-			</bounds>
+			<bounds x="684" y="79" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="686" y="81" width="48" height="8">
-			</bounds>
+			<bounds x="686" y="81" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="734" y="121" width="52" height="12">
-			</bounds>
+			<bounds x="734" y="121" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="736" y="123" width="48" height="8">
-			</bounds>
+			<bounds x="736" y="123" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_2_border" state="0">
-			<bounds x="734" y="131" width="52" height="32">
-			</bounds>
+			<bounds x="734" y="131" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_2" state="0">
-			<bounds x="736" y="133" width="48" height="28">
-			</bounds>
+			<bounds x="736" y="133" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="634" y="131" width="52" height="32">
-			</bounds>
+			<bounds x="634" y="131" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="636" y="133" width="48" height="28">
-			</bounds>
+			<bounds x="636" y="133" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_2_border" state="0">
-			<bounds x="634" y="121" width="52" height="12">
-			</bounds>
+			<bounds x="634" y="121" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_2" state="0">
-			<bounds x="636" y="123" width="48" height="8">
-			</bounds>
+			<bounds x="636" y="123" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="684" y="131" width="52" height="32">
-			</bounds>
+			<bounds x="684" y="131" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="686" y="133" width="48" height="28">
-			</bounds>
+			<bounds x="686" y="133" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2_border" state="0">
-			<bounds x="684" y="121" width="52" height="12">
-			</bounds>
+			<bounds x="684" y="121" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2" state="0">
-			<bounds x="686" y="123" width="48" height="8">
-			</bounds>
+			<bounds x="686" y="123" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="684" y="163" width="52" height="12">
-			</bounds>
+			<bounds x="684" y="163" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="686" y="165" width="48" height="8">
-			</bounds>
+			<bounds x="686" y="165" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2_border" state="0">
-			<bounds x="684" y="173" width="52" height="32">
-			</bounds>
+			<bounds x="684" y="173" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2" state="0">
-			<bounds x="686" y="175" width="48" height="28">
-			</bounds>
+			<bounds x="686" y="175" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="634" y="173" width="52" height="32">
-			</bounds>
+			<bounds x="634" y="173" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="636" y="175" width="48" height="28">
-			</bounds>
+			<bounds x="636" y="175" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_2_border" state="0">
-			<bounds x="634" y="163" width="52" height="12">
-			</bounds>
+			<bounds x="634" y="163" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_2" state="0">
-			<bounds x="636" y="165" width="48" height="8">
-			</bounds>
+			<bounds x="636" y="165" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="734" y="173" width="52" height="32">
-			</bounds>
+			<bounds x="734" y="173" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="736" y="175" width="48" height="28">
-			</bounds>
+			<bounds x="736" y="175" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_2_border" state="0">
-			<bounds x="734" y="163" width="52" height="12">
-			</bounds>
+			<bounds x="734" y="163" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_2" state="0">
-			<bounds x="736" y="165" width="48" height="8">
-			</bounds>
+			<bounds x="736" y="165" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="734" y="205" width="52" height="12">
-			</bounds>
+			<bounds x="734" y="205" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="736" y="207" width="48" height="8">
-			</bounds>
+			<bounds x="736" y="207" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_2_border" state="0">
-			<bounds x="734" y="215" width="52" height="32">
-			</bounds>
+			<bounds x="734" y="215" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_2" state="0">
-			<bounds x="736" y="217" width="48" height="28">
-			</bounds>
+			<bounds x="736" y="217" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="634" y="205" width="52" height="12">
-			</bounds>
+			<bounds x="634" y="205" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="636" y="207" width="48" height="8">
-			</bounds>
+			<bounds x="636" y="207" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_2_border" state="0">
-			<bounds x="634" y="215" width="52" height="32">
-			</bounds>
+			<bounds x="634" y="215" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_2" state="0">
-			<bounds x="636" y="217" width="48" height="28">
-			</bounds>
+			<bounds x="636" y="217" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="684" y="215" width="52" height="32">
-			</bounds>
+			<bounds x="684" y="215" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="686" y="217" width="48" height="28">
-			</bounds>
+			<bounds x="686" y="217" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_2_border" state="0">
-			<bounds x="684" y="205" width="52" height="12">
-			</bounds>
+			<bounds x="684" y="205" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_2" state="0">
-			<bounds x="686" y="207" width="48" height="8">
-			</bounds>
+			<bounds x="686" y="207" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="684" y="257" width="52" height="32">
-			</bounds>
+			<bounds x="684" y="257" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="686" y="259" width="48" height="28">
-			</bounds>
+			<bounds x="686" y="259" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="634" y="257" width="52" height="32">
-			</bounds>
+			<bounds x="634" y="257" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="636" y="259" width="48" height="28">
-			</bounds>
+			<bounds x="636" y="259" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="734" y="257" width="52" height="32">
-			</bounds>
+			<bounds x="734" y="257" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="736" y="259" width="48" height="28">
-			</bounds>
+			<bounds x="736" y="259" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_2_border" state="0">
-			<bounds x="734" y="247" width="52" height="12">
-			</bounds>
+			<bounds x="734" y="247" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_2" state="0">
-			<bounds x="736" y="249" width="48" height="8">
-			</bounds>
+			<bounds x="736" y="249" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_2_border" state="0">
-			<bounds x="634" y="247" width="52" height="12">
-			</bounds>
+			<bounds x="634" y="247" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_2" state="0">
-			<bounds x="636" y="249" width="48" height="8">
-			</bounds>
+			<bounds x="636" y="249" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_2_border" state="0">
-			<bounds x="684" y="247" width="52" height="12">
-			</bounds>
+			<bounds x="684" y="247" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_2" state="0">
-			<bounds x="686" y="249" width="48" height="8">
-			</bounds>
+			<bounds x="686" y="249" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="684" y="289" width="52" height="12">
-			</bounds>
+			<bounds x="684" y="289" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="686" y="291" width="48" height="8">
-			</bounds>
+			<bounds x="686" y="291" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="634" y="289" width="52" height="12">
-			</bounds>
+			<bounds x="634" y="289" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="636" y="291" width="48" height="8">
-			</bounds>
+			<bounds x="636" y="291" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="734" y="289" width="52" height="12">
-			</bounds>
+			<bounds x="734" y="289" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="736" y="291" width="48" height="8">
-			</bounds>
+			<bounds x="736" y="291" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_2_border" state="0">
-			<bounds x="734" y="299" width="52" height="32">
-			</bounds>
+			<bounds x="734" y="299" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_2" state="0">
-			<bounds x="736" y="301" width="48" height="28">
-			</bounds>
+			<bounds x="736" y="301" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_2_border" state="0">
-			<bounds x="634" y="299" width="52" height="32">
-			</bounds>
+			<bounds x="634" y="299" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_2" state="0">
-			<bounds x="636" y="301" width="48" height="28">
-			</bounds>
+			<bounds x="636" y="301" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2_border" state="0">
-			<bounds x="684" y="299" width="52" height="32">
-			</bounds>
+			<bounds x="684" y="299" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2" state="0">
-			<bounds x="686" y="301" width="48" height="28">
-			</bounds>
+			<bounds x="686" y="301" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="684" y="331" width="52" height="12">
-			</bounds>
+			<bounds x="684" y="331" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="686" y="333" width="48" height="8">
-			</bounds>
+			<bounds x="686" y="333" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_2_border" state="0">
-			<bounds x="684" y="341" width="52" height="32">
-			</bounds>
+			<bounds x="684" y="341" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_2" state="0">
-			<bounds x="686" y="343" width="48" height="28">
-			</bounds>
+			<bounds x="686" y="343" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="634" y="341" width="52" height="32">
-			</bounds>
+			<bounds x="634" y="341" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="636" y="343" width="48" height="28">
-			</bounds>
+			<bounds x="636" y="343" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_2_border" state="0">
-			<bounds x="634" y="331" width="52" height="12">
-			</bounds>
+			<bounds x="634" y="331" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_2" state="0">
-			<bounds x="636" y="333" width="48" height="8">
-			</bounds>
+			<bounds x="636" y="333" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="734" y="341" width="52" height="32">
-			</bounds>
+			<bounds x="734" y="341" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="736" y="343" width="48" height="28">
-			</bounds>
+			<bounds x="736" y="343" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_2_border" state="0">
-			<bounds x="734" y="331" width="52" height="12">
-			</bounds>
+			<bounds x="734" y="331" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_2" state="0">
-			<bounds x="736" y="333" width="48" height="8">
-			</bounds>
+			<bounds x="736" y="333" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="734" y="373" width="52" height="12">
-			</bounds>
+			<bounds x="734" y="373" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="736" y="375" width="48" height="8">
-			</bounds>
+			<bounds x="736" y="375" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="684" y="373" width="52" height="12">
-			</bounds>
+			<bounds x="684" y="373" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="686" y="375" width="48" height="8">
-			</bounds>
+			<bounds x="686" y="375" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_2_border" state="0">
-			<bounds x="734" y="383" width="52" height="32">
-			</bounds>
+			<bounds x="734" y="383" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_2" state="0">
-			<bounds x="736" y="385" width="48" height="28">
-			</bounds>
+			<bounds x="736" y="385" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2_border" state="0">
-			<bounds x="684" y="383" width="52" height="32">
-			</bounds>
+			<bounds x="684" y="383" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2" state="0">
-			<bounds x="686" y="385" width="48" height="28">
-			</bounds>
+			<bounds x="686" y="385" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_2_border" state="0">
-			<bounds x="684" y="89" width="52" height="32">
-			</bounds>
+			<bounds x="684" y="89" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_2" state="0">
-			<bounds x="686" y="91" width="48" height="28">
-			</bounds>
+			<bounds x="686" y="91" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_2_border" state="0">
-			<bounds x="734" y="89" width="52" height="32">
-			</bounds>
+			<bounds x="734" y="89" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_2" state="0">
-			<bounds x="736" y="91" width="48" height="28">
-			</bounds>
+			<bounds x="736" y="91" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="789" y="89" width="62" height="32">
-			</bounds>
+			<bounds x="789" y="89" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="791" y="91" width="58" height="28">
-			</bounds>
+			<bounds x="791" y="91" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="789" y="383" width="62" height="32">
-			</bounds>
+			<bounds x="789" y="383" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="791" y="385" width="58" height="28">
-			</bounds>
+			<bounds x="791" y="385" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="789" y="341" width="62" height="32">
-			</bounds>
+			<bounds x="789" y="341" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="791" y="343" width="58" height="28">
-			</bounds>
+			<bounds x="791" y="343" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="789" y="299" width="62" height="32">
-			</bounds>
+			<bounds x="789" y="299" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="791" y="301" width="58" height="28">
-			</bounds>
+			<bounds x="791" y="301" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="789" y="257" width="62" height="32">
-			</bounds>
+			<bounds x="789" y="257" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="791" y="259" width="58" height="28">
-			</bounds>
+			<bounds x="791" y="259" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="789" y="215" width="62" height="32">
-			</bounds>
+			<bounds x="789" y="215" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="791" y="217" width="58" height="28">
-			</bounds>
+			<bounds x="791" y="217" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="789" y="173" width="62" height="32">
-			</bounds>
+			<bounds x="789" y="173" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="791" y="175" width="58" height="28">
-			</bounds>
+			<bounds x="791" y="175" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="789" y="131" width="62" height="32">
-			</bounds>
+			<bounds x="789" y="131" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="791" y="133" width="58" height="28">
-			</bounds>
+			<bounds x="791" y="133" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="214" y="74" width="67" height="32">
-			</bounds>
+			<bounds x="214" y="74" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="216" y="76" width="63" height="28">
-			</bounds>
+			<bounds x="216" y="76" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="144" y="74" width="67" height="32">
-			</bounds>
+			<bounds x="144" y="74" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="146" y="76" width="63" height="28">
-			</bounds>
+			<bounds x="146" y="76" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="354" y="74" width="67" height="32">
-			</bounds>
+			<bounds x="354" y="74" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="356" y="76" width="63" height="28">
-			</bounds>
+			<bounds x="356" y="76" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="424" y="74" width="67" height="32">
-			</bounds>
+			<bounds x="424" y="74" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="426" y="76" width="63" height="28">
-			</bounds>
+			<bounds x="426" y="76" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="284" y="74" width="67" height="32">
-			</bounds>
+			<bounds x="284" y="74" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="286" y="76" width="63" height="28">
-			</bounds>
+			<bounds x="286" y="76" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="144" y="109" width="37" height="52">
-			</bounds>
+			<bounds x="144" y="109" width="37" height="52"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="146" y="111" width="33" height="48">
-			</bounds>
+			<bounds x="146" y="111" width="33" height="48"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="454" y="109" width="37" height="52">
-			</bounds>
+			<bounds x="454" y="109" width="37" height="52"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="456" y="111" width="33" height="48">
-			</bounds>
+			<bounds x="456" y="111" width="33" height="48"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="354" y="164" width="67" height="32">
-			</bounds>
+			<bounds x="354" y="164" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="356" y="166" width="63" height="28">
-			</bounds>
+			<bounds x="356" y="166" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="284" y="164" width="67" height="32">
-			</bounds>
+			<bounds x="284" y="164" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="286" y="166" width="63" height="28">
-			</bounds>
+			<bounds x="286" y="166" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="214" y="164" width="67" height="32">
-			</bounds>
+			<bounds x="214" y="164" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="216" y="166" width="63" height="28">
-			</bounds>
+			<bounds x="216" y="166" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="144" y="164" width="67" height="32">
-			</bounds>
+			<bounds x="144" y="164" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="146" y="166" width="63" height="28">
-			</bounds>
+			<bounds x="146" y="166" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="424" y="164" width="67" height="32">
-			</bounds>
+			<bounds x="424" y="164" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="426" y="166" width="63" height="28">
-			</bounds>
+			<bounds x="426" y="166" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="374" y="114" width="52" height="12">
-			</bounds>
+			<bounds x="374" y="114" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="376" y="116" width="48" height="8">
-			</bounds>
+			<bounds x="376" y="116" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="209" y="114" width="52" height="12">
-			</bounds>
+			<bounds x="209" y="114" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="211" y="116" width="48" height="8">
-			</bounds>
+			<bounds x="211" y="116" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="319" y="114" width="52" height="12">
-			</bounds>
+			<bounds x="319" y="114" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="321" y="116" width="48" height="8">
-			</bounds>
+			<bounds x="321" y="116" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="264" y="114" width="52" height="12">
-			</bounds>
+			<bounds x="264" y="114" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="266" y="116" width="48" height="8">
-			</bounds>
+			<bounds x="266" y="116" width="48" height="8"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_2_border" state="0">
-			<bounds x="209" y="124" width="52" height="32">
-			</bounds>
+			<bounds x="209" y="124" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_2" state="0">
-			<bounds x="211" y="126" width="48" height="28">
-			</bounds>
+			<bounds x="211" y="126" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_2_border" state="0">
-			<bounds x="264" y="124" width="52" height="32">
-			</bounds>
+			<bounds x="264" y="124" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_2" state="0">
-			<bounds x="266" y="126" width="48" height="28">
-			</bounds>
+			<bounds x="266" y="126" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_2_border" state="0">
-			<bounds x="319" y="124" width="52" height="32">
-			</bounds>
+			<bounds x="319" y="124" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_2" state="0">
-			<bounds x="321" y="126" width="48" height="28">
-			</bounds>
+			<bounds x="321" y="126" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_2_border" state="0">
-			<bounds x="374" y="124" width="52" height="32">
-			</bounds>
+			<bounds x="374" y="124" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_2" state="0">
-			<bounds x="376" y="126" width="48" height="28">
-			</bounds>
+			<bounds x="376" y="126" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="634" y="564" width="41" height="22">
-			</bounds>
+			<bounds x="634" y="564" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="636" y="566" width="37" height="18">
-			</bounds>
+			<bounds x="636" y="566" width="37" height="18"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="634" y="384" width="41" height="22">
-			</bounds>
+			<bounds x="634" y="384" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="636" y="386" width="37" height="18">
-			</bounds>
+			<bounds x="636" y="386" width="37" height="18"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_2_border" state="0">
-			<bounds x="639" y="583" width="31" height="22">
-			</bounds>
+			<bounds x="639" y="583" width="31" height="22"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_2" state="0">
-			<bounds x="641" y="585" width="27" height="18">
-			</bounds>
+			<bounds x="641" y="585" width="27" height="18"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_2_border" state="0">
-			<bounds x="639" y="403" width="31" height="22">
-			</bounds>
+			<bounds x="639" y="403" width="31" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_2" state="0">
-			<bounds x="641" y="405" width="27" height="18">
-			</bounds>
+			<bounds x="641" y="405" width="27" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="634" y="519" width="41" height="22">
-			</bounds>
+			<bounds x="634" y="519" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="636" y="521" width="37" height="18">
-			</bounds>
+			<bounds x="636" y="521" width="37" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="634" y="474" width="41" height="22">
-			</bounds>
+			<bounds x="634" y="474" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="636" y="476" width="37" height="18">
-			</bounds>
+			<bounds x="636" y="476" width="37" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_2_border" state="0">
-			<bounds x="639" y="493" width="31" height="22">
-			</bounds>
+			<bounds x="639" y="493" width="31" height="22"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_2" state="0">
-			<bounds x="641" y="495" width="27" height="18">
-			</bounds>
+			<bounds x="641" y="495" width="27" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_2_border" state="0">
-			<bounds x="639" y="538" width="31" height="22">
-			</bounds>
+			<bounds x="639" y="538" width="31" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_2" state="0">
-			<bounds x="641" y="540" width="27" height="18">
-			</bounds>
+			<bounds x="641" y="540" width="27" height="18"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="634" y="429" width="41" height="22">
-			</bounds>
+			<bounds x="634" y="429" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="636" y="431" width="37" height="18">
-			</bounds>
+			<bounds x="636" y="431" width="37" height="18"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2_border" state="0">
-			<bounds x="639" y="448" width="31" height="22">
-			</bounds>
+			<bounds x="639" y="448" width="31" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2" state="0">
-			<bounds x="641" y="450" width="27" height="18">
-			</bounds>
+			<bounds x="641" y="450" width="27" height="18"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="254" y="284" width="41" height="22">
-			</bounds>
+			<bounds x="254" y="284" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="256" y="286" width="37" height="18">
-			</bounds>
+			<bounds x="256" y="286" width="37" height="18"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="254" y="254" width="41" height="22">
-			</bounds>
+			<bounds x="254" y="254" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="256" y="256" width="37" height="18">
-			</bounds>
+			<bounds x="256" y="256" width="37" height="18"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="943" y="206" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="206" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="945" y="208" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="208" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="943" y="481" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="481" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="945" y="483" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="483" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="943" y="506" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="506" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="945" y="508" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="508" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="943" y="556" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="556" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="945" y="558" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="558" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="943" y="531" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="531" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="945" y="533" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="533" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="943" y="631" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="631" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="945" y="633" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="633" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="943" y="606" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="606" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="945" y="608" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="608" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="943" y="581" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="581" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="945" y="583" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="583" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="943" y="306" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="306" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="945" y="308" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="308" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="943" y="331" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="331" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="945" y="333" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="333" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="943" y="356" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="356" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="945" y="358" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="358" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="943" y="406" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="406" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="945" y="408" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="408" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="943" y="381" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="381" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="945" y="383" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="383" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="943" y="431" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="431" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="945" y="433" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="433" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="943" y="456" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="456" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="945" y="458" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="458" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="943" y="256" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="256" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="945" y="258" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="258" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="943" y="281" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="281" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="945" y="283" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="283" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="943" y="231" width="62" height="22">
-			</bounds>
+			<bounds x="943" y="231" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="945" y="233" width="58" height="18">
-			</bounds>
+			<bounds x="945" y="233" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="717" y="497" width="127" height="47">
-			</bounds>
+			<bounds x="717" y="497" width="127" height="47"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="719" y="499" width="123" height="43">
-			</bounds>
+			<bounds x="719" y="499" width="123" height="43"/>
 		</backdrop>
 		<backdrop name="lamp202" element="colour_button_300_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="684" y="419" width="167" height="22">
-			</bounds>
+			<bounds x="684" y="419" width="167" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="colour_button_300" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="686" y="421" width="163" height="18">
-			</bounds>
+			<bounds x="686" y="421" width="163" height="18"/>
 		</backdrop>
 		<backdrop name="lamp22" element="colour_button_301_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="944" y="54" width="50" height="16">
-			</bounds>
+			<bounds x="944" y="54" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp22" element="colour_button_301" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="946" y="56" width="46" height="12">
-			</bounds>
+			<bounds x="946" y="56" width="46" height="12"/>
 		</backdrop>
 		<backdrop name="lamp22" element="colour_button_302_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="944" y="24" width="50" height="16">
-			</bounds>
+			<bounds x="944" y="24" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp22" element="colour_button_302" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="946" y="26" width="46" height="12">
-			</bounds>
+			<bounds x="946" y="26" width="46" height="12"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_303_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="599" y="620" width="82" height="40">
-			</bounds>
+			<bounds x="599" y="620" width="82" height="40"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_303" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="601" y="622" width="78" height="36">
-			</bounds>
+			<bounds x="601" y="622" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_304_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="694" y="620" width="82" height="40">
-			</bounds>
+			<bounds x="694" y="620" width="82" height="40"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_304" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="696" y="622" width="78" height="36">
-			</bounds>
+			<bounds x="696" y="622" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_305_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="784" y="620" width="82" height="40">
-			</bounds>
+			<bounds x="784" y="620" width="82" height="40"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_305" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="786" y="622" width="78" height="36">
-			</bounds>
+			<bounds x="786" y="622" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_306_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="144" y="620" width="82" height="40">
-			</bounds>
+			<bounds x="144" y="620" width="82" height="40"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_306" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="146" y="622" width="78" height="36">
-			</bounds>
+			<bounds x="146" y="622" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_307_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="234" y="620" width="82" height="40">
-			</bounds>
+			<bounds x="234" y="620" width="82" height="40"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_307" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="236" y="622" width="78" height="36">
-			</bounds>
+			<bounds x="236" y="622" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_308_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="324" y="620" width="82" height="40">
-			</bounds>
+			<bounds x="324" y="620" width="82" height="40"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_308" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="326" y="622" width="78" height="36">
-			</bounds>
+			<bounds x="326" y="622" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_309_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="414" y="620" width="82" height="40">
-			</bounds>
+			<bounds x="414" y="620" width="82" height="40"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_309" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="416" y="622" width="78" height="36">
-			</bounds>
+			<bounds x="416" y="622" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_310_border" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="504" y="620" width="82" height="40">
-			</bounds>
+			<bounds x="504" y="620" width="82" height="40"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_310" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="506" y="622" width="78" height="36">
-			</bounds>
+			<bounds x="506" y="622" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="965" y="155" width="20" height="20">
-			</bounds>
+			<bounds x="965" y="155" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="led_off112" element="led_off">
-			<bounds x="967" y="156" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="156" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off113" element="led_off">
-			<bounds x="979" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="979" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off114" element="led_off">
-			<bounds x="979" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="979" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off115" element="led_off">
-			<bounds x="967" y="171" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="171" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off116" element="led_off">
-			<bounds x="967" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="967" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off117" element="led_off">
-			<bounds x="967" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="967" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off118" element="led_off">
-			<bounds x="967" y="164" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="164" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off119" element="led_dot_off">
-			<bounds x="982" y="171" width="2" height="1">
-			</bounds>
+			<bounds x="982" y="171" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="lamp112" element="led_on">
-			<bounds x="967" y="156" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="156" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp113" element="led_on">
-			<bounds x="979" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="979" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp114" element="led_on">
-			<bounds x="979" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="979" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp115" element="led_on">
-			<bounds x="967" y="171" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="171" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp116" element="led_on">
-			<bounds x="967" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="967" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp117" element="led_on">
-			<bounds x="967" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="967" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp118" element="led_on">
-			<bounds x="967" y="164" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="164" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp119" element="led_dot_on">
-			<bounds x="982" y="171" width="2" height="1">
-			</bounds>
+			<bounds x="982" y="171" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="985" y="155" width="20" height="20">
-			</bounds>
+			<bounds x="985" y="155" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="led_off120" element="led_off">
-			<bounds x="987" y="156" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="156" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="999" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="999" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="999" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="999" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="987" y="171" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="171" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="987" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="987" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="987" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="987" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="987" y="164" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="164" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off127" element="led_dot_off">
-			<bounds x="1002" y="171" width="2" height="1">
-			</bounds>
+			<bounds x="1002" y="171" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="lamp120" element="led_on">
-			<bounds x="987" y="156" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="156" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="999" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="999" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="999" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="999" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="987" y="171" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="171" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="987" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="987" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="987" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="987" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="987" y="164" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="164" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp127" element="led_dot_on">
-			<bounds x="1002" y="171" width="2" height="1">
-			</bounds>
+			<bounds x="1002" y="171" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="945" y="155" width="20" height="20">
-			</bounds>
+			<bounds x="945" y="155" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="947" y="156" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="156" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="959" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="959" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="959" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="959" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="947" y="171" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="171" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="947" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="947" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="947" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="947" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="947" y="164" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="164" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="962" y="171" width="2" height="1">
-			</bounds>
+			<bounds x="962" y="171" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="947" y="156" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="156" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="959" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="959" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="959" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="959" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="947" y="171" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="171" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="947" y="164" width="2" height="9">
-			</bounds>
+			<bounds x="947" y="164" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="947" y="156" width="2" height="9">
-			</bounds>
+			<bounds x="947" y="156" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="947" y="164" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="164" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="962" y="171" width="2" height="1">
-			</bounds>
+			<bounds x="962" y="171" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="945" y="130" width="20" height="20">
-			</bounds>
+			<bounds x="945" y="130" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="947" y="131" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="131" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="959" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="959" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="959" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="959" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="947" y="146" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="146" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="947" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="947" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="947" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="947" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="947" y="139" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="139" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="962" y="146" width="2" height="1">
-			</bounds>
+			<bounds x="962" y="146" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="947" y="131" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="131" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="959" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="959" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="959" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="959" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="947" y="146" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="146" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="947" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="947" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="947" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="947" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="947" y="139" width="14" height="1">
-			</bounds>
+			<bounds x="947" y="139" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="962" y="146" width="2" height="1">
-			</bounds>
+			<bounds x="962" y="146" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="965" y="130" width="20" height="20">
-			</bounds>
+			<bounds x="965" y="130" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="967" y="131" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="131" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="979" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="979" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="979" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="979" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="967" y="146" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="146" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="967" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="967" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="967" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="967" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="967" y="139" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="139" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="982" y="146" width="2" height="1">
-			</bounds>
+			<bounds x="982" y="146" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="967" y="131" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="131" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="979" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="979" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="979" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="979" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="967" y="146" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="146" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="967" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="967" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="967" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="967" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="967" y="139" width="14" height="1">
-			</bounds>
+			<bounds x="967" y="139" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="982" y="146" width="2" height="1">
-			</bounds>
+			<bounds x="982" y="146" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="985" y="130" width="20" height="20">
-			</bounds>
+			<bounds x="985" y="130" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="987" y="131" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="131" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="999" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="999" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="999" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="999" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="987" y="146" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="146" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="987" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="987" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="987" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="987" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="987" y="139" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="139" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="1002" y="146" width="2" height="1">
-			</bounds>
+			<bounds x="1002" y="146" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="987" y="131" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="131" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="999" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="999" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="999" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="999" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="987" y="146" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="146" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="987" y="139" width="2" height="9">
-			</bounds>
+			<bounds x="987" y="139" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="987" y="131" width="2" height="9">
-			</bounds>
+			<bounds x="987" y="131" width="2" height="9"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="987" y="139" width="14" height="1">
-			</bounds>
+			<bounds x="987" y="139" width="14" height="1"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="1002" y="146" width="2" height="1">
-			</bounds>
+			<bounds x="1002" y="146" width="2" height="1"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="440" y="260" width="30" height="40">
-			</bounds>
+			<bounds x="440" y="260" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="444" y="263" width="21" height="3">
-			</bounds>
+			<bounds x="444" y="263" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="461" y="263" width="4" height="18">
-			</bounds>
+			<bounds x="461" y="263" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="461" y="278" width="4" height="18">
-			</bounds>
+			<bounds x="461" y="278" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="444" y="292" width="21" height="3">
-			</bounds>
+			<bounds x="444" y="292" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="444" y="278" width="4" height="18">
-			</bounds>
+			<bounds x="444" y="278" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="444" y="263" width="4" height="18">
-			</bounds>
+			<bounds x="444" y="263" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="444" y="278" width="21" height="3">
-			</bounds>
+			<bounds x="444" y="278" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="465" y="292" width="4" height="3">
-			</bounds>
+			<bounds x="465" y="292" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="444" y="263" width="21" height="3">
-			</bounds>
+			<bounds x="444" y="263" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="461" y="263" width="4" height="18">
-			</bounds>
+			<bounds x="461" y="263" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="461" y="278" width="4" height="18">
-			</bounds>
+			<bounds x="461" y="278" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="444" y="292" width="21" height="3">
-			</bounds>
+			<bounds x="444" y="292" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="444" y="278" width="4" height="18">
-			</bounds>
+			<bounds x="444" y="278" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="444" y="263" width="4" height="18">
-			</bounds>
+			<bounds x="444" y="263" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="444" y="278" width="21" height="3">
-			</bounds>
+			<bounds x="444" y="278" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="465" y="292" width="4" height="3">
-			</bounds>
+			<bounds x="465" y="292" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="410" y="260" width="30" height="40">
-			</bounds>
+			<bounds x="410" y="260" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="414" y="263" width="21" height="3">
-			</bounds>
+			<bounds x="414" y="263" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="431" y="263" width="4" height="18">
-			</bounds>
+			<bounds x="431" y="263" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="431" y="278" width="4" height="18">
-			</bounds>
+			<bounds x="431" y="278" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="414" y="292" width="21" height="3">
-			</bounds>
+			<bounds x="414" y="292" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="414" y="278" width="4" height="18">
-			</bounds>
+			<bounds x="414" y="278" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="414" y="263" width="4" height="18">
-			</bounds>
+			<bounds x="414" y="263" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="414" y="278" width="21" height="3">
-			</bounds>
+			<bounds x="414" y="278" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="435" y="292" width="4" height="3">
-			</bounds>
+			<bounds x="435" y="292" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="414" y="263" width="21" height="3">
-			</bounds>
+			<bounds x="414" y="263" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="431" y="263" width="4" height="18">
-			</bounds>
+			<bounds x="431" y="263" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="431" y="278" width="4" height="18">
-			</bounds>
+			<bounds x="431" y="278" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="414" y="292" width="21" height="3">
-			</bounds>
+			<bounds x="414" y="292" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="414" y="278" width="4" height="18">
-			</bounds>
+			<bounds x="414" y="278" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="414" y="263" width="4" height="18">
-			</bounds>
+			<bounds x="414" y="263" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="414" y="278" width="21" height="3">
-			</bounds>
+			<bounds x="414" y="278" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="435" y="292" width="4" height="3">
-			</bounds>
+			<bounds x="435" y="292" width="4" height="3"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="185" y="365" width="272" height="30">
-			</bounds>
+			<bounds x="185" y="365" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="185" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="185" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="202" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="202" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="219" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="219" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="236" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="236" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="253" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="253" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="270" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="270" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="287" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="287" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="304" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="304" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="321" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="321" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="338" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="338" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="355" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="355" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="372" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="372" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="389" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="389" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="406" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="406" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="423" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="423" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="440" y="365" width="17" height="30">
-			</bounds>
+			<bounds x="440" y="365" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label5" element="label_5">
-			<bounds x="6" y="647" width="28" height="13">
-			</bounds>
+			<bounds x="6" y="647" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="505" y="285" width="28" height="10">
-			</bounds>
+			<bounds x="505" y="285" width="28" height="10"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="80" y="285" width="45" height="20">
-			</bounds>
+			<bounds x="80" y="285" width="45" height="20"/>
 		</backdrop>
 		<backdrop name="label139" element="label_139">
-			<bounds x="880" y="105" width="99" height="22">
-			</bounds>
+			<bounds x="880" y="105" width="99" height="22"/>
 		</backdrop>
 		<backdrop name="label150" element="label_150">
-			<bounds x="250" y="230" width="107" height="14">
-			</bounds>
+			<bounds x="250" y="230" width="107" height="14"/>
 		</backdrop>
 		<backdrop name="label157" element="label_157">
-			<bounds x="220" y="317" width="145" height="14">
-			</bounds>
+			<bounds x="220" y="317" width="145" height="14"/>
 		</backdrop>
 		<backdrop name="label182" element="label_182">
-			<bounds x="115" y="455" width="24" height="28">
-			</bounds>
+			<bounds x="115" y="455" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label183" element="label_183">
-			<bounds x="500" y="455" width="24" height="28">
-			</bounds>
+			<bounds x="500" y="455" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label198" element="label_198">
-			<bounds x="415" y="250" width="40" height="10">
-			</bounds>
+			<bounds x="415" y="250" width="40" height="10"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_button" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_reel" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_button" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1mongam.lay
+++ b/src/mame/layout/m1mongam.lay
@@ -8,13142 +8,8095 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.06">
-			</color>
+			<color red="0.03" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.13">
-			</color>
+			<color red="0.06" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.06">
-			</color>
+			<color red="0.03" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.13">
-			</color>
+			<color red="0.06" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.15" blue="0.35">
-			</color>
+			<color red="0.16" green="0.15" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.09">
-			</color>
+			<color red="0.04" green="0.04" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.31" blue="0.69">
-			</color>
+			<color red="0.33" green="0.31" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.17">
-			</color>
+			<color red="0.08" green="0.07" blue="0.17"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.15" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.31" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.17">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.15" blue="0.35">
-			</color>
+			<color red="0.16" green="0.15" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.09">
-			</color>
+			<color red="0.04" green="0.04" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.31" blue="0.69">
-			</color>
+			<color red="0.33" green="0.31" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.17">
-			</color>
+			<color red="0.08" green="0.07" blue="0.17"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.15" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.31" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.17">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.15" blue="0.35">
-			</color>
+			<color red="0.16" green="0.15" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.09">
-			</color>
+			<color red="0.04" green="0.04" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.31" blue="0.69">
-			</color>
+			<color red="0.33" green="0.31" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.17">
-			</color>
+			<color red="0.08" green="0.07" blue="0.17"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.15" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.31" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.17">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.15" blue="0.35">
-			</color>
+			<color red="0.16" green="0.15" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.09">
-			</color>
+			<color red="0.04" green="0.04" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.31" blue="0.69">
-			</color>
+			<color red="0.33" green="0.31" blue="0.69"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.17">
-			</color>
+			<color red="0.08" green="0.07" blue="0.17"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.15" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.31" blue="0.69">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.17">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mailbox">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mailbox">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="Antique Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="Antique Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.32" blue="0.18">
-			</color>
+			<color red="0.21" green="0.32" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.04">
-			</color>
+			<color red="0.05" green="0.08" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.64" blue="0.37">
-			</color>
+			<color red="0.42" green="0.64" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.16" blue="0.09">
-			</color>
+			<color red="0.11" green="0.16" blue="0.09"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.32" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.64" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.16" blue="0.09">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="Antique Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="Antique Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
+			<color red="0.50" green="0.39" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
+			<color red="1.00" green="0.79" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
+			<color red="0.25" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="Gold Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="Gold Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
+			<color red="0.01" green="0.49" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
+			<color red="0.00" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
+			<color red="0.02" green="0.98" blue="0.57"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
+			<color red="0.00" green="0.24" blue="0.14"/>
 		</rect>
 		<text string="Jewel Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
-		</rect>
-		<text string="Jewel Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mailbox">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mailbox">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
+			<color red="0.50" green="0.39" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
+			<color red="1.00" green="0.79" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
+			<color red="0.25" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="Gold Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="Gold Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
+			<color red="0.50" green="0.39" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
+			<color red="1.00" green="0.79" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
+			<color red="0.25" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="Gold Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="Gold Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
+			<color red="0.21" green="0.41" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
+			<color red="0.05" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
+			<color red="0.42" green="0.83" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
+			<color red="0.10" green="0.20" blue="0.04"/>
 		</rect>
 		<text string="Cash Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
-		</rect>
-		<text string="Cash Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
+			<color red="0.21" green="0.41" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
+			<color red="0.05" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
+			<color red="0.42" green="0.83" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
+			<color red="0.10" green="0.20" blue="0.04"/>
 		</rect>
 		<text string="Cash Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
-		</rect>
-		<text string="Cash Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="Antique Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="Antique Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
+			<color red="0.21" green="0.41" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
+			<color red="0.05" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
+			<color red="0.42" green="0.83" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
+			<color red="0.10" green="0.20" blue="0.04"/>
 		</rect>
 		<text string="Cash Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
-		</rect>
-		<text string="Cash Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.29" blue="0.17">
-			</color>
+			<color red="0.33" green="0.29" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.04">
-			</color>
+			<color red="0.08" green="0.07" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.65" green="0.58" blue="0.35">
-			</color>
+			<color red="0.65" green="0.58" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.15" blue="0.09">
-			</color>
+			<color red="0.16" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="Bank Holiday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.29" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.65" green="0.58" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="Bank Holiday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
+			<color red="0.36" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
+			<color red="0.73" green="0.77" blue="0.77"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
+			<color red="0.18" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Silver Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Silver Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
+			<color red="0.36" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
+			<color red="0.73" green="0.77" blue="0.77"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
+			<color red="0.18" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Silver Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Silver Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mailbox">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mailbox">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
+			<color red="0.36" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
+			<color red="0.73" green="0.77" blue="0.77"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
+			<color red="0.18" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Silver Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Silver Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
+			<color red="0.17" green="0.32" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
+			<color red="0.04" green="0.08" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
+			<color red="0.34" green="0.64" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
+			<color red="0.08" green="0.16" blue="0.16"/>
 		</rect>
 		<text string="Transport Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<text string="Transport Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.29" blue="0.17">
-			</color>
+			<color red="0.33" green="0.29" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.04">
-			</color>
+			<color red="0.08" green="0.07" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.65" green="0.58" blue="0.35">
-			</color>
+			<color red="0.65" green="0.58" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.15" blue="0.09">
-			</color>
+			<color red="0.16" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="Bank Holiday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.29" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.65" green="0.58" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="Bank Holiday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Property Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Property Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Property Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Property Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mail Box">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mail Box">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Property Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Property Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.32" blue="0.18">
-			</color>
+			<color red="0.21" green="0.32" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.04">
-			</color>
+			<color red="0.05" green="0.08" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.64" blue="0.37">
-			</color>
+			<color red="0.42" green="0.64" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.16" blue="0.09">
-			</color>
+			<color red="0.11" green="0.16" blue="0.09"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.32" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.64" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.16" blue="0.09">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
+			<color red="0.17" green="0.32" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
+			<color red="0.04" green="0.08" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
+			<color red="0.34" green="0.64" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
+			<color red="0.08" green="0.16" blue="0.16"/>
 		</rect>
 		<text string="Transport Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<text string="Transport Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Mailbox">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mailbox">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
+			<color red="0.17" green="0.32" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
+			<color red="0.04" green="0.08" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
+			<color red="0.34" green="0.64" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
+			<color red="0.08" green="0.16" blue="0.16"/>
 		</rect>
 		<text string="Transport Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<text string="Transport Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
+			<color red="0.46" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
+			<color red="0.11" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
+			<color red="0.93" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
+			<color red="0.23" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Leisure Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Leisure Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.32" blue="0.18">
-			</color>
+			<color red="0.21" green="0.32" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.04">
-			</color>
+			<color red="0.05" green="0.08" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.64" blue="0.37">
-			</color>
+			<color red="0.42" green="0.64" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.16" blue="0.09">
-			</color>
+			<color red="0.11" green="0.16" blue="0.09"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.32" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.08" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.64" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.16" blue="0.09">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
+			<color red="0.46" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
+			<color red="0.11" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
+			<color red="0.93" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
+			<color red="0.23" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Leisure">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Leisure">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.29" blue="0.17">
-			</color>
+			<color red="0.33" green="0.29" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.04">
-			</color>
+			<color red="0.08" green="0.07" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.65" green="0.58" blue="0.35">
-			</color>
+			<color red="0.65" green="0.58" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.15" blue="0.09">
-			</color>
+			<color red="0.16" green="0.15" blue="0.09"/>
 		</rect>
 		<text string="Bank Holiday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.29" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.07" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.65" green="0.58" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.15" blue="0.09">
-			</color>
-		</rect>
-		<text string="Bank Holiday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
+			<color red="0.46" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
+			<color red="0.11" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
+			<color red="0.93" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
+			<color red="0.23" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Leisure">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Leisure">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
+			<color red="0.01" green="0.49" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
+			<color red="0.00" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
+			<color red="0.02" green="0.98" blue="0.57"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
+			<color red="0.00" green="0.24" blue="0.14"/>
 		</rect>
 		<text string="Jewel Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
-		</rect>
-		<text string="Jewel Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
+			<color red="0.01" green="0.49" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
+			<color red="0.00" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
+			<color red="0.02" green="0.98" blue="0.57"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
+			<color red="0.00" green="0.24" blue="0.14"/>
 		</rect>
 		<text string="Jewel Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
-		</rect>
-		<text string="Jewel Set">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bank Charges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bank Charges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Share Value Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Share Value Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Won A Holiday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Won A Holiday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Wedding Expense">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Wedding Expense">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
+			<color red="0.36" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
+			<color red="0.73" green="0.77" blue="0.77"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
+			<color red="0.18" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Silv">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Silv">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
+			<color red="0.21" green="0.41" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
+			<color red="0.05" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
+			<color red="0.42" green="0.83" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
+			<color red="0.10" green="0.20" blue="0.04"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="Ant">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="Ant">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
+			<color red="0.50" green="0.39" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
+			<color red="1.00" green="0.79" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
+			<color red="0.25" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="Gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
+			<color red="0.01" green="0.49" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
+			<color red="0.00" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
+			<color red="0.02" green="0.98" blue="0.57"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
+			<color red="0.00" green="0.24" blue="0.14"/>
 		</rect>
 		<text string="Jew">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
-		</rect>
-		<text string="Jew">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
+			<color red="0.46" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
+			<color red="0.11" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
+			<color red="0.93" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
+			<color red="0.23" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Lei">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lei">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
+			<color red="0.17" green="0.32" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
+			<color red="0.04" green="0.08" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
+			<color red="0.34" green="0.64" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
+			<color red="0.08" green="0.16" blue="0.16"/>
 		</rect>
 		<text string="Transport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<text string="Transport">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
+			<color red="0.36" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
+			<color red="0.73" green="0.77" blue="0.77"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
+			<color red="0.18" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
+			<color red="0.36" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
+			<color red="0.73" green="0.77" blue="0.77"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
+			<color red="0.18" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
+			<color red="0.36" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
+			<color red="0.73" green="0.77" blue="0.77"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
+			<color red="0.18" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="0.77" blue="0.77">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
+			<color red="0.21" green="0.41" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
+			<color red="0.05" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
+			<color red="0.42" green="0.83" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
+			<color red="0.10" green="0.20" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
+			<color red="0.21" green="0.41" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
+			<color red="0.05" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
+			<color red="0.42" green="0.83" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
+			<color red="0.10" green="0.20" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
+			<color red="0.21" green="0.41" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
+			<color red="0.05" green="0.10" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
+			<color red="0.42" green="0.83" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
+			<color red="0.10" green="0.20" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.41" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.10" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.83" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.20" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
+			<color red="0.50" green="0.39" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
+			<color red="1.00" green="0.79" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
+			<color red="0.25" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
+			<color red="0.50" green="0.39" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
+			<color red="1.00" green="0.79" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
+			<color red="0.25" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
+			<color red="0.50" green="0.39" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
+			<color red="1.00" green="0.79" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
+			<color red="0.25" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.79" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
+			<color red="0.01" green="0.49" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
+			<color red="0.00" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
+			<color red="0.02" green="0.98" blue="0.57"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
+			<color red="0.00" green="0.24" blue="0.14"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
+			<color red="0.01" green="0.49" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
+			<color red="0.00" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
+			<color red="0.02" green="0.98" blue="0.57"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
+			<color red="0.00" green="0.24" blue="0.14"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
+			<color red="0.01" green="0.49" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
+			<color red="0.00" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
+			<color red="0.02" green="0.98" blue="0.57"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
+			<color red="0.00" green="0.24" blue="0.14"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.01" green="0.49" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.02" green="0.98" blue="0.57">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.24" blue="0.14">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
+			<color red="0.46" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
+			<color red="0.11" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
+			<color red="0.93" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
+			<color red="0.23" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
+			<color red="0.46" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
+			<color red="0.11" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
+			<color red="0.93" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
+			<color red="0.23" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
+			<color red="0.46" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
+			<color red="0.11" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
+			<color red="0.93" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
+			<color red="0.23" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
+			<color red="0.17" green="0.32" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
+			<color red="0.04" green="0.08" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
+			<color red="0.34" green="0.64" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
+			<color red="0.08" green="0.16" blue="0.16"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
+			<color red="0.17" green="0.32" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
+			<color red="0.04" green="0.08" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
+			<color red="0.34" green="0.64" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
+			<color red="0.08" green="0.16" blue="0.16"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
+			<color red="0.17" green="0.32" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
+			<color red="0.04" green="0.08" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
+			<color red="0.34" green="0.64" blue="0.66"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
+			<color red="0.08" green="0.16" blue="0.16"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.32" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.08" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.34" green="0.64" blue="0.66">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Property">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Property">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus Item">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus Item">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus Item">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus Item">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
+			<color red="0.44" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
+			<color red="0.11" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
+			<color red="0.87" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
+			<color red="0.22" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Premium Bond Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Premium Bond Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_227_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_227">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_228_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_228">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_229_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_229">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_230_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_230">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_231_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_231">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_232_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_232">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Save">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Part Wi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_234_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_234">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_235_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_235">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_6">
 		<text string="Plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_106">
 		<text string="Reserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_114">
 		<text string="On winline starts feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_115">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_117">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_118">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_120">
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_121">
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_122">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_123">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_124">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="&#xA3;3.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_134">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_135">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_136">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_137">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_138">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_139">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_140">
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_141">
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_223">
 		<text string="Nobody's Hero">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="849" height="651">
-			</bounds>
+			<bounds x="0" y="0" width="849" height="651"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="86" y="395" width="80" height="140">
-			</bounds>
+			<bounds x="86" y="395" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="86.0000" y="395.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="86.0000" y="395.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="89.3333" y="396.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="89.3333" y="396.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="92.6667" y="398.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="92.6667" y="398.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="96.0000" y="400.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="96.0000" y="400.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="99.3333" y="402.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="99.3333" y="402.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="102.6667" y="404.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="102.6667" y="404.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="86.0000" y="441.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="86.0000" y="441.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="89.3333" y="443.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="89.3333" y="443.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="92.6667" y="445.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="92.6667" y="445.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="96.0000" y="447.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="96.0000" y="447.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="99.3333" y="449.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="99.3333" y="449.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="102.6667" y="451.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="102.6667" y="451.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="86.0000" y="488.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="86.0000" y="488.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="89.3333" y="490.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="89.3333" y="490.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="92.6667" y="492.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="92.6667" y="492.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="96.0000" y="494.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="96.0000" y="494.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="99.3333" y="496.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="99.3333" y="496.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="102.6667" y="498.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="102.6667" y="498.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="86" y="395" width="80" height="140">
-			</bounds>
+			<bounds x="86" y="395" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="203" y="396" width="80" height="140">
-			</bounds>
+			<bounds x="203" y="396" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="396.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="396.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="397.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="397.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="399.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="399.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="401.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="401.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="403.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="403.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="405.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="405.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="442.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="442.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="444.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="444.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="446.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="446.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="448.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="448.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="450.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="450.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="452.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="452.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="489.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="489.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="491.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="491.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="493.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="493.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="495.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="495.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="497.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="497.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="499.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="499.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="203" y="396" width="80" height="140">
-			</bounds>
+			<bounds x="203" y="396" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="317" y="396" width="80" height="140">
-			</bounds>
+			<bounds x="317" y="396" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="317.0000" y="396.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="317.0000" y="396.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="320.3333" y="397.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="320.3333" y="397.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="323.6667" y="399.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="323.6667" y="399.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.0000" y="401.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="327.0000" y="401.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="330.3333" y="403.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="330.3333" y="403.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="333.6667" y="405.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="333.6667" y="405.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="317.0000" y="442.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="317.0000" y="442.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="320.3333" y="444.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="320.3333" y="444.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="323.6667" y="446.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="323.6667" y="446.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.0000" y="448.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="327.0000" y="448.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="330.3333" y="450.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="330.3333" y="450.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="333.6667" y="452.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="333.6667" y="452.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="317.0000" y="489.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="317.0000" y="489.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="320.3333" y="491.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="320.3333" y="491.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="323.6667" y="493.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="323.6667" y="493.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.0000" y="495.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="327.0000" y="495.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="330.3333" y="497.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="330.3333" y="497.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="333.6667" y="499.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="333.6667" y="499.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="317" y="396" width="80" height="140">
-			</bounds>
+			<bounds x="317" y="396" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="431" y="396" width="80" height="140">
-			</bounds>
+			<bounds x="431" y="396" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="431.0000" y="396.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="431.0000" y="396.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="434.3333" y="397.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="434.3333" y="397.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="437.6667" y="399.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="437.6667" y="399.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="441.0000" y="401.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="441.0000" y="401.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="444.3333" y="403.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="444.3333" y="403.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="447.6667" y="405.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="447.6667" y="405.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="431.0000" y="442.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="431.0000" y="442.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="434.3333" y="444.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="434.3333" y="444.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="437.6667" y="446.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="437.6667" y="446.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="441.0000" y="448.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="441.0000" y="448.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="444.3333" y="450.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="444.3333" y="450.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="447.6667" y="452.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="447.6667" y="452.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="431.0000" y="489.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="431.0000" y="489.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="434.3333" y="491.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="434.3333" y="491.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="437.6667" y="493.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="437.6667" y="493.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="441.0000" y="495.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="441.0000" y="495.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="444.3333" y="497.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="444.3333" y="497.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="447.6667" y="499.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="447.6667" y="499.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="431" y="396" width="80" height="140">
-			</bounds>
+			<bounds x="431" y="396" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="517" y="445" width="100" height="50">
-			</bounds>
+			<bounds x="517" y="445" width="100" height="50"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="517.0000" y="445.0000" width="100.0000" height="50.0000">
-			</bounds>
+			<bounds x="517.0000" y="445.0000" width="100.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="521.1667" y="447.0833" width="91.6667" height="45.8333">
-			</bounds>
+			<bounds x="521.1667" y="447.0833" width="91.6667" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="525.3333" y="449.1667" width="83.3333" height="41.6667">
-			</bounds>
+			<bounds x="525.3333" y="449.1667" width="83.3333" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="529.5000" y="451.2500" width="75.0000" height="37.5000">
-			</bounds>
+			<bounds x="529.5000" y="451.2500" width="75.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="533.6667" y="453.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="533.6667" y="453.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="537.8333" y="455.4167" width="58.3333" height="29.1667">
-			</bounds>
+			<bounds x="537.8333" y="455.4167" width="58.3333" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="517" y="445" width="100" height="50">
-			</bounds>
+			<bounds x="517" y="445" width="100" height="50"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="423" y="553" width="42" height="22">
-			</bounds>
+			<bounds x="423" y="553" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="425" y="555" width="38" height="18">
-			</bounds>
+			<bounds x="425" y="555" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="423" y="571" width="42" height="22">
-			</bounds>
+			<bounds x="423" y="571" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="425" y="573" width="38" height="18">
-			</bounds>
+			<bounds x="425" y="573" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="131" y="554" width="42" height="32">
-			</bounds>
+			<bounds x="131" y="554" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="133" y="556" width="38" height="28">
-			</bounds>
+			<bounds x="133" y="556" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="206" y="554" width="42" height="32">
-			</bounds>
+			<bounds x="206" y="554" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="208" y="556" width="38" height="28">
-			</bounds>
+			<bounds x="208" y="556" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="284" y="554" width="42" height="32">
-			</bounds>
+			<bounds x="284" y="554" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="286" y="556" width="38" height="28">
-			</bounds>
+			<bounds x="286" y="556" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="363" y="554" width="42" height="32">
-			</bounds>
+			<bounds x="363" y="554" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="365" y="556" width="38" height="28">
-			</bounds>
+			<bounds x="365" y="556" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="8" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="10" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="8" y="270" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="270" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="10" y="272" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="272" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="8" y="233" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="233" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="10" y="235" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="235" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="8" y="196" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="196" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="10" y="198" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="198" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="8" y="85" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="85" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="10" y="87" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="87" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="8" y="48" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="48" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="10" y="50" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="50" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="8" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="10" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="8" y="122" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="122" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="10" y="124" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="124" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="8" y="159" width="62" height="37">
-			</bounds>
+			<bounds x="8" y="159" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="10" y="161" width="58" height="33">
-			</bounds>
+			<bounds x="10" y="161" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="318" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="318" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="320" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="320" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="256" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="256" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="258" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="258" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="628" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="630" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="70" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="70" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="72" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="72" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="132" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="132" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="134" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="134" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="194" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="194" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="196" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="196" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="380" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="380" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="382" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="382" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="442" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="442" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="444" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="444" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="504" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="504" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="506" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="506" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="566" y="307" width="62" height="37">
-			</bounds>
+			<bounds x="566" y="307" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="568" y="309" width="58" height="33">
-			</bounds>
+			<bounds x="568" y="309" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="628" y="48" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="48" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="630" y="50" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="50" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="628" y="85" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="85" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="630" y="87" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="87" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="628" y="122" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="122" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="630" y="124" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="124" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="628" y="159" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="159" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="630" y="161" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="161" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="628" y="196" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="196" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="630" y="198" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="198" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="628" y="233" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="233" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="630" y="235" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="235" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="628" y="270" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="270" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="630" y="272" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="272" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="628" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="628" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="630" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="630" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="566" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="566" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="568" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="568" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="504" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="504" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="506" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="506" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="442" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="442" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="444" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="444" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="380" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="380" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="382" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="382" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="318" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="318" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="320" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="320" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="256" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="256" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="258" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="258" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="194" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="194" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="196" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="196" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="132" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="132" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="134" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="134" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="70" y="11" width="62" height="37">
-			</bounds>
+			<bounds x="70" y="11" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="72" y="13" width="58" height="33">
-			</bounds>
+			<bounds x="72" y="13" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="17" y="404" width="42" height="24">
-			</bounds>
+			<bounds x="17" y="404" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="19" y="406" width="38" height="20">
-			</bounds>
+			<bounds x="19" y="406" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="17" y="428" width="42" height="24">
-			</bounds>
+			<bounds x="17" y="428" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="19" y="430" width="38" height="20">
-			</bounds>
+			<bounds x="19" y="430" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="17" y="452" width="42" height="24">
-			</bounds>
+			<bounds x="17" y="452" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="19" y="454" width="38" height="20">
-			</bounds>
+			<bounds x="19" y="454" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="17" y="476" width="42" height="24">
-			</bounds>
+			<bounds x="17" y="476" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="19" y="478" width="38" height="20">
-			</bounds>
+			<bounds x="19" y="478" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="17" y="500" width="42" height="24">
-			</bounds>
+			<bounds x="17" y="500" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="19" y="502" width="38" height="20">
-			</bounds>
+			<bounds x="19" y="502" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="213" y="258" width="57" height="24">
-			</bounds>
+			<bounds x="213" y="258" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="215" y="260" width="53" height="20">
-			</bounds>
+			<bounds x="215" y="260" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="270" y="258" width="57" height="24">
-			</bounds>
+			<bounds x="270" y="258" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="272" y="260" width="53" height="20">
-			</bounds>
+			<bounds x="272" y="260" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="327" y="258" width="57" height="24">
-			</bounds>
+			<bounds x="327" y="258" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="329" y="260" width="53" height="20">
-			</bounds>
+			<bounds x="329" y="260" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="384" y="258" width="57" height="24">
-			</bounds>
+			<bounds x="384" y="258" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="386" y="260" width="53" height="20">
-			</bounds>
+			<bounds x="386" y="260" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="441" y="258" width="57" height="24">
-			</bounds>
+			<bounds x="441" y="258" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="443" y="260" width="53" height="20">
-			</bounds>
+			<bounds x="443" y="260" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="294" y="62" width="21" height="19">
-			</bounds>
+			<bounds x="294" y="62" width="21" height="19"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="296" y="64" width="17" height="15">
-			</bounds>
+			<bounds x="296" y="64" width="17" height="15"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="276" y="62" width="21" height="19">
-			</bounds>
+			<bounds x="276" y="62" width="21" height="19"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="278" y="64" width="17" height="15">
-			</bounds>
+			<bounds x="278" y="64" width="17" height="15"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="258" y="62" width="21" height="19">
-			</bounds>
+			<bounds x="258" y="62" width="21" height="19"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="260" y="64" width="17" height="15">
-			</bounds>
+			<bounds x="260" y="64" width="17" height="15"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="258" y="228" width="57" height="22">
-			</bounds>
+			<bounds x="258" y="228" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="260" y="230" width="53" height="18">
-			</bounds>
+			<bounds x="260" y="230" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="258" y="207" width="57" height="22">
-			</bounds>
+			<bounds x="258" y="207" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="260" y="209" width="53" height="18">
-			</bounds>
+			<bounds x="260" y="209" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="258" y="186" width="57" height="22">
-			</bounds>
+			<bounds x="258" y="186" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="260" y="188" width="53" height="18">
-			</bounds>
+			<bounds x="260" y="188" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="258" y="165" width="57" height="22">
-			</bounds>
+			<bounds x="258" y="165" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="260" y="167" width="53" height="18">
-			</bounds>
+			<bounds x="260" y="167" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="258" y="144" width="57" height="22">
-			</bounds>
+			<bounds x="258" y="144" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="260" y="146" width="53" height="18">
-			</bounds>
+			<bounds x="260" y="146" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="258" y="123" width="57" height="22">
-			</bounds>
+			<bounds x="258" y="123" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="260" y="125" width="53" height="18">
-			</bounds>
+			<bounds x="260" y="125" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="258" y="102" width="57" height="22">
-			</bounds>
+			<bounds x="258" y="102" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="260" y="104" width="53" height="18">
-			</bounds>
+			<bounds x="260" y="104" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="315" y="228" width="42" height="22">
-			</bounds>
+			<bounds x="315" y="228" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="317" y="230" width="38" height="18">
-			</bounds>
+			<bounds x="317" y="230" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="357" y="228" width="42" height="22">
-			</bounds>
+			<bounds x="357" y="228" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="359" y="230" width="38" height="18">
-			</bounds>
+			<bounds x="359" y="230" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="399" y="228" width="42" height="22">
-			</bounds>
+			<bounds x="399" y="228" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="401" y="230" width="38" height="18">
-			</bounds>
+			<bounds x="401" y="230" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="315" y="207" width="42" height="22">
-			</bounds>
+			<bounds x="315" y="207" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="317" y="209" width="38" height="18">
-			</bounds>
+			<bounds x="317" y="209" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="357" y="207" width="42" height="22">
-			</bounds>
+			<bounds x="357" y="207" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="359" y="209" width="38" height="18">
-			</bounds>
+			<bounds x="359" y="209" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="399" y="207" width="42" height="22">
-			</bounds>
+			<bounds x="399" y="207" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="401" y="209" width="38" height="18">
-			</bounds>
+			<bounds x="401" y="209" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="315" y="186" width="42" height="22">
-			</bounds>
+			<bounds x="315" y="186" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="317" y="188" width="38" height="18">
-			</bounds>
+			<bounds x="317" y="188" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="357" y="186" width="42" height="22">
-			</bounds>
+			<bounds x="357" y="186" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="359" y="188" width="38" height="18">
-			</bounds>
+			<bounds x="359" y="188" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="399" y="186" width="42" height="22">
-			</bounds>
+			<bounds x="399" y="186" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="401" y="188" width="38" height="18">
-			</bounds>
+			<bounds x="401" y="188" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="399" y="165" width="42" height="22">
-			</bounds>
+			<bounds x="399" y="165" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="401" y="167" width="38" height="18">
-			</bounds>
+			<bounds x="401" y="167" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="357" y="165" width="42" height="22">
-			</bounds>
+			<bounds x="357" y="165" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="359" y="167" width="38" height="18">
-			</bounds>
+			<bounds x="359" y="167" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="315" y="165" width="42" height="22">
-			</bounds>
+			<bounds x="315" y="165" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="317" y="167" width="38" height="18">
-			</bounds>
+			<bounds x="317" y="167" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="399" y="144" width="42" height="22">
-			</bounds>
+			<bounds x="399" y="144" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="401" y="146" width="38" height="18">
-			</bounds>
+			<bounds x="401" y="146" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="357" y="144" width="42" height="22">
-			</bounds>
+			<bounds x="357" y="144" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="359" y="146" width="38" height="18">
-			</bounds>
+			<bounds x="359" y="146" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="315" y="144" width="42" height="22">
-			</bounds>
+			<bounds x="315" y="144" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="317" y="146" width="38" height="18">
-			</bounds>
+			<bounds x="317" y="146" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="315" y="123" width="42" height="22">
-			</bounds>
+			<bounds x="315" y="123" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="317" y="125" width="38" height="18">
-			</bounds>
+			<bounds x="317" y="125" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="357" y="123" width="42" height="22">
-			</bounds>
+			<bounds x="357" y="123" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="359" y="125" width="38" height="18">
-			</bounds>
+			<bounds x="359" y="125" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="399" y="123" width="42" height="22">
-			</bounds>
+			<bounds x="399" y="123" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="401" y="125" width="38" height="18">
-			</bounds>
+			<bounds x="401" y="125" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="399" y="102" width="42" height="22">
-			</bounds>
+			<bounds x="399" y="102" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="401" y="104" width="38" height="18">
-			</bounds>
+			<bounds x="401" y="104" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="357" y="102" width="42" height="22">
-			</bounds>
+			<bounds x="357" y="102" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="359" y="104" width="38" height="18">
-			</bounds>
+			<bounds x="359" y="104" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="315" y="102" width="42" height="22">
-			</bounds>
+			<bounds x="315" y="102" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="317" y="104" width="38" height="18">
-			</bounds>
+			<bounds x="317" y="104" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="258" y="81" width="57" height="22">
-			</bounds>
+			<bounds x="258" y="81" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="260" y="83" width="53" height="18">
-			</bounds>
+			<bounds x="260" y="83" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="315" y="81" width="42" height="22">
-			</bounds>
+			<bounds x="315" y="81" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="317" y="83" width="38" height="18">
-			</bounds>
+			<bounds x="317" y="83" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="399" y="81" width="42" height="22">
-			</bounds>
+			<bounds x="399" y="81" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="401" y="83" width="38" height="18">
-			</bounds>
+			<bounds x="401" y="83" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="357" y="81" width="42" height="22">
-			</bounds>
+			<bounds x="357" y="81" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="359" y="83" width="38" height="18">
-			</bounds>
+			<bounds x="359" y="83" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="413" y="281" width="57" height="24">
-			</bounds>
+			<bounds x="413" y="281" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="415" y="283" width="53" height="20">
-			</bounds>
+			<bounds x="415" y="283" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="356" y="281" width="57" height="24">
-			</bounds>
+			<bounds x="356" y="281" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="358" y="283" width="53" height="20">
-			</bounds>
+			<bounds x="358" y="283" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="299" y="281" width="57" height="24">
-			</bounds>
+			<bounds x="299" y="281" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="301" y="283" width="53" height="20">
-			</bounds>
+			<bounds x="301" y="283" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="242" y="281" width="57" height="24">
-			</bounds>
+			<bounds x="242" y="281" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="244" y="283" width="53" height="20">
-			</bounds>
+			<bounds x="244" y="283" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="411" y="62" width="19" height="19">
-			</bounds>
+			<bounds x="411" y="62" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="413" y="64" width="15" height="15">
-			</bounds>
+			<bounds x="413" y="64" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="369" y="62" width="19" height="19">
-			</bounds>
+			<bounds x="369" y="62" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="371" y="64" width="15" height="15">
-			</bounds>
+			<bounds x="371" y="64" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="326" y="62" width="18" height="19">
-			</bounds>
+			<bounds x="326" y="62" width="18" height="19"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="328" y="64" width="14" height="15">
-			</bounds>
+			<bounds x="328" y="64" width="14" height="15"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_227_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="10" y="599" width="66" height="37">
-			</bounds>
+			<bounds x="10" y="599" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_227" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="12" y="601" width="62" height="33">
-			</bounds>
+			<bounds x="12" y="601" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_228_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="436" y="599" width="66" height="37">
-			</bounds>
+			<bounds x="436" y="599" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_228" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="438" y="601" width="62" height="33">
-			</bounds>
+			<bounds x="438" y="601" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_229_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="325" y="599" width="66" height="37">
-			</bounds>
+			<bounds x="325" y="599" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_229" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="327" y="601" width="62" height="33">
-			</bounds>
+			<bounds x="327" y="601" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_230_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="212" y="599" width="66" height="37">
-			</bounds>
+			<bounds x="212" y="599" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_230" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="214" y="601" width="62" height="33">
-			</bounds>
+			<bounds x="214" y="601" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_231_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="91" y="599" width="66" height="37">
-			</bounds>
+			<bounds x="91" y="599" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_231" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="93" y="601" width="62" height="33">
-			</bounds>
+			<bounds x="93" y="601" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_232_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="529" y="599" width="66" height="37">
-			</bounds>
+			<bounds x="529" y="599" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_232" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="531" y="601" width="62" height="33">
-			</bounds>
+			<bounds x="531" y="601" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_234_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="614" y="599" width="66" height="37">
-			</bounds>
+			<bounds x="614" y="599" width="66" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_234" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="616" y="601" width="62" height="33">
-			</bounds>
+			<bounds x="616" y="601" width="62" height="33"/>
 		</backdrop>
 		<backdrop name="lamp248" element="colour_button_235_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="631" y="434" width="47" height="62">
-			</bounds>
+			<bounds x="631" y="434" width="47" height="62"/>
 		</backdrop>
 		<backdrop name="lamp248" element="colour_button_235" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="633" y="436" width="43" height="58">
-			</bounds>
+			<bounds x="633" y="436" width="43" height="58"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="647" y="528" width="24" height="32">
-			</bounds>
+			<bounds x="647" y="528" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="650" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="664" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="664" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="650" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="650" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="650" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="650" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="650" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="650" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="667" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="667" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="650" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="664" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="664" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="650" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="650" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="650" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="650" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="650" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="650" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="650" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="667" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="667" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="623" y="528" width="24" height="32">
-			</bounds>
+			<bounds x="623" y="528" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="626" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="626" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="640" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="640" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="640" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="640" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="626" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="626" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="626" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="626" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="626" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="626" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="626" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="626" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_dot_off">
-			<bounds x="643" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="643" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="626" y="530" width="17" height="2">
-			</bounds>
+			<bounds x="626" y="530" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="640" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="640" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="640" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="640" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="626" y="554" width="17" height="2">
-			</bounds>
+			<bounds x="626" y="554" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="626" y="542" width="3" height="14">
-			</bounds>
+			<bounds x="626" y="542" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="626" y="530" width="3" height="14">
-			</bounds>
+			<bounds x="626" y="530" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="626" y="542" width="17" height="2">
-			</bounds>
+			<bounds x="626" y="542" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_dot_on">
-			<bounds x="643" y="554" width="3" height="2">
-			</bounds>
+			<bounds x="643" y="554" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="193" y="148" width="24" height="32">
-			</bounds>
+			<bounds x="193" y="148" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="196" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="196" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="210" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="210" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="210" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="210" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="196" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="196" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="196" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="196" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="196" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="196" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="196" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="196" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="213" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="213" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="196" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="196" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="210" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="210" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="210" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="210" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="196" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="196" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="196" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="196" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="196" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="196" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="196" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="196" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="213" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="213" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="145" y="148" width="24" height="32">
-			</bounds>
+			<bounds x="145" y="148" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="148" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="148" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="162" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="162" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="162" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="162" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="148" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="148" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="148" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="148" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="148" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="148" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="148" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="148" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="165" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="165" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="148" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="148" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="162" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="162" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="162" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="162" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="148" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="148" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="148" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="148" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="148" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="148" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="148" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="148" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="165" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="165" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="169" y="148" width="24" height="32">
-			</bounds>
+			<bounds x="169" y="148" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="172" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="172" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="186" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="186" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="186" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="186" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="172" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="172" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="172" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="172" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="172" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="172" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="172" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="172" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="189" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="189" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="172" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="172" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="186" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="186" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="186" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="186" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="172" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="172" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="172" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="172" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="172" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="172" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="172" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="172" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="189" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="189" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="481" y="148" width="24" height="32">
-			</bounds>
+			<bounds x="481" y="148" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="484" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="498" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="498" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="498" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="498" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="484" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="484" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="484" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="484" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="484" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="484" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="501" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="501" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="484" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="498" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="498" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="498" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="498" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="484" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="484" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="484" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="484" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="484" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="484" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="501" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="501" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="505" y="148" width="24" height="32">
-			</bounds>
+			<bounds x="505" y="148" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="508" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="508" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="522" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="522" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="522" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="522" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="508" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="508" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="508" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="508" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="508" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="508" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="508" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="508" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="525" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="525" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="508" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="508" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="522" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="522" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="522" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="522" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="508" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="508" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="508" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="508" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="508" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="508" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="508" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="508" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="525" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="525" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="529" y="148" width="24" height="32">
-			</bounds>
+			<bounds x="529" y="148" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off240" element="led_off">
-			<bounds x="532" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="532" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="546" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="546" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="546" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="546" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="532" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="532" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="532" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="532" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="532" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="532" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="532" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="532" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_dot_off">
-			<bounds x="549" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="549" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp240" element="led_on">
-			<bounds x="532" y="150" width="17" height="2">
-			</bounds>
+			<bounds x="532" y="150" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="546" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="546" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="546" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="546" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="532" y="174" width="17" height="2">
-			</bounds>
+			<bounds x="532" y="174" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="532" y="162" width="3" height="14">
-			</bounds>
+			<bounds x="532" y="162" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="532" y="150" width="3" height="14">
-			</bounds>
+			<bounds x="532" y="150" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="532" y="162" width="17" height="2">
-			</bounds>
+			<bounds x="532" y="162" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_dot_on">
-			<bounds x="549" y="174" width="3" height="2">
-			</bounds>
+			<bounds x="549" y="174" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="165" y="355" width="272" height="30">
-			</bounds>
+			<bounds x="165" y="355" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="165" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="165" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="182" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="182" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="199" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="199" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="216" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="216" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="233" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="233" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="250" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="250" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="267" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="267" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="284" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="284" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="301" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="301" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="318" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="318" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="335" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="335" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="352" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="352" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="369" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="369" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="386" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="386" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="403" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="403" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="420" y="355" width="17" height="30">
-			</bounds>
+			<bounds x="420" y="355" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label6" element="label_6">
-			<bounds x="625" y="556" width="44" height="24">
-			</bounds>
+			<bounds x="625" y="556" width="44" height="24"/>
 		</backdrop>
 		<backdrop name="label106" element="label_106">
-			<bounds x="146" y="118" width="73" height="32">
-			</bounds>
+			<bounds x="146" y="118" width="73" height="32"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="540" y="392" width="139" height="13">
-			</bounds>
+			<bounds x="540" y="392" width="139" height="13"/>
 		</backdrop>
 		<backdrop name="label115" element="label_115">
-			<bounds x="582" y="367" width="12" height="24">
-			</bounds>
+			<bounds x="582" y="367" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="label117" element="label_117">
-			<bounds x="125" y="151" width="20" height="37">
-			</bounds>
+			<bounds x="125" y="151" width="20" height="37"/>
 		</backdrop>
 		<backdrop name="label118" element="label_118">
-			<bounds x="461" y="151" width="20" height="37">
-			</bounds>
+			<bounds x="461" y="151" width="20" height="37"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="799" y="610" width="22" height="13">
-			</bounds>
+			<bounds x="799" y="610" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label120" element="label_120">
-			<bounds x="799" y="585" width="22" height="13">
-			</bounds>
+			<bounds x="799" y="585" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label121" element="label_121">
-			<bounds x="799" y="556" width="33" height="13">
-			</bounds>
+			<bounds x="799" y="556" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label122" element="label_122">
-			<bounds x="799" y="531" width="33" height="13">
-			</bounds>
+			<bounds x="799" y="531" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label123" element="label_123">
-			<bounds x="799" y="504" width="33" height="13">
-			</bounds>
+			<bounds x="799" y="504" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="799" y="478" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="478" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="799" y="449" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="449" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="799" y="424" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="424" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="799" y="398" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="398" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="799" y="370" width="33" height="13">
-			</bounds>
+			<bounds x="799" y="370" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="799" y="342" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="342" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="799" y="315" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="315" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="799" y="288" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="288" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="799" y="262" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="262" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="799" y="234" width="15" height="13">
-			</bounds>
+			<bounds x="799" y="234" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label134" element="label_134">
-			<bounds x="799" y="207" width="22" height="13">
-			</bounds>
+			<bounds x="799" y="207" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label135" element="label_135">
-			<bounds x="799" y="180" width="22" height="13">
-			</bounds>
+			<bounds x="799" y="180" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label136" element="label_136">
-			<bounds x="799" y="154" width="22" height="13">
-			</bounds>
+			<bounds x="799" y="154" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label137" element="label_137">
-			<bounds x="799" y="128" width="22" height="13">
-			</bounds>
+			<bounds x="799" y="128" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label138" element="label_138">
-			<bounds x="799" y="101" width="22" height="13">
-			</bounds>
+			<bounds x="799" y="101" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label139" element="label_139">
-			<bounds x="799" y="73" width="22" height="13">
-			</bounds>
+			<bounds x="799" y="73" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label140" element="label_140">
-			<bounds x="799" y="45" width="29" height="13">
-			</bounds>
+			<bounds x="799" y="45" width="29" height="13"/>
 		</backdrop>
 		<backdrop name="label141" element="label_141">
-			<bounds x="799" y="19" width="29" height="13">
-			</bounds>
+			<bounds x="799" y="19" width="29" height="13"/>
 		</backdrop>
 		<backdrop name="label223" element="label_223">
-			<bounds x="560" y="53" width="54" height="32">
-			</bounds>
+			<bounds x="560" y="53" width="54" height="32"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_reel" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_button" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp21" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1monmon.lay
+++ b/src/mame/layout/m1monmon.lay
@@ -8,10090 +8,6610 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string=" JACKPOT  REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string=" JACKPOT  REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="TWISTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="TWISTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="EVEN MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="EVEN MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="LUCKY DIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="LUCKY DIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REEL TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REEL TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string=" RED  HOT ROLL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string=" RED  HOT ROLL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CRAZY CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CRAZY CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HEAVENS ABOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="HEAVENS ABOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string=" LUCKY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FOR SOME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string=" LUCKY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FOR SOME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REEL RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REEL RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="16 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="16 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string=" COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
-		</text>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.23" width="0.90" height="0.18"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.41" width="0.90" height="0.18"/>
 		</text>
 		<text string="??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.59" width="0.90" height="0.18"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string=" CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_170_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_170">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_172_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_172">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SWAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_14">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.07"/>
 		</text>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.13" width="0.90" height="0.07"/>
 		</text>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.07"/>
 		</text>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.27" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.27" width="0.90" height="0.07"/>
 		</text>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.07"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.42" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.42" width="0.90" height="0.07"/>
 		</text>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.07"/>
 		</text>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.57" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.57" width="0.90" height="0.07"/>
 		</text>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.07"/>
 		</text>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.07"/>
 		</text>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.07"/>
 		</text>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.87" width="0.90" height="0.07"/>
 		</text>
 	</element>
 	<element name="label_15">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_47">
 		<text string="WIN LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_48">
 		<text string="WIN LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_122">
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_123">
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_124">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="991" height="679">
-			</bounds>
+			<bounds x="0" y="0" width="991" height="679"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="158" y="417" width="80" height="137">
-			</bounds>
+			<bounds x="158" y="417" width="80" height="137"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="158.0000" y="417.0000" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="158.0000" y="417.0000" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="161.3333" y="418.9028" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="161.3333" y="418.9028" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="164.6667" y="420.8055" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="164.6667" y="420.8055" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="168.0000" y="422.7083" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="168.0000" y="422.7083" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="171.3333" y="424.6111" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="171.3333" y="424.6111" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="174.6667" y="426.5139" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="174.6667" y="426.5139" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="158.0000" y="462.6667" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="158.0000" y="462.6667" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="161.3333" y="464.5694" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="161.3333" y="464.5694" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="164.6667" y="466.4722" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="164.6667" y="466.4722" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="168.0000" y="468.3750" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="168.0000" y="468.3750" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="171.3333" y="470.2778" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="171.3333" y="470.2778" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="174.6667" y="472.1805" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="174.6667" y="472.1805" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="158.0000" y="508.3333" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="158.0000" y="508.3333" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="161.3333" y="510.2361" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="161.3333" y="510.2361" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="164.6667" y="512.1389" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="164.6667" y="512.1389" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="168.0000" y="514.0417" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="168.0000" y="514.0417" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="171.3333" y="515.9445" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="171.3333" y="515.9445" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="174.6667" y="517.8472" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="174.6667" y="517.8472" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="158" y="417" width="80" height="137">
-			</bounds>
+			<bounds x="158" y="417" width="80" height="137"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="273" y="418" width="80" height="137">
-			</bounds>
+			<bounds x="273" y="418" width="80" height="137"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="273.0000" y="418.0000" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="273.0000" y="418.0000" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.3333" y="419.9028" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="276.3333" y="419.9028" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.6667" y="421.8055" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="279.6667" y="421.8055" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="283.0000" y="423.7083" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="283.0000" y="423.7083" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="425.6111" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="286.3333" y="425.6111" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="289.6667" y="427.5139" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="289.6667" y="427.5139" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="273.0000" y="463.6667" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="273.0000" y="463.6667" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.3333" y="465.5694" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="276.3333" y="465.5694" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.6667" y="467.4722" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="279.6667" y="467.4722" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="283.0000" y="469.3750" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="283.0000" y="469.3750" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="471.2778" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="286.3333" y="471.2778" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="289.6667" y="473.1805" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="289.6667" y="473.1805" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="273.0000" y="509.3333" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="273.0000" y="509.3333" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.3333" y="511.2361" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="276.3333" y="511.2361" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.6667" y="513.1389" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="279.6667" y="513.1389" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="283.0000" y="515.0417" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="283.0000" y="515.0417" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="516.9445" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="286.3333" y="516.9445" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="289.6667" y="518.8472" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="289.6667" y="518.8472" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="273" y="418" width="80" height="137">
-			</bounds>
+			<bounds x="273" y="418" width="80" height="137"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="388" y="419" width="80" height="137">
-			</bounds>
+			<bounds x="388" y="419" width="80" height="137"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="388.0000" y="419.0000" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="388.0000" y="419.0000" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="391.3333" y="420.9028" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="391.3333" y="420.9028" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="394.6667" y="422.8055" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="394.6667" y="422.8055" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="398.0000" y="424.7083" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="398.0000" y="424.7083" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="401.3333" y="426.6111" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="401.3333" y="426.6111" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="404.6667" y="428.5139" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="404.6667" y="428.5139" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="388.0000" y="464.6667" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="388.0000" y="464.6667" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="391.3333" y="466.5694" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="391.3333" y="466.5694" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="394.6667" y="468.4722" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="394.6667" y="468.4722" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="398.0000" y="470.3750" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="398.0000" y="470.3750" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="401.3333" y="472.2778" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="401.3333" y="472.2778" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="404.6667" y="474.1805" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="404.6667" y="474.1805" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="388.0000" y="510.3333" width="80.0000" height="45.6667">
-			</bounds>
+			<bounds x="388.0000" y="510.3333" width="80.0000" height="45.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="391.3333" y="512.2361" width="73.3333" height="41.8611">
-			</bounds>
+			<bounds x="391.3333" y="512.2361" width="73.3333" height="41.8611"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="394.6667" y="514.1389" width="66.6667" height="38.0556">
-			</bounds>
+			<bounds x="394.6667" y="514.1389" width="66.6667" height="38.0556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="398.0000" y="516.0417" width="60.0000" height="34.2500">
-			</bounds>
+			<bounds x="398.0000" y="516.0417" width="60.0000" height="34.2500"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="401.3333" y="517.9445" width="53.3333" height="30.4444">
-			</bounds>
+			<bounds x="401.3333" y="517.9445" width="53.3333" height="30.4444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="404.6667" y="519.8472" width="46.6667" height="26.6389">
-			</bounds>
+			<bounds x="404.6667" y="519.8472" width="46.6667" height="26.6389"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="388" y="419" width="80" height="137">
-			</bounds>
+			<bounds x="388" y="419" width="80" height="137"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="93" y="198" width="70" height="65">
-			</bounds>
+			<bounds x="93" y="198" width="70" height="65"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="93.0000" y="198.0000" width="70.0000" height="65.0000">
-			</bounds>
+			<bounds x="93.0000" y="198.0000" width="70.0000" height="65.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="95.9167" y="200.7083" width="64.1667" height="59.5833">
-			</bounds>
+			<bounds x="95.9167" y="200.7083" width="64.1667" height="59.5833"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="98.8333" y="203.4167" width="58.3333" height="54.1667">
-			</bounds>
+			<bounds x="98.8333" y="203.4167" width="58.3333" height="54.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="101.7500" y="206.1250" width="52.5000" height="48.7500">
-			</bounds>
+			<bounds x="101.7500" y="206.1250" width="52.5000" height="48.7500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="104.6667" y="208.8333" width="46.6667" height="43.3333">
-			</bounds>
+			<bounds x="104.6667" y="208.8333" width="46.6667" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="107.5833" y="211.5417" width="40.8333" height="37.9167">
-			</bounds>
+			<bounds x="107.5833" y="211.5417" width="40.8333" height="37.9167"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="93" y="198" width="70" height="65">
-			</bounds>
+			<bounds x="93" y="198" width="70" height="65"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="124" y="63" width="92" height="32">
-			</bounds>
+			<bounds x="124" y="63" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="126" y="65" width="88" height="28">
-			</bounds>
+			<bounds x="126" y="65" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="124" y="96" width="92" height="32">
-			</bounds>
+			<bounds x="124" y="96" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="126" y="98" width="88" height="28">
-			</bounds>
+			<bounds x="126" y="98" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="124" y="30" width="92" height="32">
-			</bounds>
+			<bounds x="124" y="30" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="126" y="32" width="88" height="28">
-			</bounds>
+			<bounds x="126" y="32" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="794" y="109" width="72" height="42">
-			</bounds>
+			<bounds x="794" y="109" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="796" y="111" width="68" height="38">
-			</bounds>
+			<bounds x="796" y="111" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="744" y="64" width="62" height="42">
-			</bounds>
+			<bounds x="744" y="64" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="746" y="66" width="58" height="38">
-			</bounds>
+			<bounds x="746" y="66" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="719" y="109" width="42" height="42">
-			</bounds>
+			<bounds x="719" y="109" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="721" y="111" width="38" height="38">
-			</bounds>
+			<bounds x="721" y="111" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="744" y="154" width="62" height="42">
-			</bounds>
+			<bounds x="744" y="154" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="746" y="156" width="58" height="38">
-			</bounds>
+			<bounds x="746" y="156" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="809" y="186" width="42" height="42">
-			</bounds>
+			<bounds x="809" y="186" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="811" y="188" width="38" height="38">
-			</bounds>
+			<bounds x="811" y="188" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="854" y="154" width="62" height="42">
-			</bounds>
+			<bounds x="854" y="154" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="856" y="156" width="58" height="38">
-			</bounds>
+			<bounds x="856" y="156" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="899" y="109" width="42" height="42">
-			</bounds>
+			<bounds x="899" y="109" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="901" y="111" width="38" height="38">
-			</bounds>
+			<bounds x="901" y="111" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="853" y="64" width="62" height="42">
-			</bounds>
+			<bounds x="853" y="64" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="855" y="66" width="58" height="38">
-			</bounds>
+			<bounds x="855" y="66" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="809" y="27" width="42" height="42">
-			</bounds>
+			<bounds x="809" y="27" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="811" y="29" width="38" height="38">
-			</bounds>
+			<bounds x="811" y="29" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="415" y="19" width="152" height="52">
-			</bounds>
+			<bounds x="415" y="19" width="152" height="52"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="417" y="21" width="148" height="48">
-			</bounds>
+			<bounds x="417" y="21" width="148" height="48"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="415" y="19" width="152" height="52">
-			</bounds>
+			<bounds x="415" y="19" width="152" height="52"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="417" y="21" width="148" height="48">
-			</bounds>
+			<bounds x="417" y="21" width="148" height="48"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="369" y="270" width="62" height="52">
-			</bounds>
+			<bounds x="369" y="270" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="371" y="272" width="58" height="48">
-			</bounds>
+			<bounds x="371" y="272" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="401" y="219" width="62" height="52">
-			</bounds>
+			<bounds x="401" y="219" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="403" y="221" width="58" height="48">
-			</bounds>
+			<bounds x="403" y="221" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="430" y="168" width="62" height="52">
-			</bounds>
+			<bounds x="430" y="168" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="432" y="170" width="58" height="48">
-			</bounds>
+			<bounds x="432" y="170" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="462" y="117" width="62" height="52">
-			</bounds>
+			<bounds x="462" y="117" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="464" y="119" width="58" height="48">
-			</bounds>
+			<bounds x="464" y="119" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="491" y="168" width="62" height="52">
-			</bounds>
+			<bounds x="491" y="168" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="493" y="170" width="58" height="48">
-			</bounds>
+			<bounds x="493" y="170" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="523" y="219" width="62" height="52">
-			</bounds>
+			<bounds x="523" y="219" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="525" y="221" width="58" height="48">
-			</bounds>
+			<bounds x="525" y="221" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="552" y="270" width="62" height="52">
-			</bounds>
+			<bounds x="552" y="270" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="554" y="272" width="58" height="48">
-			</bounds>
+			<bounds x="554" y="272" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="491" y="270" width="62" height="52">
-			</bounds>
+			<bounds x="491" y="270" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="493" y="272" width="58" height="48">
-			</bounds>
+			<bounds x="493" y="272" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="430" y="270" width="62" height="52">
-			</bounds>
+			<bounds x="430" y="270" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="432" y="272" width="58" height="48">
-			</bounds>
+			<bounds x="432" y="272" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="462" y="219" width="62" height="52">
-			</bounds>
+			<bounds x="462" y="219" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="464" y="221" width="58" height="48">
-			</bounds>
+			<bounds x="464" y="221" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="280" y="335" width="57" height="32">
-			</bounds>
+			<bounds x="280" y="335" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="282" y="337" width="53" height="28">
-			</bounds>
+			<bounds x="282" y="337" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="293" y="304" width="57" height="32">
-			</bounds>
+			<bounds x="293" y="304" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="295" y="306" width="53" height="28">
-			</bounds>
+			<bounds x="295" y="306" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="305" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="305" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="307" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="307" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="320" y="242" width="57" height="32">
-			</bounds>
+			<bounds x="320" y="242" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="322" y="244" width="53" height="28">
-			</bounds>
+			<bounds x="322" y="244" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="336" y="211" width="57" height="32">
-			</bounds>
+			<bounds x="336" y="211" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="338" y="213" width="53" height="28">
-			</bounds>
+			<bounds x="338" y="213" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="355" y="180" width="57" height="32">
-			</bounds>
+			<bounds x="355" y="180" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="357" y="182" width="53" height="28">
-			</bounds>
+			<bounds x="357" y="182" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="368" y="149" width="57" height="32">
-			</bounds>
+			<bounds x="368" y="149" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="370" y="151" width="53" height="28">
-			</bounds>
+			<bounds x="370" y="151" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="382" y="118" width="57" height="32">
-			</bounds>
+			<bounds x="382" y="118" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="384" y="120" width="53" height="28">
-			</bounds>
+			<bounds x="384" y="120" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="395" y="87" width="92" height="32">
-			</bounds>
+			<bounds x="395" y="87" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="397" y="89" width="88" height="28">
-			</bounds>
+			<bounds x="397" y="89" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="647" y="335" width="57" height="32">
-			</bounds>
+			<bounds x="647" y="335" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="649" y="337" width="53" height="28">
-			</bounds>
+			<bounds x="649" y="337" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="636" y="304" width="57" height="32">
-			</bounds>
+			<bounds x="636" y="304" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="638" y="306" width="53" height="28">
-			</bounds>
+			<bounds x="638" y="306" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="624" y="273" width="57" height="32">
-			</bounds>
+			<bounds x="624" y="273" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="626" y="275" width="53" height="28">
-			</bounds>
+			<bounds x="626" y="275" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="608" y="242" width="57" height="32">
-			</bounds>
+			<bounds x="608" y="242" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="610" y="244" width="53" height="28">
-			</bounds>
+			<bounds x="610" y="244" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="594" y="211" width="57" height="32">
-			</bounds>
+			<bounds x="594" y="211" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="596" y="213" width="53" height="28">
-			</bounds>
+			<bounds x="596" y="213" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="576" y="180" width="57" height="32">
-			</bounds>
+			<bounds x="576" y="180" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="578" y="182" width="53" height="28">
-			</bounds>
+			<bounds x="578" y="182" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="562" y="149" width="57" height="32">
-			</bounds>
+			<bounds x="562" y="149" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="564" y="151" width="53" height="28">
-			</bounds>
+			<bounds x="564" y="151" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="549" y="118" width="57" height="32">
-			</bounds>
+			<bounds x="549" y="118" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="551" y="120" width="53" height="28">
-			</bounds>
+			<bounds x="551" y="120" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="499" y="87" width="92" height="32">
-			</bounds>
+			<bounds x="499" y="87" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="501" y="89" width="88" height="28">
-			</bounds>
+			<bounds x="501" y="89" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="258" y="339" width="22" height="22">
-			</bounds>
+			<bounds x="258" y="339" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="260" y="341" width="18" height="18">
-			</bounds>
+			<bounds x="260" y="341" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="270" y="309" width="22" height="22">
-			</bounds>
+			<bounds x="270" y="309" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="272" y="311" width="18" height="18">
-			</bounds>
+			<bounds x="272" y="311" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="282" y="279" width="22" height="22">
-			</bounds>
+			<bounds x="282" y="279" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="284" y="281" width="18" height="18">
-			</bounds>
+			<bounds x="284" y="281" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="296" y="247" width="22" height="22">
-			</bounds>
+			<bounds x="296" y="247" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="298" y="249" width="18" height="18">
-			</bounds>
+			<bounds x="298" y="249" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="326" y="185" width="22" height="22">
-			</bounds>
+			<bounds x="326" y="185" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="328" y="187" width="18" height="18">
-			</bounds>
+			<bounds x="328" y="187" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="311" y="216" width="22" height="22">
-			</bounds>
+			<bounds x="311" y="216" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="313" y="218" width="18" height="18">
-			</bounds>
+			<bounds x="313" y="218" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="341" y="154" width="22" height="22">
-			</bounds>
+			<bounds x="341" y="154" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="343" y="156" width="18" height="18">
-			</bounds>
+			<bounds x="343" y="156" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="358" y="124" width="22" height="22">
-			</bounds>
+			<bounds x="358" y="124" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="360" y="126" width="18" height="18">
-			</bounds>
+			<bounds x="360" y="126" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_158_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="694" y="608" width="95" height="62">
-			</bounds>
+			<bounds x="694" y="608" width="95" height="62"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_158" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="696" y="610" width="91" height="58">
-			</bounds>
+			<bounds x="696" y="610" width="91" height="58"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_159_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="528" y="603" width="82" height="72">
-			</bounds>
+			<bounds x="528" y="603" width="82" height="72"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_159" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="530" y="605" width="78" height="68">
-			</bounds>
+			<bounds x="530" y="605" width="78" height="68"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_160_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="394" y="603" width="72" height="72">
-			</bounds>
+			<bounds x="394" y="603" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_160" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="396" y="605" width="68" height="68">
-			</bounds>
+			<bounds x="396" y="605" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_161_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="279" y="603" width="72" height="72">
-			</bounds>
+			<bounds x="279" y="603" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_161" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="281" y="605" width="68" height="68">
-			</bounds>
+			<bounds x="281" y="605" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_162_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="164" y="603" width="72" height="72">
-			</bounds>
+			<bounds x="164" y="603" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_162" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="166" y="605" width="68" height="68">
-			</bounds>
+			<bounds x="166" y="605" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_163_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="13" y="603" width="72" height="72">
-			</bounds>
+			<bounds x="13" y="603" width="72" height="72"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_163" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="15" y="605" width="68" height="68">
-			</bounds>
+			<bounds x="15" y="605" width="68" height="68"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_164_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="907" y="7" width="75" height="27">
-			</bounds>
+			<bounds x="907" y="7" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_164" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="909" y="9" width="71" height="23">
-			</bounds>
+			<bounds x="909" y="9" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_170_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="906" y="603" width="77" height="72">
-			</bounds>
+			<bounds x="906" y="603" width="77" height="72"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_170" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="908" y="605" width="73" height="68">
-			</bounds>
+			<bounds x="908" y="605" width="73" height="68"/>
 		</backdrop>
 		<backdrop name="lamp155" element="colour_button_172_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="498" y="326" width="57" height="57">
-			</bounds>
+			<bounds x="498" y="326" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp155" element="colour_button_172" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="500" y="328" width="53" height="53">
-			</bounds>
+			<bounds x="500" y="328" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="935" y="246" width="32" height="40">
-			</bounds>
+			<bounds x="935" y="246" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off216" element="led_off">
-			<bounds x="939" y="249" width="22" height="3">
-			</bounds>
+			<bounds x="939" y="249" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off217" element="led_off">
-			<bounds x="957" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="957" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off218" element="led_off">
-			<bounds x="957" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="957" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off219" element="led_off">
-			<bounds x="939" y="278" width="22" height="3">
-			</bounds>
+			<bounds x="939" y="278" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off220" element="led_off">
-			<bounds x="939" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="939" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off221" element="led_off">
-			<bounds x="939" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="939" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off222" element="led_off">
-			<bounds x="939" y="264" width="22" height="3">
-			</bounds>
+			<bounds x="939" y="264" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off223" element="led_dot_off">
-			<bounds x="962" y="278" width="4" height="3">
-			</bounds>
+			<bounds x="962" y="278" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp216" element="led_on">
-			<bounds x="939" y="249" width="22" height="3">
-			</bounds>
+			<bounds x="939" y="249" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp217" element="led_on">
-			<bounds x="957" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="957" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp218" element="led_on">
-			<bounds x="957" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="957" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp219" element="led_on">
-			<bounds x="939" y="278" width="22" height="3">
-			</bounds>
+			<bounds x="939" y="278" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp220" element="led_on">
-			<bounds x="939" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="939" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp221" element="led_on">
-			<bounds x="939" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="939" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp222" element="led_on">
-			<bounds x="939" y="264" width="22" height="3">
-			</bounds>
+			<bounds x="939" y="264" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp223" element="led_dot_on">
-			<bounds x="962" y="278" width="4" height="3">
-			</bounds>
+			<bounds x="962" y="278" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="905" y="246" width="32" height="40">
-			</bounds>
+			<bounds x="905" y="246" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off208" element="led_off">
-			<bounds x="909" y="249" width="22" height="3">
-			</bounds>
+			<bounds x="909" y="249" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off209" element="led_off">
-			<bounds x="927" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="927" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off210" element="led_off">
-			<bounds x="927" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="927" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off211" element="led_off">
-			<bounds x="909" y="278" width="22" height="3">
-			</bounds>
+			<bounds x="909" y="278" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off212" element="led_off">
-			<bounds x="909" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="909" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off213" element="led_off">
-			<bounds x="909" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="909" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off214" element="led_off">
-			<bounds x="909" y="264" width="22" height="3">
-			</bounds>
+			<bounds x="909" y="264" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off215" element="led_dot_off">
-			<bounds x="932" y="278" width="4" height="3">
-			</bounds>
+			<bounds x="932" y="278" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp208" element="led_on">
-			<bounds x="909" y="249" width="22" height="3">
-			</bounds>
+			<bounds x="909" y="249" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp209" element="led_on">
-			<bounds x="927" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="927" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp210" element="led_on">
-			<bounds x="927" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="927" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="led_on">
-			<bounds x="909" y="278" width="22" height="3">
-			</bounds>
+			<bounds x="909" y="278" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp212" element="led_on">
-			<bounds x="909" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="909" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp213" element="led_on">
-			<bounds x="909" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="909" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="led_on">
-			<bounds x="909" y="264" width="22" height="3">
-			</bounds>
+			<bounds x="909" y="264" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp215" element="led_dot_on">
-			<bounds x="932" y="278" width="4" height="3">
-			</bounds>
+			<bounds x="932" y="278" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="875" y="246" width="32" height="40">
-			</bounds>
+			<bounds x="875" y="246" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="879" y="249" width="22" height="3">
-			</bounds>
+			<bounds x="879" y="249" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="897" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="897" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="897" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="897" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="879" y="278" width="22" height="3">
-			</bounds>
+			<bounds x="879" y="278" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="879" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="879" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="879" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="879" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="879" y="264" width="22" height="3">
-			</bounds>
+			<bounds x="879" y="264" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="902" y="278" width="4" height="3">
-			</bounds>
+			<bounds x="902" y="278" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="879" y="249" width="22" height="3">
-			</bounds>
+			<bounds x="879" y="249" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="897" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="897" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="897" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="897" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="879" y="278" width="22" height="3">
-			</bounds>
+			<bounds x="879" y="278" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="879" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="879" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="879" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="879" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="879" y="264" width="22" height="3">
-			</bounds>
+			<bounds x="879" y="264" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="902" y="278" width="4" height="3">
-			</bounds>
+			<bounds x="902" y="278" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="847" y="246" width="32" height="40">
-			</bounds>
+			<bounds x="847" y="246" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off192" element="led_off">
-			<bounds x="851" y="249" width="22" height="3">
-			</bounds>
+			<bounds x="851" y="249" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off193" element="led_off">
-			<bounds x="869" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="869" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off194" element="led_off">
-			<bounds x="869" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="869" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off195" element="led_off">
-			<bounds x="851" y="278" width="22" height="3">
-			</bounds>
+			<bounds x="851" y="278" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off196" element="led_off">
-			<bounds x="851" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="851" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off197" element="led_off">
-			<bounds x="851" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="851" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off198" element="led_off">
-			<bounds x="851" y="264" width="22" height="3">
-			</bounds>
+			<bounds x="851" y="264" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off199" element="led_dot_off">
-			<bounds x="874" y="278" width="4" height="3">
-			</bounds>
+			<bounds x="874" y="278" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp192" element="led_on">
-			<bounds x="851" y="249" width="22" height="3">
-			</bounds>
+			<bounds x="851" y="249" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp193" element="led_on">
-			<bounds x="869" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="869" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp194" element="led_on">
-			<bounds x="869" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="869" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="led_on">
-			<bounds x="851" y="278" width="22" height="3">
-			</bounds>
+			<bounds x="851" y="278" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp196" element="led_on">
-			<bounds x="851" y="264" width="4" height="18">
-			</bounds>
+			<bounds x="851" y="264" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp197" element="led_on">
-			<bounds x="851" y="249" width="4" height="18">
-			</bounds>
+			<bounds x="851" y="249" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp198" element="led_on">
-			<bounds x="851" y="264" width="22" height="3">
-			</bounds>
+			<bounds x="851" y="264" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp199" element="led_dot_on">
-			<bounds x="874" y="278" width="4" height="3">
-			</bounds>
+			<bounds x="874" y="278" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="436" y="331" width="37" height="45">
-			</bounds>
+			<bounds x="436" y="331" width="37" height="45"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="441" y="335" width="26" height="4">
-			</bounds>
+			<bounds x="441" y="335" width="26" height="4"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="462" y="335" width="5" height="20">
-			</bounds>
+			<bounds x="462" y="335" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="462" y="351" width="5" height="20">
-			</bounds>
+			<bounds x="462" y="351" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="441" y="367" width="26" height="4">
-			</bounds>
+			<bounds x="441" y="367" width="26" height="4"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="441" y="351" width="5" height="20">
-			</bounds>
+			<bounds x="441" y="351" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="441" y="335" width="5" height="20">
-			</bounds>
+			<bounds x="441" y="335" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="441" y="351" width="26" height="4">
-			</bounds>
+			<bounds x="441" y="351" width="26" height="4"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="467" y="367" width="5" height="4">
-			</bounds>
+			<bounds x="467" y="367" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="441" y="335" width="26" height="4">
-			</bounds>
+			<bounds x="441" y="335" width="26" height="4"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="462" y="335" width="5" height="20">
-			</bounds>
+			<bounds x="462" y="335" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="462" y="351" width="5" height="20">
-			</bounds>
+			<bounds x="462" y="351" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="441" y="367" width="26" height="4">
-			</bounds>
+			<bounds x="441" y="367" width="26" height="4"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="441" y="351" width="5" height="20">
-			</bounds>
+			<bounds x="441" y="351" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="441" y="335" width="5" height="20">
-			</bounds>
+			<bounds x="441" y="335" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="441" y="351" width="26" height="4">
-			</bounds>
+			<bounds x="441" y="351" width="26" height="4"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="467" y="367" width="5" height="4">
-			</bounds>
+			<bounds x="467" y="367" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="751" y="425" width="50" height="70">
-			</bounds>
+			<bounds x="751" y="425" width="50" height="70"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="758" y="431" width="35" height="6">
-			</bounds>
+			<bounds x="758" y="431" width="35" height="6"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="786" y="431" width="7" height="31">
-			</bounds>
+			<bounds x="786" y="431" width="7" height="31"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="786" y="456" width="7" height="31">
-			</bounds>
+			<bounds x="786" y="456" width="7" height="31"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="758" y="482" width="35" height="6">
-			</bounds>
+			<bounds x="758" y="482" width="35" height="6"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="758" y="456" width="7" height="31">
-			</bounds>
+			<bounds x="758" y="456" width="7" height="31"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="758" y="431" width="7" height="31">
-			</bounds>
+			<bounds x="758" y="431" width="7" height="31"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="758" y="456" width="35" height="6">
-			</bounds>
+			<bounds x="758" y="456" width="35" height="6"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_dot_off">
-			<bounds x="793" y="482" width="7" height="6">
-			</bounds>
+			<bounds x="793" y="482" width="7" height="6"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="758" y="431" width="35" height="6">
-			</bounds>
+			<bounds x="758" y="431" width="35" height="6"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="786" y="431" width="7" height="31">
-			</bounds>
+			<bounds x="786" y="431" width="7" height="31"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="786" y="456" width="7" height="31">
-			</bounds>
+			<bounds x="786" y="456" width="7" height="31"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="758" y="482" width="35" height="6">
-			</bounds>
+			<bounds x="758" y="482" width="35" height="6"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="758" y="456" width="7" height="31">
-			</bounds>
+			<bounds x="758" y="456" width="7" height="31"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="758" y="431" width="7" height="31">
-			</bounds>
+			<bounds x="758" y="431" width="7" height="31"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="758" y="456" width="35" height="6">
-			</bounds>
+			<bounds x="758" y="456" width="35" height="6"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_dot_on">
-			<bounds x="793" y="482" width="7" height="6">
-			</bounds>
+			<bounds x="793" y="482" width="7" height="6"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="362" y="387" width="272" height="30">
-			</bounds>
+			<bounds x="362" y="387" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="362" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="362" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="379" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="379" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="396" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="396" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="413" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="413" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="430" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="430" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="447" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="447" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="464" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="464" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="481" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="481" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="498" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="498" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="515" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="515" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="532" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="532" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="549" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="549" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="566" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="566" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="583" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="583" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="600" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="600" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="617" y="387" width="17" height="30">
-			</bounds>
+			<bounds x="617" y="387" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label14" element="label_14">
-			<bounds x="55" y="116" width="21" height="240">
-			</bounds>
+			<bounds x="55" y="116" width="21" height="240"/>
 		</backdrop>
 		<backdrop name="label15" element="label_15">
-			<bounds x="807" y="226" width="37" height="80">
-			</bounds>
+			<bounds x="807" y="226" width="37" height="80"/>
 		</backdrop>
 		<backdrop name="label47" element="label_47">
-			<bounds x="239" y="471" width="34" height="32">
-			</bounds>
+			<bounds x="239" y="471" width="34" height="32"/>
 		</backdrop>
 		<backdrop name="label48" element="label_48">
-			<bounds x="354" y="472" width="34" height="32">
-			</bounds>
+			<bounds x="354" y="472" width="34" height="32"/>
 		</backdrop>
 		<backdrop name="label122" element="label_122">
-			<bounds x="910" y="361" width="69" height="16">
-			</bounds>
+			<bounds x="910" y="361" width="69" height="16"/>
 		</backdrop>
 		<backdrop name="label123" element="label_123">
-			<bounds x="909" y="388" width="21" height="20">
-			</bounds>
+			<bounds x="909" y="388" width="21" height="20"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="909" y="414" width="21" height="20">
-			</bounds>
+			<bounds x="909" y="414" width="21" height="20"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="909" y="438" width="21" height="20">
-			</bounds>
+			<bounds x="909" y="438" width="21" height="20"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="910" y="462" width="21" height="20">
-			</bounds>
+			<bounds x="910" y="462" width="21" height="20"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="910" y="489" width="21" height="20">
-			</bounds>
+			<bounds x="910" y="489" width="21" height="20"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="910" y="517" width="46" height="20">
-			</bounds>
+			<bounds x="910" y="517" width="46" height="20"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="909" y="543" width="46" height="20">
-			</bounds>
+			<bounds x="909" y="543" width="46" height="20"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="909" y="568" width="21" height="20">
-			</bounds>
+			<bounds x="909" y="568" width="21" height="20"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_button" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1monou.lay
+++ b/src/mame/layout/m1monou.lay
@@ -8,12070 +8,7503 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="JAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="JAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Old Kent Road 60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Old Kent Road 60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Community">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Community">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="W'chapel Road 60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="W'chapel Road 60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Income Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Income Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Kings Cross Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Kings Cross Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Angel Islington &#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Angel Islington &#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Euston Road &#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Euston Road &#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Pentonville Road &#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pentonville Road &#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
 		<text string="Jus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Jus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#x3C; ---">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#x3C; ---">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Visiting">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Visiting">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Vine St &#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vine St &#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="M'boro St &#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="M'boro St &#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Community">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Community">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Bow St &#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Bow St &#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Marylebone Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Marylebone Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="North'land &#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="North'land &#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Whitehall &#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Whitehall &#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Electric Company">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Electric Company">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Pall Mall &#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Pall Mall &#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Parking">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Parking">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Piccadilly &#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Piccadilly &#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Go To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Go To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.06">
-			</color>
+			<color red="0.03" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.13">
-			</color>
+			<color red="0.06" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Mayfair Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Mayfair Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Super Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super Tax">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.06">
-			</color>
+			<color red="0.03" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.13">
-			</color>
+			<color red="0.06" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Park Lane &#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Park Lane &#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Liverpool ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="St. Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Liverpool ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="St. Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bond St &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bond St &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Oxford St &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Oxford St &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Regent St &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Regent St &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Available">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Available">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Light A Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Light A Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Adv. Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Adv. Mayfair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Go to Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go to Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Get  Out  Of ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jail Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Get  Out  Of ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jail Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Birthday Adv.4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Birthday Adv.4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Strand &#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Strand &#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Leicester ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Sq &#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Leicester ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Sq &#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Coventry St &#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Coventry St &#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Water Works">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Water Works">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Fenchurch St Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fenchurch St Station">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Trafalgar Square &#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trafalgar Square &#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Fleet St &#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fleet St &#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Go to Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go to Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Adv. Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Adv. Piccadilly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Get out of">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jail Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Get out of">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jail Free">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_118_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_118">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_119_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_119">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_120_border">
 		<rect state="1">
-			<color red="0.00" green="0.32" blue="0.00">
-			</color>
+			<color red="0.00" green="0.32" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_120">
 		<rect state="1">
-			<color red="0.00" green="0.64" blue="0.00">
-			</color>
+			<color red="0.00" green="0.64" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_122_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_122">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_125_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_125">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_126_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_126">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="tkn">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_127_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_127">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_128_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_128">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_129_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_129">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_130_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_130">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_52">
 		<text string="Cherries">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_61">
 		<text string="Plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_62">
 		<text string="TOKENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_63">
 		<text string="+ REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_69">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_70">
 		<text string="Winnings">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_71">
 		<text string="Community Chest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_72">
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="1 Station Lit &#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_79">
 		<text string="2 Stations Lit &#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_80">
 		<text string="3 Stations Lit &#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_81">
 		<text string="4 Stations Lit Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_82">
 		<text string="Grateful thanks">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="to LEEHAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_83">
 		<text string="v1.1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_96">
 		<text string="Red Sevens">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_97">
 		<text string="Double Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="Single Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_99">
 		<text string="Bells">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_100">
 		<text string="Melons">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_101">
 		<text string="Mixed Bars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_111">
 		<text string="MFME layout by">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_113">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_114">
 		<text string="Original machine by">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="834" height="650">
-			</bounds>
+			<bounds x="0" y="0" width="834" height="650"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="213" y="407" width="71" height="158">
-			</bounds>
+			<bounds x="213" y="407" width="71" height="158"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="213.0000" y="407.0000" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="213.0000" y="407.0000" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="215.9583" y="409.1945" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="215.9583" y="409.1945" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="218.9167" y="411.3889" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="218.9167" y="411.3889" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="221.8750" y="413.5833" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="221.8750" y="413.5833" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="224.8333" y="415.7778" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="224.8333" y="415.7778" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="227.7917" y="417.9722" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="227.7917" y="417.9722" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="213.0000" y="459.6667" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="213.0000" y="459.6667" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="215.9583" y="461.8611" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="215.9583" y="461.8611" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="218.9167" y="464.0555" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="218.9167" y="464.0555" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="221.8750" y="466.2500" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="221.8750" y="466.2500" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="224.8333" y="468.4444" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="224.8333" y="468.4444" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="227.7917" y="470.6389" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="227.7917" y="470.6389" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="213.0000" y="512.3333" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="213.0000" y="512.3333" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="215.9583" y="514.5278" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="215.9583" y="514.5278" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="218.9167" y="516.7222" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="218.9167" y="516.7222" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="221.8750" y="518.9166" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="221.8750" y="518.9166" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="224.8333" y="521.1111" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="224.8333" y="521.1111" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="227.7917" y="523.3055" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="227.7917" y="523.3055" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="213" y="407" width="71" height="158">
-			</bounds>
+			<bounds x="213" y="407" width="71" height="158"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="319" y="407" width="71" height="158">
-			</bounds>
+			<bounds x="319" y="407" width="71" height="158"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="319.0000" y="407.0000" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="319.0000" y="407.0000" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.9583" y="409.1945" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="321.9583" y="409.1945" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.9167" y="411.3889" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="324.9167" y="411.3889" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.8750" y="413.5833" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="327.8750" y="413.5833" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="330.8333" y="415.7778" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="330.8333" y="415.7778" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="333.7917" y="417.9722" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="333.7917" y="417.9722" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="319.0000" y="459.6667" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="319.0000" y="459.6667" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.9583" y="461.8611" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="321.9583" y="461.8611" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.9167" y="464.0555" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="324.9167" y="464.0555" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.8750" y="466.2500" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="327.8750" y="466.2500" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="330.8333" y="468.4444" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="330.8333" y="468.4444" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="333.7917" y="470.6389" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="333.7917" y="470.6389" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="319.0000" y="512.3333" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="319.0000" y="512.3333" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.9583" y="514.5278" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="321.9583" y="514.5278" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.9167" y="516.7222" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="324.9167" y="516.7222" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.8750" y="518.9166" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="327.8750" y="518.9166" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="330.8333" y="521.1111" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="330.8333" y="521.1111" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="333.7917" y="523.3055" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="333.7917" y="523.3055" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="319" y="407" width="71" height="158">
-			</bounds>
+			<bounds x="319" y="407" width="71" height="158"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="425" y="407" width="71" height="158">
-			</bounds>
+			<bounds x="425" y="407" width="71" height="158"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="407.0000" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="425.0000" y="407.0000" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.9583" y="409.1945" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="427.9583" y="409.1945" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.9167" y="411.3889" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="430.9167" y="411.3889" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="433.8750" y="413.5833" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="433.8750" y="413.5833" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="436.8333" y="415.7778" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="436.8333" y="415.7778" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="439.7917" y="417.9722" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="439.7917" y="417.9722" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="459.6667" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="425.0000" y="459.6667" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.9583" y="461.8611" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="427.9583" y="461.8611" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.9167" y="464.0555" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="430.9167" y="464.0555" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="433.8750" y="466.2500" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="433.8750" y="466.2500" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="436.8333" y="468.4444" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="436.8333" y="468.4444" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="439.7917" y="470.6389" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="439.7917" y="470.6389" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="512.3333" width="71.0000" height="52.6667">
-			</bounds>
+			<bounds x="425.0000" y="512.3333" width="71.0000" height="52.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.9583" y="514.5278" width="65.0833" height="48.2778">
-			</bounds>
+			<bounds x="427.9583" y="514.5278" width="65.0833" height="48.2778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.9167" y="516.7222" width="59.1667" height="43.8889">
-			</bounds>
+			<bounds x="430.9167" y="516.7222" width="59.1667" height="43.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="433.8750" y="518.9166" width="53.2500" height="39.5000">
-			</bounds>
+			<bounds x="433.8750" y="518.9166" width="53.2500" height="39.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="436.8333" y="521.1111" width="47.3333" height="35.1111">
-			</bounds>
+			<bounds x="436.8333" y="521.1111" width="47.3333" height="35.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="439.7917" y="523.3055" width="41.4167" height="30.7222">
-			</bounds>
+			<bounds x="439.7917" y="523.3055" width="41.4167" height="30.7222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="425" y="407" width="71" height="158">
-			</bounds>
+			<bounds x="425" y="407" width="71" height="158"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="232" y="179" width="70" height="70">
-			</bounds>
+			<bounds x="232" y="179" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="232.0000" y="179.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="232.0000" y="179.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="234.9167" y="181.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="234.9167" y="181.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="237.8333" y="184.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="237.8333" y="184.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.7500" y="187.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="240.7500" y="187.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.6667" y="190.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="243.6667" y="190.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.5833" y="193.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="246.5833" y="193.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="232" y="179" width="70" height="70">
-			</bounds>
+			<bounds x="232" y="179" width="70" height="70"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="406" y="179" width="70" height="70">
-			</bounds>
+			<bounds x="406" y="179" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="406.0000" y="179.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="406.0000" y="179.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="408.9167" y="181.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="408.9167" y="181.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="411.8333" y="184.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="411.8333" y="184.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="414.7500" y="187.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="414.7500" y="187.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="417.6667" y="190.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="417.6667" y="190.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="420.5833" y="193.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="420.5833" y="193.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="406" y="179" width="70" height="70">
-			</bounds>
+			<bounds x="406" y="179" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="34" y="348" width="42" height="32">
-			</bounds>
+			<bounds x="34" y="348" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="36" y="350" width="38" height="28">
-			</bounds>
+			<bounds x="36" y="350" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="571" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="571" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="573" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="573" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="509" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="509" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="511" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="511" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="447" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="447" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="449" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="449" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="385" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="385" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="387" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="387" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="323" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="323" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="325" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="325" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="261" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="261" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="263" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="263" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="199" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="199" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="201" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="201" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="137" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="137" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="139" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="139" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="75" y="359" width="62" height="42">
-			</bounds>
+			<bounds x="75" y="359" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="77" y="361" width="58" height="38">
-			</bounds>
+			<bounds x="77" y="361" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="13" y="348" width="22" height="52">
-			</bounds>
+			<bounds x="13" y="348" width="22" height="52"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="15" y="350" width="18" height="48">
-			</bounds>
+			<bounds x="15" y="350" width="18" height="48"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="634" y="349" width="62" height="52">
-			</bounds>
+			<bounds x="634" y="349" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="636" y="351" width="58" height="48">
-			</bounds>
+			<bounds x="636" y="351" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_2_border" state="0">
-			<bounds x="34" y="379" width="42" height="22">
-			</bounds>
+			<bounds x="34" y="379" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_2" state="0">
-			<bounds x="36" y="381" width="38" height="18">
-			</bounds>
+			<bounds x="36" y="381" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="14" y="61" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="61" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="16" y="63" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="63" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="14" y="93" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="93" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="16" y="95" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="95" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="14" y="125" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="125" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="16" y="127" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="127" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="14" y="157" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="157" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="16" y="159" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="159" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="14" y="189" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="189" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="16" y="191" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="191" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="14" y="221" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="221" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="16" y="223" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="223" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="14" y="253" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="253" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="16" y="255" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="255" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="14" y="285" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="285" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="16" y="287" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="287" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="14" y="317" width="62" height="32">
-			</bounds>
+			<bounds x="14" y="317" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="16" y="319" width="58" height="28">
-			</bounds>
+			<bounds x="16" y="319" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="14" y="9" width="62" height="52">
-			</bounds>
+			<bounds x="14" y="9" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="16" y="11" width="58" height="48">
-			</bounds>
+			<bounds x="16" y="11" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="572" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="572" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="574" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="574" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="634" y="9" width="62" height="52">
-			</bounds>
+			<bounds x="634" y="9" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="636" y="11" width="58" height="48">
-			</bounds>
+			<bounds x="636" y="11" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="634" y="317" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="317" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="636" y="319" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="319" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="634" y="285" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="285" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="636" y="287" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="287" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="634" y="253" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="253" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="636" y="255" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="255" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="634" y="221" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="221" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="636" y="223" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="223" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="634" y="189" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="189" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="636" y="191" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="191" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="634" y="157" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="157" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="636" y="159" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="159" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="634" y="125" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="125" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="636" y="127" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="127" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="634" y="93" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="93" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="636" y="95" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="95" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="634" y="61" width="62" height="32">
-			</bounds>
+			<bounds x="634" y="61" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="636" y="63" width="58" height="28">
-			</bounds>
+			<bounds x="636" y="63" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="625" y="516" width="62" height="52">
-			</bounds>
+			<bounds x="625" y="516" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="627" y="518" width="58" height="48">
-			</bounds>
+			<bounds x="627" y="518" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="755" y="349" width="67" height="27">
-			</bounds>
+			<bounds x="755" y="349" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="757" y="351" width="63" height="23">
-			</bounds>
+			<bounds x="757" y="351" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="755" y="49" width="67" height="27">
-			</bounds>
+			<bounds x="755" y="49" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="757" y="51" width="63" height="23">
-			</bounds>
+			<bounds x="757" y="51" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="755" y="99" width="67" height="27">
-			</bounds>
+			<bounds x="755" y="99" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="757" y="101" width="63" height="23">
-			</bounds>
+			<bounds x="757" y="101" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="755" y="149" width="67" height="27">
-			</bounds>
+			<bounds x="755" y="149" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="757" y="151" width="63" height="23">
-			</bounds>
+			<bounds x="757" y="151" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="755" y="199" width="67" height="27">
-			</bounds>
+			<bounds x="755" y="199" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="757" y="201" width="63" height="23">
-			</bounds>
+			<bounds x="757" y="201" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="755" y="249" width="67" height="27">
-			</bounds>
+			<bounds x="755" y="249" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="757" y="251" width="63" height="23">
-			</bounds>
+			<bounds x="757" y="251" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="755" y="299" width="67" height="27">
-			</bounds>
+			<bounds x="755" y="299" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="757" y="301" width="63" height="23">
-			</bounds>
+			<bounds x="757" y="301" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="679" y="449" width="37" height="37">
-			</bounds>
+			<bounds x="679" y="449" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="681" y="451" width="33" height="33">
-			</bounds>
+			<bounds x="681" y="451" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="625" y="462" width="37" height="37">
-			</bounds>
+			<bounds x="625" y="462" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="627" y="464" width="33" height="33">
-			</bounds>
+			<bounds x="627" y="464" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="575" y="489" width="37" height="37">
-			</bounds>
+			<bounds x="575" y="489" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="577" y="491" width="33" height="33">
-			</bounds>
+			<bounds x="577" y="491" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="541" y="533" width="37" height="37">
-			</bounds>
+			<bounds x="541" y="533" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="543" y="535" width="33" height="33">
-			</bounds>
+			<bounds x="543" y="535" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="533" y="437" width="72" height="22">
-			</bounds>
+			<bounds x="533" y="437" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="535" y="439" width="68" height="18">
-			</bounds>
+			<bounds x="535" y="439" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="533" y="416" width="72" height="22">
-			</bounds>
+			<bounds x="533" y="416" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="535" y="418" width="68" height="18">
-			</bounds>
+			<bounds x="535" y="418" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="534" y="67" width="82" height="19">
-			</bounds>
+			<bounds x="534" y="67" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="536" y="69" width="78" height="15">
-			</bounds>
+			<bounds x="536" y="69" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="534" y="88" width="82" height="19">
-			</bounds>
+			<bounds x="534" y="88" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="536" y="90" width="78" height="15">
-			</bounds>
+			<bounds x="536" y="90" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="101" y="292" width="72" height="22">
-			</bounds>
+			<bounds x="101" y="292" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="103" y="294" width="68" height="18">
-			</bounds>
+			<bounds x="103" y="294" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="510" y="296" width="72" height="22">
-			</bounds>
+			<bounds x="510" y="296" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="512" y="298" width="68" height="18">
-			</bounds>
+			<bounds x="512" y="298" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="414" y="296" width="72" height="22">
-			</bounds>
+			<bounds x="414" y="296" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="416" y="298" width="68" height="18">
-			</bounds>
+			<bounds x="416" y="298" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="511" y="323" width="72" height="22">
-			</bounds>
+			<bounds x="511" y="323" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="513" y="325" width="68" height="18">
-			</bounds>
+			<bounds x="513" y="325" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="414" y="323" width="72" height="22">
-			</bounds>
+			<bounds x="414" y="323" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="416" y="325" width="68" height="18">
-			</bounds>
+			<bounds x="416" y="325" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="76" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="76" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="78" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="78" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="138" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="138" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="140" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="140" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="386" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="386" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="388" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="388" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="448" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="448" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="450" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="450" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="510" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="510" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="512" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="512" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="324" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="324" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="326" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="326" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="262" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="262" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="264" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="264" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="200" y="9" width="62" height="42">
-			</bounds>
+			<bounds x="200" y="9" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="202" y="11" width="58" height="38">
-			</bounds>
+			<bounds x="202" y="11" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="254" y="308" width="72" height="22">
-			</bounds>
+			<bounds x="254" y="308" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="256" y="310" width="68" height="18">
-			</bounds>
+			<bounds x="256" y="310" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="178" y="322" width="72" height="22">
-			</bounds>
+			<bounds x="178" y="322" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="180" y="324" width="68" height="18">
-			</bounds>
+			<bounds x="180" y="324" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="101" y="315" width="72" height="32">
-			</bounds>
+			<bounds x="101" y="315" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="103" y="317" width="68" height="28">
-			</bounds>
+			<bounds x="103" y="317" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="178" y="297" width="72" height="22">
-			</bounds>
+			<bounds x="178" y="297" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="180" y="299" width="68" height="18">
-			</bounds>
+			<bounds x="180" y="299" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="711" y="12" width="22" height="22">
-			</bounds>
+			<bounds x="711" y="12" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="713" y="14" width="18" height="18">
-			</bounds>
+			<bounds x="713" y="14" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="219" y="569" width="32" height="32">
-			</bounds>
+			<bounds x="219" y="569" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="221" y="571" width="28" height="28">
-			</bounds>
+			<bounds x="221" y="571" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="253" y="569" width="32" height="32">
-			</bounds>
+			<bounds x="253" y="569" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="255" y="571" width="28" height="28">
-			</bounds>
+			<bounds x="255" y="571" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="287" y="569" width="32" height="32">
-			</bounds>
+			<bounds x="287" y="569" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="289" y="571" width="28" height="28">
-			</bounds>
+			<bounds x="289" y="571" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="321" y="569" width="32" height="32">
-			</bounds>
+			<bounds x="321" y="569" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="323" y="571" width="28" height="28">
-			</bounds>
+			<bounds x="323" y="571" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="355" y="569" width="32" height="32">
-			</bounds>
+			<bounds x="355" y="569" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="357" y="571" width="28" height="28">
-			</bounds>
+			<bounds x="357" y="571" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="389" y="569" width="32" height="32">
-			</bounds>
+			<bounds x="389" y="569" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="391" y="571" width="28" height="28">
-			</bounds>
+			<bounds x="391" y="571" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="423" y="569" width="32" height="32">
-			</bounds>
+			<bounds x="423" y="569" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="425" y="571" width="28" height="28">
-			</bounds>
+			<bounds x="425" y="571" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="457" y="569" width="32" height="32">
-			</bounds>
+			<bounds x="457" y="569" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="459" y="571" width="28" height="28">
-			</bounds>
+			<bounds x="459" y="571" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="328" y="219" width="52" height="19">
-			</bounds>
+			<bounds x="328" y="219" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="330" y="221" width="48" height="15">
-			</bounds>
+			<bounds x="330" y="221" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="328" y="190" width="52" height="19">
-			</bounds>
+			<bounds x="328" y="190" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="330" y="192" width="48" height="15">
-			</bounds>
+			<bounds x="330" y="192" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_118_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="528" y="606" width="72" height="37">
-			</bounds>
+			<bounds x="528" y="606" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_118" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="530" y="608" width="68" height="33">
-			</bounds>
+			<bounds x="530" y="608" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_119_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="621" y="606" width="72" height="37">
-			</bounds>
+			<bounds x="621" y="606" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_119" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="623" y="608" width="68" height="33">
-			</bounds>
+			<bounds x="623" y="608" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_120_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="713" y="606" width="72" height="37">
-			</bounds>
+			<bounds x="713" y="606" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_120" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="715" y="608" width="68" height="33">
-			</bounds>
+			<bounds x="715" y="608" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_122_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="66" y="606" width="72" height="37">
-			</bounds>
+			<bounds x="66" y="606" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_122" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="68" y="608" width="68" height="33">
-			</bounds>
+			<bounds x="68" y="608" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_125_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="66" y="606" width="72" height="37">
-			</bounds>
+			<bounds x="66" y="606" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_125" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="68" y="608" width="68" height="33">
-			</bounds>
+			<bounds x="68" y="608" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_126_border" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="749" y="5" width="37" height="37">
-			</bounds>
+			<bounds x="749" y="5" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_126" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="751" y="7" width="33" height="33">
-			</bounds>
+			<bounds x="751" y="7" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_127_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="791" y="5" width="37" height="37">
-			</bounds>
+			<bounds x="791" y="5" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_127" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="793" y="7" width="33" height="33">
-			</bounds>
+			<bounds x="793" y="7" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_128_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="212" y="606" width="73" height="37">
-			</bounds>
+			<bounds x="212" y="606" width="73" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_128" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="214" y="608" width="69" height="33">
-			</bounds>
+			<bounds x="214" y="608" width="69" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_129_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="318" y="606" width="73" height="37">
-			</bounds>
+			<bounds x="318" y="606" width="73" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_129" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="320" y="608" width="69" height="33">
-			</bounds>
+			<bounds x="320" y="608" width="69" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_130_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="424" y="606" width="73" height="37">
-			</bounds>
+			<bounds x="424" y="606" width="73" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_130" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="426" y="608" width="69" height="33">
-			</bounds>
+			<bounds x="426" y="608" width="69" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="769" y="524" width="24" height="32">
-			</bounds>
+			<bounds x="769" y="524" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="772" y="526" width="17" height="2">
-			</bounds>
+			<bounds x="772" y="526" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="786" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="786" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="786" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="786" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="772" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="772" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="772" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="772" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="772" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="772" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="772" y="538" width="17" height="2">
-			</bounds>
+			<bounds x="772" y="538" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="789" y="550" width="3" height="2">
-			</bounds>
+			<bounds x="789" y="550" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="772" y="526" width="17" height="2">
-			</bounds>
+			<bounds x="772" y="526" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="786" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="786" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="786" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="786" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="772" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="772" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="772" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="772" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="772" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="772" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="772" y="538" width="17" height="2">
-			</bounds>
+			<bounds x="772" y="538" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="789" y="550" width="3" height="2">
-			</bounds>
+			<bounds x="789" y="550" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="746" y="524" width="24" height="32">
-			</bounds>
+			<bounds x="746" y="524" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="749" y="526" width="17" height="2">
-			</bounds>
+			<bounds x="749" y="526" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="763" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="763" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="763" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="763" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="749" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="749" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="749" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="749" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="749" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="749" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="749" y="538" width="17" height="2">
-			</bounds>
+			<bounds x="749" y="538" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="766" y="550" width="3" height="2">
-			</bounds>
+			<bounds x="766" y="550" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="749" y="526" width="17" height="2">
-			</bounds>
+			<bounds x="749" y="526" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="763" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="763" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="763" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="763" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="749" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="749" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="749" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="749" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="749" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="749" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="749" y="538" width="17" height="2">
-			</bounds>
+			<bounds x="749" y="538" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="766" y="550" width="3" height="2">
-			</bounds>
+			<bounds x="766" y="550" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="154" y="67" width="24" height="32">
-			</bounds>
+			<bounds x="154" y="67" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off216" element="led_off">
-			<bounds x="157" y="69" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="69" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off217" element="led_off">
-			<bounds x="171" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="171" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off218" element="led_off">
-			<bounds x="171" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="171" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off219" element="led_off">
-			<bounds x="157" y="93" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="93" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off220" element="led_off">
-			<bounds x="157" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="157" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off221" element="led_off">
-			<bounds x="157" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="157" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off222" element="led_off">
-			<bounds x="157" y="81" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="81" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="174" y="93" width="3" height="2">
-			</bounds>
+			<bounds x="174" y="93" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp216" element="led_on">
-			<bounds x="157" y="69" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="69" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp217" element="led_on">
-			<bounds x="171" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="171" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp218" element="led_on">
-			<bounds x="171" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="171" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp219" element="led_on">
-			<bounds x="157" y="93" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="93" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp220" element="led_on">
-			<bounds x="157" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="157" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp221" element="led_on">
-			<bounds x="157" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="157" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp222" element="led_on">
-			<bounds x="157" y="81" width="17" height="2">
-			</bounds>
+			<bounds x="157" y="81" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="174" y="93" width="3" height="2">
-			</bounds>
+			<bounds x="174" y="93" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="130" y="67" width="24" height="32">
-			</bounds>
+			<bounds x="130" y="67" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off208" element="led_off">
-			<bounds x="133" y="69" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="69" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off209" element="led_off">
-			<bounds x="147" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="147" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off210" element="led_off">
-			<bounds x="147" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="147" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off211" element="led_off">
-			<bounds x="133" y="93" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="93" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off212" element="led_off">
-			<bounds x="133" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="133" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off213" element="led_off">
-			<bounds x="133" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="133" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off214" element="led_off">
-			<bounds x="133" y="81" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="81" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off215" element="led_dot_off">
-			<bounds x="150" y="93" width="3" height="2">
-			</bounds>
+			<bounds x="150" y="93" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp208" element="led_on">
-			<bounds x="133" y="69" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="69" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp209" element="led_on">
-			<bounds x="147" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="147" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp210" element="led_on">
-			<bounds x="147" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="147" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp211" element="led_on">
-			<bounds x="133" y="93" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="93" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp212" element="led_on">
-			<bounds x="133" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="133" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp213" element="led_on">
-			<bounds x="133" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="133" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp214" element="led_on">
-			<bounds x="133" y="81" width="17" height="2">
-			</bounds>
+			<bounds x="133" y="81" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp215" element="led_dot_on">
-			<bounds x="150" y="93" width="3" height="2">
-			</bounds>
+			<bounds x="150" y="93" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="106" y="67" width="24" height="32">
-			</bounds>
+			<bounds x="106" y="67" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="109" y="69" width="17" height="2">
-			</bounds>
+			<bounds x="109" y="69" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="123" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="123" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="123" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="123" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="109" y="93" width="17" height="2">
-			</bounds>
+			<bounds x="109" y="93" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="109" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="109" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="109" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="109" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="109" y="81" width="17" height="2">
-			</bounds>
+			<bounds x="109" y="81" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="126" y="93" width="3" height="2">
-			</bounds>
+			<bounds x="126" y="93" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="109" y="69" width="17" height="2">
-			</bounds>
+			<bounds x="109" y="69" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="123" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="123" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="123" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="123" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="109" y="93" width="17" height="2">
-			</bounds>
+			<bounds x="109" y="93" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="109" y="81" width="3" height="14">
-			</bounds>
+			<bounds x="109" y="81" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="109" y="69" width="3" height="14">
-			</bounds>
+			<bounds x="109" y="69" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="109" y="81" width="17" height="2">
-			</bounds>
+			<bounds x="109" y="81" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="126" y="93" width="3" height="2">
-			</bounds>
+			<bounds x="126" y="93" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="219" y="59" width="272" height="30">
-			</bounds>
+			<bounds x="219" y="59" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="219" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="219" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="236" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="236" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="253" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="253" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="270" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="270" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="287" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="287" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="304" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="304" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="321" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="321" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="338" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="338" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="355" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="355" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="372" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="372" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="389" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="389" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="406" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="406" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="423" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="423" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="440" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="440" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="457" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="457" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="474" y="59" width="17" height="30">
-			</bounds>
+			<bounds x="474" y="59" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label52" element="label_52">
-			<bounds x="706" y="354" width="49" height="14">
-			</bounds>
+			<bounds x="706" y="354" width="49" height="14"/>
 		</backdrop>
 		<backdrop name="label61" element="label_61">
-			<bounds x="751" y="506" width="34" height="16">
-			</bounds>
+			<bounds x="751" y="506" width="34" height="16"/>
 		</backdrop>
 		<backdrop name="label62" element="label_62">
-			<bounds x="764" y="75" width="49" height="15">
-			</bounds>
+			<bounds x="764" y="75" width="49" height="15"/>
 		</backdrop>
 		<backdrop name="label63" element="label_63">
-			<bounds x="759" y="125" width="56" height="15">
-			</bounds>
+			<bounds x="759" y="125" width="56" height="15"/>
 		</backdrop>
 		<backdrop name="label69" element="label_69">
-			<bounds x="84" y="64" width="18" height="37">
-			</bounds>
+			<bounds x="84" y="64" width="18" height="37"/>
 		</backdrop>
 		<backdrop name="label70" element="label_70">
-			<bounds x="106" y="101" width="72" height="19">
-			</bounds>
+			<bounds x="106" y="101" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="label71" element="label_71">
-			<bounds x="432" y="267" width="137" height="19">
-			</bounds>
+			<bounds x="432" y="267" width="137" height="19"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="183" y="267" width="59" height="19">
-			</bounds>
+			<bounds x="183" y="267" width="59" height="19"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="312" y="106" width="86" height="14">
-			</bounds>
+			<bounds x="312" y="106" width="86" height="14"/>
 		</backdrop>
 		<backdrop name="label79" element="label_79">
-			<bounds x="309" y="121" width="92" height="14">
-			</bounds>
+			<bounds x="309" y="121" width="92" height="14"/>
 		</backdrop>
 		<backdrop name="label80" element="label_80">
-			<bounds x="309" y="136" width="92" height="14">
-			</bounds>
+			<bounds x="309" y="136" width="92" height="14"/>
 		</backdrop>
 		<backdrop name="label81" element="label_81">
-			<bounds x="305" y="151" width="102" height="14">
-			</bounds>
+			<bounds x="305" y="151" width="102" height="14"/>
 		</backdrop>
 		<backdrop name="label82" element="label_82">
-			<bounds x="760" y="393" width="53" height="42">
-			</bounds>
+			<bounds x="760" y="393" width="53" height="42"/>
 		</backdrop>
 		<backdrop name="label83" element="label_83">
-			<bounds x="809" y="635" width="21" height="14">
-			</bounds>
+			<bounds x="809" y="635" width="21" height="14"/>
 		</backdrop>
 		<backdrop name="label96" element="label_96">
-			<bounds x="709" y="49" width="41" height="28">
-			</bounds>
+			<bounds x="709" y="49" width="41" height="28"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="709" y="99" width="41" height="28">
-			</bounds>
+			<bounds x="709" y="99" width="41" height="28"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="711" y="149" width="37" height="28">
-			</bounds>
+			<bounds x="711" y="149" width="37" height="28"/>
 		</backdrop>
 		<backdrop name="label99" element="label_99">
-			<bounds x="716" y="205" width="27" height="14">
-			</bounds>
+			<bounds x="716" y="205" width="27" height="14"/>
 		</backdrop>
 		<backdrop name="label100" element="label_100">
-			<bounds x="710" y="255" width="41" height="14">
-			</bounds>
+			<bounds x="710" y="255" width="41" height="14"/>
 		</backdrop>
 		<backdrop name="label101" element="label_101">
-			<bounds x="713" y="298" width="36" height="28">
-			</bounds>
+			<bounds x="713" y="298" width="36" height="28"/>
 		</backdrop>
 		<backdrop name="label111" element="label_111">
-			<bounds x="60" y="486" width="83" height="15">
-			</bounds>
+			<bounds x="60" y="486" width="83" height="15"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="34" y="567" width="133" height="15">
-			</bounds>
+			<bounds x="34" y="567" width="133" height="15"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="48" y="423" width="109" height="15">
-			</bounds>
+			<bounds x="48" y="423" width="109" height="15"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_reel" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_button" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1nhp.lay
+++ b/src/mame/layout/m1nhp.lay
@@ -8,14986 +8,8502 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOEL'S HOUSE PARTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOEL'S HOUSE PARTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mystery Guest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mystery Guest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Franks Cracker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Franks Cracker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Number Cruncher">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Number Cruncher">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Mystery Guest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Mystery Guest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Gotcha">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gotcha">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Matrix Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Matrix Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Noel's Party Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Noel's Party Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Player Move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Player Move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Blobby Move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Blobby Move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nearest Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nearest Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Get Ready">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Get Ready">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gunge Tank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3 Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Gotcha">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gotcha">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Blobby Move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Blobby Move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Blobby Buster">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Blobby Buster">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Stop N' Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop N' Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Mystery Guest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Mystery Guest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Matrix Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Matrix Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_188_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_188">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_189_border">
 		<rect state="1">
-			<color red="0.26" green="0.26" blue="0.50">
-			</color>
+			<color red="0.26" green="0.26" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_189">
 		<rect state="1">
-			<color red="0.52" green="0.52" blue="1.00">
-			</color>
+			<color red="0.52" green="0.52" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_190_border">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.24">
-			</color>
+			<color red="0.50" green="0.37" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.06">
-			</color>
+			<color red="0.12" green="0.09" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_190">
 		<rect state="1">
-			<color red="1.00" green="0.74" blue="0.47">
-			</color>
+			<color red="1.00" green="0.74" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.12">
-			</color>
+			<color red="0.25" green="0.18" blue="0.12"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_191_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_191">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_192_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_192">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_194_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_194">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_195_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_195">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD/LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_197_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_197">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_198_border">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.24">
-			</color>
+			<color red="0.50" green="0.37" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.06">
-			</color>
+			<color red="0.12" green="0.09" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_198">
 		<rect state="1">
-			<color red="1.00" green="0.74" blue="0.47">
-			</color>
+			<color red="1.00" green="0.74" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.12">
-			</color>
+			<color red="0.25" green="0.18" blue="0.12"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_15">
 		<text string="By Phantom">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="(from an orig">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_50">
 		<text string="NTV">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_89">
 		<text string="Reel Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_103">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_105">
 		<text string="Grab A Grand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_145">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_146">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_147">
 		<text string="Observer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_170">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_171">
 		<text string="|">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_172">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_173">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_174">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_175">
 		<text string="|">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_176">
 		<text string="|">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_177">
 		<text string="|">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_178">
 		<text string="|">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_179">
 		<text string="|">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_180">
 		<text string="_">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_181">
 		<text string="_">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_182">
 		<text string="_">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_183">
 		<text string="_">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_184">
 		<text string="_">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_185">
 		<text string="_">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_186">
 		<text string="3 in a row for feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="665">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="665"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="357" y="419" width="90" height="190">
-			</bounds>
+			<bounds x="357" y="419" width="90" height="190"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="357.0000" y="419.0000" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="357.0000" y="419.0000" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="360.7500" y="421.6389" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="360.7500" y="421.6389" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="364.5000" y="424.2778" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="364.5000" y="424.2778" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="368.2500" y="426.9167" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="368.2500" y="426.9167" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="372.0000" y="429.5555" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="372.0000" y="429.5555" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="375.7500" y="432.1945" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="375.7500" y="432.1945" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="357.0000" y="482.3333" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="357.0000" y="482.3333" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="360.7500" y="484.9722" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="360.7500" y="484.9722" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="364.5000" y="487.6111" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="364.5000" y="487.6111" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="368.2500" y="490.2500" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="368.2500" y="490.2500" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="372.0000" y="492.8889" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="372.0000" y="492.8889" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="375.7500" y="495.5278" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="375.7500" y="495.5278" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="357.0000" y="545.6667" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="357.0000" y="545.6667" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="360.7500" y="548.3056" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="360.7500" y="548.3056" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="364.5000" y="550.9445" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="364.5000" y="550.9445" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="368.2500" y="553.5834" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="368.2500" y="553.5834" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="372.0000" y="556.2222" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="372.0000" y="556.2222" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="375.7500" y="558.8611" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="375.7500" y="558.8611" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="357" y="419" width="90" height="190">
-			</bounds>
+			<bounds x="357" y="419" width="90" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="449" y="419" width="90" height="190">
-			</bounds>
+			<bounds x="449" y="419" width="90" height="190"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="449.0000" y="419.0000" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="449.0000" y="419.0000" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="452.7500" y="421.6389" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="452.7500" y="421.6389" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="456.5000" y="424.2778" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="456.5000" y="424.2778" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="460.2500" y="426.9167" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="460.2500" y="426.9167" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="464.0000" y="429.5555" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="464.0000" y="429.5555" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="467.7500" y="432.1945" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="467.7500" y="432.1945" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="449.0000" y="482.3333" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="449.0000" y="482.3333" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="452.7500" y="484.9722" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="452.7500" y="484.9722" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="456.5000" y="487.6111" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="456.5000" y="487.6111" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="460.2500" y="490.2500" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="460.2500" y="490.2500" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="464.0000" y="492.8889" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="464.0000" y="492.8889" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="467.7500" y="495.5278" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="467.7500" y="495.5278" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="449.0000" y="545.6667" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="449.0000" y="545.6667" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="452.7500" y="548.3056" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="452.7500" y="548.3056" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="456.5000" y="550.9445" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="456.5000" y="550.9445" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="460.2500" y="553.5834" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="460.2500" y="553.5834" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="464.0000" y="556.2222" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="464.0000" y="556.2222" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="467.7500" y="558.8611" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="467.7500" y="558.8611" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="449" y="419" width="90" height="190">
-			</bounds>
+			<bounds x="449" y="419" width="90" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="541" y="419" width="90" height="190">
-			</bounds>
+			<bounds x="541" y="419" width="90" height="190"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="541.0000" y="419.0000" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="541.0000" y="419.0000" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="544.7500" y="421.6389" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="544.7500" y="421.6389" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="548.5000" y="424.2778" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="548.5000" y="424.2778" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="552.2500" y="426.9167" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="552.2500" y="426.9167" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="556.0000" y="429.5555" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="556.0000" y="429.5555" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="559.7500" y="432.1945" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="559.7500" y="432.1945" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="541.0000" y="482.3333" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="541.0000" y="482.3333" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="544.7500" y="484.9722" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="544.7500" y="484.9722" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="548.5000" y="487.6111" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="548.5000" y="487.6111" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="552.2500" y="490.2500" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="552.2500" y="490.2500" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="556.0000" y="492.8889" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="556.0000" y="492.8889" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="559.7500" y="495.5278" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="559.7500" y="495.5278" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="541.0000" y="545.6667" width="90.0000" height="63.3333">
-			</bounds>
+			<bounds x="541.0000" y="545.6667" width="90.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="544.7500" y="548.3056" width="82.5000" height="58.0556">
-			</bounds>
+			<bounds x="544.7500" y="548.3056" width="82.5000" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="548.5000" y="550.9445" width="75.0000" height="52.7778">
-			</bounds>
+			<bounds x="548.5000" y="550.9445" width="75.0000" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="552.2500" y="553.5834" width="67.5000" height="47.5000">
-			</bounds>
+			<bounds x="552.2500" y="553.5834" width="67.5000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="556.0000" y="556.2222" width="60.0000" height="42.2222">
-			</bounds>
+			<bounds x="556.0000" y="556.2222" width="60.0000" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="559.7500" y="558.8611" width="52.5000" height="36.9444">
-			</bounds>
+			<bounds x="559.7500" y="558.8611" width="52.5000" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="541" y="419" width="90" height="190">
-			</bounds>
+			<bounds x="541" y="419" width="90" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="400" y="167" width="80" height="70">
-			</bounds>
+			<bounds x="400" y="167" width="80" height="70"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="400" y="167" width="80" height="70">
-			</bounds>
+			<bounds x="400" y="167" width="80" height="70"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="210" y="7" width="527" height="62">
-			</bounds>
+			<bounds x="210" y="7" width="527" height="62"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="212" y="9" width="523" height="58">
-			</bounds>
+			<bounds x="212" y="9" width="523" height="58"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="651" y="329" width="52" height="32">
-			</bounds>
+			<bounds x="651" y="329" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="653" y="331" width="48" height="28">
-			</bounds>
+			<bounds x="653" y="331" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="241" y="325" width="62" height="32">
-			</bounds>
+			<bounds x="241" y="325" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="243" y="327" width="58" height="28">
-			</bounds>
+			<bounds x="243" y="327" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="193" y="313" width="52" height="32">
-			</bounds>
+			<bounds x="193" y="313" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="195" y="315" width="48" height="28">
-			</bounds>
+			<bounds x="195" y="315" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="204" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="204" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="206" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="206" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="157" y="270" width="32" height="32">
-			</bounds>
+			<bounds x="157" y="270" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="159" y="272" width="28" height="28">
-			</bounds>
+			<bounds x="159" y="272" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="145" y="300" width="52" height="32">
-			</bounds>
+			<bounds x="145" y="300" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="147" y="302" width="48" height="28">
-			</bounds>
+			<bounds x="147" y="302" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="700" y="320" width="62" height="32">
-			</bounds>
+			<bounds x="700" y="320" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="702" y="322" width="58" height="28">
-			</bounds>
+			<bounds x="702" y="322" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="806" y="232" width="32" height="32">
-			</bounds>
+			<bounds x="806" y="232" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="808" y="234" width="28" height="28">
-			</bounds>
+			<bounds x="808" y="234" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="757" y="307" width="62" height="32">
-			</bounds>
+			<bounds x="757" y="307" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="759" y="309" width="58" height="28">
-			</bounds>
+			<bounds x="759" y="309" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="811" y="278" width="52" height="32">
-			</bounds>
+			<bounds x="811" y="278" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="813" y="280" width="48" height="28">
-			</bounds>
+			<bounds x="813" y="280" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="110" y="257" width="32" height="32">
-			</bounds>
+			<bounds x="110" y="257" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="112" y="259" width="28" height="28">
-			</bounds>
+			<bounds x="112" y="259" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="97" y="286" width="52" height="32">
-			</bounds>
+			<bounds x="97" y="286" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="99" y="288" width="48" height="28">
-			</bounds>
+			<bounds x="99" y="288" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="360" y="307" width="32" height="32">
-			</bounds>
+			<bounds x="360" y="307" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="362" y="309" width="28" height="28">
-			</bounds>
+			<bounds x="362" y="309" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="312" y="306" width="32" height="32">
-			</bounds>
+			<bounds x="312" y="306" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="314" y="308" width="28" height="28">
-			</bounds>
+			<bounds x="314" y="308" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="258" y="296" width="32" height="32">
-			</bounds>
+			<bounds x="258" y="296" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="260" y="298" width="28" height="28">
-			</bounds>
+			<bounds x="260" y="298" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="408" y="307" width="32" height="32">
-			</bounds>
+			<bounds x="408" y="307" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="410" y="309" width="28" height="28">
-			</bounds>
+			<bounds x="410" y="309" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="457" y="307" width="32" height="32">
-			</bounds>
+			<bounds x="457" y="307" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="459" y="309" width="28" height="28">
-			</bounds>
+			<bounds x="459" y="309" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="504" y="307" width="32" height="32">
-			</bounds>
+			<bounds x="504" y="307" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="506" y="309" width="28" height="28">
-			</bounds>
+			<bounds x="506" y="309" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="612" y="307" width="32" height="32">
-			</bounds>
+			<bounds x="612" y="307" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="614" y="309" width="28" height="28">
-			</bounds>
+			<bounds x="614" y="309" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="558" y="307" width="32" height="32">
-			</bounds>
+			<bounds x="558" y="307" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="560" y="309" width="28" height="28">
-			</bounds>
+			<bounds x="560" y="309" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="662" y="300" width="32" height="32">
-			</bounds>
+			<bounds x="662" y="300" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="664" y="302" width="28" height="28">
-			</bounds>
+			<bounds x="664" y="302" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="714" y="291" width="32" height="32">
-			</bounds>
+			<bounds x="714" y="291" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="716" y="293" width="28" height="28">
-			</bounds>
+			<bounds x="716" y="293" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="785" y="261" width="32" height="32">
-			</bounds>
+			<bounds x="785" y="261" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="787" y="263" width="28" height="28">
-			</bounds>
+			<bounds x="787" y="263" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="751" y="278" width="32" height="32">
-			</bounds>
+			<bounds x="751" y="278" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="753" y="280" width="28" height="28">
-			</bounds>
+			<bounds x="753" y="280" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="136" y="37" width="32" height="32">
-			</bounds>
+			<bounds x="136" y="37" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="138" y="39" width="28" height="28">
-			</bounds>
+			<bounds x="138" y="39" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="61" y="24" width="32" height="32">
-			</bounds>
+			<bounds x="61" y="24" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="63" y="26" width="28" height="28">
-			</bounds>
+			<bounds x="63" y="26" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="8" y="66" width="32" height="32">
-			</bounds>
+			<bounds x="8" y="66" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="10" y="68" width="28" height="28">
-			</bounds>
+			<bounds x="10" y="68" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="1" y="122" width="32" height="32">
-			</bounds>
+			<bounds x="1" y="122" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="3" y="124" width="28" height="28">
-			</bounds>
+			<bounds x="3" y="124" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="21" y="184" width="32" height="32">
-			</bounds>
+			<bounds x="21" y="184" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="23" y="186" width="28" height="28">
-			</bounds>
+			<bounds x="23" y="186" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="84" y="180" width="62" height="32">
-			</bounds>
+			<bounds x="84" y="180" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="86" y="182" width="58" height="28">
-			</bounds>
+			<bounds x="86" y="182" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="848" y="205" width="52" height="32">
-			</bounds>
+			<bounds x="848" y="205" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="850" y="207" width="48" height="28">
-			</bounds>
+			<bounds x="850" y="207" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="833" y="243" width="52" height="32">
-			</bounds>
+			<bounds x="833" y="243" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="835" y="245" width="48" height="28">
-			</bounds>
+			<bounds x="835" y="245" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="727" y="108" width="32" height="32">
-			</bounds>
+			<bounds x="727" y="108" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="729" y="110" width="28" height="28">
-			</bounds>
+			<bounds x="729" y="110" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="787" y="95" width="52" height="32">
-			</bounds>
+			<bounds x="787" y="95" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="789" y="97" width="48" height="28">
-			</bounds>
+			<bounds x="789" y="97" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="824" y="130" width="52" height="32">
-			</bounds>
+			<bounds x="824" y="130" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="826" y="132" width="48" height="28">
-			</bounds>
+			<bounds x="826" y="132" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="845" y="167" width="52" height="32">
-			</bounds>
+			<bounds x="845" y="167" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="847" y="169" width="48" height="28">
-			</bounds>
+			<bounds x="847" y="169" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="765" y="118" width="32" height="32">
-			</bounds>
+			<bounds x="765" y="118" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="767" y="120" width="28" height="28">
-			</bounds>
+			<bounds x="767" y="120" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="819" y="200" width="32" height="32">
-			</bounds>
+			<bounds x="819" y="200" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="821" y="202" width="28" height="28">
-			</bounds>
+			<bounds x="821" y="202" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="816" y="166" width="32" height="32">
-			</bounds>
+			<bounds x="816" y="166" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="818" y="168" width="28" height="28">
-			</bounds>
+			<bounds x="818" y="168" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="796" y="138" width="32" height="32">
-			</bounds>
+			<bounds x="796" y="138" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="798" y="140" width="28" height="28">
-			</bounds>
+			<bounds x="798" y="140" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="711" y="79" width="72" height="32">
-			</bounds>
+			<bounds x="711" y="79" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="713" y="81" width="68" height="28">
-			</bounds>
+			<bounds x="713" y="81" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="602" y="73" width="62" height="32">
-			</bounds>
+			<bounds x="602" y="73" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="604" y="75" width="58" height="28">
-			</bounds>
+			<bounds x="604" y="75" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="662" y="73" width="52" height="32">
-			</bounds>
+			<bounds x="662" y="73" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="664" y="75" width="48" height="28">
-			</bounds>
+			<bounds x="664" y="75" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="124" y="595" width="42" height="42">
-			</bounds>
+			<bounds x="124" y="595" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="126" y="597" width="38" height="38">
-			</bounds>
+			<bounds x="126" y="597" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="143" y="391" width="42" height="42">
-			</bounds>
+			<bounds x="143" y="391" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="145" y="393" width="38" height="38">
-			</bounds>
+			<bounds x="145" y="393" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="104" y="407" width="42" height="42">
-			</bounds>
+			<bounds x="104" y="407" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="106" y="409" width="38" height="38">
-			</bounds>
+			<bounds x="106" y="409" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="182" y="371" width="52" height="52">
-			</bounds>
+			<bounds x="182" y="371" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="184" y="373" width="48" height="48">
-			</bounds>
+			<bounds x="184" y="373" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="552" y="73" width="52" height="32">
-			</bounds>
+			<bounds x="552" y="73" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="554" y="75" width="48" height="28">
-			</bounds>
+			<bounds x="554" y="75" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="502" y="73" width="52" height="32">
-			</bounds>
+			<bounds x="502" y="73" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="504" y="75" width="48" height="28">
-			</bounds>
+			<bounds x="504" y="75" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="452" y="73" width="52" height="32">
-			</bounds>
+			<bounds x="452" y="73" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="454" y="75" width="48" height="28">
-			</bounds>
+			<bounds x="454" y="75" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="462" y="102" width="32" height="32">
-			</bounds>
+			<bounds x="462" y="102" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="464" y="104" width="28" height="28">
-			</bounds>
+			<bounds x="464" y="104" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="512" y="102" width="32" height="32">
-			</bounds>
+			<bounds x="512" y="102" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="514" y="104" width="28" height="28">
-			</bounds>
+			<bounds x="514" y="104" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="561" y="102" width="32" height="32">
-			</bounds>
+			<bounds x="561" y="102" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="563" y="104" width="28" height="28">
-			</bounds>
+			<bounds x="563" y="104" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="618" y="102" width="32" height="32">
-			</bounds>
+			<bounds x="618" y="102" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="620" y="104" width="28" height="28">
-			</bounds>
+			<bounds x="620" y="104" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="672" y="102" width="32" height="32">
-			</bounds>
+			<bounds x="672" y="102" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="674" y="104" width="28" height="28">
-			</bounds>
+			<bounds x="674" y="104" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="151" y="217" width="32" height="32">
-			</bounds>
+			<bounds x="151" y="217" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="153" y="219" width="28" height="28">
-			</bounds>
+			<bounds x="153" y="219" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="209" y="217" width="32" height="32">
-			</bounds>
+			<bounds x="209" y="217" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="211" y="219" width="28" height="28">
-			</bounds>
+			<bounds x="211" y="219" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="199" y="188" width="52" height="32">
-			</bounds>
+			<bounds x="199" y="188" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="201" y="190" width="48" height="28">
-			</bounds>
+			<bounds x="201" y="190" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="146" y="187" width="52" height="32">
-			</bounds>
+			<bounds x="146" y="187" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="148" y="189" width="48" height="28">
-			</bounds>
+			<bounds x="148" y="189" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="252" y="188" width="32" height="32">
-			</bounds>
+			<bounds x="252" y="188" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="254" y="190" width="28" height="28">
-			</bounds>
+			<bounds x="254" y="190" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="280" y="160" width="32" height="32">
-			</bounds>
+			<bounds x="280" y="160" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="282" y="162" width="28" height="28">
-			</bounds>
+			<bounds x="282" y="162" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="321" y="132" width="32" height="32">
-			</bounds>
+			<bounds x="321" y="132" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="323" y="134" width="28" height="28">
-			</bounds>
+			<bounds x="323" y="134" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="227" y="159" width="52" height="32">
-			</bounds>
+			<bounds x="227" y="159" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="229" y="161" width="48" height="28">
-			</bounds>
+			<bounds x="229" y="161" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="303" y="101" width="52" height="32">
-			</bounds>
+			<bounds x="303" y="101" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="305" y="103" width="48" height="28">
-			</bounds>
+			<bounds x="305" y="103" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="411" y="103" width="32" height="32">
-			</bounds>
+			<bounds x="411" y="103" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="413" y="105" width="28" height="28">
-			</bounds>
+			<bounds x="413" y="105" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="359" y="104" width="32" height="32">
-			</bounds>
+			<bounds x="359" y="104" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="361" y="106" width="28" height="28">
-			</bounds>
+			<bounds x="361" y="106" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="260" y="130" width="62" height="32">
-			</bounds>
+			<bounds x="260" y="130" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="262" y="132" width="58" height="28">
-			</bounds>
+			<bounds x="262" y="132" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="342" y="74" width="62" height="32">
-			</bounds>
+			<bounds x="342" y="74" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="344" y="76" width="58" height="28">
-			</bounds>
+			<bounds x="344" y="76" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="402" y="74" width="52" height="32">
-			</bounds>
+			<bounds x="402" y="74" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="404" y="76" width="48" height="28">
-			</bounds>
+			<bounds x="404" y="76" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="151" y="80" width="102" height="72">
-			</bounds>
+			<bounds x="151" y="80" width="102" height="72"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="153" y="82" width="98" height="68">
-			</bounds>
+			<bounds x="153" y="82" width="98" height="68"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="126" y="67" width="52" height="32">
-			</bounds>
+			<bounds x="126" y="67" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="128" y="69" width="48" height="28">
-			</bounds>
+			<bounds x="128" y="69" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="64" y="53" width="62" height="32">
-			</bounds>
+			<bounds x="64" y="53" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="66" y="55" width="58" height="28">
-			</bounds>
+			<bounds x="66" y="55" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="33" y="85" width="52" height="32">
-			</bounds>
+			<bounds x="33" y="85" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="35" y="87" width="48" height="28">
-			</bounds>
+			<bounds x="35" y="87" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="31" y="121" width="52" height="32">
-			</bounds>
+			<bounds x="31" y="121" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="33" y="123" width="48" height="28">
-			</bounds>
+			<bounds x="33" y="123" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="37" y="157" width="52" height="32">
-			</bounds>
+			<bounds x="37" y="157" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="39" y="159" width="48" height="28">
-			</bounds>
+			<bounds x="39" y="159" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="86" y="209" width="32" height="32">
-			</bounds>
+			<bounds x="86" y="209" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="88" y="211" width="28" height="28">
-			</bounds>
+			<bounds x="88" y="211" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="29" y="530" width="42" height="42">
-			</bounds>
+			<bounds x="29" y="530" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="31" y="532" width="38" height="38">
-			</bounds>
+			<bounds x="31" y="532" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="46" y="569" width="42" height="42">
-			</bounds>
+			<bounds x="46" y="569" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="48" y="571" width="38" height="38">
-			</bounds>
+			<bounds x="48" y="571" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="85" y="583" width="42" height="42">
-			</bounds>
+			<bounds x="85" y="583" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="87" y="585" width="38" height="38">
-			</bounds>
+			<bounds x="87" y="585" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="17" y="491" width="42" height="42">
-			</bounds>
+			<bounds x="17" y="491" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="19" y="493" width="38" height="38">
-			</bounds>
+			<bounds x="19" y="493" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="27" y="452" width="42" height="42">
-			</bounds>
+			<bounds x="27" y="452" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="29" y="454" width="38" height="38">
-			</bounds>
+			<bounds x="29" y="454" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="65" y="428" width="42" height="42">
-			</bounds>
+			<bounds x="65" y="428" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="67" y="430" width="38" height="38">
-			</bounds>
+			<bounds x="67" y="430" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="181" y="503" width="52" height="52">
-			</bounds>
+			<bounds x="181" y="503" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="183" y="505" width="48" height="48">
-			</bounds>
+			<bounds x="183" y="505" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="93" y="503" width="52" height="52">
-			</bounds>
+			<bounds x="93" y="503" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="95" y="505" width="48" height="48">
-			</bounds>
+			<bounds x="95" y="505" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="137" y="545" width="52" height="32">
-			</bounds>
+			<bounds x="137" y="545" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="139" y="547" width="48" height="28">
-			</bounds>
+			<bounds x="139" y="547" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="163" y="474" width="52" height="32">
-			</bounds>
+			<bounds x="163" y="474" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="165" y="476" width="48" height="28">
-			</bounds>
+			<bounds x="165" y="476" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="114" y="474" width="52" height="32">
-			</bounds>
+			<bounds x="114" y="474" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="116" y="476" width="48" height="28">
-			</bounds>
+			<bounds x="116" y="476" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="384" y="242" width="52" height="32">
-			</bounds>
+			<bounds x="384" y="242" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="386" y="244" width="48" height="28">
-			</bounds>
+			<bounds x="386" y="244" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="442" y="242" width="52" height="32">
-			</bounds>
+			<bounds x="442" y="242" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="444" y="244" width="48" height="28">
-			</bounds>
+			<bounds x="444" y="244" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="543" y="336" width="62" height="32">
-			</bounds>
+			<bounds x="543" y="336" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="545" y="338" width="58" height="28">
-			</bounds>
+			<bounds x="545" y="338" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="602" y="336" width="52" height="32">
-			</bounds>
+			<bounds x="602" y="336" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="604" y="338" width="48" height="28">
-			</bounds>
+			<bounds x="604" y="338" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="300" y="335" width="52" height="32">
-			</bounds>
+			<bounds x="300" y="335" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="302" y="337" width="48" height="28">
-			</bounds>
+			<bounds x="302" y="337" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="42" y="344" width="52" height="32">
-			</bounds>
+			<bounds x="42" y="344" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="44" y="346" width="48" height="28">
-			</bounds>
+			<bounds x="44" y="346" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="15" y="373" width="52" height="32">
-			</bounds>
+			<bounds x="15" y="373" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="17" y="375" width="48" height="28">
-			</bounds>
+			<bounds x="17" y="375" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="70" y="315" width="52" height="32">
-			</bounds>
+			<bounds x="70" y="315" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="72" y="317" width="48" height="28">
-			</bounds>
+			<bounds x="72" y="317" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="445" y="336" width="52" height="32">
-			</bounds>
+			<bounds x="445" y="336" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="447" y="338" width="48" height="28">
-			</bounds>
+			<bounds x="447" y="338" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="397" y="336" width="52" height="32">
-			</bounds>
+			<bounds x="397" y="336" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="399" y="338" width="48" height="28">
-			</bounds>
+			<bounds x="399" y="338" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="349" y="336" width="52" height="32">
-			</bounds>
+			<bounds x="349" y="336" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="351" y="338" width="48" height="28">
-			</bounds>
+			<bounds x="351" y="338" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="494" y="336" width="52" height="32">
-			</bounds>
+			<bounds x="494" y="336" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="496" y="338" width="48" height="28">
-			</bounds>
+			<bounds x="496" y="338" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="906" y="66" width="52" height="32">
-			</bounds>
+			<bounds x="906" y="66" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="908" y="68" width="48" height="28">
-			</bounds>
+			<bounds x="908" y="68" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="906" y="95" width="52" height="32">
-			</bounds>
+			<bounds x="906" y="95" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="908" y="97" width="48" height="28">
-			</bounds>
+			<bounds x="908" y="97" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="906" y="182" width="52" height="32">
-			</bounds>
+			<bounds x="906" y="182" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="908" y="184" width="48" height="28">
-			</bounds>
+			<bounds x="908" y="184" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="906" y="153" width="52" height="32">
-			</bounds>
+			<bounds x="906" y="153" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="908" y="155" width="48" height="28">
-			</bounds>
+			<bounds x="908" y="155" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="906" y="124" width="52" height="32">
-			</bounds>
+			<bounds x="906" y="124" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="908" y="126" width="48" height="28">
-			</bounds>
+			<bounds x="908" y="126" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="921" y="21" width="72" height="47">
-			</bounds>
+			<bounds x="921" y="21" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="923" y="23" width="68" height="43">
-			</bounds>
+			<bounds x="923" y="23" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="955" y="66" width="52" height="32">
-			</bounds>
+			<bounds x="955" y="66" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="957" y="68" width="48" height="28">
-			</bounds>
+			<bounds x="957" y="68" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="955" y="95" width="52" height="32">
-			</bounds>
+			<bounds x="955" y="95" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="957" y="97" width="48" height="28">
-			</bounds>
+			<bounds x="957" y="97" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="955" y="124" width="52" height="32">
-			</bounds>
+			<bounds x="955" y="124" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="957" y="126" width="48" height="28">
-			</bounds>
+			<bounds x="957" y="126" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="955" y="182" width="52" height="32">
-			</bounds>
+			<bounds x="955" y="182" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="957" y="184" width="48" height="28">
-			</bounds>
+			<bounds x="957" y="184" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="955" y="153" width="52" height="32">
-			</bounds>
+			<bounds x="955" y="153" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="957" y="155" width="48" height="28">
-			</bounds>
+			<bounds x="957" y="155" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="705" y="172" width="42" height="22">
-			</bounds>
+			<bounds x="705" y="172" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="707" y="174" width="38" height="18">
-			</bounds>
+			<bounds x="707" y="174" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="722" y="194" width="42" height="22">
-			</bounds>
+			<bounds x="722" y="194" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="724" y="196" width="38" height="18">
-			</bounds>
+			<bounds x="724" y="196" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="722" y="217" width="42" height="22">
-			</bounds>
+			<bounds x="722" y="217" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="724" y="219" width="38" height="18">
-			</bounds>
+			<bounds x="724" y="219" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="706" y="239" width="42" height="22">
-			</bounds>
+			<bounds x="706" y="239" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="708" y="241" width="38" height="18">
-			</bounds>
+			<bounds x="708" y="241" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="712" y="544" width="62" height="32">
-			</bounds>
+			<bounds x="712" y="544" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="714" y="546" width="58" height="28">
-			</bounds>
+			<bounds x="714" y="546" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="770" y="544" width="62" height="32">
-			</bounds>
+			<bounds x="770" y="544" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="772" y="546" width="58" height="28">
-			</bounds>
+			<bounds x="772" y="546" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="770" y="515" width="62" height="32">
-			</bounds>
+			<bounds x="770" y="515" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="772" y="517" width="58" height="28">
-			</bounds>
+			<bounds x="772" y="517" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="712" y="515" width="62" height="32">
-			</bounds>
+			<bounds x="712" y="515" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="714" y="517" width="58" height="28">
-			</bounds>
+			<bounds x="714" y="517" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="641" y="514" width="82" height="62">
-			</bounds>
+			<bounds x="641" y="514" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="643" y="516" width="78" height="58">
-			</bounds>
+			<bounds x="643" y="516" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="821" y="514" width="82" height="62">
-			</bounds>
+			<bounds x="821" y="514" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="823" y="516" width="78" height="58">
-			</bounds>
+			<bounds x="823" y="516" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="713" y="456" width="62" height="42">
-			</bounds>
+			<bounds x="713" y="456" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="715" y="458" width="58" height="38">
-			</bounds>
+			<bounds x="715" y="458" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="741" y="417" width="62" height="42">
-			</bounds>
+			<bounds x="741" y="417" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="743" y="419" width="58" height="38">
-			</bounds>
+			<bounds x="743" y="419" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="682" y="417" width="62" height="42">
-			</bounds>
+			<bounds x="682" y="417" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="684" y="419" width="58" height="38">
-			</bounds>
+			<bounds x="684" y="419" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="800" y="417" width="62" height="42">
-			</bounds>
+			<bounds x="800" y="417" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="802" y="419" width="58" height="38">
-			</bounds>
+			<bounds x="802" y="419" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="772" y="456" width="62" height="42">
-			</bounds>
+			<bounds x="772" y="456" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="774" y="458" width="58" height="38">
-			</bounds>
+			<bounds x="774" y="458" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="721" y="368" width="102" height="52">
-			</bounds>
+			<bounds x="721" y="368" width="102" height="52"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="723" y="370" width="98" height="48">
-			</bounds>
+			<bounds x="723" y="370" width="98" height="48"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="252" y="443" width="52" height="42">
-			</bounds>
+			<bounds x="252" y="443" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="254" y="445" width="48" height="38">
-			</bounds>
+			<bounds x="254" y="445" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="317" y="561" width="27" height="27">
-			</bounds>
+			<bounds x="317" y="561" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="319" y="563" width="23" height="23">
-			</bounds>
+			<bounds x="319" y="563" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="285" y="561" width="27" height="27">
-			</bounds>
+			<bounds x="285" y="561" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="287" y="563" width="23" height="23">
-			</bounds>
+			<bounds x="287" y="563" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="253" y="561" width="27" height="27">
-			</bounds>
+			<bounds x="253" y="561" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="255" y="563" width="23" height="23">
-			</bounds>
+			<bounds x="255" y="563" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="317" y="528" width="27" height="27">
-			</bounds>
+			<bounds x="317" y="528" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="319" y="530" width="23" height="23">
-			</bounds>
+			<bounds x="319" y="530" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="285" y="528" width="27" height="27">
-			</bounds>
+			<bounds x="285" y="528" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="287" y="530" width="23" height="23">
-			</bounds>
+			<bounds x="287" y="530" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="253" y="528" width="27" height="27">
-			</bounds>
+			<bounds x="253" y="528" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="255" y="530" width="23" height="23">
-			</bounds>
+			<bounds x="255" y="530" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="253" y="495" width="27" height="27">
-			</bounds>
+			<bounds x="253" y="495" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="255" y="497" width="23" height="23">
-			</bounds>
+			<bounds x="255" y="497" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="285" y="495" width="27" height="27">
-			</bounds>
+			<bounds x="285" y="495" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="287" y="497" width="23" height="23">
-			</bounds>
+			<bounds x="287" y="497" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="317" y="495" width="27" height="27">
-			</bounds>
+			<bounds x="317" y="495" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="319" y="497" width="23" height="23">
-			</bounds>
+			<bounds x="319" y="497" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_188_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="827" y="616" width="77" height="42">
-			</bounds>
+			<bounds x="827" y="616" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_188" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="829" y="618" width="73" height="38">
-			</bounds>
+			<bounds x="829" y="618" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_189_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="741" y="616" width="77" height="42">
-			</bounds>
+			<bounds x="741" y="616" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_189" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="743" y="618" width="73" height="38">
-			</bounds>
+			<bounds x="743" y="618" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_190_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="655" y="616" width="77" height="42">
-			</bounds>
+			<bounds x="655" y="616" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_190" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="657" y="618" width="73" height="38">
-			</bounds>
+			<bounds x="657" y="618" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_191_border" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="756" y="5" width="37" height="32">
-			</bounds>
+			<bounds x="756" y="5" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_191" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="758" y="7" width="33" height="28">
-			</bounds>
+			<bounds x="758" y="7" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_192_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="793" y="5" width="37" height="32">
-			</bounds>
+			<bounds x="793" y="5" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_192" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="795" y="7" width="33" height="28">
-			</bounds>
+			<bounds x="795" y="7" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_193_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="830" y="5" width="37" height="32">
-			</bounds>
+			<bounds x="830" y="5" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_193" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="832" y="7" width="33" height="28">
-			</bounds>
+			<bounds x="832" y="7" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_194_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="867" y="5" width="37" height="32">
-			</bounds>
+			<bounds x="867" y="5" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_194" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="869" y="7" width="33" height="28">
-			</bounds>
+			<bounds x="869" y="7" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_195_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="546" y="616" width="77" height="42">
-			</bounds>
+			<bounds x="546" y="616" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_195" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="548" y="618" width="73" height="38">
-			</bounds>
+			<bounds x="548" y="618" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_196_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="454" y="616" width="77" height="42">
-			</bounds>
+			<bounds x="454" y="616" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_196" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="456" y="618" width="73" height="38">
-			</bounds>
+			<bounds x="456" y="618" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_197_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="362" y="616" width="77" height="42">
-			</bounds>
+			<bounds x="362" y="616" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_197" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="364" y="618" width="73" height="38">
-			</bounds>
+			<bounds x="364" y="618" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_198_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="257" y="616" width="77" height="42">
-			</bounds>
+			<bounds x="257" y="616" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_198" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="259" y="618" width="73" height="38">
-			</bounds>
+			<bounds x="259" y="618" width="73" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="358" y="373" width="272" height="30">
-			</bounds>
+			<bounds x="358" y="373" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="358" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="358" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="375" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="375" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="392" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="392" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="409" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="409" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="426" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="426" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="443" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="443" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="460" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="460" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="477" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="477" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="494" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="494" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="511" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="511" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="528" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="528" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="545" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="545" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="562" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="562" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="579" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="579" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="596" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="596" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="613" y="373" width="17" height="30">
-			</bounds>
+			<bounds x="613" y="373" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label15" element="label_15">
-			<bounds x="738" y="41" width="164" height="26">
-			</bounds>
+			<bounds x="738" y="41" width="164" height="26"/>
 		</backdrop>
 		<backdrop name="label50" element="label_50">
-			<bounds x="171" y="604" width="43" height="24">
-			</bounds>
+			<bounds x="171" y="604" width="43" height="24"/>
 		</backdrop>
 		<backdrop name="label89" element="label_89">
-			<bounds x="145" y="512" width="36" height="26">
-			</bounds>
+			<bounds x="145" y="512" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="label103" element="label_103">
-			<bounds x="705" y="206" width="13" height="20">
-			</bounds>
+			<bounds x="705" y="206" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="label105" element="label_105">
-			<bounds x="532" y="184" width="51" height="60">
-			</bounds>
+			<bounds x="532" y="184" width="51" height="60"/>
 		</backdrop>
 		<backdrop name="label145" element="label_145">
-			<bounds x="564" y="401" width="62" height="18">
-			</bounds>
+			<bounds x="564" y="401" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="label146" element="label_146">
-			<bounds x="376" y="401" width="42" height="18">
-			</bounds>
+			<bounds x="376" y="401" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="label147" element="label_147">
-			<bounds x="737" y="576" width="73" height="20">
-			</bounds>
+			<bounds x="737" y="576" width="73" height="20"/>
 		</backdrop>
 		<backdrop name="label170" element="label_170">
-			<bounds x="311" y="518" width="7" height="13">
-			</bounds>
+			<bounds x="311" y="518" width="7" height="13"/>
 		</backdrop>
 		<backdrop name="label171" element="label_171">
-			<bounds x="329" y="518" width="2" height="13">
-			</bounds>
+			<bounds x="329" y="518" width="2" height="13"/>
 		</backdrop>
 		<backdrop name="label172" element="label_172">
-			<bounds x="279" y="519" width="7" height="13">
-			</bounds>
+			<bounds x="279" y="519" width="7" height="13"/>
 		</backdrop>
 		<backdrop name="label173" element="label_173">
-			<bounds x="311" y="551" width="7" height="13">
-			</bounds>
+			<bounds x="311" y="551" width="7" height="13"/>
 		</backdrop>
 		<backdrop name="label174" element="label_174">
-			<bounds x="279" y="551" width="7" height="13">
-			</bounds>
+			<bounds x="279" y="551" width="7" height="13"/>
 		</backdrop>
 		<backdrop name="label175" element="label_175">
-			<bounds x="329" y="551" width="2" height="13">
-			</bounds>
+			<bounds x="329" y="551" width="2" height="13"/>
 		</backdrop>
 		<backdrop name="label176" element="label_176">
-			<bounds x="265" y="551" width="2" height="13">
-			</bounds>
+			<bounds x="265" y="551" width="2" height="13"/>
 		</backdrop>
 		<backdrop name="label177" element="label_177">
-			<bounds x="297" y="551" width="2" height="13">
-			</bounds>
+			<bounds x="297" y="551" width="2" height="13"/>
 		</backdrop>
 		<backdrop name="label178" element="label_178">
-			<bounds x="296" y="518" width="2" height="13">
-			</bounds>
+			<bounds x="296" y="518" width="2" height="13"/>
 		</backdrop>
 		<backdrop name="label179" element="label_179">
-			<bounds x="265" y="518" width="2" height="13">
-			</bounds>
+			<bounds x="265" y="518" width="2" height="13"/>
 		</backdrop>
 		<backdrop name="label180" element="label_180">
-			<bounds x="311" y="496" width="6" height="13">
-			</bounds>
+			<bounds x="311" y="496" width="6" height="13"/>
 		</backdrop>
 		<backdrop name="label181" element="label_181">
-			<bounds x="311" y="530" width="6" height="13">
-			</bounds>
+			<bounds x="311" y="530" width="6" height="13"/>
 		</backdrop>
 		<backdrop name="label182" element="label_182">
-			<bounds x="279" y="497" width="6" height="13">
-			</bounds>
+			<bounds x="279" y="497" width="6" height="13"/>
 		</backdrop>
 		<backdrop name="label183" element="label_183">
-			<bounds x="279" y="530" width="6" height="13">
-			</bounds>
+			<bounds x="279" y="530" width="6" height="13"/>
 		</backdrop>
 		<backdrop name="label184" element="label_184">
-			<bounds x="311" y="562" width="6" height="13">
-			</bounds>
+			<bounds x="311" y="562" width="6" height="13"/>
 		</backdrop>
 		<backdrop name="label185" element="label_185">
-			<bounds x="279" y="563" width="6" height="13">
-			</bounds>
+			<bounds x="279" y="563" width="6" height="13"/>
 		</backdrop>
 		<backdrop name="label186" element="label_186">
-			<bounds x="304" y="444" width="41" height="39">
-			</bounds>
+			<bounds x="304" y="444" width="41" height="39"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1nudbnke.lay
+++ b/src/mame/layout/m1nudbnke.lay
@@ -8,16558 +8,9108 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<disk state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.37" green="0.00" blue="0.49">
-			</color>
+			<color red="0.37" green="0.00" blue="0.49"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.00" blue="0.12">
-			</color>
+			<color red="0.09" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.01" blue="0.99">
-			</color>
+			<color red="0.75" green="0.01" blue="0.99"/>
 		</disk>
 		<disk state="0">
-			<color red="0.18" green="0.00" blue="0.25">
-			</color>
+			<color red="0.18" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.37" green="0.00" blue="0.49">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.01" blue="0.99">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.18" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_55_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_56_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_56_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_57_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_57_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="US">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="US">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="Sure Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="Sure Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Reel Steppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Reel Steppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Numbers In View">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Numbers In View">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="GE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="GE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="ER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="ER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="NK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="NK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="BA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="BA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.49" green="0.11" blue="0.11">
-			</color>
+			<color red="0.49" green="0.11" blue="0.11"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<disk state="1">
-			<color red="0.99" green="0.23" blue="0.23">
-			</color>
+			<color red="0.99" green="0.23" blue="0.23"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.49" green="0.11" blue="0.11">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.99" green="0.23" blue="0.23">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.49" green="0.11" blue="0.11">
-			</color>
+			<color red="0.49" green="0.11" blue="0.11"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="0.99" green="0.23" blue="0.23">
-			</color>
+			<color red="0.99" green="0.23" blue="0.23"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.49" green="0.11" blue="0.11">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.99" green="0.23" blue="0.23">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
+			<color red="0.38" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
+			<color red="0.77" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
+			<color red="0.19" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
+			<color red="0.38" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
+			<color red="0.77" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
+			<color red="0.19" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
+			<color red="0.20" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
+			<color red="0.05" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
+			<color red="0.40" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
+			<color red="0.10" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
+			<color red="0.20" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
+			<color red="0.05" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
+			<color red="0.40" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
+			<color red="0.10" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.22" blue="0.50">
-			</color>
+			<color red="0.00" green="0.22" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.05" blue="0.12">
-			</color>
+			<color red="0.00" green="0.05" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.45" blue="1.00">
-			</color>
+			<color red="0.00" green="0.45" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.25">
-			</color>
+			<color red="0.00" green="0.11" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.22" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.05" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.45" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.37" green="0.00" blue="0.49">
-			</color>
+			<color red="0.37" green="0.00" blue="0.49"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.12">
-			</color>
+			<color red="0.09" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.01" blue="0.99">
-			</color>
+			<color red="0.75" green="0.01" blue="0.99"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.00" blue="0.25">
-			</color>
+			<color red="0.18" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.37" green="0.00" blue="0.49">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.01" blue="0.99">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.00" blue="0.41">
-			</color>
+			<color red="0.49" green="0.00" blue="0.41"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.10">
-			</color>
+			<color red="0.12" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.01" blue="0.82">
-			</color>
+			<color red="0.99" green="0.01" blue="0.82"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.20">
-			</color>
+			<color red="0.25" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.00" blue="0.41">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.01" blue="0.82">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.09">
-			</color>
+			<color red="0.50" green="0.00" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.02">
-			</color>
+			<color red="0.12" green="0.00" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.18">
-			</color>
+			<color red="1.00" green="0.00" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.04">
-			</color>
+			<color red="0.25" green="0.00" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
+			<color red="0.20" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
+			<color red="0.05" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
+			<color red="0.40" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
+			<color red="0.10" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
+			<color red="0.20" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
+			<color red="0.05" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
+			<color red="0.40" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
+			<color red="0.10" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
+			<color red="0.38" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
+			<color red="0.77" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
+			<color red="0.19" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
+			<color red="0.38" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
+			<color red="0.77" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
+			<color red="0.19" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</rect>
 		<text string="STEPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="STEPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
+			<color red="0.00" green="0.38" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
+			<color red="0.00" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
+			<color red="0.00" green="0.77" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
+			<color red="0.00" green="0.19" blue="0.25"/>
 		</rect>
 		<text string="REVOLVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.38" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.77" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.19" blue="0.25">
-			</color>
-		</rect>
-		<text string="REVOLVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.22" blue="0.50">
-			</color>
+			<color red="0.00" green="0.22" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.05" blue="0.12">
-			</color>
+			<color red="0.00" green="0.05" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.45" blue="1.00">
-			</color>
+			<color red="0.00" green="0.45" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.25">
-			</color>
+			<color red="0.00" green="0.11" blue="0.25"/>
 		</rect>
 		<text string="IAOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.22" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.05" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.45" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.25">
-			</color>
-		</rect>
-		<text string="IAOK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.37" green="0.00" blue="0.49">
-			</color>
+			<color red="0.37" green="0.00" blue="0.49"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.12">
-			</color>
+			<color red="0.09" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.01" blue="0.99">
-			</color>
+			<color red="0.75" green="0.01" blue="0.99"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.00" blue="0.25">
-			</color>
+			<color red="0.18" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="NUDGE QUEST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.37" green="0.00" blue="0.49">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.01" blue="0.99">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGE QUEST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.00" blue="0.41">
-			</color>
+			<color red="0.49" green="0.00" blue="0.41"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.10">
-			</color>
+			<color red="0.12" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.01" blue="0.82">
-			</color>
+			<color red="0.99" green="0.01" blue="0.82"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.20">
-			</color>
+			<color red="0.25" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="MULTIPLIER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.00" blue="0.41">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.01" blue="0.82">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="MULTIPLIER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_59_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="Swap To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="Swap To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="Swap To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="Swap To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.11" blue="0.11">
-			</color>
+			<color red="0.49" green="0.11" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_184_2" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.23" blue="0.23">
-			</color>
+			<color red="0.99" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.09">
-			</color>
+			<color red="0.50" green="0.00" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.02">
-			</color>
+			<color red="0.12" green="0.00" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.18">
-			</color>
+			<color red="1.00" green="0.00" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.04">
-			</color>
+			<color red="0.25" green="0.00" blue="0.04"/>
 		</rect>
 		<text string="CROSSFIRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.04">
-			</color>
-		</rect>
-		<text string="CROSSFIRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="URES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="URES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.11" blue="0.11">
-			</color>
+			<color red="0.49" green="0.11" blue="0.11"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.23" blue="0.23">
-			</color>
+			<color red="0.99" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Interest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Interest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="TIMER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="TIMER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Skillshot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skillshot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_58_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="TOKENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="TOKENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_2" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_159_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
+			<color red="0.42" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
+			<color red="0.10" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_2" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
+			<color red="0.84" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
+			<color red="0.21" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_157_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_156_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_200_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_199_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_197_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_198_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_154_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_155_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
+			<color red="0.50" green="0.15" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
+			<color red="0.12" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
+			<color red="1.00" green="0.30" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
+			<color red="0.25" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.30" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_195_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_196_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_152_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_153_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
+			<color red="0.50" green="0.34" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
+			<color red="0.12" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
+			<color red="1.00" green="0.67" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
+			<color red="0.25" green="0.17" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.34" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_193_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
+			<color red="0.38" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_2" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
+			<color red="0.77" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
+			<color red="0.19" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_194_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
+			<color red="0.38" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_2" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
+			<color red="0.77" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
+			<color red="0.19" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_150_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
+			<color red="0.38" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_2" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
+			<color red="0.77" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
+			<color red="0.19" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_151_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
+			<color red="0.38" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
+			<color red="0.09" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_2" defstate="0">
 		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
+			<color red="0.77" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
+			<color red="0.19" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.77" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_191_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
+			<color red="0.20" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
+			<color red="0.05" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_2" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
+			<color red="0.40" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
+			<color red="0.10" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_192_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
+			<color red="0.20" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
+			<color red="0.05" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_2" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
+			<color red="0.40" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
+			<color red="0.10" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_148_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
+			<color red="0.20" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
+			<color red="0.05" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_2" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
+			<color red="0.40" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
+			<color red="0.10" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_149_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
+			<color red="0.20" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
+			<color red="0.05" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_2" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
+			<color red="0.40" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
+			<color red="0.10" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.20" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_190_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_190">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_192_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_192">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Number">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_194_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_194">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_195_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_195">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Swap">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_197_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_197">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_198_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_198">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_199_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_199">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_200_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_200">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist=",,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_4">
 		<text string="3 1 6 9 4 10 11 2 5 8 12 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_11">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="WINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="729" height="651">
-			</bounds>
+			<bounds x="0" y="0" width="729" height="651"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="102" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="102" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="102" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="102" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="227" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="227" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="227.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="227.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="230.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="230.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="233.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="233.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="237.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="237.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="240.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="240.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="243.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="243.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="227.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="227.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="230.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="230.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="233.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="233.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="237.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="237.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="240.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="240.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="243.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="243.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="227.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="227.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="230.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="230.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="233.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="233.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="237.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="237.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="240.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="240.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="243.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="243.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="227" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="227" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="352" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="352" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="352.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="352.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="355.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="355.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="358.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="358.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="362.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="362.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="365.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="365.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="368.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="368.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="352.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="352.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="355.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="355.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="358.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="358.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="362.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="362.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="365.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="365.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="368.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="368.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="352.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="352.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="355.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="355.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="358.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="358.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="362.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="362.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="365.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="365.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="368.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="368.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="352" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="352" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="333" y="168" width="70" height="45">
-			</bounds>
+			<bounds x="333" y="168" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="168.0000" width="70.0000" height="45.0000">
-			</bounds>
+			<bounds x="333.0000" y="168.0000" width="70.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="335.9167" y="169.8750" width="64.1667" height="41.2500">
-			</bounds>
+			<bounds x="335.9167" y="169.8750" width="64.1667" height="41.2500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="338.8333" y="171.7500" width="58.3333" height="37.5000">
-			</bounds>
+			<bounds x="338.8333" y="171.7500" width="58.3333" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="341.7500" y="173.6250" width="52.5000" height="33.7500">
-			</bounds>
+			<bounds x="341.7500" y="173.6250" width="52.5000" height="33.7500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="344.6667" y="175.5000" width="46.6667" height="30.0000">
-			</bounds>
+			<bounds x="344.6667" y="175.5000" width="46.6667" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="347.5833" y="177.3750" width="40.8333" height="26.2500">
-			</bounds>
+			<bounds x="347.5833" y="177.3750" width="40.8333" height="26.2500"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="333" y="168" width="70" height="45">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="333" y="168" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="51" y="430" width="24" height="24">
-			</bounds>
+			<bounds x="51" y="430" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="53" y="432" width="20" height="20">
-			</bounds>
+			<bounds x="53" y="432" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="12" y="455" width="24" height="24">
-			</bounds>
+			<bounds x="12" y="455" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="14" y="457" width="20" height="20">
-			</bounds>
+			<bounds x="14" y="457" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="51" y="482" width="24" height="24">
-			</bounds>
+			<bounds x="51" y="482" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="53" y="484" width="20" height="20">
-			</bounds>
+			<bounds x="53" y="484" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="12" y="507" width="24" height="24">
-			</bounds>
+			<bounds x="12" y="507" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="14" y="509" width="20" height="20">
-			</bounds>
+			<bounds x="14" y="509" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="51" y="534" width="24" height="24">
-			</bounds>
+			<bounds x="51" y="534" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="53" y="536" width="20" height="20">
-			</bounds>
+			<bounds x="53" y="536" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="12" y="559" width="24" height="24">
-			</bounds>
+			<bounds x="12" y="559" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="14" y="561" width="20" height="20">
-			</bounds>
+			<bounds x="14" y="561" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="684" y="307" width="37" height="27">
-			</bounds>
+			<bounds x="684" y="307" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="686" y="309" width="33" height="23">
-			</bounds>
+			<bounds x="686" y="309" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="684" y="274" width="37" height="27">
-			</bounds>
+			<bounds x="684" y="274" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="686" y="276" width="33" height="23">
-			</bounds>
+			<bounds x="686" y="276" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="684" y="241" width="37" height="27">
-			</bounds>
+			<bounds x="684" y="241" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="686" y="243" width="33" height="23">
-			</bounds>
+			<bounds x="686" y="243" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="684" y="208" width="37" height="27">
-			</bounds>
+			<bounds x="684" y="208" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="686" y="210" width="33" height="23">
-			</bounds>
+			<bounds x="686" y="210" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="684" y="175" width="37" height="27">
-			</bounds>
+			<bounds x="684" y="175" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="686" y="177" width="33" height="23">
-			</bounds>
+			<bounds x="686" y="177" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="639" y="321" width="37" height="27">
-			</bounds>
+			<bounds x="639" y="321" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="641" y="323" width="33" height="23">
-			</bounds>
+			<bounds x="641" y="323" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="639" y="288" width="37" height="27">
-			</bounds>
+			<bounds x="639" y="288" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="641" y="290" width="33" height="23">
-			</bounds>
+			<bounds x="641" y="290" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="639" y="255" width="37" height="27">
-			</bounds>
+			<bounds x="639" y="255" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="641" y="257" width="33" height="23">
-			</bounds>
+			<bounds x="641" y="257" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="639" y="222" width="37" height="27">
-			</bounds>
+			<bounds x="639" y="222" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="641" y="224" width="33" height="23">
-			</bounds>
+			<bounds x="641" y="224" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="639" y="189" width="37" height="27">
-			</bounds>
+			<bounds x="639" y="189" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="641" y="191" width="33" height="23">
-			</bounds>
+			<bounds x="641" y="191" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="284" y="294" width="32" height="20">
-			</bounds>
+			<bounds x="284" y="294" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="286" y="296" width="28" height="16">
-			</bounds>
+			<bounds x="286" y="296" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="422" y="294" width="32" height="20">
-			</bounds>
+			<bounds x="422" y="294" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="424" y="296" width="28" height="16">
-			</bounds>
+			<bounds x="424" y="296" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="376" y="294" width="32" height="20">
-			</bounds>
+			<bounds x="376" y="294" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="378" y="296" width="28" height="16">
-			</bounds>
+			<bounds x="378" y="296" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="330" y="294" width="32" height="20">
-			</bounds>
+			<bounds x="330" y="294" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="332" y="296" width="28" height="16">
-			</bounds>
+			<bounds x="332" y="296" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="264" y="272" width="42" height="22">
-			</bounds>
+			<bounds x="264" y="272" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="266" y="274" width="38" height="18">
-			</bounds>
+			<bounds x="266" y="274" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="320" y="272" width="42" height="22">
-			</bounds>
+			<bounds x="320" y="272" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="322" y="274" width="38" height="18">
-			</bounds>
+			<bounds x="322" y="274" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="376" y="272" width="42" height="22">
-			</bounds>
+			<bounds x="376" y="272" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="378" y="274" width="38" height="18">
-			</bounds>
+			<bounds x="378" y="274" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="432" y="272" width="42" height="22">
-			</bounds>
+			<bounds x="432" y="272" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="434" y="274" width="38" height="18">
-			</bounds>
+			<bounds x="434" y="274" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="440" y="314" width="37" height="17">
-			</bounds>
+			<bounds x="440" y="314" width="37" height="17"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="442" y="316" width="33" height="13">
-			</bounds>
+			<bounds x="442" y="316" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="395" y="314" width="37" height="17">
-			</bounds>
+			<bounds x="395" y="314" width="37" height="17"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="397" y="316" width="33" height="13">
-			</bounds>
+			<bounds x="397" y="316" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="350" y="314" width="37" height="17">
-			</bounds>
+			<bounds x="350" y="314" width="37" height="17"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="352" y="316" width="33" height="13">
-			</bounds>
+			<bounds x="352" y="316" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="305" y="314" width="37" height="17">
-			</bounds>
+			<bounds x="305" y="314" width="37" height="17"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="307" y="316" width="33" height="13">
-			</bounds>
+			<bounds x="307" y="316" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="260" y="314" width="37" height="17">
-			</bounds>
+			<bounds x="260" y="314" width="37" height="17"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="262" y="316" width="33" height="13">
-			</bounds>
+			<bounds x="262" y="316" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="404" y="230" width="56" height="19">
-			</bounds>
+			<bounds x="404" y="230" width="56" height="19"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="406" y="232" width="52" height="15">
-			</bounds>
+			<bounds x="406" y="232" width="52" height="15"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="277" y="230" width="56" height="19">
-			</bounds>
+			<bounds x="277" y="230" width="56" height="19"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="279" y="232" width="52" height="15">
-			</bounds>
+			<bounds x="279" y="232" width="52" height="15"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="353" y="219" width="52" height="32">
-			</bounds>
+			<bounds x="353" y="219" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="355" y="221" width="48" height="28">
-			</bounds>
+			<bounds x="355" y="221" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="332" y="219" width="24" height="32">
-			</bounds>
+			<bounds x="332" y="219" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="334" y="221" width="20" height="28">
-			</bounds>
+			<bounds x="334" y="221" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="398" y="250" width="42" height="22">
-			</bounds>
+			<bounds x="398" y="250" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="400" y="252" width="38" height="18">
-			</bounds>
+			<bounds x="400" y="252" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="286" y="250" width="42" height="22">
-			</bounds>
+			<bounds x="286" y="250" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="288" y="252" width="38" height="18">
-			</bounds>
+			<bounds x="288" y="252" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="348" y="250" width="42" height="22">
-			</bounds>
+			<bounds x="348" y="250" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="350" y="252" width="38" height="18">
-			</bounds>
+			<bounds x="350" y="252" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="447" y="448" width="22" height="22">
-			</bounds>
+			<bounds x="447" y="448" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="449" y="450" width="18" height="18">
-			</bounds>
+			<bounds x="449" y="450" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="489" y="448" width="22" height="22">
-			</bounds>
+			<bounds x="489" y="448" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="491" y="450" width="18" height="18">
-			</bounds>
+			<bounds x="491" y="450" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="531" y="448" width="22" height="22">
-			</bounds>
+			<bounds x="531" y="448" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="533" y="450" width="18" height="18">
-			</bounds>
+			<bounds x="533" y="450" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_2_border" state="0">
-			<bounds x="466" y="443" width="22" height="32">
-			</bounds>
+			<bounds x="466" y="443" width="22" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_2" state="0">
-			<bounds x="468" y="445" width="18" height="28">
-			</bounds>
+			<bounds x="468" y="445" width="18" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_2_border" state="0">
-			<bounds x="508" y="443" width="22" height="32">
-			</bounds>
+			<bounds x="508" y="443" width="22" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_2" state="0">
-			<bounds x="510" y="445" width="18" height="28">
-			</bounds>
+			<bounds x="510" y="445" width="18" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_2_border" state="0">
-			<bounds x="550" y="443" width="22" height="32">
-			</bounds>
+			<bounds x="550" y="443" width="22" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_2" state="0">
-			<bounds x="552" y="445" width="18" height="28">
-			</bounds>
+			<bounds x="552" y="445" width="18" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="566" y="491" width="31" height="18">
-			</bounds>
+			<bounds x="566" y="491" width="31" height="18"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="568" y="493" width="27" height="14">
-			</bounds>
+			<bounds x="568" y="493" width="27" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="594" y="491" width="20" height="18">
-			</bounds>
+			<bounds x="594" y="491" width="20" height="18"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="596" y="493" width="16" height="14">
-			</bounds>
+			<bounds x="596" y="493" width="16" height="14"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="651" y="519" width="62" height="32">
-			</bounds>
+			<bounds x="651" y="519" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="653" y="521" width="58" height="28">
-			</bounds>
+			<bounds x="653" y="521" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="589" y="519" width="62" height="32">
-			</bounds>
+			<bounds x="589" y="519" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="591" y="521" width="58" height="28">
-			</bounds>
+			<bounds x="591" y="521" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="465" y="519" width="62" height="32">
-			</bounds>
+			<bounds x="465" y="519" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="467" y="521" width="58" height="28">
-			</bounds>
+			<bounds x="467" y="521" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="527" y="519" width="62" height="32">
-			</bounds>
+			<bounds x="527" y="519" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="529" y="521" width="58" height="28">
-			</bounds>
+			<bounds x="529" y="521" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="651" y="487" width="62" height="32">
-			</bounds>
+			<bounds x="651" y="487" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="653" y="489" width="58" height="28">
-			</bounds>
+			<bounds x="653" y="489" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="658" y="351" width="32" height="22">
-			</bounds>
+			<bounds x="658" y="351" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="660" y="353" width="28" height="18">
-			</bounds>
+			<bounds x="660" y="353" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="649" y="390" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="390" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="651" y="392" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="392" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="643" y="429" width="32" height="22">
-			</bounds>
+			<bounds x="643" y="429" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="645" y="431" width="28" height="18">
-			</bounds>
+			<bounds x="645" y="431" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="625" y="443" width="22" height="32">
-			</bounds>
+			<bounds x="625" y="443" width="22" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="627" y="445" width="18" height="28">
-			</bounds>
+			<bounds x="627" y="445" width="18" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="573" y="467" width="32" height="22">
-			</bounds>
+			<bounds x="573" y="467" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="575" y="469" width="28" height="18">
-			</bounds>
+			<bounds x="575" y="469" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="625" y="154" width="102" height="22">
-			</bounds>
+			<bounds x="625" y="154" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="627" y="156" width="98" height="18">
-			</bounds>
+			<bounds x="627" y="156" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="625" y="135" width="102" height="22">
-			</bounds>
+			<bounds x="625" y="135" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="627" y="137" width="98" height="18">
-			</bounds>
+			<bounds x="627" y="137" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="72" y="15" width="72" height="61">
-			</bounds>
+			<bounds x="72" y="15" width="72" height="61"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="74" y="17" width="68" height="57">
-			</bounds>
+			<bounds x="74" y="17" width="68" height="57"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="33" y="15" width="42" height="54">
-			</bounds>
+			<bounds x="33" y="15" width="42" height="54"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="35" y="17" width="38" height="50">
-			</bounds>
+			<bounds x="35" y="17" width="38" height="50"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_2_border" state="0">
-			<bounds x="33" y="66" width="42" height="21">
-			</bounds>
+			<bounds x="33" y="66" width="42" height="21"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_2" state="0">
-			<bounds x="35" y="68" width="38" height="17">
-			</bounds>
+			<bounds x="35" y="68" width="38" height="17"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="61" y="189" width="37" height="27">
-			</bounds>
+			<bounds x="61" y="189" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="63" y="191" width="33" height="23">
-			</bounds>
+			<bounds x="63" y="191" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="61" y="222" width="37" height="27">
-			</bounds>
+			<bounds x="61" y="222" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="63" y="224" width="33" height="23">
-			</bounds>
+			<bounds x="63" y="224" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="61" y="255" width="37" height="27">
-			</bounds>
+			<bounds x="61" y="255" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="63" y="257" width="33" height="23">
-			</bounds>
+			<bounds x="63" y="257" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="61" y="288" width="37" height="27">
-			</bounds>
+			<bounds x="61" y="288" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="63" y="290" width="33" height="23">
-			</bounds>
+			<bounds x="63" y="290" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="61" y="321" width="37" height="27">
-			</bounds>
+			<bounds x="61" y="321" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="63" y="323" width="33" height="23">
-			</bounds>
+			<bounds x="63" y="323" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="16" y="175" width="37" height="27">
-			</bounds>
+			<bounds x="16" y="175" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="18" y="177" width="33" height="23">
-			</bounds>
+			<bounds x="18" y="177" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="16" y="208" width="37" height="27">
-			</bounds>
+			<bounds x="16" y="208" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="18" y="210" width="33" height="23">
-			</bounds>
+			<bounds x="18" y="210" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="16" y="241" width="37" height="27">
-			</bounds>
+			<bounds x="16" y="241" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="18" y="243" width="33" height="23">
-			</bounds>
+			<bounds x="18" y="243" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="16" y="274" width="37" height="27">
-			</bounds>
+			<bounds x="16" y="274" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="18" y="276" width="33" height="23">
-			</bounds>
+			<bounds x="18" y="276" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="16" y="307" width="37" height="27">
-			</bounds>
+			<bounds x="16" y="307" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="18" y="309" width="33" height="23">
-			</bounds>
+			<bounds x="18" y="309" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="538" y="226" width="18" height="26">
-			</bounds>
+			<bounds x="538" y="226" width="18" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="540" y="228" width="14" height="22">
-			</bounds>
+			<bounds x="540" y="228" width="14" height="22"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="523" y="226" width="18" height="26">
-			</bounds>
+			<bounds x="523" y="226" width="18" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="525" y="228" width="14" height="22">
-			</bounds>
+			<bounds x="525" y="228" width="14" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="179" y="4" width="112" height="62">
-			</bounds>
+			<bounds x="179" y="4" width="112" height="62"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="181" y="6" width="108" height="58">
-			</bounds>
+			<bounds x="181" y="6" width="108" height="58"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="288" y="4" width="72" height="62">
-			</bounds>
+			<bounds x="288" y="4" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="290" y="6" width="68" height="58">
-			</bounds>
+			<bounds x="290" y="6" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="495" y="4" width="68" height="62">
-			</bounds>
+			<bounds x="495" y="4" width="68" height="62"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="497" y="6" width="64" height="58">
-			</bounds>
+			<bounds x="497" y="6" width="64" height="58"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="426" y="4" width="72" height="62">
-			</bounds>
+			<bounds x="426" y="4" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="428" y="6" width="68" height="58">
-			</bounds>
+			<bounds x="428" y="6" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="357" y="4" width="72" height="62">
-			</bounds>
+			<bounds x="357" y="4" width="72" height="62"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="359" y="6" width="68" height="58">
-			</bounds>
+			<bounds x="359" y="6" width="68" height="58"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="409" y="168" width="19" height="19">
-			</bounds>
+			<bounds x="409" y="168" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="411" y="170" width="15" height="15">
-			</bounds>
+			<bounds x="411" y="170" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="309" y="168" width="19" height="19">
-			</bounds>
+			<bounds x="309" y="168" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="311" y="170" width="15" height="15">
-			</bounds>
+			<bounds x="311" y="170" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="536" y="271" width="15" height="24">
-			</bounds>
+			<bounds x="536" y="271" width="15" height="24"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="538" y="273" width="11" height="20">
-			</bounds>
+			<bounds x="538" y="273" width="11" height="20"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="548" y="271" width="12" height="24">
-			</bounds>
+			<bounds x="548" y="271" width="12" height="24"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="550" y="273" width="8" height="20">
-			</bounds>
+			<bounds x="550" y="273" width="8" height="20"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="533" y="249" width="17" height="25">
-			</bounds>
+			<bounds x="533" y="249" width="17" height="25"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="535" y="251" width="13" height="21">
-			</bounds>
+			<bounds x="535" y="251" width="13" height="21"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="547" y="249" width="14" height="25">
-			</bounds>
+			<bounds x="547" y="249" width="14" height="25"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="549" y="251" width="10" height="21">
-			</bounds>
+			<bounds x="549" y="251" width="10" height="21"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="541" y="292" width="14" height="23">
-			</bounds>
+			<bounds x="541" y="292" width="14" height="23"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="543" y="294" width="10" height="19">
-			</bounds>
+			<bounds x="543" y="294" width="10" height="19"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="552" y="292" width="12" height="23">
-			</bounds>
+			<bounds x="552" y="292" width="12" height="23"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="554" y="294" width="8" height="19">
-			</bounds>
+			<bounds x="554" y="294" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="504" y="312" width="112" height="22">
-			</bounds>
+			<bounds x="504" y="312" width="112" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="506" y="314" width="108" height="18">
-			</bounds>
+			<bounds x="506" y="314" width="108" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="512" y="331" width="102" height="21">
-			</bounds>
+			<bounds x="512" y="331" width="102" height="21"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="514" y="333" width="98" height="17">
-			</bounds>
+			<bounds x="514" y="333" width="98" height="17"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="518" y="349" width="92" height="20">
-			</bounds>
+			<bounds x="518" y="349" width="92" height="20"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="520" y="351" width="88" height="16">
-			</bounds>
+			<bounds x="520" y="351" width="88" height="16"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="527" y="366" width="82" height="19">
-			</bounds>
+			<bounds x="527" y="366" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="529" y="368" width="78" height="15">
-			</bounds>
+			<bounds x="529" y="368" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="533" y="382" width="72" height="17">
-			</bounds>
+			<bounds x="533" y="382" width="72" height="17"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="535" y="384" width="68" height="13">
-			</bounds>
+			<bounds x="535" y="384" width="68" height="13"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="140" y="292" width="45" height="23">
-			</bounds>
+			<bounds x="140" y="292" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="142" y="294" width="41" height="19">
-			</bounds>
+			<bounds x="142" y="294" width="41" height="19"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="182" y="292" width="18" height="23">
-			</bounds>
+			<bounds x="182" y="292" width="18" height="23"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="184" y="294" width="14" height="19">
-			</bounds>
+			<bounds x="184" y="294" width="14" height="19"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="147" y="271" width="42" height="24">
-			</bounds>
+			<bounds x="147" y="271" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="149" y="273" width="38" height="20">
-			</bounds>
+			<bounds x="149" y="273" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="186" y="271" width="42" height="24">
-			</bounds>
+			<bounds x="186" y="271" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="188" y="273" width="38" height="20">
-			</bounds>
+			<bounds x="188" y="273" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="148" y="249" width="42" height="25">
-			</bounds>
+			<bounds x="148" y="249" width="42" height="25"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="150" y="251" width="38" height="21">
-			</bounds>
+			<bounds x="150" y="251" width="38" height="21"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="187" y="249" width="68" height="25">
-			</bounds>
+			<bounds x="187" y="249" width="68" height="25"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="189" y="251" width="64" height="21">
-			</bounds>
+			<bounds x="189" y="251" width="64" height="21"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="121" y="312" width="112" height="22">
-			</bounds>
+			<bounds x="121" y="312" width="112" height="22"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="123" y="314" width="108" height="18">
-			</bounds>
+			<bounds x="123" y="314" width="108" height="18"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="123" y="331" width="102" height="21">
-			</bounds>
+			<bounds x="123" y="331" width="102" height="21"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="125" y="333" width="98" height="17">
-			</bounds>
+			<bounds x="125" y="333" width="98" height="17"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="127" y="349" width="92" height="20">
-			</bounds>
+			<bounds x="127" y="349" width="92" height="20"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="129" y="351" width="88" height="16">
-			</bounds>
+			<bounds x="129" y="351" width="88" height="16"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="129" y="366" width="82" height="19">
-			</bounds>
+			<bounds x="129" y="366" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="131" y="368" width="78" height="15">
-			</bounds>
+			<bounds x="131" y="368" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_2_border" state="0">
-			<bounds x="648" y="448" width="22" height="22">
-			</bounds>
+			<bounds x="648" y="448" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_2" state="0">
-			<bounds x="650" y="450" width="18" height="18">
-			</bounds>
+			<bounds x="650" y="450" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_2_border" state="0">
-			<bounds x="606" y="448" width="22" height="22">
-			</bounds>
+			<bounds x="606" y="448" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_2" state="0">
-			<bounds x="608" y="450" width="18" height="18">
-			</bounds>
+			<bounds x="608" y="450" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_2_border" state="0">
-			<bounds x="654" y="409" width="22" height="22">
-			</bounds>
+			<bounds x="654" y="409" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_2" state="0">
-			<bounds x="656" y="411" width="18" height="18">
-			</bounds>
+			<bounds x="656" y="411" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_2_border" state="0">
-			<bounds x="663" y="370" width="22" height="22">
-			</bounds>
+			<bounds x="663" y="370" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_2" state="0">
-			<bounds x="665" y="372" width="18" height="18">
-			</bounds>
+			<bounds x="665" y="372" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="543" y="169" width="34" height="32">
-			</bounds>
+			<bounds x="543" y="169" width="34" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="545" y="171" width="30" height="28">
-			</bounds>
+			<bounds x="545" y="171" width="30" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="514" y="169" width="32" height="32">
-			</bounds>
+			<bounds x="514" y="169" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="516" y="171" width="28" height="28">
-			</bounds>
+			<bounds x="516" y="171" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="539" y="106" width="92" height="19">
-			</bounds>
+			<bounds x="539" y="106" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="541" y="108" width="88" height="15">
-			</bounds>
+			<bounds x="541" y="108" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="431" y="94" width="92" height="19">
-			</bounds>
+			<bounds x="431" y="94" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="433" y="96" width="88" height="15">
-			</bounds>
+			<bounds x="433" y="96" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="376" y="76" width="92" height="19">
-			</bounds>
+			<bounds x="376" y="76" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="378" y="78" width="88" height="15">
-			</bounds>
+			<bounds x="378" y="78" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="268" y="76" width="92" height="19">
-			</bounds>
+			<bounds x="268" y="76" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="270" y="78" width="88" height="15">
-			</bounds>
+			<bounds x="270" y="78" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="214" y="94" width="92" height="19">
-			</bounds>
+			<bounds x="214" y="94" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="216" y="96" width="88" height="15">
-			</bounds>
+			<bounds x="216" y="96" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="106" y="106" width="92" height="19">
-			</bounds>
+			<bounds x="106" y="106" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="108" y="108" width="88" height="15">
-			</bounds>
+			<bounds x="108" y="108" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="431" y="127" width="62" height="19">
-			</bounds>
+			<bounds x="431" y="127" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="433" y="129" width="58" height="15">
-			</bounds>
+			<bounds x="433" y="129" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="471" y="143" width="52" height="19">
-			</bounds>
+			<bounds x="471" y="143" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="473" y="145" width="48" height="15">
-			</bounds>
+			<bounds x="473" y="145" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="244" y="127" width="62" height="19">
-			</bounds>
+			<bounds x="244" y="127" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="246" y="129" width="58" height="15">
-			</bounds>
+			<bounds x="246" y="129" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="214" y="143" width="52" height="19">
-			</bounds>
+			<bounds x="214" y="143" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="216" y="145" width="48" height="15">
-			</bounds>
+			<bounds x="216" y="145" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2_border" state="0">
-			<bounds x="259" y="163" width="32" height="32">
-			</bounds>
+			<bounds x="259" y="163" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2" state="0">
-			<bounds x="261" y="165" width="28" height="28">
-			</bounds>
+			<bounds x="261" y="165" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="133" y="382" width="72" height="17">
-			</bounds>
+			<bounds x="133" y="382" width="72" height="17"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="135" y="384" width="68" height="13">
-			</bounds>
+			<bounds x="135" y="384" width="68" height="13"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="140" y="202" width="67" height="27">
-			</bounds>
+			<bounds x="140" y="202" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="142" y="204" width="63" height="23">
-			</bounds>
+			<bounds x="142" y="204" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="204" y="202" width="61" height="27">
-			</bounds>
+			<bounds x="204" y="202" width="61" height="27"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="206" y="204" width="57" height="23">
-			</bounds>
+			<bounds x="206" y="204" width="57" height="23"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="132" y="169" width="62" height="32">
-			</bounds>
+			<bounds x="132" y="169" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="134" y="171" width="58" height="28">
-			</bounds>
+			<bounds x="134" y="171" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="191" y="169" width="62" height="32">
-			</bounds>
+			<bounds x="191" y="169" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="193" y="171" width="58" height="28">
-			</bounds>
+			<bounds x="193" y="171" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="476" y="202" width="57" height="27">
-			</bounds>
+			<bounds x="476" y="202" width="57" height="27"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="478" y="204" width="53" height="23">
-			</bounds>
+			<bounds x="478" y="204" width="53" height="23"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="530" y="202" width="44" height="27">
-			</bounds>
+			<bounds x="530" y="202" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="532" y="204" width="40" height="23">
-			</bounds>
+			<bounds x="532" y="204" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="446" y="163" width="32" height="32">
-			</bounds>
+			<bounds x="446" y="163" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="448" y="165" width="28" height="28">
-			</bounds>
+			<bounds x="448" y="165" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="10" y="135" width="102" height="22">
-			</bounds>
+			<bounds x="10" y="135" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="12" y="137" width="98" height="18">
-			</bounds>
+			<bounds x="12" y="137" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="10" y="154" width="102" height="22">
-			</bounds>
+			<bounds x="10" y="154" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="12" y="156" width="98" height="18">
-			</bounds>
+			<bounds x="12" y="156" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="16" y="339" width="42" height="32">
-			</bounds>
+			<bounds x="16" y="339" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="18" y="341" width="38" height="28">
-			</bounds>
+			<bounds x="18" y="341" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="26" y="95" width="56" height="19">
-			</bounds>
+			<bounds x="26" y="95" width="56" height="19"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="28" y="97" width="52" height="15">
-			</bounds>
+			<bounds x="28" y="97" width="52" height="15"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="18" y="111" width="72" height="19">
-			</bounds>
+			<bounds x="18" y="111" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="20" y="113" width="68" height="15">
-			</bounds>
+			<bounds x="20" y="113" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="196" y="226" width="60" height="26">
-			</bounds>
+			<bounds x="196" y="226" width="60" height="26"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="198" y="228" width="56" height="22">
-			</bounds>
+			<bounds x="198" y="228" width="56" height="22"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="137" y="226" width="62" height="26">
-			</bounds>
+			<bounds x="137" y="226" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="139" y="228" width="58" height="22">
-			</bounds>
+			<bounds x="139" y="228" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="589" y="31" width="32" height="32">
-			</bounds>
+			<bounds x="589" y="31" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="591" y="33" width="28" height="28">
-			</bounds>
+			<bounds x="591" y="33" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="465" y="487" width="62" height="32">
-			</bounds>
+			<bounds x="465" y="487" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="467" y="489" width="58" height="28">
-			</bounds>
+			<bounds x="467" y="489" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="515" y="425" width="82" height="18">
-			</bounds>
+			<bounds x="515" y="425" width="82" height="18"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="517" y="427" width="78" height="14">
-			</bounds>
+			<bounds x="517" y="427" width="78" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_2_border" state="0">
-			<bounds x="578" y="448" width="22" height="22">
-			</bounds>
+			<bounds x="578" y="448" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_2" state="0">
-			<bounds x="580" y="450" width="18" height="18">
-			</bounds>
+			<bounds x="580" y="450" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_2_border" state="0">
-			<bounds x="72" y="73" width="72" height="14">
-			</bounds>
+			<bounds x="72" y="73" width="72" height="14"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_2" state="0">
-			<bounds x="74" y="75" width="68" height="10">
-			</bounds>
+			<bounds x="74" y="75" width="68" height="10"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_2_border" state="0">
-			<bounds x="484" y="169" width="33" height="32">
-			</bounds>
+			<bounds x="484" y="169" width="33" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_2" state="0">
-			<bounds x="486" y="171" width="29" height="28">
-			</bounds>
+			<bounds x="486" y="171" width="29" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_2_border" state="0">
-			<bounds x="574" y="169" width="31" height="32">
-			</bounds>
+			<bounds x="574" y="169" width="31" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_2" state="0">
-			<bounds x="576" y="171" width="27" height="28">
-			</bounds>
+			<bounds x="576" y="171" width="27" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_2_border" state="0">
-			<bounds x="571" y="202" width="46" height="27">
-			</bounds>
+			<bounds x="571" y="202" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_2" state="0">
-			<bounds x="573" y="204" width="42" height="23">
-			</bounds>
+			<bounds x="573" y="204" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_2_border" state="0">
-			<bounds x="446" y="202" width="33" height="27">
-			</bounds>
+			<bounds x="446" y="202" width="33" height="27"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_2" state="0">
-			<bounds x="448" y="204" width="29" height="23">
-			</bounds>
+			<bounds x="448" y="204" width="29" height="23"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2_border" state="0">
-			<bounds x="262" y="202" width="29" height="27">
-			</bounds>
+			<bounds x="262" y="202" width="29" height="27"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2" state="0">
-			<bounds x="264" y="204" width="25" height="23">
-			</bounds>
+			<bounds x="264" y="204" width="25" height="23"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2_border" state="0">
-			<bounds x="120" y="202" width="23" height="27">
-			</bounds>
+			<bounds x="120" y="202" width="23" height="27"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2" state="0">
-			<bounds x="122" y="204" width="19" height="23">
-			</bounds>
+			<bounds x="122" y="204" width="19" height="23"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_2_border" state="0">
-			<bounds x="117" y="226" width="23" height="26">
-			</bounds>
+			<bounds x="117" y="226" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_2" state="0">
-			<bounds x="119" y="228" width="19" height="22">
-			</bounds>
+			<bounds x="119" y="228" width="19" height="22"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_2_border" state="0">
-			<bounds x="253" y="226" width="20" height="26">
-			</bounds>
+			<bounds x="253" y="226" width="20" height="26"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_2" state="0">
-			<bounds x="255" y="228" width="16" height="22">
-			</bounds>
+			<bounds x="255" y="228" width="16" height="22"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_2_border" state="0">
-			<bounds x="464" y="226" width="62" height="26">
-			</bounds>
+			<bounds x="464" y="226" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_2" state="0">
-			<bounds x="466" y="228" width="58" height="22">
-			</bounds>
+			<bounds x="466" y="228" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2_border" state="0">
-			<bounds x="553" y="226" width="67" height="26">
-			</bounds>
+			<bounds x="553" y="226" width="67" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_2" state="0">
-			<bounds x="555" y="228" width="63" height="22">
-			</bounds>
+			<bounds x="555" y="228" width="63" height="22"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_2_border" state="0">
-			<bounds x="116" y="249" width="35" height="25">
-			</bounds>
+			<bounds x="116" y="249" width="35" height="25"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_2" state="0">
-			<bounds x="118" y="251" width="31" height="21">
-			</bounds>
+			<bounds x="118" y="251" width="31" height="21"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2_border" state="0">
-			<bounds x="252" y="249" width="9" height="25">
-			</bounds>
+			<bounds x="252" y="249" width="9" height="25"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2" state="0">
-			<bounds x="254" y="251" width="5" height="21">
-			</bounds>
+			<bounds x="254" y="251" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_2_border" state="0">
-			<bounds x="476" y="249" width="60" height="25">
-			</bounds>
+			<bounds x="476" y="249" width="60" height="25"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_2" state="0">
-			<bounds x="478" y="251" width="56" height="21">
-			</bounds>
+			<bounds x="478" y="251" width="56" height="21"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_2_border" state="0">
-			<bounds x="558" y="249" width="63" height="25">
-			</bounds>
+			<bounds x="558" y="249" width="63" height="25"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_2" state="0">
-			<bounds x="560" y="251" width="59" height="21">
-			</bounds>
+			<bounds x="560" y="251" width="59" height="21"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_2_border" state="0">
-			<bounds x="117" y="271" width="33" height="24">
-			</bounds>
+			<bounds x="117" y="271" width="33" height="24"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_2" state="0">
-			<bounds x="119" y="273" width="29" height="20">
-			</bounds>
+			<bounds x="119" y="273" width="29" height="20"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2_border" state="0">
-			<bounds x="225" y="271" width="33" height="24">
-			</bounds>
+			<bounds x="225" y="271" width="33" height="24"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2" state="0">
-			<bounds x="227" y="273" width="29" height="20">
-			</bounds>
+			<bounds x="227" y="273" width="29" height="20"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_2_border" state="0">
-			<bounds x="479" y="271" width="60" height="24">
-			</bounds>
+			<bounds x="479" y="271" width="60" height="24"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_2" state="0">
-			<bounds x="481" y="273" width="56" height="20">
-			</bounds>
+			<bounds x="481" y="273" width="56" height="20"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_2_border" state="0">
-			<bounds x="557" y="271" width="63" height="24">
-			</bounds>
+			<bounds x="557" y="271" width="63" height="24"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_2" state="0">
-			<bounds x="559" y="273" width="59" height="20">
-			</bounds>
+			<bounds x="559" y="273" width="59" height="20"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_2_border" state="0">
-			<bounds x="118" y="292" width="25" height="23">
-			</bounds>
+			<bounds x="118" y="292" width="25" height="23"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_2" state="0">
-			<bounds x="120" y="294" width="21" height="19">
-			</bounds>
+			<bounds x="120" y="294" width="21" height="19"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_2_border" state="0">
-			<bounds x="197" y="292" width="52" height="23">
-			</bounds>
+			<bounds x="197" y="292" width="52" height="23"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_2" state="0">
-			<bounds x="199" y="294" width="48" height="19">
-			</bounds>
+			<bounds x="199" y="294" width="48" height="19"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_2_border" state="0">
-			<bounds x="488" y="292" width="56" height="23">
-			</bounds>
+			<bounds x="488" y="292" width="56" height="23"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_2" state="0">
-			<bounds x="490" y="294" width="52" height="19">
-			</bounds>
+			<bounds x="490" y="294" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_2_border" state="0">
-			<bounds x="561" y="292" width="58" height="23">
-			</bounds>
+			<bounds x="561" y="292" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_2" state="0">
-			<bounds x="563" y="294" width="54" height="19">
-			</bounds>
+			<bounds x="563" y="294" width="54" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="683" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="683" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="685" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="685" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="614" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="614" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="616" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="616" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="545" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="545" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="547" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="547" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="476" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="476" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="478" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="478" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="407" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="407" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="409" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="409" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="338" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="338" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="340" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="340" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="269" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="269" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="271" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="271" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="131" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="131" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="133" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="133" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="200" y="559" width="42" height="33">
-			</bounds>
+			<bounds x="200" y="559" width="42" height="33"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="202" y="561" width="38" height="29">
-			</bounds>
+			<bounds x="202" y="561" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_190_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="11" y="604" width="70" height="45">
-			</bounds>
+			<bounds x="11" y="604" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_190" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="13" y="606" width="66" height="41">
-			</bounds>
+			<bounds x="13" y="606" width="66" height="41"/>
 		</backdrop>
 		<backdrop name="lamp203" element="colour_button_192_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="20" y="370" width="68" height="45">
-			</bounds>
+			<bounds x="20" y="370" width="68" height="45"/>
 		</backdrop>
 		<backdrop name="lamp203" element="colour_button_192" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="22" y="372" width="64" height="41">
-			</bounds>
+			<bounds x="22" y="372" width="64" height="41"/>
 		</backdrop>
 		<backdrop name="lamp183" element="colour_button_193_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="334" y="113" width="68" height="42">
-			</bounds>
+			<bounds x="334" y="113" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp183" element="colour_button_193" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="336" y="115" width="64" height="38">
-			</bounds>
+			<bounds x="336" y="115" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_194_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="652" y="34" width="46" height="62">
-			</bounds>
+			<bounds x="652" y="34" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp126" element="colour_button_194" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="654" y="36" width="42" height="58">
-			</bounds>
+			<bounds x="654" y="36" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_195_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="651" y="604" width="70" height="45">
-			</bounds>
+			<bounds x="651" y="604" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_195" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="653" y="606" width="66" height="41">
-			</bounds>
+			<bounds x="653" y="606" width="66" height="41"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_196_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="562" y="604" width="70" height="45">
-			</bounds>
+			<bounds x="562" y="604" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_196" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="564" y="606" width="66" height="41">
-			</bounds>
+			<bounds x="564" y="606" width="66" height="41"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_197_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="464" y="604" width="70" height="45">
-			</bounds>
+			<bounds x="464" y="604" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_197" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="466" y="606" width="66" height="41">
-			</bounds>
+			<bounds x="466" y="606" width="66" height="41"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_198_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="357" y="604" width="70" height="45">
-			</bounds>
+			<bounds x="357" y="604" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_198" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="359" y="606" width="66" height="41">
-			</bounds>
+			<bounds x="359" y="606" width="66" height="41"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_199_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="232" y="604" width="70" height="45">
-			</bounds>
+			<bounds x="232" y="604" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_199" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="234" y="606" width="66" height="41">
-			</bounds>
+			<bounds x="234" y="606" width="66" height="41"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_200_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="107" y="604" width="70" height="45">
-			</bounds>
+			<bounds x="107" y="604" width="70" height="45"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_200" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="109" y="606" width="66" height="41">
-			</bounds>
+			<bounds x="109" y="606" width="66" height="41"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="249" y="333" width="240" height="26">
-			</bounds>
+			<bounds x="249" y="333" width="240" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="249" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="249" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="264" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="264" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="279" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="279" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="294" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="294" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="309" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="309" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="324" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="324" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="339" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="339" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="354" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="354" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="369" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="369" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="384" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="384" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="399" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="399" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="414" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="414" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="429" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="429" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="444" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="444" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="459" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="459" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="474" y="333" width="15" height="26">
-			</bounds>
+			<bounds x="474" y="333" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="label4" element="label_4">
-			<bounds x="310" y="157" width="114" height="11">
-			</bounds>
+			<bounds x="310" y="157" width="114" height="11"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="439" y="354" width="51" height="23">
-			</bounds>
+			<bounds x="439" y="354" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="249" y="354" width="50" height="23">
-			</bounds>
+			<bounds x="249" y="354" width="50" height="23"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_button" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_button" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_button" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1omega.lay
+++ b/src/mame/layout/m1omega.lay
@@ -8,11454 +8,7031 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=".40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string=".40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string=".00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string=".00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string=".60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string=".60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string=".40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string=".40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string=".20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string=".20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</rect>
 		<text string=".00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<text string=".00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.00">
-			</color>
+			<color red="0.46" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.00">
-			</color>
+			<color red="0.11" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.92" green="0.00" blue="0.00">
-			</color>
+			<color red="0.92" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.00">
-			</color>
+			<color red="0.23" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.92" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_160_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_160_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_153_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_153_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_147_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_141_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_141_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_135_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_135_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</rect>
 		<text string="NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<text string="NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</rect>
 		<text string="GES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<text string="GES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_45_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_46_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_45_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_3" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_3" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_4" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="ST WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="ST WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_4" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="NEARE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="NEARE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="MYSTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="MYSTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="12 NU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="12 NU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="WIN S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="RY WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="RY WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="DGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="DGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="ERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="ERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HIDDEN FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HIDDEN FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.41" green="0.42" blue="0.37">
-			</color>
+			<color red="0.41" green="0.42" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.09">
-			</color>
+			<color red="0.10" green="0.10" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.82" green="0.84" blue="0.74">
-			</color>
+			<color red="0.82" green="0.84" blue="0.74"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.21" blue="0.18">
-			</color>
+			<color red="0.20" green="0.21" blue="0.18"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.41" green="0.42" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.82" green="0.84" blue="0.74">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.21" blue="0.18">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="IN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="IN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="A W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="A W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_50_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_50_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_3" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_49_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_3" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_50_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_4" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="OSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="OSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_4" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="CHO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="REEL M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 		<text string="ATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="ATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_48_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
+			<color red="0.14" green="0.14" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
+			<color red="0.04" green="0.04" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_2" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
+			<color red="0.28" green="0.28" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_114_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_114">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_115_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_115">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_116_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_116">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_117_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_117">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_118_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_118">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_119_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_119">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_120_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_120">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_121_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_121">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_95">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_96">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_97">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_112">
 		<text string="Bugs and Trouty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="v1.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_113">
 		<text string="Bravest Face">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="789" height="686">
-			</bounds>
+			<bounds x="0" y="0" width="789" height="686"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="102" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="102" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="435.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="435.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="436.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="436.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="438.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="438.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="440.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="440.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="442.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="442.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="444.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="444.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="481.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="481.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="483.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="483.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="485.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="485.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="487.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="487.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="489.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="489.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="491.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="491.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="528.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="528.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="530.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="530.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="532.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="532.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="534.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="534.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="536.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="536.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="538.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="538.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="102" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="102" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="242" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="242" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="435.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="242.0000" y="435.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="436.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="245.3333" y="436.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="438.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="248.6667" y="438.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="440.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="252.0000" y="440.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="442.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="255.3333" y="442.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="444.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="258.6667" y="444.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="481.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="242.0000" y="481.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="483.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="245.3333" y="483.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="485.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="248.6667" y="485.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="487.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="252.0000" y="487.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="489.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="255.3333" y="489.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="491.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="258.6667" y="491.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="528.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="242.0000" y="528.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="530.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="245.3333" y="530.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="532.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="248.6667" y="532.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="534.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="252.0000" y="534.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="536.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="255.3333" y="536.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="538.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="258.6667" y="538.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="242" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="242" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="382" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="382" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="382.0000" y="435.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="382.0000" y="435.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="385.3333" y="436.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="385.3333" y="436.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="388.6667" y="438.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="388.6667" y="438.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.0000" y="440.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="392.0000" y="440.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.3333" y="442.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="395.3333" y="442.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.6667" y="444.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="398.6667" y="444.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="382.0000" y="481.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="382.0000" y="481.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="385.3333" y="483.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="385.3333" y="483.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="388.6667" y="485.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="388.6667" y="485.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.0000" y="487.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="392.0000" y="487.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.3333" y="489.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="395.3333" y="489.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.6667" y="491.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="398.6667" y="491.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="382.0000" y="528.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="382.0000" y="528.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="385.3333" y="530.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="385.3333" y="530.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="388.6667" y="532.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="388.6667" y="532.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.0000" y="534.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="392.0000" y="534.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.3333" y="536.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="395.3333" y="536.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.6667" y="538.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="398.6667" y="538.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="382" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="382" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="47" y="178" width="80" height="60">
-			</bounds>
+			<bounds x="47" y="178" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="47.0000" y="178.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="47.0000" y="178.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="50.3333" y="180.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="50.3333" y="180.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="53.6667" y="183.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="53.6667" y="183.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="57.0000" y="185.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="57.0000" y="185.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="60.3333" y="188.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="60.3333" y="188.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="63.6667" y="190.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="63.6667" y="190.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="47" y="178" width="80" height="60">
-			</bounds>
+			<bounds x="47" y="178" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="512" y="474" width="42" height="32">
-			</bounds>
+			<bounds x="512" y="474" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="514" y="476" width="38" height="28">
-			</bounds>
+			<bounds x="514" y="476" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="572" y="493" width="42" height="32">
-			</bounds>
+			<bounds x="572" y="493" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="574" y="495" width="38" height="28">
-			</bounds>
+			<bounds x="574" y="495" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="512" y="512" width="42" height="32">
-			</bounds>
+			<bounds x="512" y="512" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="514" y="514" width="38" height="28">
-			</bounds>
+			<bounds x="514" y="514" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="572" y="531" width="42" height="32">
-			</bounds>
+			<bounds x="572" y="531" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="574" y="533" width="38" height="28">
-			</bounds>
+			<bounds x="574" y="533" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="512" y="550" width="42" height="32">
-			</bounds>
+			<bounds x="512" y="550" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="514" y="552" width="38" height="28">
-			</bounds>
+			<bounds x="514" y="552" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="572" y="569" width="42" height="22">
-			</bounds>
+			<bounds x="572" y="569" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="574" y="571" width="38" height="18">
-			</bounds>
+			<bounds x="574" y="571" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="102" y="580" width="50" height="42">
-			</bounds>
+			<bounds x="102" y="580" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="104" y="582" width="46" height="38">
-			</bounds>
+			<bounds x="104" y="582" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="175" y="580" width="50" height="42">
-			</bounds>
+			<bounds x="175" y="580" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="177" y="582" width="46" height="38">
-			</bounds>
+			<bounds x="177" y="582" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="248" y="580" width="50" height="42">
-			</bounds>
+			<bounds x="248" y="580" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="250" y="582" width="46" height="38">
-			</bounds>
+			<bounds x="250" y="582" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="321" y="580" width="50" height="42">
-			</bounds>
+			<bounds x="321" y="580" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="323" y="582" width="46" height="38">
-			</bounds>
+			<bounds x="323" y="582" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="394" y="580" width="50" height="42">
-			</bounds>
+			<bounds x="394" y="580" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="396" y="582" width="46" height="38">
-			</bounds>
+			<bounds x="396" y="582" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="208" y="122" width="36" height="32">
-			</bounds>
+			<bounds x="208" y="122" width="36" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="210" y="124" width="32" height="28">
-			</bounds>
+			<bounds x="210" y="124" width="32" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="386" y="98" width="82" height="22">
-			</bounds>
+			<bounds x="386" y="98" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="388" y="100" width="78" height="18">
-			</bounds>
+			<bounds x="388" y="100" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="487" y="98" width="62" height="22">
-			</bounds>
+			<bounds x="487" y="98" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="489" y="100" width="58" height="18">
-			</bounds>
+			<bounds x="489" y="100" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="700" y="139" width="62" height="32">
-			</bounds>
+			<bounds x="700" y="139" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="702" y="141" width="58" height="28">
-			</bounds>
+			<bounds x="702" y="141" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="624" y="134" width="42" height="30">
-			</bounds>
+			<bounds x="624" y="134" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="626" y="136" width="38" height="26">
-			</bounds>
+			<bounds x="626" y="136" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="575" y="134" width="52" height="42">
-			</bounds>
+			<bounds x="575" y="134" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="577" y="136" width="48" height="38">
-			</bounds>
+			<bounds x="577" y="136" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="574" y="184" width="42" height="30">
-			</bounds>
+			<bounds x="574" y="184" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="576" y="186" width="38" height="26">
-			</bounds>
+			<bounds x="576" y="186" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="525" y="184" width="52" height="42">
-			</bounds>
+			<bounds x="525" y="184" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="527" y="186" width="48" height="38">
-			</bounds>
+			<bounds x="527" y="186" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="475" y="234" width="52" height="42">
-			</bounds>
+			<bounds x="475" y="234" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="477" y="236" width="48" height="38">
-			</bounds>
+			<bounds x="477" y="236" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="524" y="234" width="42" height="30">
-			</bounds>
+			<bounds x="524" y="234" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="526" y="236" width="38" height="26">
-			</bounds>
+			<bounds x="526" y="236" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="474" y="284" width="42" height="30">
-			</bounds>
+			<bounds x="474" y="284" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="476" y="286" width="38" height="26">
-			</bounds>
+			<bounds x="476" y="286" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="425" y="284" width="52" height="42">
-			</bounds>
+			<bounds x="425" y="284" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="427" y="286" width="48" height="38">
-			</bounds>
+			<bounds x="427" y="286" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="500" y="339" width="62" height="32">
-			</bounds>
+			<bounds x="500" y="339" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="502" y="341" width="58" height="28">
-			</bounds>
+			<bounds x="502" y="341" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="375" y="334" width="52" height="42">
-			</bounds>
+			<bounds x="375" y="334" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="377" y="336" width="48" height="38">
-			</bounds>
+			<bounds x="377" y="336" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="424" y="334" width="42" height="30">
-			</bounds>
+			<bounds x="424" y="334" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="426" y="336" width="38" height="26">
-			</bounds>
+			<bounds x="426" y="336" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="374" y="384" width="42" height="30">
-			</bounds>
+			<bounds x="374" y="384" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="376" y="386" width="38" height="26">
-			</bounds>
+			<bounds x="376" y="386" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="325" y="384" width="52" height="42">
-			</bounds>
+			<bounds x="325" y="384" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="327" y="386" width="48" height="38">
-			</bounds>
+			<bounds x="327" y="386" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="450" y="389" width="62" height="32">
-			</bounds>
+			<bounds x="450" y="389" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="452" y="391" width="58" height="28">
-			</bounds>
+			<bounds x="452" y="391" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="650" y="189" width="62" height="32">
-			</bounds>
+			<bounds x="650" y="189" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="652" y="191" width="58" height="28">
-			</bounds>
+			<bounds x="652" y="191" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="600" y="239" width="62" height="32">
-			</bounds>
+			<bounds x="600" y="239" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="602" y="241" width="58" height="28">
-			</bounds>
+			<bounds x="602" y="241" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="550" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="550" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="552" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="552" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="18" y="12" width="182" height="45">
-			</bounds>
+			<bounds x="18" y="12" width="182" height="45"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="20" y="14" width="178" height="41">
-			</bounds>
+			<bounds x="20" y="14" width="178" height="41"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="61" y="247" width="52" height="32">
-			</bounds>
+			<bounds x="61" y="247" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="63" y="249" width="48" height="28">
-			</bounds>
+			<bounds x="63" y="249" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="61" y="137" width="52" height="32">
-			</bounds>
+			<bounds x="61" y="137" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="63" y="139" width="48" height="28">
-			</bounds>
+			<bounds x="63" y="139" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_2_border" state="0">
-			<bounds x="624" y="161" width="42" height="15">
-			</bounds>
+			<bounds x="624" y="161" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_2" state="0">
-			<bounds x="626" y="163" width="38" height="11">
-			</bounds>
+			<bounds x="626" y="163" width="38" height="11"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2_border" state="0">
-			<bounds x="574" y="211" width="42" height="15">
-			</bounds>
+			<bounds x="574" y="211" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2" state="0">
-			<bounds x="576" y="213" width="38" height="11">
-			</bounds>
+			<bounds x="576" y="213" width="38" height="11"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_2_border" state="0">
-			<bounds x="524" y="261" width="42" height="15">
-			</bounds>
+			<bounds x="524" y="261" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_2" state="0">
-			<bounds x="526" y="263" width="38" height="11">
-			</bounds>
+			<bounds x="526" y="263" width="38" height="11"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_2_border" state="0">
-			<bounds x="474" y="311" width="42" height="15">
-			</bounds>
+			<bounds x="474" y="311" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_2" state="0">
-			<bounds x="476" y="313" width="38" height="11">
-			</bounds>
+			<bounds x="476" y="313" width="38" height="11"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_2_border" state="0">
-			<bounds x="424" y="361" width="42" height="15">
-			</bounds>
+			<bounds x="424" y="361" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_2" state="0">
-			<bounds x="426" y="363" width="38" height="11">
-			</bounds>
+			<bounds x="426" y="363" width="38" height="11"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_2_border" state="0">
-			<bounds x="374" y="411" width="42" height="15">
-			</bounds>
+			<bounds x="374" y="411" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_2" state="0">
-			<bounds x="376" y="413" width="38" height="11">
-			</bounds>
+			<bounds x="376" y="413" width="38" height="11"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="517" y="594" width="47" height="22">
-			</bounds>
+			<bounds x="517" y="594" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="519" y="596" width="43" height="18">
-			</bounds>
+			<bounds x="519" y="596" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="561" y="594" width="48" height="22">
-			</bounds>
+			<bounds x="561" y="594" width="48" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="563" y="596" width="44" height="18">
-			</bounds>
+			<bounds x="563" y="596" width="44" height="18"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="758" y="395" width="17" height="38">
-			</bounds>
+			<bounds x="758" y="395" width="17" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="760" y="397" width="13" height="34">
-			</bounds>
+			<bounds x="760" y="397" width="13" height="34"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="646" y="395" width="20" height="38">
-			</bounds>
+			<bounds x="646" y="395" width="20" height="38"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="648" y="397" width="16" height="34">
-			</bounds>
+			<bounds x="648" y="397" width="16" height="34"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="746" y="356" width="29" height="38">
-			</bounds>
+			<bounds x="746" y="356" width="29" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="748" y="358" width="25" height="34">
-			</bounds>
+			<bounds x="748" y="358" width="25" height="34"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="646" y="356" width="29" height="38">
-			</bounds>
+			<bounds x="646" y="356" width="29" height="38"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="648" y="358" width="25" height="34">
-			</bounds>
+			<bounds x="648" y="358" width="25" height="34"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="646" y="317" width="25" height="38">
-			</bounds>
+			<bounds x="646" y="317" width="25" height="38"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="648" y="319" width="21" height="34">
-			</bounds>
+			<bounds x="648" y="319" width="21" height="34"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="749" y="317" width="26" height="38">
-			</bounds>
+			<bounds x="749" y="317" width="26" height="38"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="751" y="319" width="22" height="34">
-			</bounds>
+			<bounds x="751" y="319" width="22" height="34"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="733" y="512" width="42" height="20">
-			</bounds>
+			<bounds x="733" y="512" width="42" height="20"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="735" y="514" width="38" height="16">
-			</bounds>
+			<bounds x="735" y="514" width="38" height="16"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="646" y="512" width="28" height="20">
-			</bounds>
+			<bounds x="646" y="512" width="28" height="20"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="648" y="514" width="24" height="16">
-			</bounds>
+			<bounds x="648" y="514" width="24" height="16"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_2_border" state="0">
-			<bounds x="646" y="529" width="22" height="21">
-			</bounds>
+			<bounds x="646" y="529" width="22" height="21"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_2" state="0">
-			<bounds x="648" y="531" width="18" height="17">
-			</bounds>
+			<bounds x="648" y="531" width="18" height="17"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_2_border" state="0">
-			<bounds x="756" y="529" width="19" height="21">
-			</bounds>
+			<bounds x="756" y="529" width="19" height="21"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_2" state="0">
-			<bounds x="758" y="531" width="15" height="17">
-			</bounds>
+			<bounds x="758" y="531" width="15" height="17"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_3_border" state="0">
-			<bounds x="671" y="512" width="41" height="20">
-			</bounds>
+			<bounds x="671" y="512" width="41" height="20"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_3" state="0">
-			<bounds x="673" y="514" width="37" height="16">
-			</bounds>
+			<bounds x="673" y="514" width="37" height="16"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_3_border" state="0">
-			<bounds x="709" y="512" width="27" height="20">
-			</bounds>
+			<bounds x="709" y="512" width="27" height="20"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_3" state="0">
-			<bounds x="711" y="514" width="23" height="16">
-			</bounds>
+			<bounds x="711" y="514" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_4_border" state="0">
-			<bounds x="709" y="529" width="50" height="21">
-			</bounds>
+			<bounds x="709" y="529" width="50" height="21"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_4" state="0">
-			<bounds x="711" y="531" width="46" height="17">
-			</bounds>
+			<bounds x="711" y="531" width="46" height="17"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_4_border" state="0">
-			<bounds x="665" y="529" width="47" height="21">
-			</bounds>
+			<bounds x="665" y="529" width="47" height="21"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_4" state="0">
-			<bounds x="667" y="531" width="43" height="17">
-			</bounds>
+			<bounds x="667" y="531" width="43" height="17"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_2_border" state="0">
-			<bounds x="663" y="395" width="49" height="38">
-			</bounds>
+			<bounds x="663" y="395" width="49" height="38"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_2" state="0">
-			<bounds x="665" y="397" width="45" height="34">
-			</bounds>
+			<bounds x="665" y="397" width="45" height="34"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_2_border" state="0">
-			<bounds x="672" y="356" width="40" height="38">
-			</bounds>
+			<bounds x="672" y="356" width="40" height="38"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_2" state="0">
-			<bounds x="674" y="358" width="36" height="34">
-			</bounds>
+			<bounds x="674" y="358" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_2_border" state="0">
-			<bounds x="668" y="317" width="44" height="38">
-			</bounds>
+			<bounds x="668" y="317" width="44" height="38"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_2" state="0">
-			<bounds x="670" y="319" width="40" height="34">
-			</bounds>
+			<bounds x="670" y="319" width="40" height="34"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_2_border" state="0">
-			<bounds x="709" y="395" width="52" height="38">
-			</bounds>
+			<bounds x="709" y="395" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_2" state="0">
-			<bounds x="711" y="397" width="48" height="34">
-			</bounds>
+			<bounds x="711" y="397" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_2_border" state="0">
-			<bounds x="709" y="356" width="40" height="38">
-			</bounds>
+			<bounds x="709" y="356" width="40" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_2" state="0">
-			<bounds x="711" y="358" width="36" height="34">
-			</bounds>
+			<bounds x="711" y="358" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_2_border" state="0">
-			<bounds x="709" y="317" width="43" height="38">
-			</bounds>
+			<bounds x="709" y="317" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_2" state="0">
-			<bounds x="711" y="319" width="39" height="34">
-			</bounds>
+			<bounds x="711" y="319" width="39" height="34"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="648" y="295" width="125" height="22">
-			</bounds>
+			<bounds x="648" y="295" width="125" height="22"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="650" y="297" width="121" height="18">
-			</bounds>
+			<bounds x="650" y="297" width="121" height="18"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="230" y="7" width="72" height="82">
-			</bounds>
+			<bounds x="230" y="7" width="72" height="82"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="232" y="9" width="68" height="78">
-			</bounds>
+			<bounds x="232" y="9" width="68" height="78"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="709" y="451" width="20" height="21">
-			</bounds>
+			<bounds x="709" y="451" width="20" height="21"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="711" y="453" width="16" height="17">
-			</bounds>
+			<bounds x="711" y="453" width="16" height="17"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="680" y="451" width="32" height="21">
-			</bounds>
+			<bounds x="680" y="451" width="32" height="21"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="682" y="453" width="28" height="17">
-			</bounds>
+			<bounds x="682" y="453" width="28" height="17"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_2_border" state="0">
-			<bounds x="646" y="451" width="37" height="21">
-			</bounds>
+			<bounds x="646" y="451" width="37" height="21"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_2" state="0">
-			<bounds x="648" y="453" width="33" height="17">
-			</bounds>
+			<bounds x="648" y="453" width="33" height="17"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_2_border" state="0">
-			<bounds x="726" y="451" width="49" height="21">
-			</bounds>
+			<bounds x="726" y="451" width="49" height="21"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_2" state="0">
-			<bounds x="728" y="453" width="45" height="17">
-			</bounds>
+			<bounds x="728" y="453" width="45" height="17"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_3_border" state="0">
-			<bounds x="740" y="434" width="35" height="20">
-			</bounds>
+			<bounds x="740" y="434" width="35" height="20"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_3" state="0">
-			<bounds x="742" y="436" width="31" height="16">
-			</bounds>
+			<bounds x="742" y="436" width="31" height="16"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_3_border" state="0">
-			<bounds x="646" y="434" width="36" height="20">
-			</bounds>
+			<bounds x="646" y="434" width="36" height="20"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_3" state="0">
-			<bounds x="648" y="436" width="32" height="16">
-			</bounds>
+			<bounds x="648" y="436" width="32" height="16"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_4_border" state="0">
-			<bounds x="709" y="434" width="34" height="20">
-			</bounds>
+			<bounds x="709" y="434" width="34" height="20"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_4" state="0">
-			<bounds x="711" y="436" width="30" height="16">
-			</bounds>
+			<bounds x="711" y="436" width="30" height="16"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_4_border" state="0">
-			<bounds x="679" y="434" width="33" height="20">
-			</bounds>
+			<bounds x="679" y="434" width="33" height="20"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_4" state="0">
-			<bounds x="681" y="436" width="29" height="16">
-			</bounds>
+			<bounds x="681" y="436" width="29" height="16"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="658" y="473" width="54" height="38">
-			</bounds>
+			<bounds x="658" y="473" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="660" y="475" width="50" height="34">
-			</bounds>
+			<bounds x="660" y="475" width="50" height="34"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="709" y="473" width="41" height="38">
-			</bounds>
+			<bounds x="709" y="473" width="41" height="38"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="711" y="475" width="37" height="34">
-			</bounds>
+			<bounds x="711" y="475" width="37" height="34"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_2_border" state="0">
-			<bounds x="646" y="473" width="15" height="38">
-			</bounds>
+			<bounds x="646" y="473" width="15" height="38"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_2" state="0">
-			<bounds x="648" y="475" width="11" height="34">
-			</bounds>
+			<bounds x="648" y="475" width="11" height="34"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_2_border" state="0">
-			<bounds x="747" y="473" width="28" height="38">
-			</bounds>
+			<bounds x="747" y="473" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_2" state="0">
-			<bounds x="749" y="475" width="24" height="34">
-			</bounds>
+			<bounds x="749" y="475" width="24" height="34"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_114_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="529" y="627" width="68" height="42">
-			</bounds>
+			<bounds x="529" y="627" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_114" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="531" y="629" width="64" height="38">
-			</bounds>
+			<bounds x="531" y="629" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_115_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="693" y="627" width="68" height="42">
-			</bounds>
+			<bounds x="693" y="627" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_115" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="695" y="629" width="64" height="38">
-			</bounds>
+			<bounds x="695" y="629" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_116_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="388" y="627" width="68" height="42">
-			</bounds>
+			<bounds x="388" y="627" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_116" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="390" y="629" width="64" height="38">
-			</bounds>
+			<bounds x="390" y="629" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_117_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="248" y="627" width="68" height="42">
-			</bounds>
+			<bounds x="248" y="627" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_117" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="250" y="629" width="64" height="38">
-			</bounds>
+			<bounds x="250" y="629" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_118_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="108" y="627" width="68" height="42">
-			</bounds>
+			<bounds x="108" y="627" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_118" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="110" y="629" width="64" height="38">
-			</bounds>
+			<bounds x="110" y="629" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_119_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="5" y="627" width="68" height="42">
-			</bounds>
+			<bounds x="5" y="627" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_119" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="7" y="629" width="64" height="38">
-			</bounds>
+			<bounds x="7" y="629" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_120_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="712" y="16" width="46" height="62">
-			</bounds>
+			<bounds x="712" y="16" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_120" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="714" y="18" width="42" height="58">
-			</bounds>
+			<bounds x="714" y="18" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_121_border" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="639" y="16" width="46" height="62">
-			</bounds>
+			<bounds x="639" y="16" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_121" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="641" y="18" width="42" height="58">
-			</bounds>
+			<bounds x="641" y="18" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="421" y="10" width="60" height="74">
-			</bounds>
+			<bounds x="421" y="10" width="60" height="74"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="429" y="16" width="42" height="6">
-			</bounds>
+			<bounds x="429" y="16" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="463" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="463" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="463" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="463" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="429" y="70" width="42" height="6">
-			</bounds>
+			<bounds x="429" y="70" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="429" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="429" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="429" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="429" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="429" y="43" width="42" height="6">
-			</bounds>
+			<bounds x="429" y="43" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="472" y="70" width="8" height="6">
-			</bounds>
+			<bounds x="472" y="70" width="8" height="6"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="429" y="16" width="42" height="6">
-			</bounds>
+			<bounds x="429" y="16" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="463" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="463" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="463" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="463" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="429" y="70" width="42" height="6">
-			</bounds>
+			<bounds x="429" y="70" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="429" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="429" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="429" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="429" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="429" y="43" width="42" height="6">
-			</bounds>
+			<bounds x="429" y="43" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="472" y="70" width="8" height="6">
-			</bounds>
+			<bounds x="472" y="70" width="8" height="6"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="361" y="10" width="60" height="74">
-			</bounds>
+			<bounds x="361" y="10" width="60" height="74"/>
 		</backdrop>
 		<backdrop name="led_off192" element="led_off">
-			<bounds x="369" y="16" width="42" height="6">
-			</bounds>
+			<bounds x="369" y="16" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off193" element="led_off">
-			<bounds x="403" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="403" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off194" element="led_off">
-			<bounds x="403" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="403" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off195" element="led_off">
-			<bounds x="369" y="70" width="42" height="6">
-			</bounds>
+			<bounds x="369" y="70" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off196" element="led_off">
-			<bounds x="369" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="369" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off197" element="led_off">
-			<bounds x="369" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="369" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off198" element="led_off">
-			<bounds x="369" y="43" width="42" height="6">
-			</bounds>
+			<bounds x="369" y="43" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off199" element="led_dot_off">
-			<bounds x="412" y="70" width="8" height="6">
-			</bounds>
+			<bounds x="412" y="70" width="8" height="6"/>
 		</backdrop>
 		<backdrop name="lamp192" element="led_on">
-			<bounds x="369" y="16" width="42" height="6">
-			</bounds>
+			<bounds x="369" y="16" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp193" element="led_on">
-			<bounds x="403" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="403" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp194" element="led_on">
-			<bounds x="403" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="403" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp195" element="led_on">
-			<bounds x="369" y="70" width="42" height="6">
-			</bounds>
+			<bounds x="369" y="70" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp196" element="led_on">
-			<bounds x="369" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="369" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp197" element="led_on">
-			<bounds x="369" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="369" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp198" element="led_on">
-			<bounds x="369" y="43" width="42" height="6">
-			</bounds>
+			<bounds x="369" y="43" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp199" element="led_dot_on">
-			<bounds x="412" y="70" width="8" height="6">
-			</bounds>
+			<bounds x="412" y="70" width="8" height="6"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="301" y="10" width="60" height="74">
-			</bounds>
+			<bounds x="301" y="10" width="60" height="74"/>
 		</backdrop>
 		<backdrop name="led_off184" element="led_off">
-			<bounds x="309" y="16" width="42" height="6">
-			</bounds>
+			<bounds x="309" y="16" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off185" element="led_off">
-			<bounds x="343" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="343" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off186" element="led_off">
-			<bounds x="343" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="343" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off187" element="led_off">
-			<bounds x="309" y="70" width="42" height="6">
-			</bounds>
+			<bounds x="309" y="70" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off188" element="led_off">
-			<bounds x="309" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="309" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off189" element="led_off">
-			<bounds x="309" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="309" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="led_off190" element="led_off">
-			<bounds x="309" y="43" width="42" height="6">
-			</bounds>
+			<bounds x="309" y="43" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="led_off191" element="led_dot_off">
-			<bounds x="352" y="70" width="8" height="6">
-			</bounds>
+			<bounds x="352" y="70" width="8" height="6"/>
 		</backdrop>
 		<backdrop name="lamp184" element="led_on">
-			<bounds x="309" y="16" width="42" height="6">
-			</bounds>
+			<bounds x="309" y="16" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp185" element="led_on">
-			<bounds x="343" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="343" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp186" element="led_on">
-			<bounds x="343" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="343" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp187" element="led_on">
-			<bounds x="309" y="70" width="42" height="6">
-			</bounds>
+			<bounds x="309" y="70" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp188" element="led_on">
-			<bounds x="309" y="43" width="8" height="33">
-			</bounds>
+			<bounds x="309" y="43" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp189" element="led_on">
-			<bounds x="309" y="16" width="8" height="33">
-			</bounds>
+			<bounds x="309" y="16" width="8" height="33"/>
 		</backdrop>
 		<backdrop name="lamp190" element="led_on">
-			<bounds x="309" y="43" width="42" height="6">
-			</bounds>
+			<bounds x="309" y="43" width="42" height="6"/>
 		</backdrop>
 		<backdrop name="lamp191" element="led_dot_on">
-			<bounds x="352" y="70" width="8" height="6">
-			</bounds>
+			<bounds x="352" y="70" width="8" height="6"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="701" y="583" width="24" height="32">
-			</bounds>
+			<bounds x="701" y="583" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="704" y="585" width="17" height="2">
-			</bounds>
+			<bounds x="704" y="585" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="718" y="585" width="3" height="14">
-			</bounds>
+			<bounds x="718" y="585" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="718" y="597" width="3" height="14">
-			</bounds>
+			<bounds x="718" y="597" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="704" y="609" width="17" height="2">
-			</bounds>
+			<bounds x="704" y="609" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="704" y="597" width="3" height="14">
-			</bounds>
+			<bounds x="704" y="597" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="704" y="585" width="3" height="14">
-			</bounds>
+			<bounds x="704" y="585" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="704" y="597" width="17" height="2">
-			</bounds>
+			<bounds x="704" y="597" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_dot_off">
-			<bounds x="721" y="609" width="3" height="2">
-			</bounds>
+			<bounds x="721" y="609" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="704" y="585" width="17" height="2">
-			</bounds>
+			<bounds x="704" y="585" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="718" y="585" width="3" height="14">
-			</bounds>
+			<bounds x="718" y="585" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="718" y="597" width="3" height="14">
-			</bounds>
+			<bounds x="718" y="597" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="704" y="609" width="17" height="2">
-			</bounds>
+			<bounds x="704" y="609" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="704" y="597" width="3" height="14">
-			</bounds>
+			<bounds x="704" y="597" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="704" y="585" width="3" height="14">
-			</bounds>
+			<bounds x="704" y="585" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="704" y="597" width="17" height="2">
-			</bounds>
+			<bounds x="704" y="597" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_dot_on">
-			<bounds x="721" y="609" width="3" height="2">
-			</bounds>
+			<bounds x="721" y="609" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="725" y="583" width="24" height="32">
-			</bounds>
+			<bounds x="725" y="583" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="728" y="585" width="17" height="2">
-			</bounds>
+			<bounds x="728" y="585" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="742" y="585" width="3" height="14">
-			</bounds>
+			<bounds x="742" y="585" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="742" y="597" width="3" height="14">
-			</bounds>
+			<bounds x="742" y="597" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="728" y="609" width="17" height="2">
-			</bounds>
+			<bounds x="728" y="609" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="728" y="597" width="3" height="14">
-			</bounds>
+			<bounds x="728" y="597" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="728" y="585" width="3" height="14">
-			</bounds>
+			<bounds x="728" y="585" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="728" y="597" width="17" height="2">
-			</bounds>
+			<bounds x="728" y="597" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="745" y="609" width="3" height="2">
-			</bounds>
+			<bounds x="745" y="609" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="728" y="585" width="17" height="2">
-			</bounds>
+			<bounds x="728" y="585" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="742" y="585" width="3" height="14">
-			</bounds>
+			<bounds x="742" y="585" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="742" y="597" width="3" height="14">
-			</bounds>
+			<bounds x="742" y="597" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="728" y="609" width="17" height="2">
-			</bounds>
+			<bounds x="728" y="609" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="728" y="597" width="3" height="14">
-			</bounds>
+			<bounds x="728" y="597" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="728" y="585" width="3" height="14">
-			</bounds>
+			<bounds x="728" y="585" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="728" y="597" width="17" height="2">
-			</bounds>
+			<bounds x="728" y="597" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="745" y="609" width="3" height="2">
-			</bounds>
+			<bounds x="745" y="609" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label95" element="label_95">
-			<bounds x="702" y="567" width="42" height="16">
-			</bounds>
+			<bounds x="702" y="567" width="42" height="16"/>
 		</backdrop>
 		<backdrop name="label96" element="label_96">
-			<bounds x="198" y="487" width="29" height="32">
-			</bounds>
+			<bounds x="198" y="487" width="29" height="32"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="338" y="487" width="29" height="32">
-			</bounds>
+			<bounds x="338" y="487" width="29" height="32"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="544" y="29" width="33" height="32">
-			</bounds>
+			<bounds x="544" y="29" width="33" height="32"/>
 		</backdrop>
 		<backdrop name="label112" element="label_112">
-			<bounds x="539" y="442" width="95" height="32">
-			</bounds>
+			<bounds x="539" y="442" width="95" height="32"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="4" y="667" width="78" height="16">
-			</bounds>
+			<bounds x="4" y="667" width="78" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_button" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1onbusa.lay
+++ b/src/mame/layout/m1onbusa.lay
@@ -8,12346 +8,7409 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="On The Buses">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="On The Buses">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Three Buses On">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="The Win Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Awards Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Three Buses On">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="The Win Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Awards Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Run The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Green Ligh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Run The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Green Ligh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Cappy Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Cappy Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Turbo Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Turbo Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Your">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Late">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Your">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Late">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Crash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Crash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="On ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="On ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Give ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Give ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Give">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Give">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="10 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="10 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Crash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Crash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="On The Buses">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="On The Buses">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Road Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Road Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="8 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="8 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Same Again Jack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Same Again Jack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Run The Green Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Run The Green Light">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Round The Town">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Round The Town">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Give Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Give Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Give Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Give Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="4 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="6 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="6 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Crash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Crash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Same Again Jack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Same Again Jack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Cappy Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Cappy Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Get That Bus Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Get That Bus Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="I'll Get You Butler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="I'll Get You Butler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Give">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Give">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="One For The Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="One For The Road">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Detour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Crash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Crash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="1 Knockout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="1 Knockout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Road Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Road Map">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="2 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="2 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Give">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Give">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Way">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Same">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Again J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Same">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Again J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="3 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 Knockouts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Inspector">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jackpo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jackpo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_269_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_269">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_270_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_270">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_271_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_271">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_272_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_272">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_273_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_273">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_274_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_274">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_275_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_275">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_277_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_277">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_132">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_166">
 		<text string="V1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_167">
 		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_168">
 		<text string="Plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_169">
 		<text string="Light All Give Way Signs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="For Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="661">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="661"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="110" y="425" width="80" height="140">
-			</bounds>
+			<bounds x="110" y="425" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="110.0000" y="425.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="110.0000" y="425.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="113.3333" y="426.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="113.3333" y="426.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="116.6667" y="428.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="116.6667" y="428.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="120.0000" y="430.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="120.0000" y="430.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="123.3333" y="432.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="123.3333" y="432.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="126.6667" y="434.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="126.6667" y="434.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="110.0000" y="471.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="110.0000" y="471.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="113.3333" y="473.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="113.3333" y="473.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="116.6667" y="475.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="116.6667" y="475.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="120.0000" y="477.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="120.0000" y="477.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="123.3333" y="479.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="123.3333" y="479.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="126.6667" y="481.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="126.6667" y="481.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="110.0000" y="518.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="110.0000" y="518.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="113.3333" y="520.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="113.3333" y="520.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="116.6667" y="522.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="116.6667" y="522.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="120.0000" y="524.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="120.0000" y="524.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="123.3333" y="526.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="123.3333" y="526.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="126.6667" y="528.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="126.6667" y="528.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="110" y="425" width="80" height="140">
-			</bounds>
+			<bounds x="110" y="425" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="210" y="425" width="80" height="140">
-			</bounds>
+			<bounds x="210" y="425" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="210.0000" y="425.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="210.0000" y="425.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="213.3333" y="426.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="213.3333" y="426.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="216.6667" y="428.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="216.6667" y="428.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="220.0000" y="430.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="220.0000" y="430.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="223.3333" y="432.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="223.3333" y="432.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="226.6667" y="434.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="226.6667" y="434.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="210.0000" y="471.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="210.0000" y="471.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="213.3333" y="473.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="213.3333" y="473.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="216.6667" y="475.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="216.6667" y="475.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="220.0000" y="477.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="220.0000" y="477.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="223.3333" y="479.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="223.3333" y="479.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="226.6667" y="481.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="226.6667" y="481.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="210.0000" y="518.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="210.0000" y="518.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="213.3333" y="520.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="213.3333" y="520.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="216.6667" y="522.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="216.6667" y="522.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="220.0000" y="524.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="220.0000" y="524.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="223.3333" y="526.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="223.3333" y="526.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="226.6667" y="528.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="226.6667" y="528.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="210" y="425" width="80" height="140">
-			</bounds>
+			<bounds x="210" y="425" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="310" y="425" width="80" height="140">
-			</bounds>
+			<bounds x="310" y="425" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="310.0000" y="425.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="310.0000" y="425.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="313.3333" y="426.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="313.3333" y="426.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="316.6667" y="428.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="316.6667" y="428.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="320.0000" y="430.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="320.0000" y="430.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.3333" y="432.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="323.3333" y="432.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="326.6667" y="434.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="326.6667" y="434.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="310.0000" y="471.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="310.0000" y="471.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="313.3333" y="473.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="313.3333" y="473.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="316.6667" y="475.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="316.6667" y="475.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="320.0000" y="477.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="320.0000" y="477.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.3333" y="479.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="323.3333" y="479.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="326.6667" y="481.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="326.6667" y="481.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="310.0000" y="518.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="310.0000" y="518.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="313.3333" y="520.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="313.3333" y="520.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="316.6667" y="522.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="316.6667" y="522.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="320.0000" y="524.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="320.0000" y="524.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="323.3333" y="526.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="323.3333" y="526.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="326.6667" y="528.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="326.6667" y="528.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="310" y="425" width="80" height="140">
-			</bounds>
+			<bounds x="310" y="425" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="20" y="196" width="75" height="75">
-			</bounds>
+			<bounds x="20" y="196" width="75" height="75"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="20.0000" y="196.0000" width="75.0000" height="75.0000">
-			</bounds>
+			<bounds x="20.0000" y="196.0000" width="75.0000" height="75.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="23.1250" y="199.1250" width="68.7500" height="68.7500">
-			</bounds>
+			<bounds x="23.1250" y="199.1250" width="68.7500" height="68.7500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="26.2500" y="202.2500" width="62.5000" height="62.5000">
-			</bounds>
+			<bounds x="26.2500" y="202.2500" width="62.5000" height="62.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="29.3750" y="205.3750" width="56.2500" height="56.2500">
-			</bounds>
+			<bounds x="29.3750" y="205.3750" width="56.2500" height="56.2500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="32.5000" y="208.5000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="32.5000" y="208.5000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="35.6250" y="211.6250" width="43.7500" height="43.7500">
-			</bounds>
+			<bounds x="35.6250" y="211.6250" width="43.7500" height="43.7500"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="20" y="196" width="75" height="75">
-			</bounds>
+			<bounds x="20" y="196" width="75" height="75"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="119" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="119" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="121" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="121" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="199" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="199" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="201" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="201" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="279" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="279" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="281" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="281" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="599" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="599" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="601" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="601" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="519" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="519" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="521" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="521" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="439" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="439" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="441" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="441" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="359" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="359" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="361" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="361" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="679" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="679" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="681" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="681" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="39" y="569" width="62" height="22">
-			</bounds>
+			<bounds x="39" y="569" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="41" y="571" width="58" height="18">
-			</bounds>
+			<bounds x="41" y="571" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="499" y="524" width="182" height="42">
-			</bounds>
+			<bounds x="499" y="524" width="182" height="42"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="501" y="526" width="178" height="38">
-			</bounds>
+			<bounds x="501" y="526" width="178" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="59" y="275" width="37" height="22">
-			</bounds>
+			<bounds x="59" y="275" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="61" y="277" width="33" height="18">
-			</bounds>
+			<bounds x="61" y="277" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="19" y="275" width="37" height="22">
-			</bounds>
+			<bounds x="19" y="275" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="21" y="277" width="33" height="18">
-			</bounds>
+			<bounds x="21" y="277" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="9" y="300" width="97" height="52">
-			</bounds>
+			<bounds x="9" y="300" width="97" height="52"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="11" y="302" width="93" height="48">
-			</bounds>
+			<bounds x="11" y="302" width="93" height="48"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="22" y="124" width="72" height="42">
-			</bounds>
+			<bounds x="22" y="124" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="24" y="126" width="68" height="38">
-			</bounds>
+			<bounds x="24" y="126" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="404" y="409" width="102" height="22">
-			</bounds>
+			<bounds x="404" y="409" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="406" y="411" width="98" height="18">
-			</bounds>
+			<bounds x="406" y="411" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="554" y="384" width="92" height="22">
-			</bounds>
+			<bounds x="554" y="384" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="556" y="386" width="88" height="18">
-			</bounds>
+			<bounds x="556" y="386" width="88" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="734" y="409" width="42" height="22">
-			</bounds>
+			<bounds x="734" y="409" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="736" y="411" width="38" height="18">
-			</bounds>
+			<bounds x="736" y="411" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="689" y="409" width="42" height="22">
-			</bounds>
+			<bounds x="689" y="409" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="691" y="411" width="38" height="18">
-			</bounds>
+			<bounds x="691" y="411" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="644" y="409" width="42" height="22">
-			</bounds>
+			<bounds x="644" y="409" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="646" y="411" width="38" height="18">
-			</bounds>
+			<bounds x="646" y="411" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="554" y="409" width="42" height="22">
-			</bounds>
+			<bounds x="554" y="409" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="556" y="411" width="38" height="18">
-			</bounds>
+			<bounds x="556" y="411" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="509" y="409" width="42" height="22">
-			</bounds>
+			<bounds x="509" y="409" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="511" y="411" width="38" height="18">
-			</bounds>
+			<bounds x="511" y="411" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="599" y="409" width="42" height="22">
-			</bounds>
+			<bounds x="599" y="409" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="601" y="411" width="38" height="18">
-			</bounds>
+			<bounds x="601" y="411" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="719" y="124" width="62" height="32">
-			</bounds>
+			<bounds x="719" y="124" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="721" y="126" width="58" height="28">
-			</bounds>
+			<bounds x="721" y="126" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="719" y="229" width="62" height="32">
-			</bounds>
+			<bounds x="719" y="229" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="721" y="231" width="58" height="28">
-			</bounds>
+			<bounds x="721" y="231" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="719" y="264" width="62" height="32">
-			</bounds>
+			<bounds x="719" y="264" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="721" y="266" width="58" height="28">
-			</bounds>
+			<bounds x="721" y="266" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="719" y="334" width="62" height="32">
-			</bounds>
+			<bounds x="719" y="334" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="721" y="336" width="58" height="28">
-			</bounds>
+			<bounds x="721" y="336" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="719" y="159" width="62" height="32">
-			</bounds>
+			<bounds x="719" y="159" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="721" y="161" width="58" height="28">
-			</bounds>
+			<bounds x="721" y="161" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="719" y="194" width="62" height="32">
-			</bounds>
+			<bounds x="719" y="194" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="721" y="196" width="58" height="28">
-			</bounds>
+			<bounds x="721" y="196" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="719" y="299" width="62" height="32">
-			</bounds>
+			<bounds x="719" y="299" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="721" y="301" width="58" height="28">
-			</bounds>
+			<bounds x="721" y="301" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="339" y="79" width="72" height="22">
-			</bounds>
+			<bounds x="339" y="79" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="341" y="81" width="68" height="18">
-			</bounds>
+			<bounds x="341" y="81" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="339" y="104" width="72" height="17">
-			</bounds>
+			<bounds x="339" y="104" width="72" height="17"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="341" y="106" width="68" height="13">
-			</bounds>
+			<bounds x="341" y="106" width="68" height="13"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="644" y="124" width="67" height="32">
-			</bounds>
+			<bounds x="644" y="124" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="646" y="126" width="63" height="28">
-			</bounds>
+			<bounds x="646" y="126" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="644" y="159" width="67" height="32">
-			</bounds>
+			<bounds x="644" y="159" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="646" y="161" width="63" height="28">
-			</bounds>
+			<bounds x="646" y="161" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="274" y="79" width="62" height="22">
-			</bounds>
+			<bounds x="274" y="79" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="276" y="81" width="58" height="18">
-			</bounds>
+			<bounds x="276" y="81" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="109" y="114" width="67" height="32">
-			</bounds>
+			<bounds x="109" y="114" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="111" y="116" width="63" height="28">
-			</bounds>
+			<bounds x="111" y="116" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="109" y="79" width="67" height="32">
-			</bounds>
+			<bounds x="109" y="79" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="111" y="81" width="63" height="28">
-			</bounds>
+			<bounds x="111" y="81" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="179" y="79" width="92" height="22">
-			</bounds>
+			<bounds x="179" y="79" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="181" y="81" width="88" height="18">
-			</bounds>
+			<bounds x="181" y="81" width="88" height="18"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="414" y="79" width="102" height="22">
-			</bounds>
+			<bounds x="414" y="79" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="416" y="81" width="98" height="18">
-			</bounds>
+			<bounds x="416" y="81" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="519" y="79" width="122" height="22">
-			</bounds>
+			<bounds x="519" y="79" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="521" y="81" width="118" height="18">
-			</bounds>
+			<bounds x="521" y="81" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="274" y="124" width="62" height="22">
-			</bounds>
+			<bounds x="274" y="124" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="276" y="126" width="58" height="18">
-			</bounds>
+			<bounds x="276" y="126" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="179" y="124" width="92" height="22">
-			</bounds>
+			<bounds x="179" y="124" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="181" y="126" width="88" height="18">
-			</bounds>
+			<bounds x="181" y="126" width="88" height="18"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="414" y="169" width="102" height="22">
-			</bounds>
+			<bounds x="414" y="169" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="416" y="171" width="98" height="18">
-			</bounds>
+			<bounds x="416" y="171" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="519" y="169" width="122" height="22">
-			</bounds>
+			<bounds x="519" y="169" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="521" y="171" width="118" height="18">
-			</bounds>
+			<bounds x="521" y="171" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="519" y="124" width="122" height="22">
-			</bounds>
+			<bounds x="519" y="124" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="521" y="126" width="118" height="18">
-			</bounds>
+			<bounds x="521" y="126" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="414" y="124" width="102" height="22">
-			</bounds>
+			<bounds x="414" y="124" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="416" y="126" width="98" height="18">
-			</bounds>
+			<bounds x="416" y="126" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="274" y="214" width="62" height="22">
-			</bounds>
+			<bounds x="274" y="214" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="276" y="216" width="58" height="18">
-			</bounds>
+			<bounds x="276" y="216" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="179" y="214" width="92" height="22">
-			</bounds>
+			<bounds x="179" y="214" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="181" y="216" width="88" height="18">
-			</bounds>
+			<bounds x="181" y="216" width="88" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="109" y="204" width="67" height="32">
-			</bounds>
+			<bounds x="109" y="204" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="111" y="206" width="63" height="28">
-			</bounds>
+			<bounds x="111" y="206" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="109" y="169" width="67" height="32">
-			</bounds>
+			<bounds x="109" y="169" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="111" y="171" width="63" height="28">
-			</bounds>
+			<bounds x="111" y="171" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="179" y="169" width="92" height="22">
-			</bounds>
+			<bounds x="179" y="169" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="181" y="171" width="88" height="18">
-			</bounds>
+			<bounds x="181" y="171" width="88" height="18"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="274" y="169" width="62" height="22">
-			</bounds>
+			<bounds x="274" y="169" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="276" y="171" width="58" height="18">
-			</bounds>
+			<bounds x="276" y="171" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="414" y="214" width="102" height="22">
-			</bounds>
+			<bounds x="414" y="214" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="416" y="216" width="98" height="18">
-			</bounds>
+			<bounds x="416" y="216" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="414" y="259" width="102" height="22">
-			</bounds>
+			<bounds x="414" y="259" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="416" y="261" width="98" height="18">
-			</bounds>
+			<bounds x="416" y="261" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="519" y="259" width="122" height="22">
-			</bounds>
+			<bounds x="519" y="259" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="521" y="261" width="118" height="18">
-			</bounds>
+			<bounds x="521" y="261" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="644" y="249" width="67" height="32">
-			</bounds>
+			<bounds x="644" y="249" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="646" y="251" width="63" height="28">
-			</bounds>
+			<bounds x="646" y="251" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="644" y="214" width="67" height="32">
-			</bounds>
+			<bounds x="644" y="214" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="646" y="216" width="63" height="28">
-			</bounds>
+			<bounds x="646" y="216" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="519" y="214" width="122" height="22">
-			</bounds>
+			<bounds x="519" y="214" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="521" y="216" width="118" height="18">
-			</bounds>
+			<bounds x="521" y="216" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="519" y="304" width="122" height="22">
-			</bounds>
+			<bounds x="519" y="304" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="521" y="306" width="118" height="18">
-			</bounds>
+			<bounds x="521" y="306" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="644" y="339" width="62" height="32">
-			</bounds>
+			<bounds x="644" y="339" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="646" y="341" width="58" height="28">
-			</bounds>
+			<bounds x="646" y="341" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="519" y="349" width="122" height="22">
-			</bounds>
+			<bounds x="519" y="349" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="521" y="351" width="118" height="18">
-			</bounds>
+			<bounds x="521" y="351" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="414" y="349" width="102" height="22">
-			</bounds>
+			<bounds x="414" y="349" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="416" y="351" width="98" height="18">
-			</bounds>
+			<bounds x="416" y="351" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="644" y="304" width="62" height="32">
-			</bounds>
+			<bounds x="644" y="304" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="646" y="306" width="58" height="28">
-			</bounds>
+			<bounds x="646" y="306" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="414" y="304" width="102" height="22">
-			</bounds>
+			<bounds x="414" y="304" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="416" y="306" width="98" height="18">
-			</bounds>
+			<bounds x="416" y="306" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="109" y="349" width="67" height="22">
-			</bounds>
+			<bounds x="109" y="349" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="111" y="351" width="63" height="18">
-			</bounds>
+			<bounds x="111" y="351" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="179" y="349" width="92" height="22">
-			</bounds>
+			<bounds x="179" y="349" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="181" y="351" width="88" height="18">
-			</bounds>
+			<bounds x="181" y="351" width="88" height="18"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="274" y="349" width="62" height="22">
-			</bounds>
+			<bounds x="274" y="349" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="276" y="351" width="58" height="18">
-			</bounds>
+			<bounds x="276" y="351" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="274" y="304" width="62" height="22">
-			</bounds>
+			<bounds x="274" y="304" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="276" y="306" width="58" height="18">
-			</bounds>
+			<bounds x="276" y="306" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="179" y="304" width="92" height="22">
-			</bounds>
+			<bounds x="179" y="304" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="181" y="306" width="88" height="18">
-			</bounds>
+			<bounds x="181" y="306" width="88" height="18"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="109" y="294" width="67" height="32">
-			</bounds>
+			<bounds x="109" y="294" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="111" y="296" width="63" height="28">
-			</bounds>
+			<bounds x="111" y="296" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="109" y="259" width="67" height="32">
-			</bounds>
+			<bounds x="109" y="259" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="111" y="261" width="63" height="28">
-			</bounds>
+			<bounds x="111" y="261" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="179" y="259" width="92" height="22">
-			</bounds>
+			<bounds x="179" y="259" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="181" y="261" width="88" height="18">
-			</bounds>
+			<bounds x="181" y="261" width="88" height="18"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="274" y="259" width="62" height="22">
-			</bounds>
+			<bounds x="274" y="259" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="276" y="261" width="58" height="18">
-			</bounds>
+			<bounds x="276" y="261" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="339" y="329" width="72" height="17">
-			</bounds>
+			<bounds x="339" y="329" width="72" height="17"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="341" y="331" width="68" height="13">
-			</bounds>
+			<bounds x="341" y="331" width="68" height="13"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="339" y="284" width="72" height="17">
-			</bounds>
+			<bounds x="339" y="284" width="72" height="17"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="341" y="286" width="68" height="13">
-			</bounds>
+			<bounds x="341" y="286" width="68" height="13"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="339" y="149" width="72" height="17">
-			</bounds>
+			<bounds x="339" y="149" width="72" height="17"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="341" y="151" width="68" height="13">
-			</bounds>
+			<bounds x="341" y="151" width="68" height="13"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="339" y="194" width="72" height="17">
-			</bounds>
+			<bounds x="339" y="194" width="72" height="17"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="341" y="196" width="68" height="13">
-			</bounds>
+			<bounds x="341" y="196" width="68" height="13"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="339" y="239" width="72" height="17">
-			</bounds>
+			<bounds x="339" y="239" width="72" height="17"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="341" y="241" width="68" height="13">
-			</bounds>
+			<bounds x="341" y="241" width="68" height="13"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="339" y="349" width="72" height="22">
-			</bounds>
+			<bounds x="339" y="349" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="341" y="351" width="68" height="18">
-			</bounds>
+			<bounds x="341" y="351" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="339" y="304" width="72" height="22">
-			</bounds>
+			<bounds x="339" y="304" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="341" y="306" width="68" height="18">
-			</bounds>
+			<bounds x="341" y="306" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="339" y="259" width="72" height="22">
-			</bounds>
+			<bounds x="339" y="259" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="341" y="261" width="68" height="18">
-			</bounds>
+			<bounds x="341" y="261" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="339" y="214" width="72" height="22">
-			</bounds>
+			<bounds x="339" y="214" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="341" y="216" width="68" height="18">
-			</bounds>
+			<bounds x="341" y="216" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="339" y="169" width="72" height="22">
-			</bounds>
+			<bounds x="339" y="169" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="341" y="171" width="68" height="18">
-			</bounds>
+			<bounds x="341" y="171" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="339" y="124" width="72" height="22">
-			</bounds>
+			<bounds x="339" y="124" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="341" y="126" width="68" height="18">
-			</bounds>
+			<bounds x="341" y="126" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="329" y="29" width="92" height="47">
-			</bounds>
+			<bounds x="329" y="29" width="92" height="47"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="331" y="31" width="88" height="43">
-			</bounds>
+			<bounds x="331" y="31" width="88" height="43"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="509" y="34" width="32" height="17">
-			</bounds>
+			<bounds x="509" y="34" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="511" y="36" width="28" height="13">
-			</bounds>
+			<bounds x="511" y="36" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="544" y="34" width="32" height="17">
-			</bounds>
+			<bounds x="544" y="34" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="546" y="36" width="28" height="13">
-			</bounds>
+			<bounds x="546" y="36" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="579" y="34" width="32" height="17">
-			</bounds>
+			<bounds x="579" y="34" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="581" y="36" width="28" height="13">
-			</bounds>
+			<bounds x="581" y="36" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="614" y="34" width="32" height="17">
-			</bounds>
+			<bounds x="614" y="34" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="616" y="36" width="28" height="13">
-			</bounds>
+			<bounds x="616" y="36" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="474" y="34" width="32" height="17">
-			</bounds>
+			<bounds x="474" y="34" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="476" y="36" width="28" height="13">
-			</bounds>
+			<bounds x="476" y="36" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="614" y="54" width="32" height="17">
-			</bounds>
+			<bounds x="614" y="54" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="616" y="56" width="28" height="13">
-			</bounds>
+			<bounds x="616" y="56" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="579" y="54" width="32" height="17">
-			</bounds>
+			<bounds x="579" y="54" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="581" y="56" width="28" height="13">
-			</bounds>
+			<bounds x="581" y="56" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="544" y="54" width="32" height="17">
-			</bounds>
+			<bounds x="544" y="54" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="546" y="56" width="28" height="13">
-			</bounds>
+			<bounds x="546" y="56" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="509" y="54" width="32" height="17">
-			</bounds>
+			<bounds x="509" y="54" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="511" y="56" width="28" height="13">
-			</bounds>
+			<bounds x="511" y="56" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="544" y="14" width="67" height="17">
-			</bounds>
+			<bounds x="544" y="14" width="67" height="17"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="546" y="16" width="63" height="13">
-			</bounds>
+			<bounds x="546" y="16" width="63" height="13"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="649" y="34" width="32" height="17">
-			</bounds>
+			<bounds x="649" y="34" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="651" y="36" width="28" height="13">
-			</bounds>
+			<bounds x="651" y="36" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_269_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="609" y="614" width="82" height="42">
-			</bounds>
+			<bounds x="609" y="614" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_269" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="611" y="616" width="78" height="38">
-			</bounds>
+			<bounds x="611" y="616" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_270_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="509" y="614" width="82" height="42">
-			</bounds>
+			<bounds x="509" y="614" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_270" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="511" y="616" width="78" height="38">
-			</bounds>
+			<bounds x="511" y="616" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_271_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="409" y="614" width="82" height="42">
-			</bounds>
+			<bounds x="409" y="614" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_271" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="411" y="616" width="78" height="38">
-			</bounds>
+			<bounds x="411" y="616" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_272_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="309" y="614" width="82" height="42">
-			</bounds>
+			<bounds x="309" y="614" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_272" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="311" y="616" width="78" height="38">
-			</bounds>
+			<bounds x="311" y="616" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_273_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="209" y="614" width="82" height="42">
-			</bounds>
+			<bounds x="209" y="614" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_273" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="211" y="616" width="78" height="38">
-			</bounds>
+			<bounds x="211" y="616" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_274_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="109" y="614" width="82" height="42">
-			</bounds>
+			<bounds x="109" y="614" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_274" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="111" y="616" width="78" height="38">
-			</bounds>
+			<bounds x="111" y="616" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_275_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="9" y="614" width="82" height="42">
-			</bounds>
+			<bounds x="9" y="614" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_275" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="11" y="616" width="78" height="38">
-			</bounds>
+			<bounds x="11" y="616" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp229" element="colour_button_277_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="729" y="14" width="50" height="16">
-			</bounds>
+			<bounds x="729" y="14" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp229" element="colour_button_277" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="731" y="16" width="46" height="12">
-			</bounds>
+			<bounds x="731" y="16" width="46" height="12"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="115" y="380" width="272" height="30">
-			</bounds>
+			<bounds x="115" y="380" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="115" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="115" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="132" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="132" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="149" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="149" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="166" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="166" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="183" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="183" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="200" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="200" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="217" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="217" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="234" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="234" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="251" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="251" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="268" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="268" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="285" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="285" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="302" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="302" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="319" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="319" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="336" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="336" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="353" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="353" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="370" y="380" width="17" height="30">
-			</bounds>
+			<bounds x="370" y="380" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="395" y="485" width="24" height="28">
-			</bounds>
+			<bounds x="395" y="485" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="80" y="485" width="24" height="28">
-			</bounds>
+			<bounds x="80" y="485" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label166" element="label_166">
-			<bounds x="755" y="645" width="28" height="13">
-			</bounds>
+			<bounds x="755" y="645" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="label167" element="label_167">
-			<bounds x="135" y="410" width="27" height="14">
-			</bounds>
+			<bounds x="135" y="410" width="27" height="14"/>
 		</backdrop>
 		<backdrop name="label168" element="label_168">
-			<bounds x="330" y="410" width="29" height="14">
-			</bounds>
+			<bounds x="330" y="410" width="29" height="14"/>
 		</backdrop>
 		<backdrop name="label169" element="label_169">
-			<bounds x="505" y="490" width="131" height="28">
-			</bounds>
+			<bounds x="505" y="490" width="131" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_button" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1pinkpc.lay
+++ b/src/mame/layout/m1pinkpc.lay
@@ -8,10770 +8,6825 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="P.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="P.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CAFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CAFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="DIAMOND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="DIAMOND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L. ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L. ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="DIAMOND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="DIAMOND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="MAGNIFYING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="MAGNIFYING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="JAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="JAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string=" C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="C.L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="MAGNIFYING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="MAGNIFYING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="C.L ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Advance 2 Eiffel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Advance 2 Eiffel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Advance 2 Cafe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Advance 2 Cafe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Go To Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Go To Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Advance 2 Spaces">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Advance 2 Spaces">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Back 2 Spaces">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Back 2 Spaces">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00 RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00 RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_255_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_255">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_256_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_256">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_257_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_257">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_258_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_258">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_259_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_259">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="  LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_260_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_260">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="  HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_261_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_261">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_262_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_262">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_159">
 		<text string=" STARTS FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_160">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_161">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_162">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_211">
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_240">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="888" height="851">
-			</bounds>
+			<bounds x="0" y="0" width="888" height="851"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="140" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="140" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="140.0000" y="583.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="140.0000" y="583.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="143.3333" y="584.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="143.3333" y="584.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="146.6667" y="586.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="146.6667" y="586.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="150.0000" y="588.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="150.0000" y="588.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="153.3333" y="590.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="153.3333" y="590.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="156.6667" y="592.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="156.6667" y="592.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="140.0000" y="629.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="140.0000" y="629.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="143.3333" y="631.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="143.3333" y="631.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="146.6667" y="633.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="146.6667" y="633.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="150.0000" y="635.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="150.0000" y="635.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="153.3333" y="637.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="153.3333" y="637.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="156.6667" y="639.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="156.6667" y="639.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="140.0000" y="676.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="140.0000" y="676.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="143.3333" y="678.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="143.3333" y="678.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="146.6667" y="680.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="146.6667" y="680.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="150.0000" y="682.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="150.0000" y="682.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="153.3333" y="684.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="153.3333" y="684.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="156.6667" y="686.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="156.6667" y="686.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="140" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="140" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="227" y="584" width="80" height="140">
-			</bounds>
+			<bounds x="227" y="584" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="227.0000" y="584.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="227.0000" y="584.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="230.3333" y="585.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="230.3333" y="585.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="233.6667" y="587.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="233.6667" y="587.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="237.0000" y="589.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="237.0000" y="589.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="240.3333" y="591.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="240.3333" y="591.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="243.6667" y="593.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="243.6667" y="593.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="227.0000" y="630.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="227.0000" y="630.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="230.3333" y="632.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="230.3333" y="632.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="233.6667" y="634.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="233.6667" y="634.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="237.0000" y="636.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="237.0000" y="636.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="240.3333" y="638.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="240.3333" y="638.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="243.6667" y="640.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="243.6667" y="640.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="227.0000" y="677.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="227.0000" y="677.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="230.3333" y="679.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="230.3333" y="679.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="233.6667" y="681.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="233.6667" y="681.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="237.0000" y="683.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="237.0000" y="683.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="240.3333" y="685.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="240.3333" y="685.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="243.6667" y="687.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="243.6667" y="687.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="227" y="584" width="80" height="140">
-			</bounds>
+			<bounds x="227" y="584" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="313" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="313" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="583.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="313.0000" y="583.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="584.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="316.3333" y="584.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="586.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="319.6667" y="586.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="588.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="323.0000" y="588.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="590.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="326.3333" y="590.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="592.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="329.6667" y="592.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="629.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="313.0000" y="629.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="631.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="316.3333" y="631.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="633.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="319.6667" y="633.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="635.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="323.0000" y="635.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="637.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="326.3333" y="637.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="639.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="329.6667" y="639.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="676.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="313.0000" y="676.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="678.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="316.3333" y="678.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="680.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="319.6667" y="680.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="682.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="323.0000" y="682.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="684.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="326.3333" y="684.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="686.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="329.6667" y="686.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="313" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="313" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="742" y="423" width="60" height="60">
-			</bounds>
+			<bounds x="742" y="423" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="742.0000" y="423.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="742.0000" y="423.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="744.5000" y="425.5000" width="55.0000" height="55.0000">
-			</bounds>
+			<bounds x="744.5000" y="425.5000" width="55.0000" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="747.0000" y="428.0000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="747.0000" y="428.0000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="749.5000" y="430.5000" width="45.0000" height="45.0000">
-			</bounds>
+			<bounds x="749.5000" y="430.5000" width="45.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="752.0000" y="433.0000" width="40.0000" height="40.0000">
-			</bounds>
+			<bounds x="752.0000" y="433.0000" width="40.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="754.5000" y="435.5000" width="35.0000" height="35.0000">
-			</bounds>
+			<bounds x="754.5000" y="435.5000" width="35.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="742" y="423" width="60" height="60">
-			</bounds>
+			<bounds x="742" y="423" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="799" y="433" width="46" height="46">
-			</bounds>
+			<bounds x="799" y="433" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="801" y="435" width="42" height="42">
-			</bounds>
+			<bounds x="801" y="435" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="799" y="433" width="46" height="46">
-			</bounds>
+			<bounds x="799" y="433" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="801" y="435" width="42" height="42">
-			</bounds>
+			<bounds x="801" y="435" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="698" y="433" width="46" height="46">
-			</bounds>
+			<bounds x="698" y="433" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="700" y="435" width="42" height="42">
-			</bounds>
+			<bounds x="700" y="435" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="698" y="433" width="46" height="46">
-			</bounds>
+			<bounds x="698" y="433" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="700" y="435" width="42" height="42">
-			</bounds>
+			<bounds x="700" y="435" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="141" y="760" width="36" height="34">
-			</bounds>
+			<bounds x="141" y="760" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="143" y="762" width="32" height="30">
-			</bounds>
+			<bounds x="143" y="762" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="548" y="760" width="36" height="34">
-			</bounds>
+			<bounds x="548" y="760" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="550" y="762" width="32" height="30">
-			</bounds>
+			<bounds x="550" y="762" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="412" y="760" width="36" height="34">
-			</bounds>
+			<bounds x="412" y="760" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="414" y="762" width="32" height="30">
-			</bounds>
+			<bounds x="414" y="762" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="277" y="760" width="36" height="34">
-			</bounds>
+			<bounds x="277" y="760" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="279" y="762" width="32" height="30">
-			</bounds>
+			<bounds x="279" y="762" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="28" y="668" width="58" height="46">
-			</bounds>
+			<bounds x="28" y="668" width="58" height="46"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="30" y="670" width="54" height="42">
-			</bounds>
+			<bounds x="30" y="670" width="54" height="42"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="40" y="517" width="36" height="36">
-			</bounds>
+			<bounds x="40" y="517" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="42" y="519" width="32" height="32">
-			</bounds>
+			<bounds x="42" y="519" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="40" y="554" width="36" height="36">
-			</bounds>
+			<bounds x="40" y="554" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="42" y="556" width="32" height="32">
-			</bounds>
+			<bounds x="42" y="556" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="40" y="591" width="36" height="36">
-			</bounds>
+			<bounds x="40" y="591" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="42" y="593" width="32" height="32">
-			</bounds>
+			<bounds x="42" y="593" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="40" y="627" width="36" height="36">
-			</bounds>
+			<bounds x="40" y="627" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="42" y="629" width="32" height="32">
-			</bounds>
+			<bounds x="42" y="629" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="484" y="122" width="35" height="35">
-			</bounds>
+			<bounds x="484" y="122" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="486" y="124" width="31" height="31">
-			</bounds>
+			<bounds x="486" y="124" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="424" y="117" width="62" height="46">
-			</bounds>
+			<bounds x="424" y="117" width="62" height="46"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="426" y="119" width="58" height="42">
-			</bounds>
+			<bounds x="426" y="119" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="468" y="84" width="35" height="35">
-			</bounds>
+			<bounds x="468" y="84" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="470" y="86" width="31" height="31">
-			</bounds>
+			<bounds x="470" y="86" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="489" y="41" width="46" height="46">
-			</bounds>
+			<bounds x="489" y="41" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="491" y="43" width="42" height="42">
-			</bounds>
+			<bounds x="491" y="43" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="486" y="290" width="57" height="46">
-			</bounds>
+			<bounds x="486" y="290" width="57" height="46"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="488" y="292" width="53" height="42">
-			</bounds>
+			<bounds x="488" y="292" width="53" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="496" y="202" width="46" height="46">
-			</bounds>
+			<bounds x="496" y="202" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="498" y="204" width="42" height="42">
-			</bounds>
+			<bounds x="498" y="204" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="542" y="217" width="35" height="35">
-			</bounds>
+			<bounds x="542" y="217" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="544" y="219" width="31" height="31">
-			</bounds>
+			<bounds x="544" y="219" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="496" y="246" width="46" height="46">
-			</bounds>
+			<bounds x="496" y="246" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="498" y="248" width="42" height="42">
-			</bounds>
+			<bounds x="498" y="248" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="542" y="259" width="35" height="35">
-			</bounds>
+			<bounds x="542" y="259" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="544" y="261" width="31" height="31">
-			</bounds>
+			<bounds x="544" y="261" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="542" y="298" width="35" height="35">
-			</bounds>
+			<bounds x="542" y="298" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="544" y="300" width="31" height="31">
-			</bounds>
+			<bounds x="544" y="300" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="496" y="335" width="46" height="46">
-			</bounds>
+			<bounds x="496" y="335" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="498" y="337" width="42" height="42">
-			</bounds>
+			<bounds x="498" y="337" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="542" y="348" width="35" height="35">
-			</bounds>
+			<bounds x="542" y="348" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="544" y="350" width="31" height="31">
-			</bounds>
+			<bounds x="544" y="350" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="542" y="172" width="35" height="35">
-			</bounds>
+			<bounds x="542" y="172" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="544" y="174" width="31" height="31">
-			</bounds>
+			<bounds x="544" y="174" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="486" y="157" width="57" height="46">
-			</bounds>
+			<bounds x="486" y="157" width="57" height="46"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="488" y="159" width="53" height="42">
-			</bounds>
+			<bounds x="488" y="159" width="53" height="42"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="496" y="379" width="46" height="46">
-			</bounds>
+			<bounds x="496" y="379" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="498" y="381" width="42" height="42">
-			</bounds>
+			<bounds x="498" y="381" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="497" y="426" width="35" height="35">
-			</bounds>
+			<bounds x="497" y="426" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="499" y="428" width="31" height="31">
-			</bounds>
+			<bounds x="499" y="428" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="235" y="170" width="76" height="46">
-			</bounds>
+			<bounds x="235" y="170" width="76" height="46"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="237" y="172" width="72" height="42">
-			</bounds>
+			<bounds x="237" y="172" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="197" y="177" width="35" height="35">
-			</bounds>
+			<bounds x="197" y="177" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="199" y="179" width="31" height="31">
-			</bounds>
+			<bounds x="199" y="179" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="122" y="170" width="66" height="46">
-			</bounds>
+			<bounds x="122" y="170" width="66" height="46"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="124" y="172" width="62" height="42">
-			</bounds>
+			<bounds x="124" y="172" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="143" y="133" width="35" height="35">
-			</bounds>
+			<bounds x="143" y="133" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="145" y="135" width="31" height="31">
-			</bounds>
+			<bounds x="145" y="135" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="134" y="86" width="46" height="46">
-			</bounds>
+			<bounds x="134" y="86" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="136" y="88" width="42" height="42">
-			</bounds>
+			<bounds x="136" y="88" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="128" y="41" width="80" height="46">
-			</bounds>
+			<bounds x="128" y="41" width="80" height="46"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="130" y="43" width="76" height="42">
-			</bounds>
+			<bounds x="130" y="43" width="76" height="42"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="456" y="47" width="35" height="35">
-			</bounds>
+			<bounds x="456" y="47" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="458" y="49" width="31" height="31">
-			</bounds>
+			<bounds x="458" y="49" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="375" y="47" width="35" height="35">
-			</bounds>
+			<bounds x="375" y="47" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="377" y="49" width="31" height="31">
-			</bounds>
+			<bounds x="377" y="49" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="293" y="47" width="35" height="35">
-			</bounds>
+			<bounds x="293" y="47" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="295" y="49" width="31" height="31">
-			</bounds>
+			<bounds x="295" y="49" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="208" y="47" width="35" height="35">
-			</bounds>
+			<bounds x="208" y="47" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="210" y="49" width="31" height="31">
-			</bounds>
+			<bounds x="210" y="49" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="93" y="47" width="35" height="35">
-			</bounds>
+			<bounds x="93" y="47" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="95" y="49" width="31" height="31">
-			</bounds>
+			<bounds x="95" y="49" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="228" y="249" width="35" height="35">
-			</bounds>
+			<bounds x="228" y="249" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="230" y="251" width="31" height="31">
-			</bounds>
+			<bounds x="230" y="251" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="193" y="276" width="35" height="35">
-			</bounds>
+			<bounds x="193" y="276" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="195" y="278" width="31" height="31">
-			</bounds>
+			<bounds x="195" y="278" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="160" y="306" width="35" height="35">
-			</bounds>
+			<bounds x="160" y="306" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="162" y="308" width="31" height="31">
-			</bounds>
+			<bounds x="162" y="308" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="122" y="336" width="35" height="35">
-			</bounds>
+			<bounds x="122" y="336" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="124" y="338" width="31" height="31">
-			</bounds>
+			<bounds x="124" y="338" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="90" y="375" width="35" height="35">
-			</bounds>
+			<bounds x="90" y="375" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="92" y="377" width="31" height="31">
-			</bounds>
+			<bounds x="92" y="377" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="266" y="240" width="46" height="46">
-			</bounds>
+			<bounds x="266" y="240" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="268" y="242" width="42" height="42">
-			</bounds>
+			<bounds x="268" y="242" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="128" y="421" width="35" height="35">
-			</bounds>
+			<bounds x="128" y="421" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="130" y="423" width="31" height="31">
-			</bounds>
+			<bounds x="130" y="423" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="166" y="414" width="46" height="46">
-			</bounds>
+			<bounds x="166" y="414" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="168" y="416" width="42" height="42">
-			</bounds>
+			<bounds x="168" y="416" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="214" y="423" width="35" height="35">
-			</bounds>
+			<bounds x="214" y="423" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="216" y="425" width="31" height="31">
-			</bounds>
+			<bounds x="216" y="425" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="253" y="415" width="46" height="46">
-			</bounds>
+			<bounds x="253" y="415" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="255" y="417" width="42" height="42">
-			</bounds>
+			<bounds x="255" y="417" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="299" y="423" width="35" height="35">
-			</bounds>
+			<bounds x="299" y="423" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="301" y="425" width="31" height="31">
-			</bounds>
+			<bounds x="301" y="425" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="335" y="417" width="80" height="46">
-			</bounds>
+			<bounds x="335" y="417" width="80" height="46"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="337" y="419" width="76" height="42">
-			</bounds>
+			<bounds x="337" y="419" width="76" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="414" y="424" width="35" height="35">
-			</bounds>
+			<bounds x="414" y="424" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="416" y="426" width="31" height="31">
-			</bounds>
+			<bounds x="416" y="426" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="451" y="417" width="46" height="46">
-			</bounds>
+			<bounds x="451" y="417" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="453" y="419" width="42" height="42">
-			</bounds>
+			<bounds x="453" y="419" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="80" y="413" width="46" height="46">
-			</bounds>
+			<bounds x="80" y="413" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="82" y="415" width="42" height="42">
-			</bounds>
+			<bounds x="82" y="415" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="692" y="134" width="42" height="27">
-			</bounds>
+			<bounds x="692" y="134" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="694" y="136" width="38" height="23">
-			</bounds>
+			<bounds x="694" y="136" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="694" y="218" width="42" height="27">
-			</bounds>
+			<bounds x="694" y="218" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="696" y="220" width="38" height="23">
-			</bounds>
+			<bounds x="696" y="220" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="336" y="362" width="78" height="36">
-			</bounds>
+			<bounds x="336" y="362" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="338" y="364" width="74" height="32">
-			</bounds>
+			<bounds x="338" y="364" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="336" y="327" width="78" height="36">
-			</bounds>
+			<bounds x="336" y="327" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="338" y="329" width="74" height="32">
-			</bounds>
+			<bounds x="338" y="329" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="336" y="221" width="78" height="36">
-			</bounds>
+			<bounds x="336" y="221" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="338" y="223" width="74" height="32">
-			</bounds>
+			<bounds x="338" y="223" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="336" y="256" width="78" height="36">
-			</bounds>
+			<bounds x="336" y="256" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="338" y="258" width="74" height="32">
-			</bounds>
+			<bounds x="338" y="258" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="336" y="292" width="78" height="36">
-			</bounds>
+			<bounds x="336" y="292" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="338" y="294" width="74" height="32">
-			</bounds>
+			<bounds x="338" y="294" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="336" y="186" width="78" height="36">
-			</bounds>
+			<bounds x="336" y="186" width="78" height="36"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="338" y="188" width="74" height="32">
-			</bounds>
+			<bounds x="338" y="188" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="326" y="41" width="46" height="46">
-			</bounds>
+			<bounds x="326" y="41" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="328" y="43" width="42" height="42">
-			</bounds>
+			<bounds x="328" y="43" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="410" y="41" width="46" height="46">
-			</bounds>
+			<bounds x="410" y="41" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="412" y="43" width="42" height="42">
-			</bounds>
+			<bounds x="412" y="43" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="245" y="41" width="46" height="46">
-			</bounds>
+			<bounds x="245" y="41" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="247" y="43" width="42" height="42">
-			</bounds>
+			<bounds x="247" y="43" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_2_border" state="0">
-			<bounds x="448" y="513" width="102" height="34">
-			</bounds>
+			<bounds x="448" y="513" width="102" height="34"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_2" state="0">
-			<bounds x="450" y="515" width="98" height="30">
-			</bounds>
+			<bounds x="450" y="515" width="98" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="546" y="586" width="36" height="34">
-			</bounds>
+			<bounds x="546" y="586" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="548" y="588" width="32" height="30">
-			</bounds>
+			<bounds x="548" y="588" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="548" y="639" width="36" height="34">
-			</bounds>
+			<bounds x="548" y="639" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="550" y="641" width="32" height="30">
-			</bounds>
+			<bounds x="550" y="641" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="465" y="679" width="66" height="34">
-			</bounds>
+			<bounds x="465" y="679" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="467" y="681" width="62" height="30">
-			</bounds>
+			<bounds x="467" y="681" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_255_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="835" y="4" width="48" height="24">
-			</bounds>
+			<bounds x="835" y="4" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_255" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="837" y="6" width="44" height="20">
-			</bounds>
+			<bounds x="837" y="6" width="44" height="20"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_256_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="593" y="814" width="75" height="37">
-			</bounds>
+			<bounds x="593" y="814" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_256" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="595" y="816" width="71" height="33">
-			</bounds>
+			<bounds x="595" y="816" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_257_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="495" y="814" width="75" height="37">
-			</bounds>
+			<bounds x="495" y="814" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_257" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="497" y="816" width="71" height="33">
-			</bounds>
+			<bounds x="497" y="816" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_258_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="413" y="814" width="75" height="37">
-			</bounds>
+			<bounds x="413" y="814" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_258" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="415" y="816" width="71" height="33">
-			</bounds>
+			<bounds x="415" y="816" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_259_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="329" y="814" width="75" height="37">
-			</bounds>
+			<bounds x="329" y="814" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_259" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="331" y="816" width="71" height="33">
-			</bounds>
+			<bounds x="331" y="816" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_260_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="239" y="814" width="75" height="37">
-			</bounds>
+			<bounds x="239" y="814" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_260" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="241" y="816" width="71" height="33">
-			</bounds>
+			<bounds x="241" y="816" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_261_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="151" y="814" width="75" height="37">
-			</bounds>
+			<bounds x="151" y="814" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_261" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="153" y="816" width="71" height="33">
-			</bounds>
+			<bounds x="153" y="816" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_262_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="58" y="814" width="75" height="37">
-			</bounds>
+			<bounds x="58" y="814" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_262" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="60" y="816" width="71" height="33">
-			</bounds>
+			<bounds x="60" y="816" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="634" y="698" width="24" height="32">
-			</bounds>
+			<bounds x="634" y="698" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="637" y="700" width="17" height="2">
-			</bounds>
+			<bounds x="637" y="700" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="651" y="700" width="3" height="14">
-			</bounds>
+			<bounds x="651" y="700" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="651" y="712" width="3" height="14">
-			</bounds>
+			<bounds x="651" y="712" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="637" y="724" width="17" height="2">
-			</bounds>
+			<bounds x="637" y="724" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="637" y="712" width="3" height="14">
-			</bounds>
+			<bounds x="637" y="712" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="637" y="700" width="3" height="14">
-			</bounds>
+			<bounds x="637" y="700" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="637" y="712" width="17" height="2">
-			</bounds>
+			<bounds x="637" y="712" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="654" y="724" width="3" height="2">
-			</bounds>
+			<bounds x="654" y="724" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="637" y="700" width="17" height="2">
-			</bounds>
+			<bounds x="637" y="700" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="651" y="700" width="3" height="14">
-			</bounds>
+			<bounds x="651" y="700" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="651" y="712" width="3" height="14">
-			</bounds>
+			<bounds x="651" y="712" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="637" y="724" width="17" height="2">
-			</bounds>
+			<bounds x="637" y="724" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="637" y="712" width="3" height="14">
-			</bounds>
+			<bounds x="637" y="712" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="637" y="700" width="3" height="14">
-			</bounds>
+			<bounds x="637" y="700" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="637" y="712" width="17" height="2">
-			</bounds>
+			<bounds x="637" y="712" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="654" y="724" width="3" height="2">
-			</bounds>
+			<bounds x="654" y="724" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="608" y="697" width="24" height="32">
-			</bounds>
+			<bounds x="608" y="697" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="611" y="699" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="699" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="625" y="699" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="699" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="625" y="711" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="711" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="611" y="723" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="723" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="611" y="711" width="3" height="14">
-			</bounds>
+			<bounds x="611" y="711" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="611" y="699" width="3" height="14">
-			</bounds>
+			<bounds x="611" y="699" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="611" y="711" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="711" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_dot_off">
-			<bounds x="628" y="723" width="3" height="2">
-			</bounds>
+			<bounds x="628" y="723" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="611" y="699" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="699" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="625" y="699" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="699" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="625" y="711" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="711" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="611" y="723" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="723" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="611" y="711" width="3" height="14">
-			</bounds>
+			<bounds x="611" y="711" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="611" y="699" width="3" height="14">
-			</bounds>
+			<bounds x="611" y="699" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="611" y="711" width="17" height="2">
-			</bounds>
+			<bounds x="611" y="711" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_dot_on">
-			<bounds x="628" y="723" width="3" height="2">
-			</bounds>
+			<bounds x="628" y="723" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="132" y="545" width="272" height="28">
-			</bounds>
+			<bounds x="132" y="545" width="272" height="28"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="132" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="132" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="149" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="149" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="166" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="166" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="183" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="183" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="200" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="200" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="217" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="217" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="234" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="234" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="251" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="251" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="268" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="268" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="285" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="285" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="302" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="302" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="319" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="319" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="336" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="336" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="353" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="353" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="370" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="370" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="387" y="545" width="17" height="28">
-			</bounds>
+			<bounds x="387" y="545" width="17" height="28"/>
 		</backdrop>
 		<backdrop name="label159" element="label_159">
-			<bounds x="689" y="501" width="163" height="20">
-			</bounds>
+			<bounds x="689" y="501" width="163" height="20"/>
 		</backdrop>
 		<backdrop name="label160" element="label_160">
-			<bounds x="103" y="644" width="30" height="16">
-			</bounds>
+			<bounds x="103" y="644" width="30" height="16"/>
 		</backdrop>
 		<backdrop name="label161" element="label_161">
-			<bounds x="398" y="644" width="34" height="16">
-			</bounds>
+			<bounds x="398" y="644" width="34" height="16"/>
 		</backdrop>
 		<backdrop name="label162" element="label_162">
-			<bounds x="344" y="521" width="41" height="16">
-			</bounds>
+			<bounds x="344" y="521" width="41" height="16"/>
 		</backdrop>
 		<backdrop name="label211" element="label_211">
-			<bounds x="677" y="169" width="67" height="40">
-			</bounds>
+			<bounds x="677" y="169" width="67" height="40"/>
 		</backdrop>
 		<backdrop name="label240" element="label_240">
-			<bounds x="599" y="680" width="67" height="16">
-			</bounds>
+			<bounds x="599" y="680" width="67" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1przeeb.lay
+++ b/src/mame/layout/m1przeeb.lay
@@ -8,11814 +8,7360 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="fruit stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="fruit stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Garage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Garage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="empty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="empty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="the Queen Victoria">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="the Queen Victoria">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Laundrette">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Laundrette">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="prize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="grant mitchel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="grant mitchel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="pat butcher">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="pat butcher">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="pauline fowler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="pauline fowler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="arthur fowler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="arthur fowler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="bridge street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="bridge street">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="sharon mitchel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="sharon mitchel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="mitchels garage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="mitchels garage">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="wheel clamp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="wheel clamp">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="frank butcher">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="frank butcher">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="meet the mitchels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="meet the mitchels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="lunch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="lunch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="breakfast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="breakfast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="cafe feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="cafe feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Eastenders">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="fruit stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="fruit stall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Albert">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Albert">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Square">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_269_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_269">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="dosh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_270_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_270">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_271_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_271">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_272_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_272">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_273_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_273">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="hold/lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_274_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_274">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="hold/hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_275_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_275">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_276_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_276">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_277_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_277">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_166">
 		<text string="Awards Select a Prize or Exchange for &#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_201">
 		<text string="www.reelfruits.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_216">
 		<text string="All eastenders Lit Awards Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_256">
 		<text string="Nudge Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_260">
 		<text string="dosh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="851" height="685">
-			</bounds>
+			<bounds x="0" y="0" width="851" height="685"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="189" y="464" width="80" height="140">
-			</bounds>
+			<bounds x="189" y="464" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="189.0000" y="464.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="189.0000" y="464.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.3333" y="465.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="192.3333" y="465.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.6667" y="467.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="195.6667" y="467.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="199.0000" y="469.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="199.0000" y="469.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="202.3333" y="471.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="202.3333" y="471.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="205.6667" y="473.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="205.6667" y="473.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="189.0000" y="510.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="189.0000" y="510.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.3333" y="512.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="192.3333" y="512.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.6667" y="514.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="195.6667" y="514.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="199.0000" y="516.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="199.0000" y="516.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="202.3333" y="518.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="202.3333" y="518.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="205.6667" y="520.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="205.6667" y="520.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="189.0000" y="557.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="189.0000" y="557.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.3333" y="559.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="192.3333" y="559.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.6667" y="561.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="195.6667" y="561.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="199.0000" y="563.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="199.0000" y="563.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="202.3333" y="565.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="202.3333" y="565.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="205.6667" y="567.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="205.6667" y="567.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="189" y="464" width="80" height="140">
-			</bounds>
+			<bounds x="189" y="464" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="273" y="464" width="80" height="140">
-			</bounds>
+			<bounds x="273" y="464" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="273.0000" y="464.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="273.0000" y="464.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.3333" y="465.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="276.3333" y="465.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.6667" y="467.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="279.6667" y="467.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="283.0000" y="469.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="283.0000" y="469.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="471.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="286.3333" y="471.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="289.6667" y="473.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="289.6667" y="473.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="273.0000" y="510.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="273.0000" y="510.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.3333" y="512.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="276.3333" y="512.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.6667" y="514.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="279.6667" y="514.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="283.0000" y="516.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="283.0000" y="516.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="518.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="286.3333" y="518.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="289.6667" y="520.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="289.6667" y="520.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="273.0000" y="557.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="273.0000" y="557.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.3333" y="559.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="276.3333" y="559.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.6667" y="561.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="279.6667" y="561.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="283.0000" y="563.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="283.0000" y="563.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="286.3333" y="565.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="286.3333" y="565.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="289.6667" y="567.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="289.6667" y="567.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="273" y="464" width="80" height="140">
-			</bounds>
+			<bounds x="273" y="464" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="356" y="464" width="80" height="140">
-			</bounds>
+			<bounds x="356" y="464" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="356.0000" y="464.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="356.0000" y="464.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="359.3333" y="465.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="359.3333" y="465.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="362.6667" y="467.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="362.6667" y="467.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="366.0000" y="469.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="366.0000" y="469.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="369.3333" y="471.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="369.3333" y="471.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.6667" y="473.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="372.6667" y="473.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="356.0000" y="510.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="356.0000" y="510.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="359.3333" y="512.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="359.3333" y="512.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="362.6667" y="514.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="362.6667" y="514.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="366.0000" y="516.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="366.0000" y="516.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="369.3333" y="518.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="369.3333" y="518.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.6667" y="520.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="372.6667" y="520.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="356.0000" y="557.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="356.0000" y="557.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="359.3333" y="559.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="359.3333" y="559.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="362.6667" y="561.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="362.6667" y="561.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="366.0000" y="563.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="366.0000" y="563.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="369.3333" y="565.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="369.3333" y="565.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.6667" y="567.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="372.6667" y="567.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="356" y="464" width="80" height="140">
-			</bounds>
+			<bounds x="356" y="464" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="269" y="56" width="80" height="70">
-			</bounds>
+			<bounds x="269" y="56" width="80" height="70"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="269.0000" y="56.0000" width="80.0000" height="70.0000">
-			</bounds>
+			<bounds x="269.0000" y="56.0000" width="80.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="272.3333" y="58.9167" width="73.3333" height="64.1667">
-			</bounds>
+			<bounds x="272.3333" y="58.9167" width="73.3333" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="275.6667" y="61.8333" width="66.6667" height="58.3333">
-			</bounds>
+			<bounds x="275.6667" y="61.8333" width="66.6667" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="279.0000" y="64.7500" width="60.0000" height="52.5000">
-			</bounds>
+			<bounds x="279.0000" y="64.7500" width="60.0000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="282.3333" y="67.6667" width="53.3333" height="46.6667">
-			</bounds>
+			<bounds x="282.3333" y="67.6667" width="53.3333" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="285.6667" y="70.5833" width="46.6667" height="40.8333">
-			</bounds>
+			<bounds x="285.6667" y="70.5833" width="46.6667" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="269" y="56" width="80" height="70">
-			</bounds>
+			<bounds x="269" y="56" width="80" height="70"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="142" y="1" width="57" height="52">
-			</bounds>
+			<bounds x="142" y="1" width="57" height="52"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="144" y="3" width="53" height="48">
-			</bounds>
+			<bounds x="144" y="3" width="53" height="48"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="237" y="1" width="57" height="52">
-			</bounds>
+			<bounds x="237" y="1" width="57" height="52"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="239" y="3" width="53" height="48">
-			</bounds>
+			<bounds x="239" y="3" width="53" height="48"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="418" y="1" width="57" height="52">
-			</bounds>
+			<bounds x="418" y="1" width="57" height="52"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="420" y="3" width="53" height="48">
-			</bounds>
+			<bounds x="420" y="3" width="53" height="48"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="326" y="1" width="57" height="52">
-			</bounds>
+			<bounds x="326" y="1" width="57" height="52"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="328" y="3" width="53" height="48">
-			</bounds>
+			<bounds x="328" y="3" width="53" height="48"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="670" y="195" width="102" height="32">
-			</bounds>
+			<bounds x="670" y="195" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="672" y="197" width="98" height="28">
-			</bounds>
+			<bounds x="672" y="197" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="16" y="81" width="62" height="42">
-			</bounds>
+			<bounds x="16" y="81" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="18" y="83" width="58" height="38">
-			</bounds>
+			<bounds x="18" y="83" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="74" y="578" width="49" height="32">
-			</bounds>
+			<bounds x="74" y="578" width="49" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="76" y="580" width="45" height="28">
-			</bounds>
+			<bounds x="76" y="580" width="45" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="74" y="544" width="49" height="32">
-			</bounds>
+			<bounds x="74" y="544" width="49" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="76" y="546" width="45" height="28">
-			</bounds>
+			<bounds x="76" y="546" width="45" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="74" y="510" width="49" height="32">
-			</bounds>
+			<bounds x="74" y="510" width="49" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="76" y="512" width="45" height="28">
-			</bounds>
+			<bounds x="76" y="512" width="45" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="74" y="476" width="49" height="32">
-			</bounds>
+			<bounds x="74" y="476" width="49" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="76" y="478" width="45" height="28">
-			</bounds>
+			<bounds x="76" y="478" width="45" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="74" y="611" width="49" height="29">
-			</bounds>
+			<bounds x="74" y="611" width="49" height="29"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="76" y="613" width="45" height="25">
-			</bounds>
+			<bounds x="76" y="613" width="45" height="25"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="589" y="145" width="49" height="37">
-			</bounds>
+			<bounds x="589" y="145" width="49" height="37"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="591" y="147" width="45" height="33">
-			</bounds>
+			<bounds x="591" y="147" width="45" height="33"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="589" y="106" width="49" height="37">
-			</bounds>
+			<bounds x="589" y="106" width="49" height="37"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="591" y="108" width="45" height="33">
-			</bounds>
+			<bounds x="591" y="108" width="45" height="33"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="642" y="145" width="49" height="37">
-			</bounds>
+			<bounds x="642" y="145" width="49" height="37"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="644" y="147" width="45" height="33">
-			</bounds>
+			<bounds x="644" y="147" width="45" height="33"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="642" y="106" width="49" height="37">
-			</bounds>
+			<bounds x="642" y="106" width="49" height="37"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="644" y="108" width="45" height="33">
-			</bounds>
+			<bounds x="644" y="108" width="45" height="33"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="589" y="71" width="102" height="32">
-			</bounds>
+			<bounds x="589" y="71" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="591" y="73" width="98" height="28">
-			</bounds>
+			<bounds x="591" y="73" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="715" y="73" width="102" height="32">
-			</bounds>
+			<bounds x="715" y="73" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="717" y="75" width="98" height="28">
-			</bounds>
+			<bounds x="717" y="75" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="74" y="430" width="122" height="27">
-			</bounds>
+			<bounds x="74" y="430" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="76" y="432" width="118" height="23">
-			</bounds>
+			<bounds x="76" y="432" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="198" y="425" width="242" height="37">
-			</bounds>
+			<bounds x="198" y="425" width="242" height="37"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="200" y="427" width="238" height="33">
-			</bounds>
+			<bounds x="200" y="427" width="238" height="33"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="532" y="390" width="62" height="32">
-			</bounds>
+			<bounds x="532" y="390" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="534" y="392" width="58" height="28">
-			</bounds>
+			<bounds x="534" y="392" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="527" y="357" width="62" height="32">
-			</bounds>
+			<bounds x="527" y="357" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="529" y="359" width="58" height="28">
-			</bounds>
+			<bounds x="529" y="359" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="522" y="325" width="62" height="32">
-			</bounds>
+			<bounds x="522" y="325" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="524" y="327" width="58" height="28">
-			</bounds>
+			<bounds x="524" y="327" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="35" y="392" width="62" height="32">
-			</bounds>
+			<bounds x="35" y="392" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="37" y="394" width="58" height="28">
-			</bounds>
+			<bounds x="37" y="394" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="40" y="360" width="62" height="32">
-			</bounds>
+			<bounds x="40" y="360" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="42" y="362" width="58" height="28">
-			</bounds>
+			<bounds x="42" y="362" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="45" y="327" width="62" height="32">
-			</bounds>
+			<bounds x="45" y="327" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="47" y="329" width="58" height="28">
-			</bounds>
+			<bounds x="47" y="329" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="50" y="294" width="62" height="32">
-			</bounds>
+			<bounds x="50" y="294" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="52" y="296" width="58" height="28">
-			</bounds>
+			<bounds x="52" y="296" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="55" y="261" width="62" height="32">
-			</bounds>
+			<bounds x="55" y="261" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="57" y="263" width="58" height="28">
-			</bounds>
+			<bounds x="57" y="263" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="60" y="228" width="62" height="32">
-			</bounds>
+			<bounds x="60" y="228" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="62" y="230" width="58" height="28">
-			</bounds>
+			<bounds x="62" y="230" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="65" y="195" width="62" height="32">
-			</bounds>
+			<bounds x="65" y="195" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="67" y="197" width="58" height="28">
-			</bounds>
+			<bounds x="67" y="197" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="70" y="162" width="62" height="32">
-			</bounds>
+			<bounds x="70" y="162" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="72" y="164" width="58" height="28">
-			</bounds>
+			<bounds x="72" y="164" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="97" y="391" width="62" height="32">
-			</bounds>
+			<bounds x="97" y="391" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="99" y="393" width="58" height="28">
-			</bounds>
+			<bounds x="99" y="393" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="159" y="391" width="62" height="32">
-			</bounds>
+			<bounds x="159" y="391" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="161" y="393" width="58" height="28">
-			</bounds>
+			<bounds x="161" y="393" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="221" y="391" width="62" height="32">
-			</bounds>
+			<bounds x="221" y="391" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="223" y="393" width="58" height="28">
-			</bounds>
+			<bounds x="223" y="393" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="283" y="391" width="62" height="32">
-			</bounds>
+			<bounds x="283" y="391" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="285" y="393" width="58" height="28">
-			</bounds>
+			<bounds x="285" y="393" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="345" y="391" width="62" height="32">
-			</bounds>
+			<bounds x="345" y="391" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="347" y="393" width="58" height="28">
-			</bounds>
+			<bounds x="347" y="393" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="407" y="391" width="62" height="32">
-			</bounds>
+			<bounds x="407" y="391" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="409" y="393" width="58" height="28">
-			</bounds>
+			<bounds x="409" y="393" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="469" y="391" width="62" height="32">
-			</bounds>
+			<bounds x="469" y="391" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="471" y="393" width="58" height="28">
-			</bounds>
+			<bounds x="471" y="393" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="497" y="162" width="62" height="32">
-			</bounds>
+			<bounds x="497" y="162" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="499" y="164" width="58" height="28">
-			</bounds>
+			<bounds x="499" y="164" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="502" y="195" width="62" height="32">
-			</bounds>
+			<bounds x="502" y="195" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="504" y="197" width="58" height="28">
-			</bounds>
+			<bounds x="504" y="197" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="507" y="227" width="62" height="32">
-			</bounds>
+			<bounds x="507" y="227" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="509" y="229" width="58" height="28">
-			</bounds>
+			<bounds x="509" y="229" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="512" y="259" width="62" height="32">
-			</bounds>
+			<bounds x="512" y="259" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="514" y="261" width="58" height="28">
-			</bounds>
+			<bounds x="514" y="261" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="517" y="292" width="62" height="32">
-			</bounds>
+			<bounds x="517" y="292" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="519" y="294" width="58" height="28">
-			</bounds>
+			<bounds x="519" y="294" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="75" y="129" width="62" height="32">
-			</bounds>
+			<bounds x="75" y="129" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="77" y="131" width="58" height="28">
-			</bounds>
+			<bounds x="77" y="131" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="144" y="129" width="62" height="32">
-			</bounds>
+			<bounds x="144" y="129" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="146" y="131" width="58" height="28">
-			</bounds>
+			<bounds x="146" y="131" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="211" y="129" width="62" height="32">
-			</bounds>
+			<bounds x="211" y="129" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="213" y="131" width="58" height="28">
-			</bounds>
+			<bounds x="213" y="131" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="279" y="129" width="62" height="32">
-			</bounds>
+			<bounds x="279" y="129" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="281" y="131" width="58" height="28">
-			</bounds>
+			<bounds x="281" y="131" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="354" y="128" width="62" height="32">
-			</bounds>
+			<bounds x="354" y="128" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="356" y="130" width="58" height="28">
-			</bounds>
+			<bounds x="356" y="130" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="423" y="128" width="62" height="32">
-			</bounds>
+			<bounds x="423" y="128" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="425" y="130" width="58" height="28">
-			</bounds>
+			<bounds x="425" y="130" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="492" y="128" width="62" height="32">
-			</bounds>
+			<bounds x="492" y="128" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="494" y="130" width="58" height="28">
-			</bounds>
+			<bounds x="494" y="130" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="719" y="245" width="82" height="24">
-			</bounds>
+			<bounds x="719" y="245" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="721" y="247" width="78" height="20">
-			</bounds>
+			<bounds x="721" y="247" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="719" y="334" width="82" height="19">
-			</bounds>
+			<bounds x="719" y="334" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="721" y="336" width="78" height="15">
-			</bounds>
+			<bounds x="721" y="336" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="719" y="313" width="82" height="19">
-			</bounds>
+			<bounds x="719" y="313" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="721" y="315" width="78" height="15">
-			</bounds>
+			<bounds x="721" y="315" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="719" y="292" width="82" height="19">
-			</bounds>
+			<bounds x="719" y="292" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="721" y="294" width="78" height="15">
-			</bounds>
+			<bounds x="721" y="294" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="719" y="271" width="82" height="19">
-			</bounds>
+			<bounds x="719" y="271" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="721" y="273" width="78" height="15">
-			</bounds>
+			<bounds x="721" y="273" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="636" y="245" width="82" height="24">
-			</bounds>
+			<bounds x="636" y="245" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="638" y="247" width="78" height="20">
-			</bounds>
+			<bounds x="638" y="247" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="636" y="334" width="82" height="19">
-			</bounds>
+			<bounds x="636" y="334" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="638" y="336" width="78" height="15">
-			</bounds>
+			<bounds x="638" y="336" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="636" y="313" width="82" height="19">
-			</bounds>
+			<bounds x="636" y="313" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="638" y="315" width="78" height="15">
-			</bounds>
+			<bounds x="638" y="315" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="636" y="292" width="82" height="19">
-			</bounds>
+			<bounds x="636" y="292" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="638" y="294" width="78" height="15">
-			</bounds>
+			<bounds x="638" y="294" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="636" y="271" width="82" height="19">
-			</bounds>
+			<bounds x="636" y="271" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="638" y="273" width="78" height="15">
-			</bounds>
+			<bounds x="638" y="273" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="667" y="356" width="102" height="19">
-			</bounds>
+			<bounds x="667" y="356" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="669" y="358" width="98" height="15">
-			</bounds>
+			<bounds x="669" y="358" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="685" y="417" width="82" height="27">
-			</bounds>
+			<bounds x="685" y="417" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="687" y="419" width="78" height="23">
-			</bounds>
+			<bounds x="687" y="419" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="603" y="417" width="82" height="27">
-			</bounds>
+			<bounds x="603" y="417" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="605" y="419" width="78" height="23">
-			</bounds>
+			<bounds x="605" y="419" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="767" y="417" width="82" height="27">
-			</bounds>
+			<bounds x="767" y="417" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="769" y="419" width="78" height="23">
-			</bounds>
+			<bounds x="769" y="419" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="485" y="619" width="72" height="27">
-			</bounds>
+			<bounds x="485" y="619" width="72" height="27"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="487" y="621" width="68" height="23">
-			</bounds>
+			<bounds x="487" y="621" width="68" height="23"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="691" y="491" width="52" height="27">
-			</bounds>
+			<bounds x="691" y="491" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="693" y="493" width="48" height="23">
-			</bounds>
+			<bounds x="693" y="493" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="691" y="464" width="52" height="27">
-			</bounds>
+			<bounds x="691" y="464" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="693" y="466" width="48" height="23">
-			</bounds>
+			<bounds x="693" y="466" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="691" y="521" width="52" height="27">
-			</bounds>
+			<bounds x="691" y="521" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="693" y="523" width="48" height="23">
-			</bounds>
+			<bounds x="693" y="523" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="691" y="548" width="52" height="27">
-			</bounds>
+			<bounds x="691" y="548" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="693" y="550" width="48" height="23">
-			</bounds>
+			<bounds x="693" y="550" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="691" y="575" width="52" height="27">
-			</bounds>
+			<bounds x="691" y="575" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="693" y="577" width="48" height="23">
-			</bounds>
+			<bounds x="693" y="577" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="691" y="602" width="52" height="27">
-			</bounds>
+			<bounds x="691" y="602" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="693" y="604" width="48" height="23">
-			</bounds>
+			<bounds x="693" y="604" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="596" y="629" width="92" height="19">
-			</bounds>
+			<bounds x="596" y="629" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="598" y="631" width="88" height="15">
-			</bounds>
+			<bounds x="598" y="631" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="458" y="513" width="46" height="22">
-			</bounds>
+			<bounds x="458" y="513" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="460" y="515" width="42" height="18">
-			</bounds>
+			<bounds x="460" y="515" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="458" y="535" width="46" height="22">
-			</bounds>
+			<bounds x="458" y="535" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="460" y="537" width="42" height="18">
-			</bounds>
+			<bounds x="460" y="537" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="158" y="180" width="82" height="41">
-			</bounds>
+			<bounds x="158" y="180" width="82" height="41"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="160" y="182" width="78" height="37">
-			</bounds>
+			<bounds x="160" y="182" width="78" height="37"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="289" y="302" width="47" height="42">
-			</bounds>
+			<bounds x="289" y="302" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="291" y="304" width="43" height="38">
-			</bounds>
+			<bounds x="291" y="304" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="288" y="219" width="47" height="42">
-			</bounds>
+			<bounds x="288" y="219" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="290" y="221" width="43" height="38">
-			</bounds>
+			<bounds x="290" y="221" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="338" y="259" width="47" height="42">
-			</bounds>
+			<bounds x="338" y="259" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="340" y="261" width="43" height="38">
-			</bounds>
+			<bounds x="340" y="261" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="240" y="260" width="47" height="42">
-			</bounds>
+			<bounds x="240" y="260" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="242" y="262" width="43" height="38">
-			</bounds>
+			<bounds x="242" y="262" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="colour_button_269_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="606" y="385" width="75" height="27">
-			</bounds>
+			<bounds x="606" y="385" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp166" element="colour_button_269" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="608" y="387" width="71" height="23">
-			</bounds>
+			<bounds x="608" y="387" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_270_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="774" y="655" width="75" height="27">
-			</bounds>
+			<bounds x="774" y="655" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_270" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="776" y="657" width="71" height="23">
-			</bounds>
+			<bounds x="776" y="657" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_271_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="637" y="655" width="81" height="27">
-			</bounds>
+			<bounds x="637" y="655" width="81" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_271" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="639" y="657" width="77" height="23">
-			</bounds>
+			<bounds x="639" y="657" width="77" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_272_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="489" y="655" width="75" height="27">
-			</bounds>
+			<bounds x="489" y="655" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_272" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="491" y="657" width="71" height="23">
-			</bounds>
+			<bounds x="491" y="657" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_273_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="359" y="655" width="75" height="27">
-			</bounds>
+			<bounds x="359" y="655" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_273" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="361" y="657" width="71" height="23">
-			</bounds>
+			<bounds x="361" y="657" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_274_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="274" y="655" width="75" height="27">
-			</bounds>
+			<bounds x="274" y="655" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_274" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="276" y="657" width="71" height="23">
-			</bounds>
+			<bounds x="276" y="657" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_275_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="177" y="655" width="75" height="27">
-			</bounds>
+			<bounds x="177" y="655" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_275" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="179" y="657" width="71" height="23">
-			</bounds>
+			<bounds x="179" y="657" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_276_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="14" y="655" width="75" height="27">
-			</bounds>
+			<bounds x="14" y="655" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_276" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="16" y="657" width="71" height="23">
-			</bounds>
+			<bounds x="16" y="657" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_277_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="727" y="24" width="75" height="27">
-			</bounds>
+			<bounds x="727" y="24" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_277" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="729" y="26" width="71" height="23">
-			</bounds>
+			<bounds x="729" y="26" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="730" y="109" width="24" height="32">
-			</bounds>
+			<bounds x="730" y="109" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off216" element="led_off">
-			<bounds x="733" y="111" width="17" height="2">
-			</bounds>
+			<bounds x="733" y="111" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off217" element="led_off">
-			<bounds x="747" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="747" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off218" element="led_off">
-			<bounds x="747" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="747" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off219" element="led_off">
-			<bounds x="733" y="135" width="17" height="2">
-			</bounds>
+			<bounds x="733" y="135" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off220" element="led_off">
-			<bounds x="733" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="733" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off221" element="led_off">
-			<bounds x="733" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="733" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off222" element="led_off">
-			<bounds x="733" y="123" width="17" height="2">
-			</bounds>
+			<bounds x="733" y="123" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off223" element="led_dot_off">
-			<bounds x="750" y="135" width="3" height="2">
-			</bounds>
+			<bounds x="750" y="135" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp216" element="led_on">
-			<bounds x="733" y="111" width="17" height="2">
-			</bounds>
+			<bounds x="733" y="111" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp217" element="led_on">
-			<bounds x="747" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="747" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp218" element="led_on">
-			<bounds x="747" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="747" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp219" element="led_on">
-			<bounds x="733" y="135" width="17" height="2">
-			</bounds>
+			<bounds x="733" y="135" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp220" element="led_on">
-			<bounds x="733" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="733" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp221" element="led_on">
-			<bounds x="733" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="733" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp222" element="led_on">
-			<bounds x="733" y="123" width="17" height="2">
-			</bounds>
+			<bounds x="733" y="123" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp223" element="led_dot_on">
-			<bounds x="750" y="135" width="3" height="2">
-			</bounds>
+			<bounds x="750" y="135" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="754" y="109" width="24" height="32">
-			</bounds>
+			<bounds x="754" y="109" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off224" element="led_off">
-			<bounds x="757" y="111" width="17" height="2">
-			</bounds>
+			<bounds x="757" y="111" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="771" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="771" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="771" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="771" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="757" y="135" width="17" height="2">
-			</bounds>
+			<bounds x="757" y="135" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="757" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="757" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="757" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="757" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="757" y="123" width="17" height="2">
-			</bounds>
+			<bounds x="757" y="123" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_dot_off">
-			<bounds x="774" y="135" width="3" height="2">
-			</bounds>
+			<bounds x="774" y="135" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp224" element="led_on">
-			<bounds x="757" y="111" width="17" height="2">
-			</bounds>
+			<bounds x="757" y="111" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="771" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="771" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="771" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="771" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="757" y="135" width="17" height="2">
-			</bounds>
+			<bounds x="757" y="135" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="757" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="757" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="757" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="757" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="757" y="123" width="17" height="2">
-			</bounds>
+			<bounds x="757" y="123" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_dot_on">
-			<bounds x="774" y="135" width="3" height="2">
-			</bounds>
+			<bounds x="774" y="135" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="778" y="109" width="24" height="32">
-			</bounds>
+			<bounds x="778" y="109" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off232" element="led_off">
-			<bounds x="781" y="111" width="17" height="2">
-			</bounds>
+			<bounds x="781" y="111" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off233" element="led_off">
-			<bounds x="795" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="795" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off234" element="led_off">
-			<bounds x="795" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="795" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off235" element="led_off">
-			<bounds x="781" y="135" width="17" height="2">
-			</bounds>
+			<bounds x="781" y="135" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off236" element="led_off">
-			<bounds x="781" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="781" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off237" element="led_off">
-			<bounds x="781" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="781" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off238" element="led_off">
-			<bounds x="781" y="123" width="17" height="2">
-			</bounds>
+			<bounds x="781" y="123" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off239" element="led_dot_off">
-			<bounds x="798" y="135" width="3" height="2">
-			</bounds>
+			<bounds x="798" y="135" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp232" element="led_on">
-			<bounds x="781" y="111" width="17" height="2">
-			</bounds>
+			<bounds x="781" y="111" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp233" element="led_on">
-			<bounds x="795" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="795" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp234" element="led_on">
-			<bounds x="795" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="795" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp235" element="led_on">
-			<bounds x="781" y="135" width="17" height="2">
-			</bounds>
+			<bounds x="781" y="135" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp236" element="led_on">
-			<bounds x="781" y="123" width="3" height="14">
-			</bounds>
+			<bounds x="781" y="123" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp237" element="led_on">
-			<bounds x="781" y="111" width="3" height="14">
-			</bounds>
+			<bounds x="781" y="111" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp238" element="led_on">
-			<bounds x="781" y="123" width="17" height="2">
-			</bounds>
+			<bounds x="781" y="123" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp239" element="led_dot_on">
-			<bounds x="798" y="135" width="3" height="2">
-			</bounds>
+			<bounds x="798" y="135" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="492" y="431" width="24" height="32">
-			</bounds>
+			<bounds x="492" y="431" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="495" y="433" width="17" height="2">
-			</bounds>
+			<bounds x="495" y="433" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="509" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="509" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="509" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="509" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="495" y="457" width="17" height="2">
-			</bounds>
+			<bounds x="495" y="457" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="495" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="495" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="495" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="495" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="495" y="445" width="17" height="2">
-			</bounds>
+			<bounds x="495" y="445" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="512" y="457" width="3" height="2">
-			</bounds>
+			<bounds x="512" y="457" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="495" y="433" width="17" height="2">
-			</bounds>
+			<bounds x="495" y="433" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="509" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="509" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="509" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="509" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="495" y="457" width="17" height="2">
-			</bounds>
+			<bounds x="495" y="457" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="495" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="495" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="495" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="495" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="495" y="445" width="17" height="2">
-			</bounds>
+			<bounds x="495" y="445" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="512" y="457" width="3" height="2">
-			</bounds>
+			<bounds x="512" y="457" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="516" y="431" width="24" height="32">
-			</bounds>
+			<bounds x="516" y="431" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="519" y="433" width="17" height="2">
-			</bounds>
+			<bounds x="519" y="433" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="533" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="533" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="533" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="533" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="519" y="457" width="17" height="2">
-			</bounds>
+			<bounds x="519" y="457" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="519" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="519" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="519" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="519" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="519" y="445" width="17" height="2">
-			</bounds>
+			<bounds x="519" y="445" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="536" y="457" width="3" height="2">
-			</bounds>
+			<bounds x="536" y="457" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="519" y="433" width="17" height="2">
-			</bounds>
+			<bounds x="519" y="433" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="533" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="533" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="533" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="533" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="519" y="457" width="17" height="2">
-			</bounds>
+			<bounds x="519" y="457" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="519" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="519" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="519" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="519" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="519" y="445" width="17" height="2">
-			</bounds>
+			<bounds x="519" y="445" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="536" y="457" width="3" height="2">
-			</bounds>
+			<bounds x="536" y="457" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="540" y="431" width="24" height="32">
-			</bounds>
+			<bounds x="540" y="431" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off96" element="led_off">
-			<bounds x="543" y="433" width="17" height="2">
-			</bounds>
+			<bounds x="543" y="433" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off97" element="led_off">
-			<bounds x="557" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="557" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off98" element="led_off">
-			<bounds x="557" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="557" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off99" element="led_off">
-			<bounds x="543" y="457" width="17" height="2">
-			</bounds>
+			<bounds x="543" y="457" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off100" element="led_off">
-			<bounds x="543" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="543" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off101" element="led_off">
-			<bounds x="543" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="543" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off102" element="led_off">
-			<bounds x="543" y="445" width="17" height="2">
-			</bounds>
+			<bounds x="543" y="445" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off103" element="led_dot_off">
-			<bounds x="560" y="457" width="3" height="2">
-			</bounds>
+			<bounds x="560" y="457" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp96" element="led_on">
-			<bounds x="543" y="433" width="17" height="2">
-			</bounds>
+			<bounds x="543" y="433" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp97" element="led_on">
-			<bounds x="557" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="557" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp98" element="led_on">
-			<bounds x="557" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="557" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp99" element="led_on">
-			<bounds x="543" y="457" width="17" height="2">
-			</bounds>
+			<bounds x="543" y="457" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp100" element="led_on">
-			<bounds x="543" y="445" width="3" height="14">
-			</bounds>
+			<bounds x="543" y="445" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp101" element="led_on">
-			<bounds x="543" y="433" width="3" height="14">
-			</bounds>
+			<bounds x="543" y="433" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp102" element="led_on">
-			<bounds x="543" y="445" width="17" height="2">
-			</bounds>
+			<bounds x="543" y="445" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp103" element="led_dot_on">
-			<bounds x="560" y="457" width="3" height="2">
-			</bounds>
+			<bounds x="560" y="457" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="409" y="176" width="24" height="32">
-			</bounds>
+			<bounds x="409" y="176" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off112" element="led_off">
-			<bounds x="412" y="178" width="17" height="2">
-			</bounds>
+			<bounds x="412" y="178" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off113" element="led_off">
-			<bounds x="426" y="178" width="3" height="14">
-			</bounds>
+			<bounds x="426" y="178" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off114" element="led_off">
-			<bounds x="426" y="190" width="3" height="14">
-			</bounds>
+			<bounds x="426" y="190" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off115" element="led_off">
-			<bounds x="412" y="202" width="17" height="2">
-			</bounds>
+			<bounds x="412" y="202" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off116" element="led_off">
-			<bounds x="412" y="190" width="3" height="14">
-			</bounds>
+			<bounds x="412" y="190" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off117" element="led_off">
-			<bounds x="412" y="178" width="3" height="14">
-			</bounds>
+			<bounds x="412" y="178" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off118" element="led_off">
-			<bounds x="412" y="190" width="17" height="2">
-			</bounds>
+			<bounds x="412" y="190" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off119" element="led_dot_off">
-			<bounds x="429" y="202" width="3" height="2">
-			</bounds>
+			<bounds x="429" y="202" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp112" element="led_on">
-			<bounds x="412" y="178" width="17" height="2">
-			</bounds>
+			<bounds x="412" y="178" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp113" element="led_on">
-			<bounds x="426" y="178" width="3" height="14">
-			</bounds>
+			<bounds x="426" y="178" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp114" element="led_on">
-			<bounds x="426" y="190" width="3" height="14">
-			</bounds>
+			<bounds x="426" y="190" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp115" element="led_on">
-			<bounds x="412" y="202" width="17" height="2">
-			</bounds>
+			<bounds x="412" y="202" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp116" element="led_on">
-			<bounds x="412" y="190" width="3" height="14">
-			</bounds>
+			<bounds x="412" y="190" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp117" element="led_on">
-			<bounds x="412" y="178" width="3" height="14">
-			</bounds>
+			<bounds x="412" y="178" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp118" element="led_on">
-			<bounds x="412" y="190" width="17" height="2">
-			</bounds>
+			<bounds x="412" y="190" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp119" element="led_dot_on">
-			<bounds x="429" y="202" width="3" height="2">
-			</bounds>
+			<bounds x="429" y="202" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="385" y="176" width="24" height="32">
-			</bounds>
+			<bounds x="385" y="176" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="388" y="178" width="17" height="2">
-			</bounds>
+			<bounds x="388" y="178" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="402" y="178" width="3" height="14">
-			</bounds>
+			<bounds x="402" y="178" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="402" y="190" width="3" height="14">
-			</bounds>
+			<bounds x="402" y="190" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="388" y="202" width="17" height="2">
-			</bounds>
+			<bounds x="388" y="202" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="388" y="190" width="3" height="14">
-			</bounds>
+			<bounds x="388" y="190" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="388" y="178" width="3" height="14">
-			</bounds>
+			<bounds x="388" y="178" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="388" y="190" width="17" height="2">
-			</bounds>
+			<bounds x="388" y="190" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="405" y="202" width="3" height="2">
-			</bounds>
+			<bounds x="405" y="202" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="388" y="178" width="17" height="2">
-			</bounds>
+			<bounds x="388" y="178" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="402" y="178" width="3" height="14">
-			</bounds>
+			<bounds x="402" y="178" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="402" y="190" width="3" height="14">
-			</bounds>
+			<bounds x="402" y="190" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="388" y="202" width="17" height="2">
-			</bounds>
+			<bounds x="388" y="202" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="388" y="190" width="3" height="14">
-			</bounds>
+			<bounds x="388" y="190" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="388" y="178" width="3" height="14">
-			</bounds>
+			<bounds x="388" y="178" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="388" y="190" width="17" height="2">
-			</bounds>
+			<bounds x="388" y="190" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="405" y="202" width="3" height="2">
-			</bounds>
+			<bounds x="405" y="202" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="175" y="353" width="272" height="30">
-			</bounds>
+			<bounds x="175" y="353" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="175" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="175" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="192" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="192" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="209" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="209" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="226" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="226" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="243" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="243" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="260" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="260" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="277" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="277" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="294" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="294" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="311" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="311" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="328" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="328" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="345" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="345" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="362" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="362" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="379" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="379" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="396" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="396" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="413" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="413" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="430" y="353" width="17" height="30">
-			</bounds>
+			<bounds x="430" y="353" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label166" element="label_166">
-			<bounds x="163" y="641" width="222" height="13">
-			</bounds>
+			<bounds x="163" y="641" width="222" height="13"/>
 		</backdrop>
 		<backdrop name="label201" element="label_201">
-			<bounds x="688" y="4" width="118" height="14">
-			</bounds>
+			<bounds x="688" y="4" width="118" height="14"/>
 		</backdrop>
 		<backdrop name="label216" element="label_216">
-			<bounds x="605" y="445" width="183" height="13">
-			</bounds>
+			<bounds x="605" y="445" width="183" height="13"/>
 		</backdrop>
 		<backdrop name="label256" element="label_256">
-			<bounds x="381" y="210" width="45" height="32">
-			</bounds>
+			<bounds x="381" y="210" width="45" height="32"/>
 		</backdrop>
 		<backdrop name="label260" element="label_260">
-			<bounds x="506" y="466" width="30" height="16">
-			</bounds>
+			<bounds x="506" y="466" width="30" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_button" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1retpp.lay
+++ b/src/mame/layout/m1retpp.lay
@@ -6,12554 +6,7365 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png">
-		</image>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
+			<color red="0.48" green="0.45" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
+			<color red="0.96" green="0.91" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
+			<color red="0.24" green="0.23" blue="0.01"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.50">
-			</color>
+			<color red="0.50" green="0.13" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.12">
-			</color>
+			<color red="0.12" green="0.03" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="1.00">
-			</color>
+			<color red="1.00" green="0.25" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.25">
-			</color>
+			<color red="0.25" green="0.06" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.50">
-			</color>
+			<color red="0.50" green="0.23" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.12">
-			</color>
+			<color red="0.12" green="0.05" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="1.00">
-			</color>
+			<color red="1.00" green="0.46" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.25">
-			</color>
+			<color red="0.25" green="0.11" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Pink">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Sprint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pink">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Sprint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.50">
-			</color>
+			<color red="0.50" green="0.29" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.12">
-			</color>
+			<color red="0.12" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="1.00">
-			</color>
+			<color red="1.00" green="0.58" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.25">
-			</color>
+			<color red="0.25" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.50">
-			</color>
+			<color red="0.50" green="0.27" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.12">
-			</color>
+			<color red="0.12" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.54" blue="1.00">
-			</color>
+			<color red="1.00" green="0.54" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.54" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.50">
-			</color>
+			<color red="0.50" green="0.02" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.04" blue="1.00">
-			</color>
+			<color red="1.00" green="0.04" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.25">
-			</color>
+			<color red="0.25" green="0.01" blue="0.25"/>
 		</rect>
 		<text string="In The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pink">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.04" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.25">
-			</color>
-		</rect>
-		<text string="In The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Pink">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.50">
-			</color>
+			<color red="0.50" green="0.04" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.12">
-			</color>
+			<color red="0.12" green="0.01" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="1.00">
-			</color>
+			<color red="1.00" green="0.08" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.25">
-			</color>
+			<color red="0.25" green="0.02" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.50">
-			</color>
+			<color red="0.50" green="0.06" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.12">
-			</color>
+			<color red="0.12" green="0.02" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="1.00">
-			</color>
+			<color red="1.00" green="0.13" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.25">
-			</color>
+			<color red="0.25" green="0.03" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.50">
-			</color>
+			<color red="0.50" green="0.08" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.12">
-			</color>
+			<color red="0.12" green="0.02" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="1.00">
-			</color>
+			<color red="1.00" green="0.17" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.25">
-			</color>
+			<color red="0.25" green="0.04" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.50">
-			</color>
+			<color red="0.50" green="0.10" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.12">
-			</color>
+			<color red="0.12" green="0.02" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.21" blue="1.00">
-			</color>
+			<color red="1.00" green="0.21" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.25">
-			</color>
+			<color red="0.25" green="0.05" blue="0.25"/>
 		</rect>
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.21" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.25">
-			</color>
-		</rect>
-		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.50">
-			</color>
+			<color red="0.50" green="0.16" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.12">
-			</color>
+			<color red="0.12" green="0.04" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="1.00">
-			</color>
+			<color red="1.00" green="0.33" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.25">
-			</color>
+			<color red="0.25" green="0.08" blue="0.25"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.50">
-			</color>
+			<color red="0.50" green="0.15" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.12">
-			</color>
+			<color red="0.12" green="0.04" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="1.00">
-			</color>
+			<color red="1.00" green="0.29" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.25">
-			</color>
+			<color red="0.25" green="0.07" blue="0.25"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.29" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
+			<color red="0.50" green="0.33" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
+			<color red="0.12" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.67" blue="1.00">
-			</color>
+			<color red="1.00" green="0.67" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
+			<color red="0.25" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.67" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.50">
-			</color>
+			<color red="0.50" green="0.31" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.12">
-			</color>
+			<color red="0.12" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.62" blue="1.00">
-			</color>
+			<color red="1.00" green="0.62" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.25">
-			</color>
+			<color red="0.25" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.62" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.50">
-			</color>
+			<color red="0.50" green="0.35" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.12">
-			</color>
+			<color red="0.12" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.71" blue="1.00">
-			</color>
+			<color red="1.00" green="0.71" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.25">
-			</color>
+			<color red="0.25" green="0.18" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.71" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.50">
-			</color>
+			<color red="0.50" green="0.37" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.12">
-			</color>
+			<color red="0.12" green="0.09" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="1.00">
-			</color>
+			<color red="1.00" green="0.75" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.25">
-			</color>
+			<color red="0.25" green="0.18" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.40" blue="0.50">
-			</color>
+			<color red="0.50" green="0.40" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.12">
-			</color>
+			<color red="0.12" green="0.10" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.79" blue="1.00">
-			</color>
+			<color red="1.00" green="0.79" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.25">
-			</color>
+			<color red="0.25" green="0.20" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.40" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.79" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
+			<color red="0.48" green="0.45" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
+			<color red="0.96" green="0.91" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
+			<color red="0.24" green="0.23" blue="0.01"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.50">
-			</color>
+			<color red="0.50" green="0.21" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.12">
-			</color>
+			<color red="0.12" green="0.05" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="1.00">
-			</color>
+			<color red="1.00" green="0.42" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.25">
-			</color>
+			<color red="0.25" green="0.10" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.19" blue="0.50">
-			</color>
+			<color red="0.50" green="0.19" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.12">
-			</color>
+			<color red="0.12" green="0.05" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.38" blue="1.00">
-			</color>
+			<color red="1.00" green="0.38" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.25">
-			</color>
+			<color red="0.25" green="0.09" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.19" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.38" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_255_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_255_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.13">
-			</color>
+			<color red="0.49" green="0.16" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.03">
-			</color>
+			<color red="0.12" green="0.04" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.33" blue="0.25">
-			</color>
+			<color red="0.99" green="0.33" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.06">
-			</color>
+			<color red="0.25" green="0.08" blue="0.06"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.16" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.33" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.06">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="BOMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="BOMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_32_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_216_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_216_2" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="BOMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="BOMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
+			<color red="0.48" green="0.45" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
+			<color red="0.96" green="0.91" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
+			<color red="0.24" green="0.23" blue="0.01"/>
 		</rect>
 		<text string="Free Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
-		</rect>
-		<text string="Free Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
+			<color red="0.49" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
+			<color red="0.99" green="0.79" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
+			<color red="0.25" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
+			<color red="0.48" green="0.45" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
+			<color red="0.96" green="0.91" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
+			<color red="0.24" green="0.23" blue="0.01"/>
 		</rect>
 		<text string="Arc De Triomphe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
-		</rect>
-		<text string="Arc De Triomphe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
+			<color red="0.49" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
+			<color red="0.99" green="0.79" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
+			<color red="0.25" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="Advance 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="Advance 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
+			<color red="0.48" green="0.45" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
+			<color red="0.96" green="0.91" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
+			<color red="0.24" green="0.23" blue="0.01"/>
 		</rect>
 		<text string="Go">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Back ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.45" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.91" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.23" blue="0.01">
-			</color>
-		</rect>
-		<text string="Go">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Back ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
+			<color red="0.49" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
+			<color red="0.99" green="0.79" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
+			<color red="0.25" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="Goto Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="Goto Jail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
+			<color red="0.49" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
+			<color red="0.99" green="0.79" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
+			<color red="0.25" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="Respin Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.79" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="Respin Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="PI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="PI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string=" P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.37" blue="0.03">
-			</color>
+			<color red="0.47" green="0.37" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.75" blue="0.05">
-			</color>
+			<color red="0.95" green="0.75" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.18" blue="0.01">
-			</color>
+			<color red="0.24" green="0.18" blue="0.01"/>
 		</rect>
 		<text string="Return of the">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.37" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.75" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.18" blue="0.01">
-			</color>
-		</rect>
-		<text string="Return of the">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.12" blue="0.01">
-			</color>
+			<color red="0.49" green="0.12" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.98" green="0.24" blue="0.02">
-			</color>
+			<color red="0.98" green="0.24" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.00">
-			</color>
+			<color red="0.24" green="0.06" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.12" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.98" green="0.24" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_52_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.12" blue="0.01">
-			</color>
+			<color red="0.49" green="0.12" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_2" defstate="0">
 		<rect state="1">
-			<color red="0.98" green="0.24" blue="0.02">
-			</color>
+			<color red="0.98" green="0.24" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.00">
-			</color>
+			<color red="0.24" green="0.06" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.12" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.98" green="0.24" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.15" blue="0.05">
-			</color>
+			<color red="0.49" green="0.15" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.01">
-			</color>
+			<color red="0.12" green="0.04" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.98" green="0.30" blue="0.10">
-			</color>
+			<color red="0.98" green="0.30" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.07" blue="0.02">
-			</color>
+			<color red="0.24" green="0.07" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.15" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.98" green="0.30" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.07" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.18" blue="0.09">
-			</color>
+			<color red="0.49" green="0.18" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.02">
-			</color>
+			<color red="0.12" green="0.04" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="0.98" green="0.36" blue="0.18">
-			</color>
+			<color red="0.98" green="0.36" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.09" blue="0.04">
-			</color>
+			<color red="0.24" green="0.09" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.18" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.98" green="0.36" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.09" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.21" blue="0.13">
-			</color>
+			<color red="0.49" green="0.21" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.03">
-			</color>
+			<color red="0.12" green="0.05" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.42" blue="0.26">
-			</color>
+			<color red="0.99" green="0.42" blue="0.26"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.06">
-			</color>
+			<color red="0.25" green="0.11" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.21" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.42" blue="0.26">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.24" blue="0.17">
-			</color>
+			<color red="0.49" green="0.24" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.04">
-			</color>
+			<color red="0.12" green="0.06" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.49" blue="0.35">
-			</color>
+			<color red="0.99" green="0.49" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.12" blue="0.09">
-			</color>
+			<color red="0.25" green="0.12" blue="0.09"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.24" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.49" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.12" blue="0.09">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.27" blue="0.21">
-			</color>
+			<color red="0.49" green="0.27" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
+			<color red="0.12" green="0.07" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.99" green="0.55" blue="0.43">
-			</color>
+			<color red="0.99" green="0.55" blue="0.43"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.11">
-			</color>
+			<color red="0.25" green="0.14" blue="0.11"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.27" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.99" green="0.55" blue="0.43">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.11">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.12" blue="0.01">
-			</color>
+			<color red="0.49" green="0.12" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_3" defstate="0">
 		<rect state="1">
-			<color red="0.98" green="0.24" blue="0.02">
-			</color>
+			<color red="0.98" green="0.24" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.00">
-			</color>
+			<color red="0.24" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.12" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.98" green="0.24" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.12" blue="0.01">
-			</color>
+			<color red="0.49" green="0.12" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_4" defstate="0">
 		<rect state="1">
-			<color red="0.98" green="0.24" blue="0.02">
-			</color>
+			<color red="0.98" green="0.24" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.00">
-			</color>
+			<color red="0.24" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="+ Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.12" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.98" green="0.24" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.17" blue="0.17">
-			</color>
+			<color red="0.50" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.35" blue="0.35">
-			</color>
+			<color red="1.00" green="0.35" blue="0.35"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.09">
-			</color>
+			<color red="0.25" green="0.09" blue="0.09"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.35" blue="0.35">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.09">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_60">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_61">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_110">
 		<text string="On Winline Start Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_148">
 		<text string="Many Thanks To Nick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_149">
 		<text string="V1.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_151">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
-			<bounds x="0" y="0" width="687" height="681">
-			</bounds>
+		<backdrop element="backdrop_colour">
+			<bounds x="0" y="0" width="687" height="681"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="134" y="413" width="80" height="120">
-			</bounds>
+			<bounds x="134" y="413" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="134.0000" y="413.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="134.0000" y="413.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="137.3333" y="414.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="137.3333" y="414.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="140.6667" y="416.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="140.6667" y="416.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="144.0000" y="418.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="144.0000" y="418.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="147.3333" y="419.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="147.3333" y="419.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="150.6667" y="421.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="150.6667" y="421.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="134.0000" y="453.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="134.0000" y="453.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="137.3333" y="454.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="137.3333" y="454.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="140.6667" y="456.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="140.6667" y="456.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="144.0000" y="458.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="144.0000" y="458.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="147.3333" y="459.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="147.3333" y="459.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="150.6667" y="461.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="150.6667" y="461.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="134.0000" y="493.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="134.0000" y="493.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="137.3333" y="494.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="137.3333" y="494.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="140.6667" y="496.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="140.6667" y="496.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="144.0000" y="498.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="144.0000" y="498.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="147.3333" y="499.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="147.3333" y="499.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="150.6667" y="501.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="150.6667" y="501.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="134" y="413" width="80" height="120">
-			</bounds>
+			<bounds x="134" y="413" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="234" y="413" width="80" height="120">
-			</bounds>
+			<bounds x="234" y="413" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="234.0000" y="413.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="234.0000" y="413.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="237.3333" y="414.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="237.3333" y="414.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="240.6667" y="416.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="240.6667" y="416.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="244.0000" y="418.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="244.0000" y="418.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="247.3333" y="419.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="247.3333" y="419.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="250.6667" y="421.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="250.6667" y="421.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="234.0000" y="453.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="234.0000" y="453.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="237.3333" y="454.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="237.3333" y="454.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="240.6667" y="456.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="240.6667" y="456.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="244.0000" y="458.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="244.0000" y="458.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="247.3333" y="459.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="247.3333" y="459.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="250.6667" y="461.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="250.6667" y="461.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="234.0000" y="493.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="234.0000" y="493.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="237.3333" y="494.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="237.3333" y="494.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="240.6667" y="496.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="240.6667" y="496.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="244.0000" y="498.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="244.0000" y="498.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="247.3333" y="499.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="247.3333" y="499.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="250.6667" y="501.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="250.6667" y="501.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="234" y="413" width="80" height="120">
-			</bounds>
+			<bounds x="234" y="413" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="345" y="413" width="100" height="120">
-			</bounds>
+			<bounds x="345" y="413" width="100" height="120"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="345.0000" y="413.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="345.0000" y="413.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="349.1667" y="414.6667" width="91.6667" height="36.6667">
-			</bounds>
+			<bounds x="349.1667" y="414.6667" width="91.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="353.3333" y="416.3333" width="83.3333" height="33.3333">
-			</bounds>
+			<bounds x="353.3333" y="416.3333" width="83.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="357.5000" y="418.0000" width="75.0000" height="30.0000">
-			</bounds>
+			<bounds x="357.5000" y="418.0000" width="75.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="361.6667" y="419.6667" width="66.6667" height="26.6667">
-			</bounds>
+			<bounds x="361.6667" y="419.6667" width="66.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="365.8333" y="421.3333" width="58.3333" height="23.3333">
-			</bounds>
+			<bounds x="365.8333" y="421.3333" width="58.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="345.0000" y="453.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="345.0000" y="453.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="349.1667" y="454.6667" width="91.6667" height="36.6667">
-			</bounds>
+			<bounds x="349.1667" y="454.6667" width="91.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="353.3333" y="456.3333" width="83.3333" height="33.3333">
-			</bounds>
+			<bounds x="353.3333" y="456.3333" width="83.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="357.5000" y="458.0000" width="75.0000" height="30.0000">
-			</bounds>
+			<bounds x="357.5000" y="458.0000" width="75.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="361.6667" y="459.6667" width="66.6667" height="26.6667">
-			</bounds>
+			<bounds x="361.6667" y="459.6667" width="66.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="365.8333" y="461.3333" width="58.3333" height="23.3333">
-			</bounds>
+			<bounds x="365.8333" y="461.3333" width="58.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="345.0000" y="493.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="345.0000" y="493.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="349.1667" y="494.6667" width="91.6667" height="36.6667">
-			</bounds>
+			<bounds x="349.1667" y="494.6667" width="91.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="353.3333" y="496.3333" width="83.3333" height="33.3333">
-			</bounds>
+			<bounds x="353.3333" y="496.3333" width="83.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="357.5000" y="498.0000" width="75.0000" height="30.0000">
-			</bounds>
+			<bounds x="357.5000" y="498.0000" width="75.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="361.6667" y="499.6667" width="66.6667" height="26.6667">
-			</bounds>
+			<bounds x="361.6667" y="499.6667" width="66.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="365.8333" y="501.3333" width="58.3333" height="23.3333">
-			</bounds>
+			<bounds x="365.8333" y="501.3333" width="58.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="345" y="413" width="100" height="120">
-			</bounds>
+			<bounds x="345" y="413" width="100" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="143" y="204" width="60" height="50">
-			</bounds>
+			<bounds x="143" y="204" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="143.0000" y="204.0000" width="60.0000" height="50.0000">
-			</bounds>
+			<bounds x="143.0000" y="204.0000" width="60.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="145.5000" y="206.0833" width="55.0000" height="45.8333">
-			</bounds>
+			<bounds x="145.5000" y="206.0833" width="55.0000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="148.0000" y="208.1667" width="50.0000" height="41.6667">
-			</bounds>
+			<bounds x="148.0000" y="208.1667" width="50.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="150.5000" y="210.2500" width="45.0000" height="37.5000">
-			</bounds>
+			<bounds x="150.5000" y="210.2500" width="45.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="153.0000" y="212.3333" width="40.0000" height="33.3333">
-			</bounds>
+			<bounds x="153.0000" y="212.3333" width="40.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="155.5000" y="214.4167" width="35.0000" height="29.1667">
-			</bounds>
+			<bounds x="155.5000" y="214.4167" width="35.0000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="143" y="204" width="60" height="50">
-			</bounds>
+			<bounds x="143" y="204" width="60" height="50"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="350" y="204" width="60" height="50">
-			</bounds>
+			<bounds x="350" y="204" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="350.0000" y="204.0000" width="60.0000" height="50.0000">
-			</bounds>
+			<bounds x="350.0000" y="204.0000" width="60.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="352.5000" y="206.0833" width="55.0000" height="45.8333">
-			</bounds>
+			<bounds x="352.5000" y="206.0833" width="55.0000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="355.0000" y="208.1667" width="50.0000" height="41.6667">
-			</bounds>
+			<bounds x="355.0000" y="208.1667" width="50.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="357.5000" y="210.2500" width="45.0000" height="37.5000">
-			</bounds>
+			<bounds x="357.5000" y="210.2500" width="45.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="360.0000" y="212.3333" width="40.0000" height="33.3333">
-			</bounds>
+			<bounds x="360.0000" y="212.3333" width="40.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="362.5000" y="214.4167" width="35.0000" height="29.1667">
-			</bounds>
+			<bounds x="362.5000" y="214.4167" width="35.0000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="350" y="204" width="60" height="50">
-			</bounds>
+			<bounds x="350" y="204" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="105" y="119" width="52" height="32">
-			</bounds>
+			<bounds x="105" y="119" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="107" y="121" width="48" height="28">
-			</bounds>
+			<bounds x="107" y="121" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="542" y="576" width="67" height="32">
-			</bounds>
+			<bounds x="542" y="576" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="544" y="578" width="63" height="28">
-			</bounds>
+			<bounds x="544" y="578" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="47" y="371" width="82" height="32">
-			</bounds>
+			<bounds x="47" y="371" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="49" y="373" width="78" height="28">
-			</bounds>
+			<bounds x="49" y="373" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="239" y="203" width="82" height="32">
-			</bounds>
+			<bounds x="239" y="203" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="241" y="205" width="78" height="28">
-			</bounds>
+			<bounds x="241" y="205" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="275" y="161" width="82" height="32">
-			</bounds>
+			<bounds x="275" y="161" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="277" y="163" width="78" height="28">
-			</bounds>
+			<bounds x="277" y="163" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="450" y="119" width="82" height="32">
-			</bounds>
+			<bounds x="450" y="119" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="452" y="121" width="78" height="28">
-			</bounds>
+			<bounds x="452" y="121" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="327" y="119" width="82" height="32">
-			</bounds>
+			<bounds x="327" y="119" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="329" y="121" width="78" height="28">
-			</bounds>
+			<bounds x="329" y="121" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="41" y="119" width="72" height="32">
-			</bounds>
+			<bounds x="41" y="119" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="43" y="121" width="68" height="28">
-			</bounds>
+			<bounds x="43" y="121" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="27" y="161" width="82" height="32">
-			</bounds>
+			<bounds x="27" y="161" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="29" y="163" width="78" height="28">
-			</bounds>
+			<bounds x="29" y="163" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="10" y="203" width="82" height="32">
-			</bounds>
+			<bounds x="10" y="203" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="12" y="205" width="78" height="28">
-			</bounds>
+			<bounds x="12" y="205" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="4" y="245" width="82" height="32">
-			</bounds>
+			<bounds x="4" y="245" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="6" y="247" width="78" height="28">
-			</bounds>
+			<bounds x="6" y="247" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="17" y="287" width="82" height="32">
-			</bounds>
+			<bounds x="17" y="287" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="19" y="289" width="78" height="28">
-			</bounds>
+			<bounds x="19" y="289" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="26" y="329" width="82" height="32">
-			</bounds>
+			<bounds x="26" y="329" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="28" y="331" width="78" height="28">
-			</bounds>
+			<bounds x="28" y="331" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="193" y="329" width="82" height="32">
-			</bounds>
+			<bounds x="193" y="329" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="195" y="331" width="78" height="28">
-			</bounds>
+			<bounds x="195" y="331" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="170" y="371" width="82" height="32">
-			</bounds>
+			<bounds x="170" y="371" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="172" y="373" width="78" height="28">
-			</bounds>
+			<bounds x="172" y="373" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="527" y="203" width="82" height="32">
-			</bounds>
+			<bounds x="527" y="203" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="529" y="205" width="78" height="28">
-			</bounds>
+			<bounds x="529" y="205" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="484" y="161" width="82" height="32">
-			</bounds>
+			<bounds x="484" y="161" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="486" y="163" width="78" height="28">
-			</bounds>
+			<bounds x="486" y="163" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="545" y="245" width="82" height="32">
-			</bounds>
+			<bounds x="545" y="245" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="547" y="247" width="78" height="28">
-			</bounds>
+			<bounds x="547" y="247" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="561" y="287" width="82" height="32">
-			</bounds>
+			<bounds x="561" y="287" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="563" y="289" width="78" height="28">
-			</bounds>
+			<bounds x="563" y="289" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="571" y="329" width="82" height="32">
-			</bounds>
+			<bounds x="571" y="329" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="573" y="331" width="78" height="28">
-			</bounds>
+			<bounds x="573" y="331" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="604" y="371" width="52" height="32">
-			</bounds>
+			<bounds x="604" y="371" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="606" y="373" width="48" height="28">
-			</bounds>
+			<bounds x="606" y="373" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="218" y="245" width="82" height="32">
-			</bounds>
+			<bounds x="218" y="245" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="220" y="247" width="78" height="28">
-			</bounds>
+			<bounds x="220" y="247" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="207" y="287" width="82" height="32">
-			</bounds>
+			<bounds x="207" y="287" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="209" y="289" width="78" height="28">
-			</bounds>
+			<bounds x="209" y="289" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="85" y="83" width="27" height="27">
-			</bounds>
+			<bounds x="85" y="83" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="87" y="85" width="23" height="23">
-			</bounds>
+			<bounds x="87" y="85" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="463" y="215" width="14" height="14">
-			</bounds>
+			<bounds x="463" y="215" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="465" y="217" width="10" height="10">
-			</bounds>
+			<bounds x="465" y="217" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="453" y="212" width="14" height="14">
-			</bounds>
+			<bounds x="453" y="212" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="455" y="214" width="10" height="10">
-			</bounds>
+			<bounds x="455" y="214" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="443" y="209" width="14" height="14">
-			</bounds>
+			<bounds x="443" y="209" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="445" y="211" width="10" height="10">
-			</bounds>
+			<bounds x="445" y="211" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="433" y="214" width="14" height="14">
-			</bounds>
+			<bounds x="433" y="214" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="435" y="216" width="10" height="10">
-			</bounds>
+			<bounds x="435" y="216" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="425" y="224" width="14" height="14">
-			</bounds>
+			<bounds x="425" y="224" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="427" y="226" width="10" height="10">
-			</bounds>
+			<bounds x="427" y="226" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="420" y="236" width="14" height="14">
-			</bounds>
+			<bounds x="420" y="236" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="422" y="238" width="10" height="10">
-			</bounds>
+			<bounds x="422" y="238" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1_border" state="0">
-			<bounds x="413" y="246" width="14" height="14">
-			</bounds>
+			<bounds x="413" y="246" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1" state="0">
-			<bounds x="415" y="248" width="10" height="10">
-			</bounds>
+			<bounds x="415" y="248" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="472" y="220" width="14" height="14">
-			</bounds>
+			<bounds x="472" y="220" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="474" y="222" width="10" height="10">
-			</bounds>
+			<bounds x="474" y="222" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="481" y="227" width="14" height="14">
-			</bounds>
+			<bounds x="481" y="227" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="483" y="229" width="10" height="10">
-			</bounds>
+			<bounds x="483" y="229" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="490" y="233" width="14" height="14">
-			</bounds>
+			<bounds x="490" y="233" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="492" y="235" width="10" height="10">
-			</bounds>
+			<bounds x="492" y="235" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="500" y="237" width="14" height="14">
-			</bounds>
+			<bounds x="500" y="237" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="502" y="239" width="10" height="10">
-			</bounds>
+			<bounds x="502" y="239" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="510" y="241" width="14" height="14">
-			</bounds>
+			<bounds x="510" y="241" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="512" y="243" width="10" height="10">
-			</bounds>
+			<bounds x="512" y="243" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="399" y="266" width="14" height="14">
-			</bounds>
+			<bounds x="399" y="266" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="401" y="268" width="10" height="10">
-			</bounds>
+			<bounds x="401" y="268" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="408" y="258" width="14" height="14">
-			</bounds>
+			<bounds x="408" y="258" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="410" y="260" width="10" height="10">
-			</bounds>
+			<bounds x="410" y="260" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="335" y="268" width="14" height="14">
-			</bounds>
+			<bounds x="335" y="268" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="337" y="270" width="10" height="10">
-			</bounds>
+			<bounds x="337" y="270" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="344" y="273" width="14" height="14">
-			</bounds>
+			<bounds x="344" y="273" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="346" y="275" width="10" height="10">
-			</bounds>
+			<bounds x="346" y="275" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="354" y="276" width="14" height="14">
-			</bounds>
+			<bounds x="354" y="276" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="356" y="278" width="10" height="10">
-			</bounds>
+			<bounds x="356" y="278" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="366" y="276" width="14" height="14">
-			</bounds>
+			<bounds x="366" y="276" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="368" y="278" width="10" height="10">
-			</bounds>
+			<bounds x="368" y="278" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="378" y="275" width="14" height="14">
-			</bounds>
+			<bounds x="378" y="275" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="380" y="277" width="10" height="10">
-			</bounds>
+			<bounds x="380" y="277" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="389" y="272" width="14" height="14">
-			</bounds>
+			<bounds x="389" y="272" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="391" y="274" width="10" height="10">
-			</bounds>
+			<bounds x="391" y="274" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="541" y="496" width="14" height="14">
-			</bounds>
+			<bounds x="541" y="496" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="543" y="498" width="10" height="10">
-			</bounds>
+			<bounds x="543" y="498" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="530" y="497" width="14" height="14">
-			</bounds>
+			<bounds x="530" y="497" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="532" y="499" width="10" height="10">
-			</bounds>
+			<bounds x="532" y="499" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="519" y="498" width="14" height="14">
-			</bounds>
+			<bounds x="519" y="498" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="521" y="500" width="10" height="10">
-			</bounds>
+			<bounds x="521" y="500" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="507" y="498" width="14" height="14">
-			</bounds>
+			<bounds x="507" y="498" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="509" y="500" width="10" height="10">
-			</bounds>
+			<bounds x="509" y="500" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="495" y="498" width="14" height="14">
-			</bounds>
+			<bounds x="495" y="498" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="497" y="500" width="10" height="10">
-			</bounds>
+			<bounds x="497" y="500" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="483" y="498" width="14" height="14">
-			</bounds>
+			<bounds x="483" y="498" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="485" y="500" width="10" height="10">
-			</bounds>
+			<bounds x="485" y="500" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="472" y="496" width="14" height="14">
-			</bounds>
+			<bounds x="472" y="496" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="474" y="498" width="10" height="10">
-			</bounds>
+			<bounds x="474" y="498" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="462" y="494" width="14" height="14">
-			</bounds>
+			<bounds x="462" y="494" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="464" y="496" width="10" height="10">
-			</bounds>
+			<bounds x="464" y="496" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="453" y="489" width="14" height="14">
-			</bounds>
+			<bounds x="453" y="489" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="455" y="491" width="10" height="10">
-			</bounds>
+			<bounds x="455" y="491" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="443" y="486" width="14" height="14">
-			</bounds>
+			<bounds x="443" y="486" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="445" y="488" width="10" height="10">
-			</bounds>
+			<bounds x="445" y="488" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="18" y="543" width="57" height="37">
-			</bounds>
+			<bounds x="18" y="543" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="20" y="545" width="53" height="33">
-			</bounds>
+			<bounds x="20" y="545" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="317" y="474" width="14" height="14">
-			</bounds>
+			<bounds x="317" y="474" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="319" y="476" width="10" height="10">
-			</bounds>
+			<bounds x="319" y="476" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="215" y="474" width="14" height="14">
-			</bounds>
+			<bounds x="215" y="474" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="217" y="476" width="10" height="10">
-			</bounds>
+			<bounds x="217" y="476" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="120" y="467" width="14" height="14">
-			</bounds>
+			<bounds x="120" y="467" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="122" y="469" width="10" height="10">
-			</bounds>
+			<bounds x="122" y="469" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="110" y="463" width="14" height="14">
-			</bounds>
+			<bounds x="110" y="463" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="112" y="465" width="10" height="10">
-			</bounds>
+			<bounds x="112" y="465" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="99" y="461" width="14" height="14">
-			</bounds>
+			<bounds x="99" y="461" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="101" y="463" width="10" height="10">
-			</bounds>
+			<bounds x="101" y="463" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="88" y="459" width="14" height="14">
-			</bounds>
+			<bounds x="88" y="459" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="90" y="461" width="10" height="10">
-			</bounds>
+			<bounds x="90" y="461" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="77" y="461" width="14" height="14">
-			</bounds>
+			<bounds x="77" y="461" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="79" y="463" width="10" height="10">
-			</bounds>
+			<bounds x="79" y="463" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="66" y="464" width="14" height="14">
-			</bounds>
+			<bounds x="66" y="464" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="68" y="466" width="10" height="10">
-			</bounds>
+			<bounds x="68" y="466" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="55" y="467" width="14" height="14">
-			</bounds>
+			<bounds x="55" y="467" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="57" y="469" width="10" height="10">
-			</bounds>
+			<bounds x="57" y="469" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="44" y="470" width="14" height="14">
-			</bounds>
+			<bounds x="44" y="470" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="46" y="472" width="10" height="10">
-			</bounds>
+			<bounds x="46" y="472" width="10" height="10"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="25" y="490" width="42" height="32">
-			</bounds>
+			<bounds x="25" y="490" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="27" y="492" width="38" height="28">
-			</bounds>
+			<bounds x="27" y="492" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_2_border" state="0">
-			<bounds x="41" y="482" width="10" height="12">
-			</bounds>
+			<bounds x="41" y="482" width="10" height="12"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_2" state="0">
-			<bounds x="43" y="484" width="6" height="8">
-			</bounds>
+			<bounds x="43" y="484" width="6" height="8"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="515" y="253" width="10" height="12">
-			</bounds>
+			<bounds x="515" y="253" width="10" height="12"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="517" y="255" width="6" height="8">
-			</bounds>
+			<bounds x="517" y="255" width="6" height="8"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_2_border" state="0">
-			<bounds x="499" y="261" width="42" height="32">
-			</bounds>
+			<bounds x="499" y="261" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_2" state="0">
-			<bounds x="501" y="263" width="38" height="28">
-			</bounds>
+			<bounds x="501" y="263" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="399" y="334" width="32" height="27">
-			</bounds>
+			<bounds x="399" y="334" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="401" y="336" width="28" height="23">
-			</bounds>
+			<bounds x="401" y="336" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="358" y="334" width="43" height="27">
-			</bounds>
+			<bounds x="358" y="334" width="43" height="27"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="360" y="336" width="39" height="23">
-			</bounds>
+			<bounds x="360" y="336" width="39" height="23"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="308" y="334" width="52" height="27">
-			</bounds>
+			<bounds x="308" y="334" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="310" y="336" width="48" height="23">
-			</bounds>
+			<bounds x="310" y="336" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="308" y="359" width="52" height="27">
-			</bounds>
+			<bounds x="308" y="359" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="310" y="361" width="48" height="23">
-			</bounds>
+			<bounds x="310" y="361" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="358" y="359" width="43" height="27">
-			</bounds>
+			<bounds x="358" y="359" width="43" height="27"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="360" y="361" width="39" height="23">
-			</bounds>
+			<bounds x="360" y="361" width="39" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="399" y="359" width="32" height="27">
-			</bounds>
+			<bounds x="399" y="359" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="401" y="361" width="28" height="23">
-			</bounds>
+			<bounds x="401" y="361" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="429" y="334" width="52" height="27">
-			</bounds>
+			<bounds x="429" y="334" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="431" y="336" width="48" height="23">
-			</bounds>
+			<bounds x="431" y="336" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="138" y="51" width="30" height="42">
-			</bounds>
+			<bounds x="138" y="51" width="30" height="42"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="140" y="53" width="26" height="38">
-			</bounds>
+			<bounds x="140" y="53" width="26" height="38"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="165" y="51" width="42" height="42">
-			</bounds>
+			<bounds x="165" y="51" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="167" y="53" width="38" height="38">
-			</bounds>
+			<bounds x="167" y="53" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="448" y="51" width="42" height="42">
-			</bounds>
+			<bounds x="448" y="51" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="450" y="53" width="38" height="38">
-			</bounds>
+			<bounds x="450" y="53" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="409" y="51" width="42" height="42">
-			</bounds>
+			<bounds x="409" y="51" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="411" y="53" width="38" height="38">
-			</bounds>
+			<bounds x="411" y="53" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="370" y="51" width="42" height="42">
-			</bounds>
+			<bounds x="370" y="51" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="372" y="53" width="38" height="38">
-			</bounds>
+			<bounds x="372" y="53" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="331" y="51" width="42" height="42">
-			</bounds>
+			<bounds x="331" y="51" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="333" y="53" width="38" height="38">
-			</bounds>
+			<bounds x="333" y="53" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="292" y="51" width="42" height="42">
-			</bounds>
+			<bounds x="292" y="51" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="294" y="53" width="38" height="38">
-			</bounds>
+			<bounds x="294" y="53" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="253" y="51" width="42" height="42">
-			</bounds>
+			<bounds x="253" y="51" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="255" y="53" width="38" height="38">
-			</bounds>
+			<bounds x="255" y="53" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="204" y="51" width="52" height="42">
-			</bounds>
+			<bounds x="204" y="51" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="206" y="53" width="48" height="38">
-			</bounds>
+			<bounds x="206" y="53" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="243" y="25" width="142" height="27">
-			</bounds>
+			<bounds x="243" y="25" width="142" height="27"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="245" y="27" width="138" height="23">
-			</bounds>
+			<bounds x="245" y="27" width="138" height="23"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="668" y="417" width="10" height="41">
-			</bounds>
+			<bounds x="668" y="417" width="10" height="41"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="670" y="419" width="6" height="37">
-			</bounds>
+			<bounds x="670" y="419" width="6" height="37"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_2_border" state="0">
-			<bounds x="606" y="417" width="10" height="41">
-			</bounds>
+			<bounds x="606" y="417" width="10" height="41"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_2" state="0">
-			<bounds x="608" y="419" width="6" height="37">
-			</bounds>
+			<bounds x="608" y="419" width="6" height="37"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="607" y="456" width="72" height="32">
-			</bounds>
+			<bounds x="607" y="456" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="609" y="458" width="68" height="28">
-			</bounds>
+			<bounds x="609" y="458" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="607" y="486" width="72" height="32">
-			</bounds>
+			<bounds x="607" y="486" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="609" y="488" width="68" height="28">
-			</bounds>
+			<bounds x="609" y="488" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="607" y="516" width="72" height="32">
-			</bounds>
+			<bounds x="607" y="516" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="609" y="518" width="68" height="28">
-			</bounds>
+			<bounds x="609" y="518" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="608" y="546" width="72" height="32">
-			</bounds>
+			<bounds x="608" y="546" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="610" y="548" width="68" height="28">
-			</bounds>
+			<bounds x="610" y="548" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="608" y="576" width="72" height="32">
-			</bounds>
+			<bounds x="608" y="576" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="610" y="578" width="68" height="28">
-			</bounds>
+			<bounds x="610" y="578" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_3_border" state="0">
-			<bounds x="612" y="417" width="60" height="22">
-			</bounds>
+			<bounds x="612" y="417" width="60" height="22"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_3" state="0">
-			<bounds x="614" y="419" width="56" height="18">
-			</bounds>
+			<bounds x="614" y="419" width="56" height="18"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_4_border" state="0">
-			<bounds x="612" y="436" width="60" height="22">
-			</bounds>
+			<bounds x="612" y="436" width="60" height="22"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_4" state="0">
-			<bounds x="614" y="438" width="56" height="18">
-			</bounds>
+			<bounds x="614" y="438" width="56" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="187" y="122" width="46" height="22">
-			</bounds>
+			<bounds x="187" y="122" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="189" y="124" width="42" height="18">
-			</bounds>
+			<bounds x="189" y="124" width="42" height="18"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="231" y="122" width="42" height="22">
-			</bounds>
+			<bounds x="231" y="122" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="233" y="124" width="38" height="18">
-			</bounds>
+			<bounds x="233" y="124" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_154_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="442" y="611" width="68" height="42">
-			</bounds>
+			<bounds x="442" y="611" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_154" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="444" y="613" width="64" height="38">
-			</bounds>
+			<bounds x="444" y="613" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_155_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="526" y="611" width="68" height="42">
-			</bounds>
+			<bounds x="526" y="611" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_155" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="528" y="613" width="64" height="38">
-			</bounds>
+			<bounds x="528" y="613" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_156_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="610" y="611" width="68" height="42">
-			</bounds>
+			<bounds x="610" y="611" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_156" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="612" y="613" width="64" height="38">
-			</bounds>
+			<bounds x="612" y="613" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_157_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="12" y="611" width="68" height="42">
-			</bounds>
+			<bounds x="12" y="611" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_157" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="14" y="613" width="64" height="38">
-			</bounds>
+			<bounds x="14" y="613" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_158_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="137" y="611" width="68" height="42">
-			</bounds>
+			<bounds x="137" y="611" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_158" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="139" y="613" width="64" height="38">
-			</bounds>
+			<bounds x="139" y="613" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_159_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="239" y="611" width="68" height="42">
-			</bounds>
+			<bounds x="239" y="611" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_159" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="241" y="613" width="64" height="38">
-			</bounds>
+			<bounds x="241" y="613" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_160_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="340" y="611" width="68" height="42">
-			</bounds>
+			<bounds x="340" y="611" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_160" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="342" y="613" width="64" height="38">
-			</bounds>
+			<bounds x="342" y="613" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp127" element="colour_button_162_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="532" y="32" width="47" height="62">
-			</bounds>
+			<bounds x="532" y="32" width="47" height="62"/>
 		</backdrop>
 		<backdrop name="lamp127" element="colour_button_162" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="534" y="34" width="43" height="58">
-			</bounds>
+			<bounds x="534" y="34" width="43" height="58"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_166_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="12" y="611" width="68" height="42">
-			</bounds>
+			<bounds x="12" y="611" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_166" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="14" y="613" width="64" height="38">
-			</bounds>
+			<bounds x="14" y="613" width="64" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="329" y="311" width="208" height="20">
-			</bounds>
+			<bounds x="329" y="311" width="208" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="329" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="329" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="342" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="342" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="355" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="355" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="368" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="368" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="381" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="381" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="394" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="394" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="407" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="407" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="420" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="420" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="433" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="433" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="446" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="446" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="459" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="459" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="472" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="472" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="485" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="485" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="498" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="498" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="511" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="511" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="524" y="311" width="13" height="20">
-			</bounds>
+			<bounds x="524" y="311" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="label60" element="label_60">
-			<bounds x="473" y="297" width="67" height="16">
-			</bounds>
+			<bounds x="473" y="297" width="67" height="16"/>
 		</backdrop>
 		<backdrop name="label61" element="label_61">
-			<bounds x="349" y="297" width="41" height="16">
-			</bounds>
+			<bounds x="349" y="297" width="41" height="16"/>
 		</backdrop>
 		<backdrop name="label110" element="label_110">
-			<bounds x="468" y="471" width="94" height="26">
-			</bounds>
+			<bounds x="468" y="471" width="94" height="26"/>
 		</backdrop>
 		<backdrop name="label148" element="label_148">
-			<bounds x="476" y="7" width="116" height="11">
-			</bounds>
+			<bounds x="476" y="7" width="116" height="11"/>
 		</backdrop>
 		<backdrop name="label149" element="label_149">
-			<bounds x="630" y="657" width="27" height="16">
-			</bounds>
+			<bounds x="630" y="657" width="27" height="16"/>
 		</backdrop>
 		<backdrop name="label151" element="label_151">
-			<bounds x="2" y="63" width="102" height="12">
-			</bounds>
+			<bounds x="2" y="63" width="102" height="12"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_reel" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_button" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp25" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1search.lay
+++ b/src/mame/layout/m1search.lay
@@ -8,8360 +8,5733 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3 + REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3 + REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="STOP ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="STOP ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HIGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="HIGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_56_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_56">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_57_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_57">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_58_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_58">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_59_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_59">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_60_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_60">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_61_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_61">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_62_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_62">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_63_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_63">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_64_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_64">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_65_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_65">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_66_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_66">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="HIGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_16">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_27">
 		<text string="GAMES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_51">
 		<text string="&#xA3;6 JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_53">
 		<text string="With Thanks to Rom Man for the Reelbands">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="521">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="521"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="184" y="311" width="80" height="140">
-			</bounds>
+			<bounds x="184" y="311" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="184" y="311" width="80" height="140">
-			</bounds>
+			<bounds x="184" y="311" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="266" y="311" width="80" height="140">
-			</bounds>
+			<bounds x="266" y="311" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="266" y="311" width="80" height="140">
-			</bounds>
+			<bounds x="266" y="311" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="348" y="311" width="80" height="140">
-			</bounds>
+			<bounds x="348" y="311" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="348" y="311" width="80" height="140">
-			</bounds>
+			<bounds x="348" y="311" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="268" y="129" width="80" height="40">
-			</bounds>
+			<bounds x="268" y="129" width="80" height="40"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="268" y="129" width="80" height="40">
-			</bounds>
+			<bounds x="268" y="129" width="80" height="40"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="470" y="107" width="102" height="32">
-			</bounds>
+			<bounds x="470" y="107" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="472" y="109" width="98" height="28">
-			</bounds>
+			<bounds x="472" y="109" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="470" y="167" width="102" height="32">
-			</bounds>
+			<bounds x="470" y="167" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="472" y="169" width="98" height="28">
-			</bounds>
+			<bounds x="472" y="169" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="470" y="137" width="102" height="32">
-			</bounds>
+			<bounds x="470" y="137" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="472" y="139" width="98" height="28">
-			</bounds>
+			<bounds x="472" y="139" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="470" y="47" width="102" height="32">
-			</bounds>
+			<bounds x="470" y="47" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="472" y="49" width="98" height="28">
-			</bounds>
+			<bounds x="472" y="49" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="470" y="17" width="102" height="32">
-			</bounds>
+			<bounds x="470" y="17" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="472" y="19" width="98" height="28">
-			</bounds>
+			<bounds x="472" y="19" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="470" y="77" width="102" height="32">
-			</bounds>
+			<bounds x="470" y="77" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="472" y="79" width="98" height="28">
-			</bounds>
+			<bounds x="472" y="79" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="575" y="47" width="42" height="32">
-			</bounds>
+			<bounds x="575" y="47" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="577" y="49" width="38" height="28">
-			</bounds>
+			<bounds x="577" y="49" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="575" y="77" width="42" height="32">
-			</bounds>
+			<bounds x="575" y="77" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="577" y="79" width="38" height="28">
-			</bounds>
+			<bounds x="577" y="79" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="575" y="167" width="42" height="32">
-			</bounds>
+			<bounds x="575" y="167" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="577" y="169" width="38" height="28">
-			</bounds>
+			<bounds x="577" y="169" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="575" y="137" width="42" height="32">
-			</bounds>
+			<bounds x="575" y="137" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="577" y="139" width="38" height="28">
-			</bounds>
+			<bounds x="577" y="139" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="575" y="107" width="42" height="32">
-			</bounds>
+			<bounds x="575" y="107" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="577" y="109" width="38" height="28">
-			</bounds>
+			<bounds x="577" y="109" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="575" y="17" width="42" height="32">
-			</bounds>
+			<bounds x="575" y="17" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="577" y="19" width="38" height="28">
-			</bounds>
+			<bounds x="577" y="19" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="668" y="185" width="52" height="32">
-			</bounds>
+			<bounds x="668" y="185" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="670" y="187" width="48" height="28">
-			</bounds>
+			<bounds x="670" y="187" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="484" y="351" width="42" height="42">
-			</bounds>
+			<bounds x="484" y="351" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="486" y="353" width="38" height="38">
-			</bounds>
+			<bounds x="486" y="353" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="484" y="399" width="42" height="42">
-			</bounds>
+			<bounds x="484" y="399" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="486" y="401" width="38" height="38">
-			</bounds>
+			<bounds x="486" y="401" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="484" y="303" width="42" height="42">
-			</bounds>
+			<bounds x="484" y="303" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="486" y="305" width="38" height="38">
-			</bounds>
+			<bounds x="486" y="305" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="134" y="344" width="47" height="27">
-			</bounds>
+			<bounds x="134" y="344" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="136" y="346" width="43" height="23">
-			</bounds>
+			<bounds x="136" y="346" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="134" y="395" width="47" height="27">
-			</bounds>
+			<bounds x="134" y="395" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="136" y="397" width="43" height="23">
-			</bounds>
+			<bounds x="136" y="397" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="178" y="273" width="62" height="32">
-			</bounds>
+			<bounds x="178" y="273" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="180" y="275" width="58" height="28">
-			</bounds>
+			<bounds x="180" y="275" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="367" y="273" width="62" height="32">
-			</bounds>
+			<bounds x="367" y="273" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="369" y="275" width="58" height="28">
-			</bounds>
+			<bounds x="369" y="275" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="304" y="273" width="62" height="32">
-			</bounds>
+			<bounds x="304" y="273" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="306" y="275" width="58" height="28">
-			</bounds>
+			<bounds x="306" y="275" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="241" y="273" width="62" height="32">
-			</bounds>
+			<bounds x="241" y="273" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="243" y="275" width="58" height="28">
-			</bounds>
+			<bounds x="243" y="275" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="286" y="106" width="42" height="22">
-			</bounds>
+			<bounds x="286" y="106" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="288" y="108" width="38" height="18">
-			</bounds>
+			<bounds x="288" y="108" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="286" y="172" width="42" height="22">
-			</bounds>
+			<bounds x="286" y="172" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="288" y="174" width="38" height="18">
-			</bounds>
+			<bounds x="288" y="174" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="279" y="82" width="57" height="22">
-			</bounds>
+			<bounds x="279" y="82" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="281" y="84" width="53" height="18">
-			</bounds>
+			<bounds x="281" y="84" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="339" y="31" width="22" height="22">
-			</bounds>
+			<bounds x="339" y="31" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="341" y="33" width="18" height="18">
-			</bounds>
+			<bounds x="341" y="33" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="279" y="31" width="57" height="22">
-			</bounds>
+			<bounds x="279" y="31" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="281" y="33" width="53" height="18">
-			</bounds>
+			<bounds x="281" y="33" width="53" height="18"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="255" y="31" width="22" height="22">
-			</bounds>
+			<bounds x="255" y="31" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="257" y="33" width="18" height="18">
-			</bounds>
+			<bounds x="257" y="33" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_56_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="746" y="5" width="34" height="27">
-			</bounds>
+			<bounds x="746" y="5" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_56" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="748" y="7" width="30" height="23">
-			</bounds>
+			<bounds x="748" y="7" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_57_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="746" y="34" width="34" height="27">
-			</bounds>
+			<bounds x="746" y="34" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_57" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="748" y="36" width="30" height="23">
-			</bounds>
+			<bounds x="748" y="36" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_58_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="746" y="63" width="34" height="27">
-			</bounds>
+			<bounds x="746" y="63" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_58" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="748" y="65" width="30" height="23">
-			</bounds>
+			<bounds x="748" y="65" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_59_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="584" y="453" width="75" height="37">
-			</bounds>
+			<bounds x="584" y="453" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_59" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="586" y="455" width="71" height="33">
-			</bounds>
+			<bounds x="586" y="455" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_60_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="73" y="453" width="75" height="37">
-			</bounds>
+			<bounds x="73" y="453" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_60" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="75" y="455" width="71" height="33">
-			</bounds>
+			<bounds x="75" y="455" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_61_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="349" y="453" width="75" height="37">
-			</bounds>
+			<bounds x="349" y="453" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_61" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="351" y="455" width="71" height="33">
-			</bounds>
+			<bounds x="351" y="455" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_62_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="268" y="453" width="75" height="37">
-			</bounds>
+			<bounds x="268" y="453" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_62" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="270" y="455" width="71" height="33">
-			</bounds>
+			<bounds x="270" y="455" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_63_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="187" y="453" width="75" height="37">
-			</bounds>
+			<bounds x="187" y="453" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_63" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="189" y="455" width="71" height="33">
-			</bounds>
+			<bounds x="189" y="455" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_64_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="469" y="453" width="75" height="37">
-			</bounds>
+			<bounds x="469" y="453" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_64" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="471" y="455" width="71" height="33">
-			</bounds>
+			<bounds x="471" y="455" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_65_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="319" y="222" width="75" height="37">
-			</bounds>
+			<bounds x="319" y="222" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_65" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="321" y="224" width="71" height="33">
-			</bounds>
+			<bounds x="321" y="224" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_66_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="214" y="222" width="75" height="37">
-			</bounds>
+			<bounds x="214" y="222" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_66" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="216" y="224" width="71" height="33">
-			</bounds>
+			<bounds x="216" y="224" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="710" y="336" width="24" height="32">
-			</bounds>
+			<bounds x="710" y="336" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="713" y="338" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="338" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="727" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="727" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="727" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="727" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="713" y="362" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="362" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="713" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="713" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="713" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="713" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="713" y="350" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="350" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="730" y="362" width="3" height="2">
-			</bounds>
+			<bounds x="730" y="362" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="713" y="338" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="338" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="727" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="727" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="727" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="727" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="713" y="362" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="362" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="713" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="713" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="713" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="713" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="713" y="350" width="17" height="2">
-			</bounds>
+			<bounds x="713" y="350" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="730" y="362" width="3" height="2">
-			</bounds>
+			<bounds x="730" y="362" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="686" y="336" width="24" height="32">
-			</bounds>
+			<bounds x="686" y="336" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="689" y="338" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="338" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="703" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="703" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="703" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="703" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="689" y="362" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="362" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="689" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="689" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="689" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="689" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="689" y="350" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="350" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="706" y="362" width="3" height="2">
-			</bounds>
+			<bounds x="706" y="362" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="689" y="338" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="338" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="703" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="703" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="703" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="703" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="689" y="362" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="362" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="689" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="689" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="689" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="689" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="689" y="350" width="17" height="2">
-			</bounds>
+			<bounds x="689" y="350" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="706" y="362" width="3" height="2">
-			</bounds>
+			<bounds x="706" y="362" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="662" y="336" width="24" height="32">
-			</bounds>
+			<bounds x="662" y="336" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="665" y="338" width="17" height="2">
-			</bounds>
+			<bounds x="665" y="338" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="679" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="679" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="679" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="679" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="665" y="362" width="17" height="2">
-			</bounds>
+			<bounds x="665" y="362" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="665" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="665" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="665" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="665" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="665" y="350" width="17" height="2">
-			</bounds>
+			<bounds x="665" y="350" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="682" y="362" width="3" height="2">
-			</bounds>
+			<bounds x="682" y="362" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="665" y="338" width="17" height="2">
-			</bounds>
+			<bounds x="665" y="338" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="679" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="679" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="679" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="679" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="665" y="362" width="17" height="2">
-			</bounds>
+			<bounds x="665" y="362" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="665" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="665" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="665" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="665" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="665" y="350" width="17" height="2">
-			</bounds>
+			<bounds x="665" y="350" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="682" y="362" width="3" height="2">
-			</bounds>
+			<bounds x="682" y="362" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="639" y="336" width="24" height="32">
-			</bounds>
+			<bounds x="639" y="336" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="642" y="338" width="17" height="2">
-			</bounds>
+			<bounds x="642" y="338" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="656" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="656" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="656" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="656" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="642" y="362" width="17" height="2">
-			</bounds>
+			<bounds x="642" y="362" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="642" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="642" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="642" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="642" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="642" y="350" width="17" height="2">
-			</bounds>
+			<bounds x="642" y="350" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off71" element="led_dot_off">
-			<bounds x="659" y="362" width="3" height="2">
-			</bounds>
+			<bounds x="659" y="362" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="642" y="338" width="17" height="2">
-			</bounds>
+			<bounds x="642" y="338" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="656" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="656" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="656" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="656" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="642" y="362" width="17" height="2">
-			</bounds>
+			<bounds x="642" y="362" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="642" y="350" width="3" height="14">
-			</bounds>
+			<bounds x="642" y="350" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="642" y="338" width="3" height="14">
-			</bounds>
+			<bounds x="642" y="338" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="642" y="350" width="17" height="2">
-			</bounds>
+			<bounds x="642" y="350" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp71" element="led_dot_on">
-			<bounds x="659" y="362" width="3" height="2">
-			</bounds>
+			<bounds x="659" y="362" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="687" y="396" width="24" height="32">
-			</bounds>
+			<bounds x="687" y="396" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="690" y="398" width="17" height="2">
-			</bounds>
+			<bounds x="690" y="398" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="704" y="398" width="3" height="14">
-			</bounds>
+			<bounds x="704" y="398" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="704" y="410" width="3" height="14">
-			</bounds>
+			<bounds x="704" y="410" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="690" y="422" width="17" height="2">
-			</bounds>
+			<bounds x="690" y="422" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="690" y="410" width="3" height="14">
-			</bounds>
+			<bounds x="690" y="410" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="690" y="398" width="3" height="14">
-			</bounds>
+			<bounds x="690" y="398" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="690" y="410" width="17" height="2">
-			</bounds>
+			<bounds x="690" y="410" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_dot_off">
-			<bounds x="707" y="422" width="3" height="2">
-			</bounds>
+			<bounds x="707" y="422" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="690" y="398" width="17" height="2">
-			</bounds>
+			<bounds x="690" y="398" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="704" y="398" width="3" height="14">
-			</bounds>
+			<bounds x="704" y="398" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="704" y="410" width="3" height="14">
-			</bounds>
+			<bounds x="704" y="410" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="690" y="422" width="17" height="2">
-			</bounds>
+			<bounds x="690" y="422" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="690" y="410" width="3" height="14">
-			</bounds>
+			<bounds x="690" y="410" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="690" y="398" width="3" height="14">
-			</bounds>
+			<bounds x="690" y="398" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="690" y="410" width="17" height="2">
-			</bounds>
+			<bounds x="690" y="410" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_dot_on">
-			<bounds x="707" y="422" width="3" height="2">
-			</bounds>
+			<bounds x="707" y="422" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="663" y="396" width="24" height="32">
-			</bounds>
+			<bounds x="663" y="396" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off48" element="led_off">
-			<bounds x="666" y="398" width="17" height="2">
-			</bounds>
+			<bounds x="666" y="398" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off49" element="led_off">
-			<bounds x="680" y="398" width="3" height="14">
-			</bounds>
+			<bounds x="680" y="398" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off50" element="led_off">
-			<bounds x="680" y="410" width="3" height="14">
-			</bounds>
+			<bounds x="680" y="410" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off51" element="led_off">
-			<bounds x="666" y="422" width="17" height="2">
-			</bounds>
+			<bounds x="666" y="422" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off52" element="led_off">
-			<bounds x="666" y="410" width="3" height="14">
-			</bounds>
+			<bounds x="666" y="410" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off53" element="led_off">
-			<bounds x="666" y="398" width="3" height="14">
-			</bounds>
+			<bounds x="666" y="398" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off54" element="led_off">
-			<bounds x="666" y="410" width="17" height="2">
-			</bounds>
+			<bounds x="666" y="410" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off55" element="led_dot_off">
-			<bounds x="683" y="422" width="3" height="2">
-			</bounds>
+			<bounds x="683" y="422" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp48" element="led_on">
-			<bounds x="666" y="398" width="17" height="2">
-			</bounds>
+			<bounds x="666" y="398" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp49" element="led_on">
-			<bounds x="680" y="398" width="3" height="14">
-			</bounds>
+			<bounds x="680" y="398" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp50" element="led_on">
-			<bounds x="680" y="410" width="3" height="14">
-			</bounds>
+			<bounds x="680" y="410" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp51" element="led_on">
-			<bounds x="666" y="422" width="17" height="2">
-			</bounds>
+			<bounds x="666" y="422" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp52" element="led_on">
-			<bounds x="666" y="410" width="3" height="14">
-			</bounds>
+			<bounds x="666" y="410" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp53" element="led_on">
-			<bounds x="666" y="398" width="3" height="14">
-			</bounds>
+			<bounds x="666" y="398" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp54" element="led_on">
-			<bounds x="666" y="410" width="17" height="2">
-			</bounds>
+			<bounds x="666" y="410" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp55" element="led_dot_on">
-			<bounds x="683" y="422" width="3" height="2">
-			</bounds>
+			<bounds x="683" y="422" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="621" y="222" width="48" height="64">
-			</bounds>
+			<bounds x="621" y="222" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off184" element="led_off">
-			<bounds x="627" y="227" width="34" height="5">
-			</bounds>
+			<bounds x="627" y="227" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off185" element="led_off">
-			<bounds x="655" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="655" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off186" element="led_off">
-			<bounds x="655" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="655" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off187" element="led_off">
-			<bounds x="627" y="274" width="34" height="5">
-			</bounds>
+			<bounds x="627" y="274" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off188" element="led_off">
-			<bounds x="627" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="627" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off189" element="led_off">
-			<bounds x="627" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="627" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off190" element="led_off">
-			<bounds x="627" y="251" width="34" height="5">
-			</bounds>
+			<bounds x="627" y="251" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off191" element="led_dot_off">
-			<bounds x="662" y="274" width="6" height="5">
-			</bounds>
+			<bounds x="662" y="274" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp184" element="led_on">
-			<bounds x="627" y="227" width="34" height="5">
-			</bounds>
+			<bounds x="627" y="227" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp185" element="led_on">
-			<bounds x="655" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="655" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp186" element="led_on">
-			<bounds x="655" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="655" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp187" element="led_on">
-			<bounds x="627" y="274" width="34" height="5">
-			</bounds>
+			<bounds x="627" y="274" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp188" element="led_on">
-			<bounds x="627" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="627" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp189" element="led_on">
-			<bounds x="627" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="627" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp190" element="led_on">
-			<bounds x="627" y="251" width="34" height="5">
-			</bounds>
+			<bounds x="627" y="251" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp191" element="led_dot_on">
-			<bounds x="662" y="274" width="6" height="5">
-			</bounds>
+			<bounds x="662" y="274" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="717" y="222" width="48" height="64">
-			</bounds>
+			<bounds x="717" y="222" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off200" element="led_off">
-			<bounds x="723" y="227" width="34" height="5">
-			</bounds>
+			<bounds x="723" y="227" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="751" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="751" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="751" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="751" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off203" element="led_off">
-			<bounds x="723" y="274" width="34" height="5">
-			</bounds>
+			<bounds x="723" y="274" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off204" element="led_off">
-			<bounds x="723" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="723" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off205" element="led_off">
-			<bounds x="723" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="723" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off206" element="led_off">
-			<bounds x="723" y="251" width="34" height="5">
-			</bounds>
+			<bounds x="723" y="251" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off207" element="led_dot_off">
-			<bounds x="758" y="274" width="6" height="5">
-			</bounds>
+			<bounds x="758" y="274" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp200" element="led_on">
-			<bounds x="723" y="227" width="34" height="5">
-			</bounds>
+			<bounds x="723" y="227" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="751" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="751" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="751" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="751" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp203" element="led_on">
-			<bounds x="723" y="274" width="34" height="5">
-			</bounds>
+			<bounds x="723" y="274" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp204" element="led_on">
-			<bounds x="723" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="723" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp205" element="led_on">
-			<bounds x="723" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="723" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp206" element="led_on">
-			<bounds x="723" y="251" width="34" height="5">
-			</bounds>
+			<bounds x="723" y="251" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp207" element="led_dot_on">
-			<bounds x="758" y="274" width="6" height="5">
-			</bounds>
+			<bounds x="758" y="274" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="669" y="222" width="48" height="64">
-			</bounds>
+			<bounds x="669" y="222" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off192" element="led_off">
-			<bounds x="675" y="227" width="34" height="5">
-			</bounds>
+			<bounds x="675" y="227" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off193" element="led_off">
-			<bounds x="703" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="703" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off194" element="led_off">
-			<bounds x="703" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="703" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off195" element="led_off">
-			<bounds x="675" y="274" width="34" height="5">
-			</bounds>
+			<bounds x="675" y="274" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off196" element="led_off">
-			<bounds x="675" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="675" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off197" element="led_off">
-			<bounds x="675" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="675" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off198" element="led_off">
-			<bounds x="675" y="251" width="34" height="5">
-			</bounds>
+			<bounds x="675" y="251" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off199" element="led_dot_off">
-			<bounds x="710" y="274" width="6" height="5">
-			</bounds>
+			<bounds x="710" y="274" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp192" element="led_on">
-			<bounds x="675" y="227" width="34" height="5">
-			</bounds>
+			<bounds x="675" y="227" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp193" element="led_on">
-			<bounds x="703" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="703" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp194" element="led_on">
-			<bounds x="703" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="703" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp195" element="led_on">
-			<bounds x="675" y="274" width="34" height="5">
-			</bounds>
+			<bounds x="675" y="274" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp196" element="led_on">
-			<bounds x="675" y="251" width="6" height="29">
-			</bounds>
+			<bounds x="675" y="251" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp197" element="led_on">
-			<bounds x="675" y="227" width="6" height="29">
-			</bounds>
+			<bounds x="675" y="227" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp198" element="led_on">
-			<bounds x="675" y="251" width="34" height="5">
-			</bounds>
+			<bounds x="675" y="251" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp199" element="led_dot_on">
-			<bounds x="710" y="274" width="6" height="5">
-			</bounds>
+			<bounds x="710" y="274" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="label16" element="label_16">
-			<bounds x="648" y="315" width="77" height="16">
-			</bounds>
+			<bounds x="648" y="315" width="77" height="16"/>
 		</backdrop>
 		<backdrop name="label27" element="label_27">
-			<bounds x="660" y="378" width="54" height="16">
-			</bounds>
+			<bounds x="660" y="378" width="54" height="16"/>
 		</backdrop>
 		<backdrop name="label51" element="label_51">
-			<bounds x="60" y="54" width="69" height="32">
-			</bounds>
+			<bounds x="60" y="54" width="69" height="32"/>
 		</backdrop>
 		<backdrop name="label53" element="label_53">
-			<bounds x="2" y="99" width="149" height="26">
-			</bounds>
+			<bounds x="2" y="99" width="149" height="26"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_button" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_button" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1sptlgtc.lay
+++ b/src/mame/layout/m1sptlgtc.lay
@@ -8,9366 +8,6294 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="l">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="l">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="h">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="h">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="g">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="g">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="repeat chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="repeat chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="choose a win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="choose a win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="no">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="no">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_217_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_217">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_255_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_255">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_256_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_256">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_257_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_257">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_258_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_258">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_259_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_259">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_260_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_260">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_261_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_261">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_262_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_262">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_146">
 		<text string="bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_147">
 		<text string="credits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_214">
 		<text string="THANKS TO DAVE, GEDDY AND BUGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="709" height="592">
-			</bounds>
+			<bounds x="0" y="0" width="709" height="592"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="166" y="362" width="80" height="140">
-			</bounds>
+			<bounds x="166" y="362" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="166.0000" y="362.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="166.0000" y="362.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="169.3333" y="363.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="169.3333" y="363.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="172.6667" y="365.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="172.6667" y="365.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="176.0000" y="367.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="176.0000" y="367.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="179.3333" y="369.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="179.3333" y="369.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="182.6667" y="371.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="182.6667" y="371.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="166.0000" y="408.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="166.0000" y="408.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="169.3333" y="410.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="169.3333" y="410.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="172.6667" y="412.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="172.6667" y="412.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="176.0000" y="414.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="176.0000" y="414.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="179.3333" y="416.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="179.3333" y="416.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="182.6667" y="418.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="182.6667" y="418.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="166.0000" y="455.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="166.0000" y="455.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="169.3333" y="457.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="169.3333" y="457.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="172.6667" y="459.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="172.6667" y="459.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="176.0000" y="461.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="176.0000" y="461.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="179.3333" y="463.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="179.3333" y="463.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="182.6667" y="465.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="182.6667" y="465.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="166" y="362" width="80" height="140">
-			</bounds>
+			<bounds x="166" y="362" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="250" y="362" width="80" height="140">
-			</bounds>
+			<bounds x="250" y="362" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="250.0000" y="362.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="250.0000" y="362.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="253.3333" y="363.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="253.3333" y="363.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="256.6667" y="365.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="256.6667" y="365.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="260.0000" y="367.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="260.0000" y="367.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="263.3333" y="369.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="263.3333" y="369.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="266.6667" y="371.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="266.6667" y="371.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="250.0000" y="408.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="250.0000" y="408.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="253.3333" y="410.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="253.3333" y="410.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="256.6667" y="412.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="256.6667" y="412.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="260.0000" y="414.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="260.0000" y="414.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="263.3333" y="416.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="263.3333" y="416.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="266.6667" y="418.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="266.6667" y="418.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="250.0000" y="455.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="250.0000" y="455.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="253.3333" y="457.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="253.3333" y="457.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="256.6667" y="459.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="256.6667" y="459.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="260.0000" y="461.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="260.0000" y="461.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="263.3333" y="463.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="263.3333" y="463.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="266.6667" y="465.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="266.6667" y="465.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="250" y="362" width="80" height="140">
-			</bounds>
+			<bounds x="250" y="362" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="334" y="362" width="80" height="140">
-			</bounds>
+			<bounds x="334" y="362" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="334.0000" y="362.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="334.0000" y="362.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="337.3333" y="363.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="337.3333" y="363.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.6667" y="365.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="340.6667" y="365.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="344.0000" y="367.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="344.0000" y="367.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="347.3333" y="369.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="347.3333" y="369.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="350.6667" y="371.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="350.6667" y="371.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="334.0000" y="408.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="334.0000" y="408.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="337.3333" y="410.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="337.3333" y="410.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.6667" y="412.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="340.6667" y="412.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="344.0000" y="414.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="344.0000" y="414.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="347.3333" y="416.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="347.3333" y="416.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="350.6667" y="418.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="350.6667" y="418.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="334.0000" y="455.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="334.0000" y="455.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="337.3333" y="457.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="337.3333" y="457.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.6667" y="459.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="340.6667" y="459.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="344.0000" y="461.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="344.0000" y="461.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="347.3333" y="463.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="347.3333" y="463.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="350.6667" y="465.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="350.6667" y="465.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="334" y="362" width="80" height="140">
-			</bounds>
+			<bounds x="334" y="362" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="53" y="180" width="80" height="80">
-			</bounds>
+			<bounds x="53" y="180" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="53.0000" y="180.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="53.0000" y="180.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="56.3333" y="183.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="56.3333" y="183.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="59.6667" y="186.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="59.6667" y="186.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="63.0000" y="190.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="63.0000" y="190.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="66.3333" y="193.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="66.3333" y="193.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="69.6667" y="196.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="69.6667" y="196.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="53" y="180" width="80" height="80">
-			</bounds>
+			<bounds x="53" y="180" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="64" y="401" width="36" height="24">
-			</bounds>
+			<bounds x="64" y="401" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="66" y="403" width="32" height="20">
-			</bounds>
+			<bounds x="66" y="403" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="64" y="427" width="36" height="24">
-			</bounds>
+			<bounds x="64" y="427" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="66" y="429" width="32" height="20">
-			</bounds>
+			<bounds x="66" y="429" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="64" y="453" width="36" height="24">
-			</bounds>
+			<bounds x="64" y="453" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="66" y="455" width="32" height="20">
-			</bounds>
+			<bounds x="66" y="455" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="327" y="14" width="28" height="34">
-			</bounds>
+			<bounds x="327" y="14" width="28" height="34"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="329" y="16" width="24" height="30">
-			</bounds>
+			<bounds x="329" y="16" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="299" y="14" width="28" height="34">
-			</bounds>
+			<bounds x="299" y="14" width="28" height="34"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="301" y="16" width="24" height="30">
-			</bounds>
+			<bounds x="301" y="16" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="271" y="14" width="28" height="34">
-			</bounds>
+			<bounds x="271" y="14" width="28" height="34"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="273" y="16" width="24" height="30">
-			</bounds>
+			<bounds x="273" y="16" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="179" y="14" width="36" height="34">
-			</bounds>
+			<bounds x="179" y="14" width="36" height="34"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="181" y="16" width="32" height="30">
-			</bounds>
+			<bounds x="181" y="16" width="32" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="215" y="14" width="28" height="34">
-			</bounds>
+			<bounds x="215" y="14" width="28" height="34"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="217" y="16" width="24" height="30">
-			</bounds>
+			<bounds x="217" y="16" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="243" y="14" width="28" height="34">
-			</bounds>
+			<bounds x="243" y="14" width="28" height="34"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="245" y="16" width="24" height="30">
-			</bounds>
+			<bounds x="245" y="16" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="411" y="14" width="28" height="34">
-			</bounds>
+			<bounds x="411" y="14" width="28" height="34"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="413" y="16" width="24" height="30">
-			</bounds>
+			<bounds x="413" y="16" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="383" y="14" width="28" height="34">
-			</bounds>
+			<bounds x="383" y="14" width="28" height="34"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="385" y="16" width="24" height="30">
-			</bounds>
+			<bounds x="385" y="16" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="355" y="14" width="28" height="34">
-			</bounds>
+			<bounds x="355" y="14" width="28" height="34"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="357" y="16" width="24" height="30">
-			</bounds>
+			<bounds x="357" y="16" width="24" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="587" y="115" width="68" height="24">
-			</bounds>
+			<bounds x="587" y="115" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="589" y="117" width="64" height="20">
-			</bounds>
+			<bounds x="589" y="117" width="64" height="20"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="596" y="41" width="46" height="26">
-			</bounds>
+			<bounds x="596" y="41" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="598" y="43" width="42" height="22">
-			</bounds>
+			<bounds x="598" y="43" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="307" y="106" width="46" height="36">
-			</bounds>
+			<bounds x="307" y="106" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="309" y="108" width="42" height="32">
-			</bounds>
+			<bounds x="309" y="108" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="61" y="514" width="40" height="26">
-			</bounds>
+			<bounds x="61" y="514" width="40" height="26"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="63" y="516" width="36" height="22">
-			</bounds>
+			<bounds x="63" y="516" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="54" y="489" width="50" height="26">
-			</bounds>
+			<bounds x="54" y="489" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="56" y="491" width="46" height="22">
-			</bounds>
+			<bounds x="56" y="491" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="354" y="178" width="46" height="36">
-			</bounds>
+			<bounds x="354" y="178" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="356" y="180" width="42" height="32">
-			</bounds>
+			<bounds x="356" y="180" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="354" y="142" width="46" height="36">
-			</bounds>
+			<bounds x="354" y="142" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="356" y="144" width="42" height="32">
-			</bounds>
+			<bounds x="356" y="144" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="354" y="214" width="46" height="36">
-			</bounds>
+			<bounds x="354" y="214" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="356" y="216" width="42" height="32">
-			</bounds>
+			<bounds x="356" y="216" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="354" y="250" width="46" height="36">
-			</bounds>
+			<bounds x="354" y="250" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="356" y="252" width="42" height="32">
-			</bounds>
+			<bounds x="356" y="252" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="400" y="106" width="58" height="36">
-			</bounds>
+			<bounds x="400" y="106" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="402" y="108" width="54" height="32">
-			</bounds>
+			<bounds x="402" y="108" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="354" y="106" width="46" height="36">
-			</bounds>
+			<bounds x="354" y="106" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="356" y="108" width="42" height="32">
-			</bounds>
+			<bounds x="356" y="108" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="354" y="286" width="46" height="36">
-			</bounds>
+			<bounds x="354" y="286" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="356" y="288" width="42" height="32">
-			</bounds>
+			<bounds x="356" y="288" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="325" y="329" width="46" height="24">
-			</bounds>
+			<bounds x="325" y="329" width="46" height="24"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="327" y="331" width="42" height="20">
-			</bounds>
+			<bounds x="327" y="331" width="42" height="20"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="307" y="286" width="46" height="36">
-			</bounds>
+			<bounds x="307" y="286" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="309" y="288" width="42" height="32">
-			</bounds>
+			<bounds x="309" y="288" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="307" y="250" width="46" height="36">
-			</bounds>
+			<bounds x="307" y="250" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="309" y="252" width="42" height="32">
-			</bounds>
+			<bounds x="309" y="252" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="307" y="214" width="46" height="36">
-			</bounds>
+			<bounds x="307" y="214" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="309" y="216" width="42" height="32">
-			</bounds>
+			<bounds x="309" y="216" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="307" y="178" width="46" height="36">
-			</bounds>
+			<bounds x="307" y="178" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="309" y="180" width="42" height="32">
-			</bounds>
+			<bounds x="309" y="180" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="307" y="142" width="46" height="36">
-			</bounds>
+			<bounds x="307" y="142" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="309" y="144" width="42" height="32">
-			</bounds>
+			<bounds x="309" y="144" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="179" y="509" width="54" height="36">
-			</bounds>
+			<bounds x="179" y="509" width="54" height="36"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="181" y="511" width="50" height="32">
-			</bounds>
+			<bounds x="181" y="511" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="235" y="509" width="54" height="36">
-			</bounds>
+			<bounds x="235" y="509" width="54" height="36"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="237" y="511" width="50" height="32">
-			</bounds>
+			<bounds x="237" y="511" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="291" y="509" width="54" height="36">
-			</bounds>
+			<bounds x="291" y="509" width="54" height="36"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="293" y="511" width="50" height="32">
-			</bounds>
+			<bounds x="293" y="511" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="347" y="509" width="54" height="36">
-			</bounds>
+			<bounds x="347" y="509" width="54" height="36"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="349" y="511" width="50" height="32">
-			</bounds>
+			<bounds x="349" y="511" width="50" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="75" y="263" width="34" height="24">
-			</bounds>
+			<bounds x="75" y="263" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="77" y="265" width="30" height="20">
-			</bounds>
+			<bounds x="77" y="265" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="75" y="154" width="34" height="24">
-			</bounds>
+			<bounds x="75" y="154" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="77" y="156" width="30" height="20">
-			</bounds>
+			<bounds x="77" y="156" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="301" y="74" width="68" height="26">
-			</bounds>
+			<bounds x="301" y="74" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="303" y="76" width="64" height="22">
-			</bounds>
+			<bounds x="303" y="76" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="370" y="74" width="46" height="26">
-			</bounds>
+			<bounds x="370" y="74" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="372" y="76" width="42" height="22">
-			</bounds>
+			<bounds x="372" y="76" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="254" y="74" width="46" height="26">
-			</bounds>
+			<bounds x="254" y="74" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="256" y="76" width="42" height="22">
-			</bounds>
+			<bounds x="256" y="76" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_217_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="657" y="1" width="45" height="27">
-			</bounds>
+			<bounds x="657" y="1" width="45" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_217" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="659" y="3" width="41" height="23">
-			</bounds>
+			<bounds x="659" y="3" width="41" height="23"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_255_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="513" y="550" width="36" height="36">
-			</bounds>
+			<bounds x="513" y="550" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_255" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="515" y="552" width="32" height="32">
-			</bounds>
+			<bounds x="515" y="552" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_256_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="550" y="550" width="36" height="36">
-			</bounds>
+			<bounds x="550" y="550" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_256" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="552" y="552" width="32" height="32">
-			</bounds>
+			<bounds x="552" y="552" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_257_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="63" y="559" width="75" height="27">
-			</bounds>
+			<bounds x="63" y="559" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_257" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="65" y="561" width="71" height="23">
-			</bounds>
+			<bounds x="65" y="561" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_258_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="163" y="559" width="75" height="27">
-			</bounds>
+			<bounds x="163" y="559" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_258" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="165" y="561" width="71" height="23">
-			</bounds>
+			<bounds x="165" y="561" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_259_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="253" y="559" width="75" height="27">
-			</bounds>
+			<bounds x="253" y="559" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_259" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="255" y="561" width="71" height="23">
-			</bounds>
+			<bounds x="255" y="561" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_260_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="340" y="559" width="75" height="27">
-			</bounds>
+			<bounds x="340" y="559" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_260" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="342" y="561" width="71" height="23">
-			</bounds>
+			<bounds x="342" y="561" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_261_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="437" y="559" width="75" height="27">
-			</bounds>
+			<bounds x="437" y="559" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_261" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="439" y="561" width="71" height="23">
-			</bounds>
+			<bounds x="439" y="561" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_262_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="588" y="559" width="75" height="27">
-			</bounds>
+			<bounds x="588" y="559" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_262" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="590" y="561" width="71" height="23">
-			</bounds>
+			<bounds x="590" y="561" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="507" y="495" width="24" height="32">
-			</bounds>
+			<bounds x="507" y="495" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="510" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="524" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="524" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="524" y="509" width="3" height="14">
-			</bounds>
+			<bounds x="524" y="509" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="510" y="521" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="521" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="510" y="509" width="3" height="14">
-			</bounds>
+			<bounds x="510" y="509" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="510" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="510" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="510" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="527" y="521" width="3" height="2">
-			</bounds>
+			<bounds x="527" y="521" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="510" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="524" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="524" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="524" y="509" width="3" height="14">
-			</bounds>
+			<bounds x="524" y="509" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="510" y="521" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="521" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="510" y="509" width="3" height="14">
-			</bounds>
+			<bounds x="510" y="509" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="510" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="510" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="510" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="510" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="527" y="521" width="3" height="2">
-			</bounds>
+			<bounds x="527" y="521" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="484" y="495" width="24" height="32">
-			</bounds>
+			<bounds x="484" y="495" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off48" element="led_off">
-			<bounds x="487" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="487" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off49" element="led_off">
-			<bounds x="501" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="501" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off50" element="led_off">
-			<bounds x="501" y="509" width="3" height="14">
-			</bounds>
+			<bounds x="501" y="509" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off51" element="led_off">
-			<bounds x="487" y="521" width="17" height="2">
-			</bounds>
+			<bounds x="487" y="521" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off52" element="led_off">
-			<bounds x="487" y="509" width="3" height="14">
-			</bounds>
+			<bounds x="487" y="509" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off53" element="led_off">
-			<bounds x="487" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="487" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off54" element="led_off">
-			<bounds x="487" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="487" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="504" y="521" width="3" height="2">
-			</bounds>
+			<bounds x="504" y="521" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp48" element="led_on">
-			<bounds x="487" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="487" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp49" element="led_on">
-			<bounds x="501" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="501" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp50" element="led_on">
-			<bounds x="501" y="509" width="3" height="14">
-			</bounds>
+			<bounds x="501" y="509" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp51" element="led_on">
-			<bounds x="487" y="521" width="17" height="2">
-			</bounds>
+			<bounds x="487" y="521" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp52" element="led_on">
-			<bounds x="487" y="509" width="3" height="14">
-			</bounds>
+			<bounds x="487" y="509" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp53" element="led_on">
-			<bounds x="487" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="487" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp54" element="led_on">
-			<bounds x="487" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="487" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="504" y="521" width="3" height="2">
-			</bounds>
+			<bounds x="504" y="521" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="294" y="326" width="24" height="32">
-			</bounds>
+			<bounds x="294" y="326" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off216" element="led_off">
-			<bounds x="297" y="328" width="17" height="2">
-			</bounds>
+			<bounds x="297" y="328" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off217" element="led_off">
-			<bounds x="311" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="311" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off218" element="led_off">
-			<bounds x="311" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="311" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off219" element="led_off">
-			<bounds x="297" y="352" width="17" height="2">
-			</bounds>
+			<bounds x="297" y="352" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off220" element="led_off">
-			<bounds x="297" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="297" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off221" element="led_off">
-			<bounds x="297" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="297" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off222" element="led_off">
-			<bounds x="297" y="340" width="17" height="2">
-			</bounds>
+			<bounds x="297" y="340" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="314" y="352" width="3" height="2">
-			</bounds>
+			<bounds x="314" y="352" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp216" element="led_on">
-			<bounds x="297" y="328" width="17" height="2">
-			</bounds>
+			<bounds x="297" y="328" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp217" element="led_on">
-			<bounds x="311" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="311" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp218" element="led_on">
-			<bounds x="311" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="311" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp219" element="led_on">
-			<bounds x="297" y="352" width="17" height="2">
-			</bounds>
+			<bounds x="297" y="352" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp220" element="led_on">
-			<bounds x="297" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="297" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp221" element="led_on">
-			<bounds x="297" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="297" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp222" element="led_on">
-			<bounds x="297" y="340" width="17" height="2">
-			</bounds>
+			<bounds x="297" y="340" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="314" y="352" width="3" height="2">
-			</bounds>
+			<bounds x="314" y="352" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="271" y="326" width="24" height="32">
-			</bounds>
+			<bounds x="271" y="326" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off208" element="led_off">
-			<bounds x="274" y="328" width="17" height="2">
-			</bounds>
+			<bounds x="274" y="328" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off209" element="led_off">
-			<bounds x="288" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="288" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off210" element="led_off">
-			<bounds x="288" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="288" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off211" element="led_off">
-			<bounds x="274" y="352" width="17" height="2">
-			</bounds>
+			<bounds x="274" y="352" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off212" element="led_off">
-			<bounds x="274" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="274" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off213" element="led_off">
-			<bounds x="274" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="274" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off214" element="led_off">
-			<bounds x="274" y="340" width="17" height="2">
-			</bounds>
+			<bounds x="274" y="340" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="291" y="352" width="3" height="2">
-			</bounds>
+			<bounds x="291" y="352" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp208" element="led_on">
-			<bounds x="274" y="328" width="17" height="2">
-			</bounds>
+			<bounds x="274" y="328" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp209" element="led_on">
-			<bounds x="288" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="288" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp210" element="led_on">
-			<bounds x="288" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="288" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp211" element="led_on">
-			<bounds x="274" y="352" width="17" height="2">
-			</bounds>
+			<bounds x="274" y="352" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp212" element="led_on">
-			<bounds x="274" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="274" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp213" element="led_on">
-			<bounds x="274" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="274" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp214" element="led_on">
-			<bounds x="274" y="340" width="17" height="2">
-			</bounds>
+			<bounds x="274" y="340" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="291" y="352" width="3" height="2">
-			</bounds>
+			<bounds x="291" y="352" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="550" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="550" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="553" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="553" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="567" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="567" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="567" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="567" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="553" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="553" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="553" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="553" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="553" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="553" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="570" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="570" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="553" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="553" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="567" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="567" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="567" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="567" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="553" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="553" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="553" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="553" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="553" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="553" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="570" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="570" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="526" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="526" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="529" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="529" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="543" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="543" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="543" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="543" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="529" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="529" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="529" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="529" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="529" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="529" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="529" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="529" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="546" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="546" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="529" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="529" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="543" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="543" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="543" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="543" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="529" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="529" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="529" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="529" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="529" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="529" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="529" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="529" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="546" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="546" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="503" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="503" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="506" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="506" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="520" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="520" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="520" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="520" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="506" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="506" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="506" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="506" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="506" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="506" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="506" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="506" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="523" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="523" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="506" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="506" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="520" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="520" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="520" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="520" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="506" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="506" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="506" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="506" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="506" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="506" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="506" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="506" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="523" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="523" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="481" y="409" width="24" height="32">
-			</bounds>
+			<bounds x="481" y="409" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="484" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="498" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="498" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="498" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="498" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="484" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="484" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="484" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="484" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="484" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="484" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="501" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="501" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="484" y="411" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="411" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="498" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="498" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="498" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="498" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="484" y="435" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="435" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="484" y="423" width="3" height="14">
-			</bounds>
+			<bounds x="484" y="423" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="484" y="411" width="3" height="14">
-			</bounds>
+			<bounds x="484" y="411" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="484" y="423" width="17" height="2">
-			</bounds>
+			<bounds x="484" y="423" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="501" y="435" width="3" height="2">
-			</bounds>
+			<bounds x="501" y="435" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="247" y="326" width="24" height="32">
-			</bounds>
+			<bounds x="247" y="326" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_off">
-			<bounds x="250" y="328" width="17" height="2">
-			</bounds>
+			<bounds x="250" y="328" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off201" element="led_off">
-			<bounds x="264" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="264" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off202" element="led_off">
-			<bounds x="264" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="264" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_off">
-			<bounds x="250" y="352" width="17" height="2">
-			</bounds>
+			<bounds x="250" y="352" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_off">
-			<bounds x="250" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="250" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_off">
-			<bounds x="250" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="250" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_off">
-			<bounds x="250" y="340" width="17" height="2">
-			</bounds>
+			<bounds x="250" y="340" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="267" y="352" width="3" height="2">
-			</bounds>
+			<bounds x="267" y="352" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_on">
-			<bounds x="250" y="328" width="17" height="2">
-			</bounds>
+			<bounds x="250" y="328" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp201" element="led_on">
-			<bounds x="264" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="264" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp202" element="led_on">
-			<bounds x="264" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="264" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_on">
-			<bounds x="250" y="352" width="17" height="2">
-			</bounds>
+			<bounds x="250" y="352" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_on">
-			<bounds x="250" y="340" width="3" height="14">
-			</bounds>
+			<bounds x="250" y="340" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_on">
-			<bounds x="250" y="328" width="3" height="14">
-			</bounds>
+			<bounds x="250" y="328" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_on">
-			<bounds x="250" y="340" width="17" height="2">
-			</bounds>
+			<bounds x="250" y="340" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="267" y="352" width="3" height="2">
-			</bounds>
+			<bounds x="267" y="352" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label146" element="label_146">
-			<bounds x="503" y="394" width="28" height="16">
-			</bounds>
+			<bounds x="503" y="394" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="label147" element="label_147">
-			<bounds x="482" y="482" width="39" height="16">
-			</bounds>
+			<bounds x="482" y="482" width="39" height="16"/>
 		</backdrop>
 		<backdrop name="label214" element="label_214">
-			<bounds x="462" y="9" width="159" height="28">
-			</bounds>
+			<bounds x="462" y="9" width="159" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_button" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1startr.lay
+++ b/src/mame/layout/m1startr.lay
@@ -8,13620 +8,7988 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.37" blue="0.50">
-			</color>
+			<color red="0.25" green="0.37" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.09" blue="0.12">
-			</color>
+			<color red="0.06" green="0.09" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.75" blue="1.00">
-			</color>
+			<color red="0.50" green="0.75" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.18" blue="0.25">
-			</color>
+			<color red="0.13" green="0.18" blue="0.25"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.37" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.09" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.75" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.18" blue="0.25">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.15" green="0.32" blue="0.50">
-			</color>
+			<color red="0.15" green="0.32" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
+			<color red="0.04" green="0.08" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="0.29" green="0.65" blue="1.00">
-			</color>
+			<color red="0.29" green="0.65" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.07" green="0.16" blue="0.25">
-			</color>
+			<color red="0.07" green="0.16" blue="0.25"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.15" green="0.32" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.04" green="0.08" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.29" green="0.65" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.07" green="0.16" blue="0.25">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.05" green="0.27" blue="0.50">
-			</color>
+			<color red="0.05" green="0.27" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.01" green="0.07" blue="0.12">
-			</color>
+			<color red="0.01" green="0.07" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="0.11" green="0.55" blue="1.00">
-			</color>
+			<color red="0.11" green="0.55" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.14" blue="0.25">
-			</color>
+			<color red="0.03" green="0.14" blue="0.25"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.05" green="0.27" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.01" green="0.07" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.11" green="0.55" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.14" blue="0.25">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.21" blue="0.42">
-			</color>
+			<color red="0.00" green="0.21" blue="0.42"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.05" blue="0.10">
-			</color>
+			<color red="0.00" green="0.05" blue="0.10"/>
 		</disk>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.42" blue="0.84">
-			</color>
+			<color red="0.00" green="0.42" blue="0.84"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.10" blue="0.21">
-			</color>
+			<color red="0.00" green="0.10" blue="0.21"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.21" blue="0.42">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.05" blue="0.10">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.42" blue="0.84">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.10" blue="0.21">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.17" blue="0.50">
-			</color>
+			<color red="0.17" green="0.17" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.12">
-			</color>
+			<color red="0.04" green="0.04" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.35" green="0.35" blue="1.00">
-			</color>
+			<color red="0.35" green="0.35" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.25">
-			</color>
+			<color red="0.09" green="0.09" blue="0.25"/>
 		</rect>
 		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.17" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.35" green="0.35" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ALWAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="GOING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="FORWARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ALWAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="GOING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="FORWARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="KLINGON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ATTACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="KLINGON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ATTACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SLIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SLIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EVASIVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="MANOE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="UVRES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EVASIVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="MANOE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="UVRES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ASTEROID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ASTEROID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TRIBBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TROUBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRIBBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TROUBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="PLUMS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="PLUMS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="IT'S LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JIM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="IT'S LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JIM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TRANS-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PORTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRANS-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PORTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SLIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SLIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WE COME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="IN PEACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WE COME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="IN PEACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SLIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SLIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="777">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="777">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JACKPO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SLIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SLIP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.04">
-			</color>
+			<color red="0.00" green="0.00" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.32">
-			</color>
+			<color red="0.00" green="0.00" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 		<text string="BLACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.32">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-		<text string="BLACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STORM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STORM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENGINE ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENGINE ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STORM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STORM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.04">
-			</color>
+			<color red="0.00" green="0.00" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.32">
-			</color>
+			<color red="0.00" green="0.00" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 		<text string="BLACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.32">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-		<text string="BLACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="TRIPLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="TRIPLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="OPEN A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANNEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="OPEN A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANNEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ALERT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ALERT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="DOUBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="DOUBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="PHOTON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TORPEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="PHOTON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TORPEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STORM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STORM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Scotty Beam Me Up!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Scotty Beam Me Up!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SHOOT TO KILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOOT TO KILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.20">
-			</color>
+			<color red="0.50" green="0.50" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.05">
-			</color>
+			<color red="0.12" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.39">
-			</color>
+			<color red="1.00" green="1.00" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.10">
-			</color>
+			<color red="0.25" green="0.25" blue="0.10"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.10">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.50" blue="0.36">
-			</color>
+			<color red="0.36" green="0.50" blue="0.36"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.09">
-			</color>
+			<color red="0.09" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="1.00" blue="0.73">
-			</color>
+			<color red="0.73" green="1.00" blue="0.73"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.25" blue="0.18">
-			</color>
+			<color red="0.18" green="0.25" blue="0.18"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.50" blue="0.36">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="1.00" blue="0.73">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.25" blue="0.18">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.29">
-			</color>
+			<color red="0.50" green="0.50" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.07">
-			</color>
+			<color red="0.12" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.58">
-			</color>
+			<color red="1.00" green="1.00" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.15">
-			</color>
+			<color red="0.25" green="0.25" blue="0.15"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.15">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.40">
-			</color>
+			<color red="0.50" green="0.50" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.10">
-			</color>
+			<color red="0.12" green="0.12" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.79">
-			</color>
+			<color red="1.00" green="1.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.20">
-			</color>
+			<color red="0.25" green="0.25" blue="0.20"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.20">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.19" green="0.50" blue="0.19">
-			</color>
+			<color red="0.19" green="0.50" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
+			<color red="0.05" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="1.00" blue="0.38">
-			</color>
+			<color red="0.38" green="1.00" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.25" blue="0.09">
-			</color>
+			<color red="0.09" green="0.25" blue="0.09"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.19" green="0.50" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="1.00" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.25" blue="0.09">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.27" green="0.50" blue="0.27">
-			</color>
+			<color red="0.27" green="0.50" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.12" blue="0.07">
-			</color>
+			<color red="0.07" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.55" green="1.00" blue="0.55">
-			</color>
+			<color red="0.55" green="1.00" blue="0.55"/>
 		</rect>
 		<rect state="0">
-			<color red="0.14" green="0.25" blue="0.14">
-			</color>
+			<color red="0.14" green="0.25" blue="0.14"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.27" green="0.50" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.55" green="1.00" blue="0.55">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.14" green="0.25" blue="0.14">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_167_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_2" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SICK BAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SICK BAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="He's Dead Jim">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="He's Dead Jim">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Life Signs Normal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Life Signs Normal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ENGINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="BROKEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="BROKEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="Crystal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="ABLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="ABLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" AVAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string=" AVAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Its Life Jim But">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Its Life Jim But">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Not As We Know It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Not As We Know It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Explode">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Explode">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Klingon Ambush">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Klingon Ambush">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Damaged Shields">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Damaged Shields">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Crystal Failure">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Crystal Failure">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ION STORM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ION STORM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Slingshot Effect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Slingshot Effect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Core Meltdown">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Core Meltdown">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Parallel Universe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Parallel Universe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Engage Shields">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Engage Shields">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_152_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_152">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD / LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD / HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_29">
 		<text string="&#x3C;&#x3C;&#x3C; GALACTIC JUNCTION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_104">
 		<text string="TRANSPORTER ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_113">
 		<text string="v2.1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="SHIELDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="Classic layout by">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_140">
 		<text string="Original machine by">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="787" height="660">
-			</bounds>
+			<bounds x="0" y="0" width="787" height="660"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="242" y="472" width="80" height="134">
-			</bounds>
+			<bounds x="242" y="472" width="80" height="134"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="472.0000" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="242.0000" y="472.0000" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="473.8611" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="245.3333" y="473.8611" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="475.7222" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="248.6667" y="475.7222" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="477.5833" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="252.0000" y="477.5833" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="479.4445" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="255.3333" y="479.4445" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="481.3055" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="258.6667" y="481.3055" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="516.6667" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="242.0000" y="516.6667" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="518.5278" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="245.3333" y="518.5278" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="520.3889" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="248.6667" y="520.3889" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="522.2500" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="252.0000" y="522.2500" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="524.1111" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="255.3333" y="524.1111" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="525.9722" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="258.6667" y="525.9722" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="561.3333" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="242.0000" y="561.3333" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="563.1944" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="245.3333" y="563.1944" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="565.0555" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="248.6667" y="565.0555" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="566.9166" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="252.0000" y="566.9166" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="568.7778" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="255.3333" y="568.7778" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="570.6389" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="258.6667" y="570.6389" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="242" y="472" width="80" height="134">
-			</bounds>
+			<bounds x="242" y="472" width="80" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="324" y="472" width="80" height="134">
-			</bounds>
+			<bounds x="324" y="472" width="80" height="134"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="324.0000" y="472.0000" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="324.0000" y="472.0000" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="327.3333" y="473.8611" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="327.3333" y="473.8611" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="330.6667" y="475.7222" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="330.6667" y="475.7222" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="334.0000" y="477.5833" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="334.0000" y="477.5833" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="337.3333" y="479.4445" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="337.3333" y="479.4445" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="340.6667" y="481.3055" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="340.6667" y="481.3055" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="324.0000" y="516.6667" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="324.0000" y="516.6667" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="327.3333" y="518.5278" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="327.3333" y="518.5278" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="330.6667" y="520.3889" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="330.6667" y="520.3889" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="334.0000" y="522.2500" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="334.0000" y="522.2500" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="337.3333" y="524.1111" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="337.3333" y="524.1111" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="340.6667" y="525.9722" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="340.6667" y="525.9722" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="324.0000" y="561.3333" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="324.0000" y="561.3333" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="327.3333" y="563.1944" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="327.3333" y="563.1944" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="330.6667" y="565.0555" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="330.6667" y="565.0555" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="334.0000" y="566.9166" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="334.0000" y="566.9166" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="337.3333" y="568.7778" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="337.3333" y="568.7778" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="340.6667" y="570.6389" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="340.6667" y="570.6389" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="324" y="472" width="80" height="134">
-			</bounds>
+			<bounds x="324" y="472" width="80" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="406" y="472" width="80" height="134">
-			</bounds>
+			<bounds x="406" y="472" width="80" height="134"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="406.0000" y="472.0000" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="406.0000" y="472.0000" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="409.3333" y="473.8611" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="409.3333" y="473.8611" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="412.6667" y="475.7222" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="412.6667" y="475.7222" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="416.0000" y="477.5833" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="416.0000" y="477.5833" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="419.3333" y="479.4445" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="419.3333" y="479.4445" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="422.6667" y="481.3055" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="422.6667" y="481.3055" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="406.0000" y="516.6667" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="406.0000" y="516.6667" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="409.3333" y="518.5278" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="409.3333" y="518.5278" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="412.6667" y="520.3889" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="412.6667" y="520.3889" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="416.0000" y="522.2500" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="416.0000" y="522.2500" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="419.3333" y="524.1111" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="419.3333" y="524.1111" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="422.6667" y="525.9722" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="422.6667" y="525.9722" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="406.0000" y="561.3333" width="80.0000" height="44.6667">
-			</bounds>
+			<bounds x="406.0000" y="561.3333" width="80.0000" height="44.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="409.3333" y="563.1944" width="73.3333" height="40.9444">
-			</bounds>
+			<bounds x="409.3333" y="563.1944" width="73.3333" height="40.9444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="412.6667" y="565.0555" width="66.6667" height="37.2222">
-			</bounds>
+			<bounds x="412.6667" y="565.0555" width="66.6667" height="37.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="416.0000" y="566.9166" width="60.0000" height="33.5000">
-			</bounds>
+			<bounds x="416.0000" y="566.9166" width="60.0000" height="33.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="419.3333" y="568.7778" width="53.3333" height="29.7778">
-			</bounds>
+			<bounds x="419.3333" y="568.7778" width="53.3333" height="29.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="422.6667" y="570.6389" width="46.6667" height="26.0556">
-			</bounds>
+			<bounds x="422.6667" y="570.6389" width="46.6667" height="26.0556"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="406" y="472" width="80" height="134">
-			</bounds>
+			<bounds x="406" y="472" width="80" height="134"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="56" y="199" width="70" height="70">
-			</bounds>
+			<bounds x="56" y="199" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="56.0000" y="199.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="56.0000" y="199.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="58.9167" y="201.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="58.9167" y="201.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="61.8333" y="204.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="61.8333" y="204.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="64.7500" y="207.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="64.7500" y="207.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="67.6667" y="210.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="67.6667" y="210.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="70.5833" y="213.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="70.5833" y="213.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="56" y="199" width="70" height="70">
-			</bounds>
+			<bounds x="56" y="199" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="192" y="526" width="27" height="27">
-			</bounds>
+			<bounds x="192" y="526" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="194" y="528" width="23" height="23">
-			</bounds>
+			<bounds x="194" y="528" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="4" y="608" width="47" height="19">
-			</bounds>
+			<bounds x="4" y="608" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="6" y="610" width="43" height="15">
-			</bounds>
+			<bounds x="6" y="610" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="173" y="581" width="52" height="19">
-			</bounds>
+			<bounds x="173" y="581" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="175" y="583" width="48" height="15">
-			</bounds>
+			<bounds x="175" y="583" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="159" y="537" width="27" height="27">
-			</bounds>
+			<bounds x="159" y="537" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="161" y="539" width="23" height="23">
-			</bounds>
+			<bounds x="161" y="539" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="132" y="559" width="27" height="27">
-			</bounds>
+			<bounds x="132" y="559" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="134" y="561" width="23" height="23">
-			</bounds>
+			<bounds x="134" y="561" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="105" y="579" width="27" height="27">
-			</bounds>
+			<bounds x="105" y="579" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="107" y="581" width="23" height="23">
-			</bounds>
+			<bounds x="107" y="581" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="74" y="565" width="27" height="27">
-			</bounds>
+			<bounds x="74" y="565" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="76" y="567" width="23" height="23">
-			</bounds>
+			<bounds x="76" y="567" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="42" y="579" width="27" height="27">
-			</bounds>
+			<bounds x="42" y="579" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="44" y="581" width="23" height="23">
-			</bounds>
+			<bounds x="44" y="581" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="14" y="535" width="82" height="19">
-			</bounds>
+			<bounds x="14" y="535" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="16" y="537" width="78" height="15">
-			</bounds>
+			<bounds x="16" y="537" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="725" y="398" width="57" height="34">
-			</bounds>
+			<bounds x="725" y="398" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="727" y="400" width="53" height="30">
-			</bounds>
+			<bounds x="727" y="400" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="663" y="397" width="57" height="34">
-			</bounds>
+			<bounds x="663" y="397" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="665" y="399" width="53" height="30">
-			</bounds>
+			<bounds x="665" y="399" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="602" y="396" width="57" height="34">
-			</bounds>
+			<bounds x="602" y="396" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="604" y="398" width="53" height="30">
-			</bounds>
+			<bounds x="604" y="398" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="292" y="387" width="57" height="34">
-			</bounds>
+			<bounds x="292" y="387" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="294" y="389" width="53" height="30">
-			</bounds>
+			<bounds x="294" y="389" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="416" y="392" width="57" height="34">
-			</bounds>
+			<bounds x="416" y="392" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="418" y="394" width="53" height="30">
-			</bounds>
+			<bounds x="418" y="394" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="354" y="391" width="57" height="34">
-			</bounds>
+			<bounds x="354" y="391" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="356" y="393" width="53" height="30">
-			</bounds>
+			<bounds x="356" y="393" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="540" y="395" width="57" height="34">
-			</bounds>
+			<bounds x="540" y="395" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="542" y="397" width="53" height="30">
-			</bounds>
+			<bounds x="542" y="397" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="478" y="394" width="57" height="34">
-			</bounds>
+			<bounds x="478" y="394" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="480" y="396" width="53" height="30">
-			</bounds>
+			<bounds x="480" y="396" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="568" y="242" width="57" height="34">
-			</bounds>
+			<bounds x="568" y="242" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="570" y="244" width="53" height="30">
-			</bounds>
+			<bounds x="570" y="244" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="301" y="85" width="57" height="34">
-			</bounds>
+			<bounds x="301" y="85" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="303" y="87" width="53" height="30">
-			</bounds>
+			<bounds x="303" y="87" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="428" y="99" width="57" height="34">
-			</bounds>
+			<bounds x="428" y="99" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="430" y="101" width="53" height="30">
-			</bounds>
+			<bounds x="430" y="101" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="364" y="85" width="57" height="34">
-			</bounds>
+			<bounds x="364" y="85" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="366" y="87" width="53" height="30">
-			</bounds>
+			<bounds x="366" y="87" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="239" y="100" width="57" height="34">
-			</bounds>
+			<bounds x="239" y="100" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="241" y="102" width="53" height="30">
-			</bounds>
+			<bounds x="241" y="102" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="178" y="260" width="57" height="34">
-			</bounds>
+			<bounds x="178" y="260" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="180" y="262" width="53" height="30">
-			</bounds>
+			<bounds x="180" y="262" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="178" y="220" width="57" height="34">
-			</bounds>
+			<bounds x="178" y="220" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="180" y="222" width="53" height="30">
-			</bounds>
+			<bounds x="180" y="222" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="189" y="179" width="57" height="34">
-			</bounds>
+			<bounds x="189" y="179" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="191" y="181" width="53" height="30">
-			</bounds>
+			<bounds x="191" y="181" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="528" y="163" width="57" height="34">
-			</bounds>
+			<bounds x="528" y="163" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="530" y="165" width="53" height="30">
-			</bounds>
+			<bounds x="530" y="165" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="488" y="125" width="57" height="34">
-			</bounds>
+			<bounds x="488" y="125" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="490" y="127" width="53" height="30">
-			</bounds>
+			<bounds x="490" y="127" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="207" y="139" width="57" height="34">
-			</bounds>
+			<bounds x="207" y="139" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="209" y="141" width="53" height="30">
-			</bounds>
+			<bounds x="209" y="141" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="203" y="337" width="57" height="34">
-			</bounds>
+			<bounds x="203" y="337" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="205" y="339" width="53" height="30">
-			</bounds>
+			<bounds x="205" y="339" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="229" y="376" width="57" height="34">
-			</bounds>
+			<bounds x="229" y="376" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="231" y="378" width="53" height="30">
-			</bounds>
+			<bounds x="231" y="378" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="191" y="298" width="57" height="34">
-			</bounds>
+			<bounds x="191" y="298" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="193" y="300" width="53" height="30">
-			</bounds>
+			<bounds x="193" y="300" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="349" y="227" width="57" height="34">
-			</bounds>
+			<bounds x="349" y="227" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="351" y="229" width="53" height="30">
-			</bounds>
+			<bounds x="351" y="229" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="332" y="267" width="57" height="34">
-			</bounds>
+			<bounds x="332" y="267" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="334" y="269" width="53" height="30">
-			</bounds>
+			<bounds x="334" y="269" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="363" y="305" width="57" height="34">
-			</bounds>
+			<bounds x="363" y="305" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="365" y="307" width="53" height="30">
-			</bounds>
+			<bounds x="365" y="307" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="429" y="303" width="57" height="34">
-			</bounds>
+			<bounds x="429" y="303" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="431" y="305" width="53" height="30">
-			</bounds>
+			<bounds x="431" y="305" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="476" y="266" width="57" height="34">
-			</bounds>
+			<bounds x="476" y="266" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="478" y="268" width="53" height="30">
-			</bounds>
+			<bounds x="478" y="268" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="485" y="227" width="57" height="34">
-			</bounds>
+			<bounds x="485" y="227" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="487" y="229" width="53" height="30">
-			</bounds>
+			<bounds x="487" y="229" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="463" y="186" width="57" height="34">
-			</bounds>
+			<bounds x="463" y="186" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="465" y="188" width="53" height="30">
-			</bounds>
+			<bounds x="465" y="188" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="420" y="147" width="57" height="34">
-			</bounds>
+			<bounds x="420" y="147" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="422" y="149" width="53" height="30">
-			</bounds>
+			<bounds x="422" y="149" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="356" y="132" width="57" height="34">
-			</bounds>
+			<bounds x="356" y="132" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="358" y="134" width="53" height="30">
-			</bounds>
+			<bounds x="358" y="134" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="292" y="142" width="57" height="34">
-			</bounds>
+			<bounds x="292" y="142" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="294" y="144" width="53" height="30">
-			</bounds>
+			<bounds x="294" y="144" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="260" y="184" width="57" height="34">
-			</bounds>
+			<bounds x="260" y="184" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="262" y="186" width="53" height="30">
-			</bounds>
+			<bounds x="262" y="186" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="249" y="228" width="57" height="34">
-			</bounds>
+			<bounds x="249" y="228" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="251" y="230" width="53" height="30">
-			</bounds>
+			<bounds x="251" y="230" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="254" y="270" width="57" height="34">
-			</bounds>
+			<bounds x="254" y="270" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="256" y="272" width="53" height="30">
-			</bounds>
+			<bounds x="256" y="272" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="271" y="309" width="57" height="34">
-			</bounds>
+			<bounds x="271" y="309" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="273" y="311" width="53" height="30">
-			</bounds>
+			<bounds x="273" y="311" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="322" y="347" width="57" height="34">
-			</bounds>
+			<bounds x="322" y="347" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="324" y="349" width="53" height="30">
-			</bounds>
+			<bounds x="324" y="349" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="390" y="349" width="57" height="34">
-			</bounds>
+			<bounds x="390" y="349" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="392" y="351" width="53" height="30">
-			</bounds>
+			<bounds x="392" y="351" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="458" y="341" width="57" height="34">
-			</bounds>
+			<bounds x="458" y="341" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="460" y="343" width="53" height="30">
-			</bounds>
+			<bounds x="460" y="343" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="521" y="322" width="57" height="34">
-			</bounds>
+			<bounds x="521" y="322" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="523" y="324" width="53" height="30">
-			</bounds>
+			<bounds x="523" y="324" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="554" y="283" width="57" height="34">
-			</bounds>
+			<bounds x="554" y="283" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="556" y="285" width="53" height="30">
-			</bounds>
+			<bounds x="556" y="285" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="559" y="201" width="57" height="34">
-			</bounds>
+			<bounds x="559" y="201" width="57" height="34"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="561" y="203" width="53" height="30">
-			</bounds>
+			<bounds x="561" y="203" width="53" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="74" y="337" width="37" height="37">
-			</bounds>
+			<bounds x="74" y="337" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="76" y="339" width="33" height="33">
-			</bounds>
+			<bounds x="76" y="339" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="74" y="376" width="37" height="37">
-			</bounds>
+			<bounds x="74" y="376" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="76" y="378" width="33" height="33">
-			</bounds>
+			<bounds x="76" y="378" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="118" y="351" width="52" height="52">
-			</bounds>
+			<bounds x="118" y="351" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="120" y="353" width="48" height="48">
-			</bounds>
+			<bounds x="120" y="353" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="42" y="306" width="102" height="22">
-			</bounds>
+			<bounds x="42" y="306" width="102" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="44" y="308" width="98" height="18">
-			</bounds>
+			<bounds x="44" y="308" width="98" height="18"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="357" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="357" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="359" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="359" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="395" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="395" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="397" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="397" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="414" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="414" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="416" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="416" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="376" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="376" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="378" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="378" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="243" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="243" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="245" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="245" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="338" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="338" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="340" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="340" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="319" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="319" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="321" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="321" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="300" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="300" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="302" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="302" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="281" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="281" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="283" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="283" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="262" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="262" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="264" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="264" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="242" y="13" width="40" height="27">
-			</bounds>
+			<bounds x="242" y="13" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="244" y="15" width="36" height="23">
-			</bounds>
+			<bounds x="244" y="15" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="283" y="13" width="40" height="27">
-			</bounds>
+			<bounds x="283" y="13" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="285" y="15" width="36" height="23">
-			</bounds>
+			<bounds x="285" y="15" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="324" y="13" width="40" height="27">
-			</bounds>
+			<bounds x="324" y="13" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="326" y="15" width="36" height="23">
-			</bounds>
+			<bounds x="326" y="15" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="365" y="13" width="40" height="27">
-			</bounds>
+			<bounds x="365" y="13" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="367" y="15" width="36" height="23">
-			</bounds>
+			<bounds x="367" y="15" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="406" y="13" width="40" height="27">
-			</bounds>
+			<bounds x="406" y="13" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="408" y="15" width="36" height="23">
-			</bounds>
+			<bounds x="408" y="15" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="447" y="13" width="40" height="27">
-			</bounds>
+			<bounds x="447" y="13" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="449" y="15" width="36" height="23">
-			</bounds>
+			<bounds x="449" y="15" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="28" y="376" width="37" height="37">
-			</bounds>
+			<bounds x="28" y="376" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="30" y="378" width="33" height="33">
-			</bounds>
+			<bounds x="30" y="378" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="28" y="337" width="37" height="37">
-			</bounds>
+			<bounds x="28" y="337" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="30" y="339" width="33" height="33">
-			</bounds>
+			<bounds x="30" y="339" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_2_border" state="0">
-			<bounds x="131" y="83" width="25" height="52">
-			</bounds>
+			<bounds x="131" y="83" width="25" height="52"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_2" state="0">
-			<bounds x="133" y="85" width="21" height="48">
-			</bounds>
+			<bounds x="133" y="85" width="21" height="48"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2_border" state="0">
-			<bounds x="56" y="83" width="25" height="52">
-			</bounds>
+			<bounds x="56" y="83" width="25" height="52"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_2" state="0">
-			<bounds x="58" y="85" width="21" height="48">
-			</bounds>
+			<bounds x="58" y="85" width="21" height="48"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_2_border" state="0">
-			<bounds x="106" y="83" width="25" height="52">
-			</bounds>
+			<bounds x="106" y="83" width="25" height="52"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_2" state="0">
-			<bounds x="108" y="85" width="21" height="48">
-			</bounds>
+			<bounds x="108" y="85" width="21" height="48"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_2_border" state="0">
-			<bounds x="81" y="83" width="25" height="52">
-			</bounds>
+			<bounds x="81" y="83" width="25" height="52"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_2" state="0">
-			<bounds x="83" y="85" width="21" height="48">
-			</bounds>
+			<bounds x="83" y="85" width="21" height="48"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2_border" state="0">
-			<bounds x="31" y="83" width="25" height="52">
-			</bounds>
+			<bounds x="31" y="83" width="25" height="52"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_2" state="0">
-			<bounds x="33" y="85" width="21" height="48">
-			</bounds>
+			<bounds x="33" y="85" width="21" height="48"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="56" y="270" width="72" height="27">
-			</bounds>
+			<bounds x="56" y="270" width="72" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="58" y="272" width="68" height="23">
-			</bounds>
+			<bounds x="58" y="272" width="68" height="23"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="56" y="171" width="72" height="27">
-			</bounds>
+			<bounds x="56" y="171" width="72" height="27"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="58" y="173" width="68" height="23">
-			</bounds>
+			<bounds x="58" y="173" width="68" height="23"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="679" y="157" width="62" height="27">
-			</bounds>
+			<bounds x="679" y="157" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="681" y="159" width="58" height="23">
-			</bounds>
+			<bounds x="681" y="159" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="679" y="195" width="62" height="32">
-			</bounds>
+			<bounds x="679" y="195" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="681" y="197" width="58" height="28">
-			</bounds>
+			<bounds x="681" y="197" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="679" y="231" width="62" height="32">
-			</bounds>
+			<bounds x="679" y="231" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="681" y="233" width="58" height="28">
-			</bounds>
+			<bounds x="681" y="233" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="562" y="11" width="47" height="32">
-			</bounds>
+			<bounds x="562" y="11" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="564" y="13" width="43" height="28">
-			</bounds>
+			<bounds x="564" y="13" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="605" y="52" width="52" height="42">
-			</bounds>
+			<bounds x="605" y="52" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="607" y="54" width="48" height="38">
-			</bounds>
+			<bounds x="607" y="54" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="608" y="6" width="47" height="32">
-			</bounds>
+			<bounds x="608" y="6" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="610" y="8" width="43" height="28">
-			</bounds>
+			<bounds x="610" y="8" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="544" y="40" width="47" height="32">
-			</bounds>
+			<bounds x="544" y="40" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="546" y="42" width="43" height="28">
-			</bounds>
+			<bounds x="546" y="42" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="608" y="107" width="47" height="32">
-			</bounds>
+			<bounds x="608" y="107" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="610" y="109" width="43" height="28">
-			</bounds>
+			<bounds x="610" y="109" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="672" y="72" width="47" height="32">
-			</bounds>
+			<bounds x="672" y="72" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="674" y="74" width="43" height="28">
-			</bounds>
+			<bounds x="674" y="74" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="654" y="101" width="47" height="32">
-			</bounds>
+			<bounds x="654" y="101" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="656" y="103" width="43" height="28">
-			</bounds>
+			<bounds x="656" y="103" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="544" y="72" width="47" height="32">
-			</bounds>
+			<bounds x="544" y="72" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="546" y="74" width="43" height="28">
-			</bounds>
+			<bounds x="546" y="74" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="562" y="101" width="47" height="32">
-			</bounds>
+			<bounds x="562" y="101" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="564" y="103" width="43" height="28">
-			</bounds>
+			<bounds x="564" y="103" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="672" y="40" width="47" height="32">
-			</bounds>
+			<bounds x="672" y="40" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="674" y="42" width="43" height="28">
-			</bounds>
+			<bounds x="674" y="42" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="654" y="11" width="47" height="32">
-			</bounds>
+			<bounds x="654" y="11" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="656" y="13" width="43" height="28">
-			</bounds>
+			<bounds x="656" y="13" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="605" y="449" width="33" height="18">
-			</bounds>
+			<bounds x="605" y="449" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="607" y="451" width="29" height="14">
-			</bounds>
+			<bounds x="607" y="451" width="29" height="14"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="516" y="449" width="56" height="18">
-			</bounds>
+			<bounds x="516" y="449" width="56" height="18"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="518" y="451" width="52" height="14">
-			</bounds>
+			<bounds x="518" y="451" width="52" height="14"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="569" y="449" width="39" height="18">
-			</bounds>
+			<bounds x="569" y="449" width="39" height="18"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="571" y="451" width="35" height="14">
-			</bounds>
+			<bounds x="571" y="451" width="35" height="14"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="657" y="268" width="108" height="17">
-			</bounds>
+			<bounds x="657" y="268" width="108" height="17"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="659" y="270" width="104" height="13">
-			</bounds>
+			<bounds x="659" y="270" width="104" height="13"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="657" y="282" width="108" height="17">
-			</bounds>
+			<bounds x="657" y="282" width="108" height="17"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="659" y="284" width="104" height="13">
-			</bounds>
+			<bounds x="659" y="284" width="104" height="13"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="155" y="492" width="44" height="27">
-			</bounds>
+			<bounds x="155" y="492" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="157" y="494" width="40" height="23">
-			</bounds>
+			<bounds x="157" y="494" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="111" y="492" width="44" height="27">
-			</bounds>
+			<bounds x="111" y="492" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="113" y="494" width="40" height="23">
-			</bounds>
+			<bounds x="113" y="494" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="67" y="492" width="44" height="27">
-			</bounds>
+			<bounds x="67" y="492" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="69" y="494" width="40" height="23">
-			</bounds>
+			<bounds x="69" y="494" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="23" y="492" width="44" height="27">
-			</bounds>
+			<bounds x="23" y="492" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="25" y="494" width="40" height="23">
-			</bounds>
+			<bounds x="25" y="494" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="60" y="441" width="72" height="22">
-			</bounds>
+			<bounds x="60" y="441" width="72" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="62" y="443" width="68" height="18">
-			</bounds>
+			<bounds x="62" y="443" width="68" height="18"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="11" y="463" width="44" height="27">
-			</bounds>
+			<bounds x="11" y="463" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="13" y="465" width="40" height="23">
-			</bounds>
+			<bounds x="13" y="465" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="55" y="463" width="44" height="27">
-			</bounds>
+			<bounds x="55" y="463" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="57" y="465" width="40" height="23">
-			</bounds>
+			<bounds x="57" y="465" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="99" y="463" width="44" height="27">
-			</bounds>
+			<bounds x="99" y="463" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="101" y="465" width="40" height="23">
-			</bounds>
+			<bounds x="101" y="465" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="143" y="463" width="44" height="27">
-			</bounds>
+			<bounds x="143" y="463" width="44" height="27"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="145" y="465" width="40" height="23">
-			</bounds>
+			<bounds x="145" y="465" width="40" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_150_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="148" y="614" width="75" height="39">
-			</bounds>
+			<bounds x="148" y="614" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_150" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="150" y="616" width="71" height="35">
-			</bounds>
+			<bounds x="150" y="616" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_151_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="148" y="614" width="75" height="39">
-			</bounds>
+			<bounds x="148" y="614" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_151" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="150" y="616" width="71" height="35">
-			</bounds>
+			<bounds x="150" y="616" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_152_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="506" y="614" width="75" height="39">
-			</bounds>
+			<bounds x="506" y="614" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_152" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="508" y="616" width="71" height="35">
-			</bounds>
+			<bounds x="508" y="616" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_153_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="605" y="614" width="75" height="39">
-			</bounds>
+			<bounds x="605" y="614" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_153" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="607" y="616" width="71" height="35">
-			</bounds>
+			<bounds x="607" y="616" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_154_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="706" y="614" width="75" height="39">
-			</bounds>
+			<bounds x="706" y="614" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_154" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="708" y="616" width="71" height="35">
-			</bounds>
+			<bounds x="708" y="616" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_155_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="740" y="7" width="42" height="42">
-			</bounds>
+			<bounds x="740" y="7" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_155" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="742" y="9" width="38" height="38">
-			</bounds>
+			<bounds x="742" y="9" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_156_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="407" y="614" width="75" height="39">
-			</bounds>
+			<bounds x="407" y="614" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_156" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="409" y="616" width="71" height="35">
-			</bounds>
+			<bounds x="409" y="616" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_157_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="327" y="614" width="75" height="39">
-			</bounds>
+			<bounds x="327" y="614" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_157" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="329" y="616" width="71" height="35">
-			</bounds>
+			<bounds x="329" y="616" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_158_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="247" y="614" width="75" height="39">
-			</bounds>
+			<bounds x="247" y="614" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_158" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="249" y="616" width="71" height="35">
-			</bounds>
+			<bounds x="249" y="616" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="680" y="333" width="32" height="40">
-			</bounds>
+			<bounds x="680" y="333" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="684" y="336" width="22" height="3">
-			</bounds>
+			<bounds x="684" y="336" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="702" y="336" width="4" height="18">
-			</bounds>
+			<bounds x="702" y="336" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="702" y="351" width="4" height="18">
-			</bounds>
+			<bounds x="702" y="351" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="684" y="365" width="22" height="3">
-			</bounds>
+			<bounds x="684" y="365" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="684" y="351" width="4" height="18">
-			</bounds>
+			<bounds x="684" y="351" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="684" y="336" width="4" height="18">
-			</bounds>
+			<bounds x="684" y="336" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="684" y="351" width="22" height="3">
-			</bounds>
+			<bounds x="684" y="351" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="707" y="365" width="4" height="3">
-			</bounds>
+			<bounds x="707" y="365" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="684" y="336" width="22" height="3">
-			</bounds>
+			<bounds x="684" y="336" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="702" y="336" width="4" height="18">
-			</bounds>
+			<bounds x="702" y="336" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="702" y="351" width="4" height="18">
-			</bounds>
+			<bounds x="702" y="351" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="684" y="365" width="22" height="3">
-			</bounds>
+			<bounds x="684" y="365" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="684" y="351" width="4" height="18">
-			</bounds>
+			<bounds x="684" y="351" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="684" y="336" width="4" height="18">
-			</bounds>
+			<bounds x="684" y="336" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="684" y="351" width="22" height="3">
-			</bounds>
+			<bounds x="684" y="351" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="707" y="365" width="4" height="3">
-			</bounds>
+			<bounds x="707" y="365" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="712" y="333" width="32" height="40">
-			</bounds>
+			<bounds x="712" y="333" width="32" height="40"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="716" y="336" width="22" height="3">
-			</bounds>
+			<bounds x="716" y="336" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="734" y="336" width="4" height="18">
-			</bounds>
+			<bounds x="734" y="336" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="734" y="351" width="4" height="18">
-			</bounds>
+			<bounds x="734" y="351" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="716" y="365" width="22" height="3">
-			</bounds>
+			<bounds x="716" y="365" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="716" y="351" width="4" height="18">
-			</bounds>
+			<bounds x="716" y="351" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="716" y="336" width="4" height="18">
-			</bounds>
+			<bounds x="716" y="336" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="716" y="351" width="22" height="3">
-			</bounds>
+			<bounds x="716" y="351" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="739" y="365" width="4" height="3">
-			</bounds>
+			<bounds x="739" y="365" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="716" y="336" width="22" height="3">
-			</bounds>
+			<bounds x="716" y="336" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="734" y="336" width="4" height="18">
-			</bounds>
+			<bounds x="734" y="336" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="734" y="351" width="4" height="18">
-			</bounds>
+			<bounds x="734" y="351" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="716" y="365" width="22" height="3">
-			</bounds>
+			<bounds x="716" y="365" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="716" y="351" width="4" height="18">
-			</bounds>
+			<bounds x="716" y="351" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="716" y="336" width="4" height="18">
-			</bounds>
+			<bounds x="716" y="336" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="716" y="351" width="22" height="3">
-			</bounds>
+			<bounds x="716" y="351" width="22" height="3"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="739" y="365" width="4" height="3">
-			</bounds>
+			<bounds x="739" y="365" width="4" height="3"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="286" y="448" width="160" height="18">
-			</bounds>
+			<bounds x="286" y="448" width="160" height="18"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="286" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="286" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="296" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="296" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="306" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="306" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="316" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="316" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="326" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="326" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="336" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="336" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="346" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="346" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="356" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="356" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="366" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="366" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="376" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="376" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="386" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="386" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="396" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="396" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="406" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="406" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="416" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="416" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="426" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="426" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="436" y="448" width="10" height="18">
-			</bounds>
+			<bounds x="436" y="448" width="10" height="18"/>
 		</backdrop>
 		<backdrop name="label29" element="label_29">
-			<bounds x="335" y="190" width="48" height="33">
-			</bounds>
+			<bounds x="335" y="190" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="label104" element="label_104">
-			<bounds x="40" y="69" width="109" height="14">
-			</bounds>
+			<bounds x="40" y="69" width="109" height="14"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="2" y="645" width="21" height="13">
-			</bounds>
+			<bounds x="2" y="645" width="21" height="13"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="691" y="317" width="42" height="14">
-			</bounds>
+			<bounds x="691" y="317" width="42" height="14"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="684" y="505" width="74" height="12">
-			</bounds>
+			<bounds x="684" y="505" width="74" height="12"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="671" y="581" width="102" height="12">
-			</bounds>
+			<bounds x="671" y="581" width="102" height="12"/>
 		</backdrop>
 		<backdrop name="label140" element="label_140">
-			<bounds x="679" y="453" width="83" height="12">
-			</bounds>
+			<bounds x="679" y="453" width="83" height="12"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1sudnima.lay
+++ b/src/mame/layout/m1sudnima.lay
@@ -8,9180 +8,6147 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="STOP A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="STOP A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="FRUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="FRUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="IMPACT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="IMPACT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUDDEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUDDEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SCORE  HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SCORE  HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="  &#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="  &#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_224_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_224">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_246_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_246">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_247_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_247">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_248_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_248">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_249_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_249">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_250_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_250">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_251_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_251">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_252_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_252">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_253_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_253">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_121">
 		<text string="GAMES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="707" height="608">
-			</bounds>
+			<bounds x="0" y="0" width="707" height="608"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="90" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="90" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="90.0000" y="379.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="90.0000" y="379.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="93.3333" y="380.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="93.3333" y="380.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="96.6667" y="382.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="96.6667" y="382.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="100.0000" y="384.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="100.0000" y="384.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="103.3333" y="386.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="103.3333" y="386.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="106.6667" y="388.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="106.6667" y="388.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="90.0000" y="425.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="90.0000" y="425.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="93.3333" y="427.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="93.3333" y="427.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="96.6667" y="429.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="96.6667" y="429.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="100.0000" y="431.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="100.0000" y="431.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="103.3333" y="433.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="103.3333" y="433.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="106.6667" y="435.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="106.6667" y="435.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="90.0000" y="472.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="90.0000" y="472.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="93.3333" y="474.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="93.3333" y="474.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="96.6667" y="476.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="96.6667" y="476.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="100.0000" y="478.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="100.0000" y="478.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="103.3333" y="480.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="103.3333" y="480.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="106.6667" y="482.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="106.6667" y="482.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="90" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="90" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="172" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="172" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="172.0000" y="379.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="172.0000" y="379.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="175.3333" y="380.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="175.3333" y="380.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="178.6667" y="382.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="178.6667" y="382.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="182.0000" y="384.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="182.0000" y="384.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="185.3333" y="386.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="185.3333" y="386.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="188.6667" y="388.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="188.6667" y="388.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="172.0000" y="425.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="172.0000" y="425.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="175.3333" y="427.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="175.3333" y="427.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="178.6667" y="429.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="178.6667" y="429.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="182.0000" y="431.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="182.0000" y="431.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="185.3333" y="433.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="185.3333" y="433.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="188.6667" y="435.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="188.6667" y="435.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="172.0000" y="472.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="172.0000" y="472.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="175.3333" y="474.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="175.3333" y="474.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="178.6667" y="476.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="178.6667" y="476.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="182.0000" y="478.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="182.0000" y="478.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="185.3333" y="480.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="185.3333" y="480.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="188.6667" y="482.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="188.6667" y="482.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="172" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="172" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="254" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="254" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="379.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="254.0000" y="379.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="257.3333" y="380.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="257.3333" y="380.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="260.6667" y="382.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="260.6667" y="382.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="264.0000" y="384.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="264.0000" y="384.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="267.3333" y="386.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="267.3333" y="386.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="270.6667" y="388.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="270.6667" y="388.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="425.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="254.0000" y="425.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="257.3333" y="427.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="257.3333" y="427.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="260.6667" y="429.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="260.6667" y="429.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="264.0000" y="431.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="264.0000" y="431.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="267.3333" y="433.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="267.3333" y="433.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="270.6667" y="435.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="270.6667" y="435.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="472.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="254.0000" y="472.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="257.3333" y="474.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="257.3333" y="474.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="260.6667" y="476.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="260.6667" y="476.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="264.0000" y="478.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="264.0000" y="478.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="267.3333" y="480.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="267.3333" y="480.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="270.6667" y="482.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="270.6667" y="482.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="254" y="379" width="80" height="140">
-			</bounds>
+			<bounds x="254" y="379" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="48" y="150" width="80" height="60">
-			</bounds>
+			<bounds x="48" y="150" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="48.0000" y="150.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="48.0000" y="150.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="51.3333" y="152.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="51.3333" y="152.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="54.6667" y="155.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="54.6667" y="155.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="58.0000" y="157.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="58.0000" y="157.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="61.3333" y="160.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="61.3333" y="160.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="64.6667" y="162.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="64.6667" y="162.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="48" y="150" width="80" height="60">
-			</bounds>
+			<bounds x="48" y="150" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="245" y="527" width="50" height="36">
-			</bounds>
+			<bounds x="245" y="527" width="50" height="36"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="247" y="529" width="46" height="32">
-			</bounds>
+			<bounds x="247" y="529" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="193" y="527" width="50" height="36">
-			</bounds>
+			<bounds x="193" y="527" width="50" height="36"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="195" y="529" width="46" height="32">
-			</bounds>
+			<bounds x="195" y="529" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="141" y="527" width="50" height="36">
-			</bounds>
+			<bounds x="141" y="527" width="50" height="36"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="143" y="529" width="46" height="32">
-			</bounds>
+			<bounds x="143" y="529" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="89" y="527" width="50" height="36">
-			</bounds>
+			<bounds x="89" y="527" width="50" height="36"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="91" y="529" width="46" height="32">
-			</bounds>
+			<bounds x="91" y="529" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="365" y="308" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="308" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="367" y="310" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="310" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="295" y="527" width="50" height="36">
-			</bounds>
+			<bounds x="295" y="527" width="50" height="36"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="297" y="529" width="46" height="32">
-			</bounds>
+			<bounds x="297" y="529" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="178" y="19" width="90" height="36">
-			</bounds>
+			<bounds x="178" y="19" width="90" height="36"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="180" y="21" width="86" height="32">
-			</bounds>
+			<bounds x="180" y="21" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="92" y="19" width="90" height="36">
-			</bounds>
+			<bounds x="92" y="19" width="90" height="36"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="94" y="21" width="86" height="32">
-			</bounds>
+			<bounds x="94" y="21" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="64" y="213" width="46" height="36">
-			</bounds>
+			<bounds x="64" y="213" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="66" y="215" width="42" height="32">
-			</bounds>
+			<bounds x="66" y="215" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="63" y="112" width="46" height="36">
-			</bounds>
+			<bounds x="63" y="112" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="65" y="114" width="42" height="32">
-			</bounds>
+			<bounds x="65" y="114" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="459" y="82" width="46" height="36">
-			</bounds>
+			<bounds x="459" y="82" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="461" y="84" width="42" height="32">
-			</bounds>
+			<bounds x="461" y="84" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="412" y="118" width="46" height="36">
-			</bounds>
+			<bounds x="412" y="118" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="414" y="120" width="42" height="32">
-			</bounds>
+			<bounds x="414" y="120" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="412" y="262" width="46" height="36">
-			</bounds>
+			<bounds x="412" y="262" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="414" y="264" width="42" height="32">
-			</bounds>
+			<bounds x="414" y="264" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="412" y="226" width="46" height="36">
-			</bounds>
+			<bounds x="412" y="226" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="414" y="228" width="42" height="32">
-			</bounds>
+			<bounds x="414" y="228" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="412" y="190" width="46" height="36">
-			</bounds>
+			<bounds x="412" y="190" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="414" y="192" width="42" height="32">
-			</bounds>
+			<bounds x="414" y="192" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="412" y="154" width="46" height="36">
-			</bounds>
+			<bounds x="412" y="154" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="414" y="156" width="42" height="32">
-			</bounds>
+			<bounds x="414" y="156" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="412" y="82" width="46" height="36">
-			</bounds>
+			<bounds x="412" y="82" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="414" y="84" width="42" height="32">
-			</bounds>
+			<bounds x="414" y="84" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="365" y="154" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="154" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="367" y="156" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="156" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="365" y="190" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="190" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="367" y="192" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="192" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="365" y="226" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="226" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="367" y="228" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="228" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="365" y="262" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="262" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="367" y="264" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="264" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="365" y="118" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="118" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="367" y="120" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="120" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="365" y="82" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="82" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="367" y="84" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="84" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="365" y="416" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="416" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="367" y="418" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="418" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="365" y="380" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="380" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="367" y="382" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="382" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="365" y="344" width="46" height="36">
-			</bounds>
+			<bounds x="365" y="344" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="367" y="346" width="42" height="32">
-			</bounds>
+			<bounds x="367" y="346" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="357" y="459" width="68" height="28">
-			</bounds>
+			<bounds x="357" y="459" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="359" y="461" width="64" height="24">
-			</bounds>
+			<bounds x="359" y="461" width="64" height="24"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="523" y="354" width="36" height="36">
-			</bounds>
+			<bounds x="523" y="354" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="525" y="356" width="32" height="32">
-			</bounds>
+			<bounds x="525" y="356" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="485" y="354" width="36" height="36">
-			</bounds>
+			<bounds x="485" y="354" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="487" y="356" width="32" height="32">
-			</bounds>
+			<bounds x="487" y="356" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="447" y="354" width="36" height="36">
-			</bounds>
+			<bounds x="447" y="354" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="449" y="356" width="32" height="32">
-			</bounds>
+			<bounds x="449" y="356" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="428" y="324" width="90" height="26">
-			</bounds>
+			<bounds x="428" y="324" width="90" height="26"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="430" y="326" width="86" height="22">
-			</bounds>
+			<bounds x="430" y="326" width="86" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="521" y="324" width="58" height="26">
-			</bounds>
+			<bounds x="521" y="324" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="523" y="326" width="54" height="22">
-			</bounds>
+			<bounds x="523" y="326" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="396" y="44" width="82" height="34">
-			</bounds>
+			<bounds x="396" y="44" width="82" height="34"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="398" y="46" width="78" height="30">
-			</bounds>
+			<bounds x="398" y="46" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="568" y="86" width="46" height="26">
-			</bounds>
+			<bounds x="568" y="86" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="570" y="88" width="42" height="22">
-			</bounds>
+			<bounds x="570" y="88" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="519" y="86" width="48" height="26">
-			</bounds>
+			<bounds x="519" y="86" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="521" y="88" width="44" height="22">
-			</bounds>
+			<bounds x="521" y="88" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="533" y="59" width="68" height="26">
-			</bounds>
+			<bounds x="533" y="59" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="535" y="61" width="64" height="22">
-			</bounds>
+			<bounds x="535" y="61" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="348" y="527" width="48" height="36">
-			</bounds>
+			<bounds x="348" y="527" width="48" height="36"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="350" y="529" width="44" height="32">
-			</bounds>
+			<bounds x="350" y="529" width="44" height="32"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="348" y="494" width="48" height="36">
-			</bounds>
+			<bounds x="348" y="494" width="48" height="36"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="350" y="496" width="44" height="32">
-			</bounds>
+			<bounds x="350" y="496" width="44" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_224_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="657" y="1" width="46" height="36">
-			</bounds>
+			<bounds x="657" y="1" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_224" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="659" y="3" width="42" height="32">
-			</bounds>
+			<bounds x="659" y="3" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_246_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="243" y="317" width="46" height="26">
-			</bounds>
+			<bounds x="243" y="317" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_246" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="245" y="319" width="42" height="22">
-			</bounds>
+			<bounds x="245" y="319" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_247_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="293" y="317" width="46" height="26">
-			</bounds>
+			<bounds x="293" y="317" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_247" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="295" y="319" width="42" height="22">
-			</bounds>
+			<bounds x="295" y="319" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_248_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="3" y="566" width="75" height="37">
-			</bounds>
+			<bounds x="3" y="566" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_248" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="5" y="568" width="71" height="33">
-			</bounds>
+			<bounds x="5" y="568" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_249_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="94" y="566" width="75" height="37">
-			</bounds>
+			<bounds x="94" y="566" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_249" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="96" y="568" width="71" height="33">
-			</bounds>
+			<bounds x="96" y="568" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_250_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="175" y="566" width="75" height="37">
-			</bounds>
+			<bounds x="175" y="566" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_250" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="177" y="568" width="71" height="33">
-			</bounds>
+			<bounds x="177" y="568" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_251_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="256" y="566" width="75" height="37">
-			</bounds>
+			<bounds x="256" y="566" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_251" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="258" y="568" width="71" height="33">
-			</bounds>
+			<bounds x="258" y="568" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_252_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="332" y="566" width="75" height="37">
-			</bounds>
+			<bounds x="332" y="566" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_252" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="334" y="568" width="71" height="33">
-			</bounds>
+			<bounds x="334" y="568" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_253_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="414" y="566" width="75" height="37">
-			</bounds>
+			<bounds x="414" y="566" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_253" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="416" y="568" width="71" height="33">
-			</bounds>
+			<bounds x="416" y="568" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="445" y="524" width="24" height="32">
-			</bounds>
+			<bounds x="445" y="524" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="448" y="526" width="17" height="2">
-			</bounds>
+			<bounds x="448" y="526" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="462" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="462" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="462" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="462" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="448" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="448" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="448" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="448" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="448" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="448" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="448" y="538" width="17" height="2">
-			</bounds>
+			<bounds x="448" y="538" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="465" y="550" width="3" height="2">
-			</bounds>
+			<bounds x="465" y="550" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="448" y="526" width="17" height="2">
-			</bounds>
+			<bounds x="448" y="526" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="462" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="462" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="462" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="462" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="448" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="448" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="448" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="448" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="448" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="448" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="448" y="538" width="17" height="2">
-			</bounds>
+			<bounds x="448" y="538" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="465" y="550" width="3" height="2">
-			</bounds>
+			<bounds x="465" y="550" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="421" y="524" width="24" height="32">
-			</bounds>
+			<bounds x="421" y="524" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="424" y="526" width="17" height="2">
-			</bounds>
+			<bounds x="424" y="526" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="438" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="438" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="438" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="438" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="424" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="424" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="424" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="424" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="424" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="424" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="424" y="538" width="17" height="2">
-			</bounds>
+			<bounds x="424" y="538" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="441" y="550" width="3" height="2">
-			</bounds>
+			<bounds x="441" y="550" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="424" y="526" width="17" height="2">
-			</bounds>
+			<bounds x="424" y="526" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="438" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="438" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="438" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="438" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="424" y="550" width="17" height="2">
-			</bounds>
+			<bounds x="424" y="550" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="424" y="538" width="3" height="14">
-			</bounds>
+			<bounds x="424" y="538" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="424" y="526" width="3" height="14">
-			</bounds>
+			<bounds x="424" y="526" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="424" y="538" width="17" height="2">
-			</bounds>
+			<bounds x="424" y="538" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="441" y="550" width="3" height="2">
-			</bounds>
+			<bounds x="441" y="550" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="554" y="483" width="24" height="32">
-			</bounds>
+			<bounds x="554" y="483" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off48" element="led_off">
-			<bounds x="557" y="485" width="17" height="2">
-			</bounds>
+			<bounds x="557" y="485" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off49" element="led_off">
-			<bounds x="571" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="571" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off50" element="led_off">
-			<bounds x="571" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="571" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off51" element="led_off">
-			<bounds x="557" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="557" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off52" element="led_off">
-			<bounds x="557" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="557" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off53" element="led_off">
-			<bounds x="557" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="557" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off54" element="led_off">
-			<bounds x="557" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="557" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="574" y="509" width="3" height="2">
-			</bounds>
+			<bounds x="574" y="509" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp48" element="led_on">
-			<bounds x="557" y="485" width="17" height="2">
-			</bounds>
+			<bounds x="557" y="485" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp49" element="led_on">
-			<bounds x="571" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="571" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp50" element="led_on">
-			<bounds x="571" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="571" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp51" element="led_on">
-			<bounds x="557" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="557" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp52" element="led_on">
-			<bounds x="557" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="557" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp53" element="led_on">
-			<bounds x="557" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="557" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp54" element="led_on">
-			<bounds x="557" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="557" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="574" y="509" width="3" height="2">
-			</bounds>
+			<bounds x="574" y="509" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="576" y="483" width="24" height="32">
-			</bounds>
+			<bounds x="576" y="483" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_off">
-			<bounds x="579" y="485" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="485" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="593" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="593" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="593" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="593" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="579" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="579" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="579" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="579" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="579" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="579" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="596" y="509" width="3" height="2">
-			</bounds>
+			<bounds x="596" y="509" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_on">
-			<bounds x="579" y="485" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="485" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="593" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="593" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="593" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="593" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="579" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="579" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="579" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="579" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="579" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="579" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="579" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="596" y="509" width="3" height="2">
-			</bounds>
+			<bounds x="596" y="509" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="622" y="483" width="24" height="32">
-			</bounds>
+			<bounds x="622" y="483" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="625" y="485" width="17" height="2">
-			</bounds>
+			<bounds x="625" y="485" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="639" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="639" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="639" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="639" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="625" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="625" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="625" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="625" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="625" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="625" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="642" y="509" width="3" height="2">
-			</bounds>
+			<bounds x="642" y="509" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="625" y="485" width="17" height="2">
-			</bounds>
+			<bounds x="625" y="485" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="639" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="639" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="639" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="639" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="625" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="625" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="625" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="625" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="625" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="625" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="625" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="642" y="509" width="3" height="2">
-			</bounds>
+			<bounds x="642" y="509" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="598" y="483" width="24" height="32">
-			</bounds>
+			<bounds x="598" y="483" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off64" element="led_off">
-			<bounds x="601" y="485" width="17" height="2">
-			</bounds>
+			<bounds x="601" y="485" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off65" element="led_off">
-			<bounds x="615" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="615" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off66" element="led_off">
-			<bounds x="615" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="615" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off67" element="led_off">
-			<bounds x="601" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="601" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off68" element="led_off">
-			<bounds x="601" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="601" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off69" element="led_off">
-			<bounds x="601" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="601" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off70" element="led_off">
-			<bounds x="601" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="601" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="618" y="509" width="3" height="2">
-			</bounds>
+			<bounds x="618" y="509" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp64" element="led_on">
-			<bounds x="601" y="485" width="17" height="2">
-			</bounds>
+			<bounds x="601" y="485" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp65" element="led_on">
-			<bounds x="615" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="615" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp66" element="led_on">
-			<bounds x="615" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="615" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp67" element="led_on">
-			<bounds x="601" y="509" width="17" height="2">
-			</bounds>
+			<bounds x="601" y="509" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp68" element="led_on">
-			<bounds x="601" y="497" width="3" height="14">
-			</bounds>
+			<bounds x="601" y="497" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="led_on">
-			<bounds x="601" y="485" width="3" height="14">
-			</bounds>
+			<bounds x="601" y="485" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="led_on">
-			<bounds x="601" y="497" width="17" height="2">
-			</bounds>
+			<bounds x="601" y="497" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="618" y="509" width="3" height="2">
-			</bounds>
+			<bounds x="618" y="509" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label121" element="label_121">
-			<bounds x="414" y="501" width="65" height="20">
-			</bounds>
+			<bounds x="414" y="501" width="65" height="20"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="568" y="521" width="65" height="13">
-			</bounds>
+			<bounds x="568" y="521" width="65" height="13"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="519" y="470" width="36" height="75">
-			</bounds>
+			<bounds x="519" y="470" width="36" height="75"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_button" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1taknot.lay
+++ b/src/mame/layout/m1taknot.lay
@@ -8,11630 +8,6936 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LETTERS HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LETTERS HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="THREE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="THREE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTES HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTES HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Note Matrix">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2.40+rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Note Matrix">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.40+rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.80 JackPot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.80 JackPot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Yes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lineup">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lineup">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Number Sprint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Number Sprint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Stop n step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop n step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Big ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cross Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cross Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_99_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_99">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_100_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_100">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_101_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_101">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_102_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_102">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_103_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_103">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_104_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_104">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_105_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_105">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_107_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_107">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_108_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_108">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_109_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_109">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="reset">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_60">
 		<text string="nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_72">
 		<text string="WIN BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="513">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="513"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="107" y="314" width="100" height="140">
-			</bounds>
+			<bounds x="107" y="314" width="100" height="140"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="107" y="314" width="100" height="140">
-			</bounds>
+			<bounds x="107" y="314" width="100" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="207" y="314" width="100" height="140">
-			</bounds>
+			<bounds x="207" y="314" width="100" height="140"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="207" y="314" width="100" height="140">
-			</bounds>
+			<bounds x="207" y="314" width="100" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="307" y="314" width="100" height="140">
-			</bounds>
+			<bounds x="307" y="314" width="100" height="140"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="307" y="314" width="100" height="140">
-			</bounds>
+			<bounds x="307" y="314" width="100" height="140"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="336" y="284" width="72" height="32">
-			</bounds>
+			<bounds x="336" y="284" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="338" y="286" width="68" height="28">
-			</bounds>
+			<bounds x="338" y="286" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="278" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="278" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="280" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="280" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="307" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="307" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="309" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="309" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="163" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="163" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="165" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="165" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="192" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="192" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="194" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="194" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="221" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="221" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="223" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="223" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="250" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="250" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="252" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="252" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="106" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="106" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="108" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="108" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="135" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="135" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="137" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="137" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="6" y="355" width="19" height="19">
-			</bounds>
+			<bounds x="6" y="355" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="8" y="357" width="15" height="15">
-			</bounds>
+			<bounds x="8" y="357" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="6" y="375" width="19" height="19">
-			</bounds>
+			<bounds x="6" y="375" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="8" y="377" width="15" height="15">
-			</bounds>
+			<bounds x="8" y="377" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="6" y="395" width="19" height="19">
-			</bounds>
+			<bounds x="6" y="395" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="8" y="397" width="15" height="15">
-			</bounds>
+			<bounds x="8" y="397" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="46" y="395" width="19" height="19">
-			</bounds>
+			<bounds x="46" y="395" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="48" y="397" width="15" height="15">
-			</bounds>
+			<bounds x="48" y="397" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="46" y="375" width="19" height="19">
-			</bounds>
+			<bounds x="46" y="375" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="48" y="377" width="15" height="15">
-			</bounds>
+			<bounds x="48" y="377" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="46" y="355" width="19" height="19">
-			</bounds>
+			<bounds x="46" y="355" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="48" y="357" width="15" height="15">
-			</bounds>
+			<bounds x="48" y="357" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="26" y="395" width="19" height="19">
-			</bounds>
+			<bounds x="26" y="395" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="28" y="397" width="15" height="15">
-			</bounds>
+			<bounds x="28" y="397" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="26" y="375" width="19" height="19">
-			</bounds>
+			<bounds x="26" y="375" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="28" y="377" width="15" height="15">
-			</bounds>
+			<bounds x="28" y="377" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="26" y="355" width="19" height="19">
-			</bounds>
+			<bounds x="26" y="355" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="28" y="357" width="15" height="15">
-			</bounds>
+			<bounds x="28" y="357" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="66" y="413" width="42" height="42">
-			</bounds>
+			<bounds x="66" y="413" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="68" y="415" width="38" height="38">
-			</bounds>
+			<bounds x="68" y="415" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="66" y="374" width="42" height="42">
-			</bounds>
+			<bounds x="66" y="374" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="68" y="376" width="38" height="38">
-			</bounds>
+			<bounds x="68" y="376" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="66" y="335" width="42" height="42">
-			</bounds>
+			<bounds x="66" y="335" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="68" y="337" width="38" height="38">
-			</bounds>
+			<bounds x="68" y="337" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="66" y="313" width="42" height="26">
-			</bounds>
+			<bounds x="66" y="313" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="68" y="315" width="38" height="22">
-			</bounds>
+			<bounds x="68" y="315" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="213" y="75" width="79" height="32">
-			</bounds>
+			<bounds x="213" y="75" width="79" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="215" y="77" width="75" height="28">
-			</bounds>
+			<bounds x="215" y="77" width="75" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="166" y="229" width="52" height="52">
-			</bounds>
+			<bounds x="166" y="229" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="168" y="231" width="48" height="48">
-			</bounds>
+			<bounds x="168" y="231" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="226" y="229" width="52" height="52">
-			</bounds>
+			<bounds x="226" y="229" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="228" y="231" width="48" height="48">
-			</bounds>
+			<bounds x="228" y="231" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="286" y="229" width="52" height="52">
-			</bounds>
+			<bounds x="286" y="229" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="288" y="231" width="48" height="48">
-			</bounds>
+			<bounds x="288" y="231" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="286" y="169" width="52" height="52">
-			</bounds>
+			<bounds x="286" y="169" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="288" y="171" width="48" height="48">
-			</bounds>
+			<bounds x="288" y="171" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="286" y="109" width="52" height="52">
-			</bounds>
+			<bounds x="286" y="109" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="288" y="111" width="48" height="48">
-			</bounds>
+			<bounds x="288" y="111" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="166" y="109" width="52" height="52">
-			</bounds>
+			<bounds x="166" y="109" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="168" y="111" width="48" height="48">
-			</bounds>
+			<bounds x="168" y="111" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="166" y="169" width="52" height="52">
-			</bounds>
+			<bounds x="166" y="169" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="168" y="171" width="48" height="48">
-			</bounds>
+			<bounds x="168" y="171" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="226" y="169" width="52" height="52">
-			</bounds>
+			<bounds x="226" y="169" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="228" y="171" width="48" height="48">
-			</bounds>
+			<bounds x="228" y="171" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="226" y="109" width="52" height="52">
-			</bounds>
+			<bounds x="226" y="109" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="228" y="111" width="48" height="48">
-			</bounds>
+			<bounds x="228" y="111" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="530" y="377" width="42" height="42">
-			</bounds>
+			<bounds x="530" y="377" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="532" y="379" width="38" height="38">
-			</bounds>
+			<bounds x="532" y="379" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="689" y="388" width="32" height="32">
-			</bounds>
+			<bounds x="689" y="388" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="691" y="390" width="28" height="28">
-			</bounds>
+			<bounds x="691" y="390" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="659" y="389" width="32" height="32">
-			</bounds>
+			<bounds x="659" y="389" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="661" y="391" width="28" height="28">
-			</bounds>
+			<bounds x="661" y="391" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="569" y="389" width="32" height="32">
-			</bounds>
+			<bounds x="569" y="389" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="571" y="391" width="28" height="28">
-			</bounds>
+			<bounds x="571" y="391" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="659" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="659" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="661" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="661" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="689" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="689" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="691" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="691" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="569" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="569" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="571" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="571" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="599" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="599" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="601" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="601" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="629" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="629" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="631" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="631" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="599" y="329" width="32" height="32">
-			</bounds>
+			<bounds x="599" y="329" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="601" y="331" width="28" height="28">
-			</bounds>
+			<bounds x="601" y="331" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="569" y="329" width="32" height="32">
-			</bounds>
+			<bounds x="569" y="329" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="571" y="331" width="28" height="28">
-			</bounds>
+			<bounds x="571" y="331" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="659" y="329" width="32" height="32">
-			</bounds>
+			<bounds x="659" y="329" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="661" y="331" width="28" height="28">
-			</bounds>
+			<bounds x="661" y="331" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="629" y="329" width="32" height="32">
-			</bounds>
+			<bounds x="629" y="329" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="631" y="331" width="28" height="28">
-			</bounds>
+			<bounds x="631" y="331" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="689" y="329" width="32" height="32">
-			</bounds>
+			<bounds x="689" y="329" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="691" y="331" width="28" height="28">
-			</bounds>
+			<bounds x="691" y="331" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="659" y="299" width="32" height="32">
-			</bounds>
+			<bounds x="659" y="299" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="661" y="301" width="28" height="28">
-			</bounds>
+			<bounds x="661" y="301" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="689" y="299" width="32" height="32">
-			</bounds>
+			<bounds x="689" y="299" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="691" y="301" width="28" height="28">
-			</bounds>
+			<bounds x="691" y="301" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="579" y="267" width="82" height="32">
-			</bounds>
+			<bounds x="579" y="267" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="581" y="269" width="78" height="28">
-			</bounds>
+			<bounds x="581" y="269" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="662" y="267" width="52" height="32">
-			</bounds>
+			<bounds x="662" y="267" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="664" y="269" width="48" height="28">
-			</bounds>
+			<bounds x="664" y="269" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="629" y="389" width="32" height="32">
-			</bounds>
+			<bounds x="629" y="389" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="631" y="391" width="28" height="28">
-			</bounds>
+			<bounds x="631" y="391" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="599" y="389" width="32" height="32">
-			</bounds>
+			<bounds x="599" y="389" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="601" y="391" width="28" height="28">
-			</bounds>
+			<bounds x="601" y="391" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="629" y="299" width="32" height="32">
-			</bounds>
+			<bounds x="629" y="299" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="631" y="301" width="28" height="28">
-			</bounds>
+			<bounds x="631" y="301" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="569" y="299" width="32" height="32">
-			</bounds>
+			<bounds x="569" y="299" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="571" y="301" width="28" height="28">
-			</bounds>
+			<bounds x="571" y="301" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="599" y="299" width="32" height="32">
-			</bounds>
+			<bounds x="599" y="299" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="601" y="301" width="28" height="28">
-			</bounds>
+			<bounds x="601" y="301" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="582" y="169" width="97" height="32">
-			</bounds>
+			<bounds x="582" y="169" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="584" y="171" width="93" height="28">
-			</bounds>
+			<bounds x="584" y="171" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="643" y="229" width="32" height="32">
-			</bounds>
+			<bounds x="643" y="229" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="645" y="231" width="28" height="28">
-			</bounds>
+			<bounds x="645" y="231" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="643" y="199" width="32" height="32">
-			</bounds>
+			<bounds x="643" y="199" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="645" y="201" width="28" height="28">
-			</bounds>
+			<bounds x="645" y="201" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="614" y="199" width="32" height="32">
-			</bounds>
+			<bounds x="614" y="199" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="616" y="201" width="28" height="28">
-			</bounds>
+			<bounds x="616" y="201" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="585" y="199" width="32" height="32">
-			</bounds>
+			<bounds x="585" y="199" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="587" y="201" width="28" height="28">
-			</bounds>
+			<bounds x="587" y="201" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="614" y="229" width="32" height="32">
-			</bounds>
+			<bounds x="614" y="229" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="616" y="231" width="28" height="28">
-			</bounds>
+			<bounds x="616" y="231" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="585" y="229" width="32" height="32">
-			</bounds>
+			<bounds x="585" y="229" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="587" y="231" width="28" height="28">
-			</bounds>
+			<bounds x="587" y="231" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="582" y="83" width="97" height="32">
-			</bounds>
+			<bounds x="582" y="83" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="584" y="85" width="93" height="28">
-			</bounds>
+			<bounds x="584" y="85" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="582" y="111" width="97" height="32">
-			</bounds>
+			<bounds x="582" y="111" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="584" y="113" width="93" height="28">
-			</bounds>
+			<bounds x="584" y="113" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="582" y="140" width="97" height="32">
-			</bounds>
+			<bounds x="582" y="140" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="584" y="142" width="93" height="28">
-			</bounds>
+			<bounds x="584" y="142" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="582" y="54" width="97" height="32">
-			</bounds>
+			<bounds x="582" y="54" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="584" y="56" width="93" height="28">
-			</bounds>
+			<bounds x="584" y="56" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="288" y="91" width="28" height="19">
-			</bounds>
+			<bounds x="288" y="91" width="28" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="290" y="93" width="24" height="15">
-			</bounds>
+			<bounds x="290" y="93" width="24" height="15"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="313" y="91" width="27" height="19">
-			</bounds>
+			<bounds x="313" y="91" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="315" y="93" width="23" height="15">
-			</bounds>
+			<bounds x="315" y="93" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="288" y="75" width="52" height="19">
-			</bounds>
+			<bounds x="288" y="75" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="290" y="77" width="48" height="15">
-			</bounds>
+			<bounds x="290" y="77" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="410" y="255" width="32" height="32">
-			</bounds>
+			<bounds x="410" y="255" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="412" y="257" width="28" height="28">
-			</bounds>
+			<bounds x="412" y="257" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="435" y="193" width="52" height="32">
-			</bounds>
+			<bounds x="435" y="193" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="437" y="195" width="48" height="28">
-			</bounds>
+			<bounds x="437" y="195" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="435" y="162" width="52" height="32">
-			</bounds>
+			<bounds x="435" y="162" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="437" y="164" width="48" height="28">
-			</bounds>
+			<bounds x="437" y="164" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="435" y="131" width="52" height="32">
-			</bounds>
+			<bounds x="435" y="131" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="437" y="133" width="48" height="28">
-			</bounds>
+			<bounds x="437" y="133" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="373" y="12" width="102" height="62">
-			</bounds>
+			<bounds x="373" y="12" width="102" height="62"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="375" y="14" width="98" height="58">
-			</bounds>
+			<bounds x="375" y="14" width="98" height="58"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="436" y="224" width="52" height="32">
-			</bounds>
+			<bounds x="436" y="224" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="438" y="226" width="48" height="28">
-			</bounds>
+			<bounds x="438" y="226" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="306" y="42" width="32" height="32">
-			</bounds>
+			<bounds x="306" y="42" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="308" y="44" width="28" height="28">
-			</bounds>
+			<bounds x="308" y="44" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="306" y="12" width="32" height="32">
-			</bounds>
+			<bounds x="306" y="12" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="308" y="14" width="28" height="28">
-			</bounds>
+			<bounds x="308" y="14" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="336" y="12" width="32" height="32">
-			</bounds>
+			<bounds x="336" y="12" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="338" y="14" width="28" height="28">
-			</bounds>
+			<bounds x="338" y="14" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="276" y="42" width="32" height="32">
-			</bounds>
+			<bounds x="276" y="42" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="278" y="44" width="28" height="28">
-			</bounds>
+			<bounds x="278" y="44" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="216" y="42" width="32" height="32">
-			</bounds>
+			<bounds x="216" y="42" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="218" y="44" width="28" height="28">
-			</bounds>
+			<bounds x="218" y="44" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="246" y="42" width="32" height="32">
-			</bounds>
+			<bounds x="246" y="42" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="248" y="44" width="28" height="28">
-			</bounds>
+			<bounds x="248" y="44" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="246" y="12" width="32" height="32">
-			</bounds>
+			<bounds x="246" y="12" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="248" y="14" width="28" height="28">
-			</bounds>
+			<bounds x="248" y="14" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="216" y="12" width="32" height="32">
-			</bounds>
+			<bounds x="216" y="12" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="218" y="14" width="28" height="28">
-			</bounds>
+			<bounds x="218" y="14" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="276" y="12" width="32" height="32">
-			</bounds>
+			<bounds x="276" y="12" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="278" y="14" width="28" height="28">
-			</bounds>
+			<bounds x="278" y="14" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="336" y="42" width="32" height="32">
-			</bounds>
+			<bounds x="336" y="42" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="338" y="44" width="28" height="28">
-			</bounds>
+			<bounds x="338" y="44" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="430" y="73" width="52" height="32">
-			</bounds>
+			<bounds x="430" y="73" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="432" y="75" width="48" height="28">
-			</bounds>
+			<bounds x="432" y="75" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="479" y="101" width="37" height="37">
-			</bounds>
+			<bounds x="479" y="101" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="481" y="103" width="33" height="33">
-			</bounds>
+			<bounds x="481" y="103" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="398" y="101" width="37" height="37">
-			</bounds>
+			<bounds x="398" y="101" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="400" y="103" width="33" height="33">
-			</bounds>
+			<bounds x="400" y="103" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="425" y="101" width="37" height="37">
-			</bounds>
+			<bounds x="425" y="101" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="427" y="103" width="33" height="33">
-			</bounds>
+			<bounds x="427" y="103" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="452" y="101" width="37" height="37">
-			</bounds>
+			<bounds x="452" y="101" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="454" y="103" width="33" height="33">
-			</bounds>
+			<bounds x="454" y="103" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="412" y="324" width="72" height="32">
-			</bounds>
+			<bounds x="412" y="324" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="414" y="326" width="68" height="28">
-			</bounds>
+			<bounds x="414" y="326" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="412" y="402" width="72" height="32">
-			</bounds>
+			<bounds x="412" y="402" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="414" y="404" width="68" height="28">
-			</bounds>
+			<bounds x="414" y="404" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_99_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="312" y="458" width="92" height="52">
-			</bounds>
+			<bounds x="312" y="458" width="92" height="52"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_99" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="314" y="460" width="88" height="48">
-			</bounds>
+			<bounds x="314" y="460" width="88" height="48"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_100_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="112" y="458" width="92" height="52">
-			</bounds>
+			<bounds x="112" y="458" width="92" height="52"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_100" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="114" y="460" width="88" height="48">
-			</bounds>
+			<bounds x="114" y="460" width="88" height="48"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_101_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="211" y="458" width="92" height="52">
-			</bounds>
+			<bounds x="211" y="458" width="92" height="52"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_101" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="213" y="460" width="88" height="48">
-			</bounds>
+			<bounds x="213" y="460" width="88" height="48"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_102_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="411" y="457" width="92" height="52">
-			</bounds>
+			<bounds x="411" y="457" width="92" height="52"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_102" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="413" y="459" width="88" height="48">
-			</bounds>
+			<bounds x="413" y="459" width="88" height="48"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_103_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="5" y="458" width="92" height="52">
-			</bounds>
+			<bounds x="5" y="458" width="92" height="52"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_103" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="7" y="460" width="88" height="48">
-			</bounds>
+			<bounds x="7" y="460" width="88" height="48"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_104_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="511" y="458" width="92" height="52">
-			</bounds>
+			<bounds x="511" y="458" width="92" height="52"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_104" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="513" y="460" width="88" height="48">
-			</bounds>
+			<bounds x="513" y="460" width="88" height="48"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_105_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="607" y="458" width="92" height="52">
-			</bounds>
+			<bounds x="607" y="458" width="92" height="52"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_105" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="609" y="460" width="88" height="48">
-			</bounds>
+			<bounds x="609" y="460" width="88" height="48"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_107_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="615" y="421" width="27" height="27">
-			</bounds>
+			<bounds x="615" y="421" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_107" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="617" y="423" width="23" height="23">
-			</bounds>
+			<bounds x="617" y="423" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp62" element="colour_button_108_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="411" y="353" width="75" height="52">
-			</bounds>
+			<bounds x="411" y="353" width="75" height="52"/>
 		</backdrop>
 		<backdrop name="lamp62" element="colour_button_108" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="413" y="355" width="71" height="48">
-			</bounds>
+			<bounds x="413" y="355" width="71" height="48"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_109_border" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="27" y="77" width="75" height="27">
-			</bounds>
+			<bounds x="27" y="77" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_109" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="29" y="79" width="71" height="23">
-			</bounds>
+			<bounds x="29" y="79" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="645" y="418" width="24" height="32">
-			</bounds>
+			<bounds x="645" y="418" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="648" y="420" width="17" height="2">
-			</bounds>
+			<bounds x="648" y="420" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="662" y="420" width="3" height="14">
-			</bounds>
+			<bounds x="662" y="420" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="662" y="432" width="3" height="14">
-			</bounds>
+			<bounds x="662" y="432" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="648" y="444" width="17" height="2">
-			</bounds>
+			<bounds x="648" y="444" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="648" y="432" width="3" height="14">
-			</bounds>
+			<bounds x="648" y="432" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="648" y="420" width="3" height="14">
-			</bounds>
+			<bounds x="648" y="420" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="648" y="432" width="17" height="2">
-			</bounds>
+			<bounds x="648" y="432" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="665" y="444" width="3" height="2">
-			</bounds>
+			<bounds x="665" y="444" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="648" y="420" width="17" height="2">
-			</bounds>
+			<bounds x="648" y="420" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="662" y="420" width="3" height="14">
-			</bounds>
+			<bounds x="662" y="420" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="662" y="432" width="3" height="14">
-			</bounds>
+			<bounds x="662" y="432" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="648" y="444" width="17" height="2">
-			</bounds>
+			<bounds x="648" y="444" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="648" y="432" width="3" height="14">
-			</bounds>
+			<bounds x="648" y="432" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="648" y="420" width="3" height="14">
-			</bounds>
+			<bounds x="648" y="420" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="648" y="432" width="17" height="2">
-			</bounds>
+			<bounds x="648" y="432" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="665" y="444" width="3" height="2">
-			</bounds>
+			<bounds x="665" y="444" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="669" y="418" width="24" height="32">
-			</bounds>
+			<bounds x="669" y="418" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="672" y="420" width="17" height="2">
-			</bounds>
+			<bounds x="672" y="420" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="686" y="420" width="3" height="14">
-			</bounds>
+			<bounds x="686" y="420" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="686" y="432" width="3" height="14">
-			</bounds>
+			<bounds x="686" y="432" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="672" y="444" width="17" height="2">
-			</bounds>
+			<bounds x="672" y="444" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="672" y="432" width="3" height="14">
-			</bounds>
+			<bounds x="672" y="432" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="672" y="420" width="3" height="14">
-			</bounds>
+			<bounds x="672" y="420" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="672" y="432" width="17" height="2">
-			</bounds>
+			<bounds x="672" y="432" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="689" y="444" width="3" height="2">
-			</bounds>
+			<bounds x="689" y="444" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="672" y="420" width="17" height="2">
-			</bounds>
+			<bounds x="672" y="420" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="686" y="420" width="3" height="14">
-			</bounds>
+			<bounds x="686" y="420" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="686" y="432" width="3" height="14">
-			</bounds>
+			<bounds x="686" y="432" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="672" y="444" width="17" height="2">
-			</bounds>
+			<bounds x="672" y="444" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="672" y="432" width="3" height="14">
-			</bounds>
+			<bounds x="672" y="432" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="672" y="420" width="3" height="14">
-			</bounds>
+			<bounds x="672" y="420" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="672" y="432" width="17" height="2">
-			</bounds>
+			<bounds x="672" y="432" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="689" y="444" width="3" height="2">
-			</bounds>
+			<bounds x="689" y="444" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label60" element="label_60">
-			<bounds x="376" y="123" width="35" height="13">
-			</bounds>
+			<bounds x="376" y="123" width="35" height="13"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="606" y="8" width="51" height="48">
-			</bounds>
+			<bounds x="606" y="8" width="51" height="48"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_button" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1thatlfc.lay
+++ b/src/mame/layout/m1thatlfc.lay
@@ -8,11362 +8,6898 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.34" blue="0.17">
-			</color>
+			<color red="0.00" green="0.34" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.04">
-			</color>
+			<color red="0.00" green="0.08" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.68" blue="0.34">
-			</color>
+			<color red="0.00" green="0.68" blue="0.34"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.08">
-			</color>
+			<color red="0.00" green="0.17" blue="0.08"/>
 		</rect>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.34" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.68" blue="0.34">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.17" blue="0.08">
-			</color>
-		</rect>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_38_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_38_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_37_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_37_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_40_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_40_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_39_2_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_39_2" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repea">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repea">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.45" blue="0.47">
-			</color>
+			<color red="0.03" green="0.45" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.12">
-			</color>
+			<color red="0.00" green="0.11" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.89" blue="0.94">
-			</color>
+			<color red="0.06" green="0.89" blue="0.94"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.22" blue="0.24">
-			</color>
+			<color red="0.01" green="0.22" blue="0.24"/>
 		</rect>
 		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.45" blue="0.47">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.89" blue="0.94">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.22" blue="0.24">
-			</color>
-		</rect>
-		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="fe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="fe">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Li">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Li">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="at">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="at">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="'s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="'s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Th">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Th">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
+			<color red="0.47" green="0.41" blue="0.03"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
+			<color red="0.93" green="0.82" blue="0.07"/>
 		</disk>
 		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
+			<color red="0.23" green="0.20" blue="0.02"/>
 		</disk>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
-		</disk>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
+			<color red="0.47" green="0.41" blue="0.03"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
+			<color red="0.93" green="0.82" blue="0.07"/>
 		</disk>
 		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
+			<color red="0.23" green="0.20" blue="0.02"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
+			<color red="0.47" green="0.41" blue="0.03"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
+			<color red="0.93" green="0.82" blue="0.07"/>
 		</disk>
 		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
+			<color red="0.23" green="0.20" blue="0.02"/>
 		</disk>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
-		</disk>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
+			<color red="0.47" green="0.41" blue="0.03"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
+			<color red="0.93" green="0.82" blue="0.07"/>
 		</disk>
 		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
+			<color red="0.23" green="0.20" blue="0.02"/>
 		</disk>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
-		</disk>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
+			<color red="0.47" green="0.41" blue="0.03"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
+			<color red="0.93" green="0.82" blue="0.07"/>
 		</disk>
 		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
+			<color red="0.23" green="0.20" blue="0.02"/>
 		</disk>
 		<text string="&#xA3;3 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
-		</disk>
-		<text string="&#xA3;3 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
+			<color red="0.47" green="0.41" blue="0.03"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
+			<color red="0.93" green="0.82" blue="0.07"/>
 		</disk>
 		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
+			<color red="0.23" green="0.20" blue="0.02"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
+			<color red="0.47" green="0.41" blue="0.03"/>
 		</disk>
 		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
+			<color red="0.93" green="0.82" blue="0.07"/>
 		</disk>
 		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
+			<color red="0.23" green="0.20" blue="0.02"/>
 		</disk>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.47" green="0.41" blue="0.03">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.93" green="0.82" blue="0.07">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
-		</disk>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.03" green="0.45" blue="0.47">
-			</color>
+			<color red="0.03" green="0.45" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.12">
-			</color>
+			<color red="0.00" green="0.11" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.06" green="0.89" blue="0.94">
-			</color>
+			<color red="0.06" green="0.89" blue="0.94"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.22" blue="0.24">
-			</color>
+			<color red="0.01" green="0.22" blue="0.24"/>
 		</rect>
 		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.03" green="0.45" blue="0.47">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.06" green="0.89" blue="0.94">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.22" blue="0.24">
-			</color>
-		</rect>
-		<text string="Bankrupt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
+			<color red="0.47" green="0.44" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
+			<color red="0.95" green="0.89" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
+			<color red="0.24" green="0.22" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.44" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.95" green="0.89" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.22" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="That's Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="That's Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_99_border">
 		<rect state="1">
-			<color red="0.47" green="0.29" blue="0.02">
-			</color>
+			<color red="0.47" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_99">
 		<rect state="1">
-			<color red="0.95" green="0.59" blue="0.05">
-			</color>
+			<color red="0.95" green="0.59" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_100_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.15">
-			</color>
+			<color red="0.50" green="0.50" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.04">
-			</color>
+			<color red="0.12" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_100">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.29">
-			</color>
+			<color red="1.00" green="1.00" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.07">
-			</color>
+			<color red="0.25" green="0.25" blue="0.07"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_101_border">
 		<rect state="1">
-			<color red="0.21" green="0.43" blue="0.45">
-			</color>
+			<color red="0.21" green="0.43" blue="0.45"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.11" blue="0.11">
-			</color>
+			<color red="0.05" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="colour_button_101">
 		<rect state="1">
-			<color red="0.43" green="0.86" blue="0.91">
-			</color>
+			<color red="0.43" green="0.86" blue="0.91"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.21" blue="0.22">
-			</color>
+			<color red="0.11" green="0.21" blue="0.22"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_102_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_102">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_104_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_104">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_105_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_105">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_106_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_106">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_109_border">
 		<rect state="1">
-			<color red="0.48" green="0.39" blue="0.10">
-			</color>
+			<color red="0.48" green="0.39" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.02">
-			</color>
+			<color red="0.12" green="0.09" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="colour_button_109">
 		<rect state="1">
-			<color red="0.96" green="0.78" blue="0.20">
-			</color>
+			<color red="0.96" green="0.78" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.19" blue="0.05">
-			</color>
+			<color red="0.24" green="0.19" blue="0.05"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_22">
 		<text string="Many thanks to Chris Wren and Dialtone for all their hard work on  MFME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_25">
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_49">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="521">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="521"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="213" y="296" width="70" height="140">
-			</bounds>
+			<bounds x="213" y="296" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="213.0000" y="296.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="213.0000" y="296.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="215.9167" y="297.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="215.9167" y="297.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="218.8333" y="299.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="218.8333" y="299.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="221.7500" y="301.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="221.7500" y="301.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="224.6667" y="303.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="224.6667" y="303.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="227.5833" y="305.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="227.5833" y="305.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="213.0000" y="342.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="213.0000" y="342.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="215.9167" y="344.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="215.9167" y="344.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="218.8333" y="346.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="218.8333" y="346.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="221.7500" y="348.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="221.7500" y="348.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="224.6667" y="350.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="224.6667" y="350.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="227.5833" y="352.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="227.5833" y="352.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="213.0000" y="389.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="213.0000" y="389.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="215.9167" y="391.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="215.9167" y="391.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="218.8333" y="393.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="218.8333" y="393.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="221.7500" y="395.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="221.7500" y="395.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="224.6667" y="397.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="224.6667" y="397.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="227.5833" y="399.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="227.5833" y="399.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="213" y="296" width="70" height="140">
-			</bounds>
+			<bounds x="213" y="296" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="285" y="296" width="70" height="140">
-			</bounds>
+			<bounds x="285" y="296" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="285.0000" y="296.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="285.0000" y="296.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="287.9167" y="297.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="287.9167" y="297.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="290.8333" y="299.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="290.8333" y="299.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="293.7500" y="301.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="293.7500" y="301.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="296.6667" y="303.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="296.6667" y="303.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="299.5833" y="305.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="299.5833" y="305.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="285.0000" y="342.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="285.0000" y="342.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="287.9167" y="344.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="287.9167" y="344.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="290.8333" y="346.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="290.8333" y="346.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="293.7500" y="348.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="293.7500" y="348.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="296.6667" y="350.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="296.6667" y="350.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="299.5833" y="352.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="299.5833" y="352.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="285.0000" y="389.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="285.0000" y="389.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="287.9167" y="391.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="287.9167" y="391.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="290.8333" y="393.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="290.8333" y="393.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="293.7500" y="395.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="293.7500" y="395.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="296.6667" y="397.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="296.6667" y="397.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="299.5833" y="399.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="299.5833" y="399.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="285" y="296" width="70" height="140">
-			</bounds>
+			<bounds x="285" y="296" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="357" y="296" width="70" height="140">
-			</bounds>
+			<bounds x="357" y="296" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="357.0000" y="296.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="357.0000" y="296.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="359.9167" y="297.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="359.9167" y="297.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="362.8333" y="299.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="362.8333" y="299.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.7500" y="301.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="365.7500" y="301.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.6667" y="303.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="368.6667" y="303.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.5833" y="305.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="371.5833" y="305.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="357.0000" y="342.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="357.0000" y="342.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="359.9167" y="344.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="359.9167" y="344.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="362.8333" y="346.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="362.8333" y="346.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.7500" y="348.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="365.7500" y="348.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.6667" y="350.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="368.6667" y="350.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.5833" y="352.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="371.5833" y="352.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="357.0000" y="389.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="357.0000" y="389.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="359.9167" y="391.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="359.9167" y="391.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="362.8333" y="393.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="362.8333" y="393.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.7500" y="395.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="365.7500" y="395.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.6667" y="397.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="368.6667" y="397.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.5833" y="399.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="371.5833" y="399.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="357" y="296" width="70" height="140">
-			</bounds>
+			<bounds x="357" y="296" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="17" y="205" width="60" height="75">
-			</bounds>
+			<bounds x="17" y="205" width="60" height="75"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="17.0000" y="205.0000" width="60.0000" height="75.0000">
-			</bounds>
+			<bounds x="17.0000" y="205.0000" width="60.0000" height="75.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="19.5000" y="208.1250" width="55.0000" height="68.7500">
-			</bounds>
+			<bounds x="19.5000" y="208.1250" width="55.0000" height="68.7500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="22.0000" y="211.2500" width="50.0000" height="62.5000">
-			</bounds>
+			<bounds x="22.0000" y="211.2500" width="50.0000" height="62.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="24.5000" y="214.3750" width="45.0000" height="56.2500">
-			</bounds>
+			<bounds x="24.5000" y="214.3750" width="45.0000" height="56.2500"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="27.0000" y="217.5000" width="40.0000" height="50.0000">
-			</bounds>
+			<bounds x="27.0000" y="217.5000" width="40.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="29.5000" y="220.6250" width="35.0000" height="43.7500">
-			</bounds>
+			<bounds x="29.5000" y="220.6250" width="35.0000" height="43.7500"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="17" y="205" width="60" height="75">
-			</bounds>
+			<bounds x="17" y="205" width="60" height="75"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="616" y="13" width="22" height="24">
-			</bounds>
+			<bounds x="616" y="13" width="22" height="24"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="618" y="15" width="18" height="20">
-			</bounds>
+			<bounds x="618" y="15" width="18" height="20"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="374" y="100" width="57" height="32">
-			</bounds>
+			<bounds x="374" y="100" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="376" y="102" width="53" height="28">
-			</bounds>
+			<bounds x="376" y="102" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="374" y="132" width="57" height="32">
-			</bounds>
+			<bounds x="374" y="132" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="376" y="134" width="53" height="28">
-			</bounds>
+			<bounds x="376" y="134" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="89" y="228" width="57" height="32">
-			</bounds>
+			<bounds x="89" y="228" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="91" y="230" width="53" height="28">
-			</bounds>
+			<bounds x="91" y="230" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="89" y="260" width="57" height="32">
-			</bounds>
+			<bounds x="89" y="260" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="91" y="262" width="53" height="28">
-			</bounds>
+			<bounds x="91" y="262" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="146" y="260" width="57" height="32">
-			</bounds>
+			<bounds x="146" y="260" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="148" y="262" width="53" height="28">
-			</bounds>
+			<bounds x="148" y="262" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="203" y="260" width="57" height="32">
-			</bounds>
+			<bounds x="203" y="260" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="205" y="262" width="53" height="28">
-			</bounds>
+			<bounds x="205" y="262" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="260" y="260" width="57" height="32">
-			</bounds>
+			<bounds x="260" y="260" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="262" y="262" width="53" height="28">
-			</bounds>
+			<bounds x="262" y="262" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="317" y="260" width="57" height="32">
-			</bounds>
+			<bounds x="317" y="260" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="319" y="262" width="53" height="28">
-			</bounds>
+			<bounds x="319" y="262" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="374" y="260" width="57" height="32">
-			</bounds>
+			<bounds x="374" y="260" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="376" y="262" width="53" height="28">
-			</bounds>
+			<bounds x="376" y="262" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="431" y="260" width="57" height="32">
-			</bounds>
+			<bounds x="431" y="260" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="433" y="262" width="53" height="28">
-			</bounds>
+			<bounds x="433" y="262" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="488" y="260" width="57" height="32">
-			</bounds>
+			<bounds x="488" y="260" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="490" y="262" width="53" height="28">
-			</bounds>
+			<bounds x="490" y="262" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="487" y="448" width="57" height="17">
-			</bounds>
+			<bounds x="487" y="448" width="57" height="17"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="489" y="450" width="53" height="13">
-			</bounds>
+			<bounds x="489" y="450" width="53" height="13"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="509" y="356" width="13" height="18">
-			</bounds>
+			<bounds x="509" y="356" width="13" height="18"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="511" y="358" width="9" height="14">
-			</bounds>
+			<bounds x="511" y="358" width="9" height="14"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="509" y="390" width="13" height="18">
-			</bounds>
+			<bounds x="509" y="390" width="13" height="18"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="511" y="392" width="9" height="14">
-			</bounds>
+			<bounds x="511" y="392" width="9" height="14"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_2_border" state="0">
-			<bounds x="500" y="373" width="31" height="21">
-			</bounds>
+			<bounds x="500" y="373" width="31" height="21"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_2" state="0">
-			<bounds x="502" y="375" width="27" height="17">
-			</bounds>
+			<bounds x="502" y="375" width="27" height="17"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="509" y="424" width="13" height="18">
-			</bounds>
+			<bounds x="509" y="424" width="13" height="18"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="511" y="426" width="9" height="14">
-			</bounds>
+			<bounds x="511" y="426" width="9" height="14"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_2_border" state="0">
-			<bounds x="500" y="407" width="31" height="21">
-			</bounds>
+			<bounds x="500" y="407" width="31" height="21"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_2" state="0">
-			<bounds x="502" y="409" width="27" height="17">
-			</bounds>
+			<bounds x="502" y="409" width="27" height="17"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="509" y="322" width="13" height="18">
-			</bounds>
+			<bounds x="509" y="322" width="13" height="18"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="511" y="324" width="9" height="14">
-			</bounds>
+			<bounds x="511" y="324" width="9" height="14"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_2_border" state="0">
-			<bounds x="500" y="305" width="31" height="21">
-			</bounds>
+			<bounds x="500" y="305" width="31" height="21"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_2" state="0">
-			<bounds x="502" y="307" width="27" height="17">
-			</bounds>
+			<bounds x="502" y="307" width="27" height="17"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_2_border" state="0">
-			<bounds x="500" y="339" width="31" height="21">
-			</bounds>
+			<bounds x="500" y="339" width="31" height="21"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_2" state="0">
-			<bounds x="502" y="341" width="27" height="17">
-			</bounds>
+			<bounds x="502" y="341" width="27" height="17"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="456" y="152" width="92" height="37">
-			</bounds>
+			<bounds x="456" y="152" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="458" y="154" width="88" height="33">
-			</bounds>
+			<bounds x="458" y="154" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="456" y="117" width="92" height="37">
-			</bounds>
+			<bounds x="456" y="117" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="458" y="119" width="88" height="33">
-			</bounds>
+			<bounds x="458" y="119" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="704" y="433" width="8" height="19">
-			</bounds>
+			<bounds x="704" y="433" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="706" y="435" width="4" height="15">
-			</bounds>
+			<bounds x="706" y="435" width="4" height="15"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="704" y="449" width="8" height="19">
-			</bounds>
+			<bounds x="704" y="449" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="706" y="451" width="4" height="15">
-			</bounds>
+			<bounds x="706" y="451" width="4" height="15"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="691" y="447" width="16" height="8">
-			</bounds>
+			<bounds x="691" y="447" width="16" height="8"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="693" y="449" width="12" height="4">
-			</bounds>
+			<bounds x="693" y="449" width="12" height="4"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="686" y="433" width="8" height="19">
-			</bounds>
+			<bounds x="686" y="433" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="688" y="435" width="4" height="15">
-			</bounds>
+			<bounds x="688" y="435" width="4" height="15"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="686" y="449" width="8" height="19">
-			</bounds>
+			<bounds x="686" y="449" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="688" y="451" width="4" height="15">
-			</bounds>
+			<bounds x="688" y="451" width="4" height="15"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="691" y="462" width="16" height="8">
-			</bounds>
+			<bounds x="691" y="462" width="16" height="8"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="693" y="464" width="12" height="4">
-			</bounds>
+			<bounds x="693" y="464" width="12" height="4"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="691" y="431" width="16" height="8">
-			</bounds>
+			<bounds x="691" y="431" width="16" height="8"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="693" y="433" width="12" height="4">
-			</bounds>
+			<bounds x="693" y="433" width="12" height="4"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="663" y="431" width="16" height="8">
-			</bounds>
+			<bounds x="663" y="431" width="16" height="8"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="665" y="433" width="12" height="4">
-			</bounds>
+			<bounds x="665" y="433" width="12" height="4"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="663" y="447" width="16" height="8">
-			</bounds>
+			<bounds x="663" y="447" width="16" height="8"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="665" y="449" width="12" height="4">
-			</bounds>
+			<bounds x="665" y="449" width="12" height="4"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="658" y="433" width="8" height="19">
-			</bounds>
+			<bounds x="658" y="433" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="660" y="435" width="4" height="15">
-			</bounds>
+			<bounds x="660" y="435" width="4" height="15"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="658" y="449" width="8" height="19">
-			</bounds>
+			<bounds x="658" y="449" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="660" y="451" width="4" height="15">
-			</bounds>
+			<bounds x="660" y="451" width="4" height="15"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="663" y="462" width="16" height="8">
-			</bounds>
+			<bounds x="663" y="462" width="16" height="8"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="665" y="464" width="12" height="4">
-			</bounds>
+			<bounds x="665" y="464" width="12" height="4"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="676" y="449" width="8" height="19">
-			</bounds>
+			<bounds x="676" y="449" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="678" y="451" width="4" height="15">
-			</bounds>
+			<bounds x="678" y="451" width="4" height="15"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="676" y="433" width="8" height="19">
-			</bounds>
+			<bounds x="676" y="433" width="8" height="19"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="678" y="435" width="4" height="15">
-			</bounds>
+			<bounds x="678" y="435" width="4" height="15"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="89" y="68" width="57" height="32">
-			</bounds>
+			<bounds x="89" y="68" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="91" y="70" width="53" height="28">
-			</bounds>
+			<bounds x="91" y="70" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="89" y="36" width="57" height="32">
-			</bounds>
+			<bounds x="89" y="36" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="91" y="38" width="53" height="28">
-			</bounds>
+			<bounds x="91" y="38" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="317" y="68" width="57" height="32">
-			</bounds>
+			<bounds x="317" y="68" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="319" y="70" width="53" height="28">
-			</bounds>
+			<bounds x="319" y="70" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="260" y="68" width="57" height="32">
-			</bounds>
+			<bounds x="260" y="68" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="262" y="70" width="53" height="28">
-			</bounds>
+			<bounds x="262" y="70" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="374" y="68" width="57" height="32">
-			</bounds>
+			<bounds x="374" y="68" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="376" y="70" width="53" height="28">
-			</bounds>
+			<bounds x="376" y="70" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="203" y="68" width="57" height="32">
-			</bounds>
+			<bounds x="203" y="68" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="205" y="70" width="53" height="28">
-			</bounds>
+			<bounds x="205" y="70" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="146" y="68" width="57" height="32">
-			</bounds>
+			<bounds x="146" y="68" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="148" y="70" width="53" height="28">
-			</bounds>
+			<bounds x="148" y="70" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="89" y="196" width="57" height="32">
-			</bounds>
+			<bounds x="89" y="196" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="91" y="198" width="53" height="28">
-			</bounds>
+			<bounds x="91" y="198" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="374" y="164" width="57" height="32">
-			</bounds>
+			<bounds x="374" y="164" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="376" y="166" width="53" height="28">
-			</bounds>
+			<bounds x="376" y="166" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="260" y="196" width="57" height="32">
-			</bounds>
+			<bounds x="260" y="196" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="262" y="198" width="53" height="28">
-			</bounds>
+			<bounds x="262" y="198" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="317" y="196" width="57" height="32">
-			</bounds>
+			<bounds x="317" y="196" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="319" y="198" width="53" height="28">
-			</bounds>
+			<bounds x="319" y="198" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="374" y="196" width="57" height="32">
-			</bounds>
+			<bounds x="374" y="196" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="376" y="198" width="53" height="28">
-			</bounds>
+			<bounds x="376" y="198" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="203" y="196" width="57" height="32">
-			</bounds>
+			<bounds x="203" y="196" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="205" y="198" width="53" height="28">
-			</bounds>
+			<bounds x="205" y="198" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="146" y="196" width="57" height="32">
-			</bounds>
+			<bounds x="146" y="196" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="148" y="198" width="53" height="28">
-			</bounds>
+			<bounds x="148" y="198" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="295" y="127" width="50" height="42">
-			</bounds>
+			<bounds x="295" y="127" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="297" y="129" width="46" height="38">
-			</bounds>
+			<bounds x="297" y="129" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="256" y="127" width="46" height="42">
-			</bounds>
+			<bounds x="256" y="127" width="46" height="42"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="258" y="129" width="42" height="38">
-			</bounds>
+			<bounds x="258" y="129" width="42" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="168" y="127" width="47" height="42">
-			</bounds>
+			<bounds x="168" y="127" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="170" y="129" width="43" height="38">
-			</bounds>
+			<bounds x="170" y="129" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="210" y="127" width="39" height="42">
-			</bounds>
+			<bounds x="210" y="127" width="39" height="42"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="212" y="129" width="35" height="38">
-			</bounds>
+			<bounds x="212" y="129" width="35" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="116" y="127" width="57" height="42">
-			</bounds>
+			<bounds x="116" y="127" width="57" height="42"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="118" y="129" width="53" height="38">
-			</bounds>
+			<bounds x="118" y="129" width="53" height="38"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="89" y="4" width="57" height="32">
-			</bounds>
+			<bounds x="89" y="4" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="91" y="6" width="53" height="28">
-			</bounds>
+			<bounds x="91" y="6" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="146" y="4" width="57" height="32">
-			</bounds>
+			<bounds x="146" y="4" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="148" y="6" width="53" height="28">
-			</bounds>
+			<bounds x="148" y="6" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="203" y="4" width="57" height="32">
-			</bounds>
+			<bounds x="203" y="4" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="205" y="6" width="53" height="28">
-			</bounds>
+			<bounds x="205" y="6" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="488" y="4" width="57" height="32">
-			</bounds>
+			<bounds x="488" y="4" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="490" y="6" width="53" height="28">
-			</bounds>
+			<bounds x="490" y="6" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="431" y="4" width="57" height="32">
-			</bounds>
+			<bounds x="431" y="4" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="433" y="6" width="53" height="28">
-			</bounds>
+			<bounds x="433" y="6" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="711" y="48" width="62" height="42">
-			</bounds>
+			<bounds x="711" y="48" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="713" y="50" width="58" height="38">
-			</bounds>
+			<bounds x="713" y="50" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="711" y="364" width="62" height="42">
-			</bounds>
+			<bounds x="711" y="364" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="713" y="366" width="58" height="38">
-			</bounds>
+			<bounds x="713" y="366" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="711" y="311" width="62" height="42">
-			</bounds>
+			<bounds x="711" y="311" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="713" y="313" width="58" height="38">
-			</bounds>
+			<bounds x="713" y="313" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="711" y="101" width="62" height="42">
-			</bounds>
+			<bounds x="711" y="101" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="713" y="103" width="58" height="38">
-			</bounds>
+			<bounds x="713" y="103" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="711" y="154" width="62" height="42">
-			</bounds>
+			<bounds x="711" y="154" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="713" y="156" width="58" height="38">
-			</bounds>
+			<bounds x="713" y="156" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="711" y="207" width="62" height="42">
-			</bounds>
+			<bounds x="711" y="207" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="713" y="209" width="58" height="38">
-			</bounds>
+			<bounds x="713" y="209" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="711" y="260" width="62" height="42">
-			</bounds>
+			<bounds x="711" y="260" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="713" y="262" width="58" height="38">
-			</bounds>
+			<bounds x="713" y="262" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="97" y="333" width="52" height="37">
-			</bounds>
+			<bounds x="97" y="333" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="99" y="335" width="48" height="33">
-			</bounds>
+			<bounds x="99" y="335" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="97" y="370" width="52" height="37">
-			</bounds>
+			<bounds x="97" y="370" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="99" y="372" width="48" height="33">
-			</bounds>
+			<bounds x="99" y="372" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="97" y="407" width="52" height="37">
-			</bounds>
+			<bounds x="97" y="407" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="99" y="409" width="48" height="33">
-			</bounds>
+			<bounds x="99" y="409" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="97" y="296" width="52" height="37">
-			</bounds>
+			<bounds x="97" y="296" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="99" y="298" width="48" height="33">
-			</bounds>
+			<bounds x="99" y="298" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="89" y="447" width="67" height="17">
-			</bounds>
+			<bounds x="89" y="447" width="67" height="17"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="91" y="449" width="63" height="13">
-			</bounds>
+			<bounds x="91" y="449" width="63" height="13"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="374" y="4" width="57" height="32">
-			</bounds>
+			<bounds x="374" y="4" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="376" y="6" width="53" height="28">
-			</bounds>
+			<bounds x="376" y="6" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="317" y="4" width="57" height="32">
-			</bounds>
+			<bounds x="317" y="4" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="319" y="6" width="53" height="28">
-			</bounds>
+			<bounds x="319" y="6" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="260" y="4" width="57" height="32">
-			</bounds>
+			<bounds x="260" y="4" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="262" y="6" width="53" height="28">
-			</bounds>
+			<bounds x="262" y="6" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="210" y="441" width="216" height="32">
-			</bounds>
+			<bounds x="210" y="441" width="216" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="212" y="443" width="212" height="28">
-			</bounds>
+			<bounds x="212" y="443" width="212" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="27" y="182" width="21" height="21">
-			</bounds>
+			<bounds x="27" y="182" width="21" height="21"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="29" y="184" width="17" height="17">
-			</bounds>
+			<bounds x="29" y="184" width="17" height="17"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="46" y="182" width="21" height="21">
-			</bounds>
+			<bounds x="46" y="182" width="21" height="21"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="48" y="184" width="17" height="17">
-			</bounds>
+			<bounds x="48" y="184" width="17" height="17"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_99_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="683" y="8" width="65" height="29">
-			</bounds>
+			<bounds x="683" y="8" width="65" height="29"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_99" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="685" y="10" width="61" height="25">
-			</bounds>
+			<bounds x="685" y="10" width="61" height="25"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_100_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="474" y="475" width="62" height="42">
-			</bounds>
+			<bounds x="474" y="475" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_100" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="476" y="477" width="58" height="38">
-			</bounds>
+			<bounds x="476" y="477" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_101_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="564" y="475" width="62" height="42">
-			</bounds>
+			<bounds x="564" y="475" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_101" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="566" y="477" width="58" height="38">
-			</bounds>
+			<bounds x="566" y="477" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_102_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="654" y="475" width="62" height="42">
-			</bounds>
+			<bounds x="654" y="475" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_102" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="656" y="477" width="58" height="38">
-			</bounds>
+			<bounds x="656" y="477" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_104_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="217" y="475" width="62" height="42">
-			</bounds>
+			<bounds x="217" y="475" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_104" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="219" y="477" width="58" height="38">
-			</bounds>
+			<bounds x="219" y="477" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_105_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="289" y="475" width="62" height="42">
-			</bounds>
+			<bounds x="289" y="475" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_105" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="291" y="477" width="58" height="38">
-			</bounds>
+			<bounds x="291" y="477" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_106_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="361" y="475" width="62" height="42">
-			</bounds>
+			<bounds x="361" y="475" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_106" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="363" y="477" width="58" height="38">
-			</bounds>
+			<bounds x="363" y="477" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_109_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="103" y="475" width="62" height="42">
-			</bounds>
+			<bounds x="103" y="475" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_109" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="105" y="477" width="58" height="38">
-			</bounds>
+			<bounds x="105" y="477" width="58" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="214" y="39" width="214" height="26">
-			</bounds>
+			<bounds x="214" y="39" width="214" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="214" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="214" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="227" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="227" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="240" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="240" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="253" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="253" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="266" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="266" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="279" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="279" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="292" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="292" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="305" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="305" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="318" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="318" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="331" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="331" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="344" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="344" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="357" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="357" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="370" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="370" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="383" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="383" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="396" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="396" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="409" y="39" width="13" height="26">
-			</bounds>
+			<bounds x="409" y="39" width="13" height="26"/>
 		</backdrop>
 		<backdrop name="label22" element="label_22">
-			<bounds x="24" y="27" width="48" height="121">
-			</bounds>
+			<bounds x="24" y="27" width="48" height="121"/>
 		</backdrop>
 		<backdrop name="label25" element="label_25">
-			<bounds x="502" y="291" width="25" height="11">
-			</bounds>
+			<bounds x="502" y="291" width="25" height="11"/>
 		</backdrop>
 		<backdrop name="label49" element="label_49">
-			<bounds x="654" y="413" width="63" height="21">
-			</bounds>
+			<bounds x="654" y="413" width="63" height="21"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_button" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1topstr.lay
+++ b/src/mame/layout/m1topstr.lay
@@ -8,11160 +8,6944 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Skillsho">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Skillsho">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Numbers">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Numbers">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="N Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="N Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Line Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Line Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Black">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Black">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="No Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="No Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="REPEAT?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="90p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="90p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="70p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="70p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="8p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="8p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="6p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="6p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="4p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="4p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="2p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="2p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="22p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="22p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="24p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="24p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="26p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="26p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="28p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="28p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="12p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="12p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="14p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="14p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="16p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="16p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="18p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="18p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Fruit Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="10p Per Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="10p Per Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_184_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_184">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_185_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_185">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_186_border">
 		<rect state="1">
-			<color red="0.15" green="0.15" blue="0.15">
-			</color>
+			<color red="0.15" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.04">
-			</color>
+			<color red="0.04" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="colour_button_186">
 		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.29">
-			</color>
+			<color red="0.29" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.07">
-			</color>
+			<color red="0.07" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="BLACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_187_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_187">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_188_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_188">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_189_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_189">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_190_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_190">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_191_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_191">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_192_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_192">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_194_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_194">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_114">
 		<text string="Credits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_117">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_118">
 		<text string="&#x3C;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_142">
 		<text string="SAME-SAME-ANY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PAYS 4P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_148">
 		<text string="Pays lit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" coins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_158">
 		<text string="l">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_159">
 		<text string="l">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_160">
 		<text string="-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_161">
 		<text string="-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_178">
 		<text string="MFME V 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="768" height="676">
-			</bounds>
+			<bounds x="0" y="0" width="768" height="676"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="170" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="170" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="170.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="170.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="173.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="173.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="176.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="176.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="180.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="180.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="183.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="183.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="186.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="186.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="170.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="170.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="173.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="173.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="176.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="176.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="180.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="180.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="183.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="183.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="186.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="186.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="170.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="170.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="173.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="173.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="176.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="176.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="180.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="180.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="183.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="183.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="186.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="186.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="170" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="170" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="255" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="255" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="255.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="255.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="258.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="261.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="265.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="268.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="268.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="271.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="271.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="255.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="255.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="258.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="261.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="265.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="268.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="268.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="271.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="271.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="255.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="255.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="258.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="261.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="265.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="268.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="268.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="271.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="271.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="255" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="255" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="339" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="339" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="339.0000" y="414.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="339.0000" y="414.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.3333" y="415.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="342.3333" y="415.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.6667" y="417.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="345.6667" y="417.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.0000" y="419.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="349.0000" y="419.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.3333" y="421.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="352.3333" y="421.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6667" y="423.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="355.6667" y="423.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="339.0000" y="460.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="339.0000" y="460.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.3333" y="462.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="342.3333" y="462.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.6667" y="464.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="345.6667" y="464.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.0000" y="466.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="349.0000" y="466.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.3333" y="468.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="352.3333" y="468.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6667" y="470.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="355.6667" y="470.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="339.0000" y="507.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="339.0000" y="507.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.3333" y="509.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="342.3333" y="509.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.6667" y="511.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="345.6667" y="511.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.0000" y="513.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="349.0000" y="513.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.3333" y="515.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="352.3333" y="515.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6667" y="517.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="355.6667" y="517.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="339" y="414" width="80" height="140">
-			</bounds>
+			<bounds x="339" y="414" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="267" y="52" width="100" height="100">
-			</bounds>
+			<bounds x="267" y="52" width="100" height="100"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="267" y="52" width="100" height="100">
-			</bounds>
+			<bounds x="267" y="52" width="100" height="100"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="34" y="18" width="82" height="52">
-			</bounds>
+			<bounds x="34" y="18" width="82" height="52"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="36" y="20" width="78" height="48">
-			</bounds>
+			<bounds x="36" y="20" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="433" y="508" width="72" height="42">
-			</bounds>
+			<bounds x="433" y="508" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="435" y="510" width="68" height="38">
-			</bounds>
+			<bounds x="435" y="510" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="433" y="415" width="72" height="42">
-			</bounds>
+			<bounds x="433" y="415" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="435" y="417" width="68" height="38">
-			</bounds>
+			<bounds x="435" y="417" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="34" y="67" width="82" height="52">
-			</bounds>
+			<bounds x="34" y="67" width="82" height="52"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="36" y="69" width="78" height="48">
-			</bounds>
+			<bounds x="36" y="69" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="34" y="116" width="82" height="52">
-			</bounds>
+			<bounds x="34" y="116" width="82" height="52"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="36" y="118" width="78" height="48">
-			</bounds>
+			<bounds x="36" y="118" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="39" y="390" width="77" height="32">
-			</bounds>
+			<bounds x="39" y="390" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="41" y="392" width="73" height="28">
-			</bounds>
+			<bounds x="41" y="392" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="38" y="360" width="77" height="32">
-			</bounds>
+			<bounds x="38" y="360" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="40" y="362" width="73" height="28">
-			</bounds>
+			<bounds x="40" y="362" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="38" y="421" width="77" height="32">
-			</bounds>
+			<bounds x="38" y="421" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="40" y="423" width="73" height="28">
-			</bounds>
+			<bounds x="40" y="423" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="39" y="452" width="38" height="38">
-			</bounds>
+			<bounds x="39" y="452" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="41" y="454" width="34" height="34">
-			</bounds>
+			<bounds x="41" y="454" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="78" y="452" width="38" height="38">
-			</bounds>
+			<bounds x="78" y="452" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="80" y="454" width="34" height="34">
-			</bounds>
+			<bounds x="80" y="454" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="39" y="489" width="38" height="38">
-			</bounds>
+			<bounds x="39" y="489" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="41" y="491" width="34" height="34">
-			</bounds>
+			<bounds x="41" y="491" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="77" y="489" width="38" height="38">
-			</bounds>
+			<bounds x="77" y="489" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="79" y="491" width="34" height="34">
-			</bounds>
+			<bounds x="79" y="491" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="38" y="329" width="77" height="32">
-			</bounds>
+			<bounds x="38" y="329" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="40" y="331" width="73" height="28">
-			</bounds>
+			<bounds x="40" y="331" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="491" y="242" width="60" height="42">
-			</bounds>
+			<bounds x="491" y="242" width="60" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="493" y="244" width="56" height="38">
-			</bounds>
+			<bounds x="493" y="244" width="56" height="38"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="421" y="57" width="77" height="50">
-			</bounds>
+			<bounds x="421" y="57" width="77" height="50"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="423" y="59" width="73" height="46">
-			</bounds>
+			<bounds x="423" y="59" width="73" height="46"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="459" y="153" width="67" height="46">
-			</bounds>
+			<bounds x="459" y="153" width="67" height="46"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="461" y="155" width="63" height="42">
-			</bounds>
+			<bounds x="461" y="155" width="63" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="478" y="199" width="62" height="44">
-			</bounds>
+			<bounds x="478" y="199" width="62" height="44"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="480" y="201" width="58" height="40">
-			</bounds>
+			<bounds x="480" y="201" width="58" height="40"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="441" y="106" width="72" height="48">
-			</bounds>
+			<bounds x="441" y="106" width="72" height="48"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="443" y="108" width="68" height="44">
-			</bounds>
+			<bounds x="443" y="108" width="68" height="44"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="398" y="6" width="82" height="52">
-			</bounds>
+			<bounds x="398" y="6" width="82" height="52"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="400" y="8" width="78" height="48">
-			</bounds>
+			<bounds x="400" y="8" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="393" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="393" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="395" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="395" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="425" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="425" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="427" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="427" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="361" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="361" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="363" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="363" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="329" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="329" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="331" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="331" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="297" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="297" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="299" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="299" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="263" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="263" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="265" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="265" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="199" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="199" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="201" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="201" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="232" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="232" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="234" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="234" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="456" y="280" width="32" height="42">
-			</bounds>
+			<bounds x="456" y="280" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="458" y="282" width="28" height="38">
-			</bounds>
+			<bounds x="458" y="282" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="152" y="285" width="42" height="32">
-			</bounds>
+			<bounds x="152" y="285" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="154" y="287" width="38" height="28">
-			</bounds>
+			<bounds x="154" y="287" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="499" y="293" width="42" height="19">
-			</bounds>
+			<bounds x="499" y="293" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="501" y="295" width="38" height="15">
-			</bounds>
+			<bounds x="501" y="295" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="302" y="154" width="32" height="32">
-			</bounds>
+			<bounds x="302" y="154" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="304" y="156" width="28" height="28">
-			</bounds>
+			<bounds x="304" y="156" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="273" y="190" width="42" height="19">
-			</bounds>
+			<bounds x="273" y="190" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="275" y="192" width="38" height="15">
-			</bounds>
+			<bounds x="275" y="192" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="318" y="190" width="42" height="19">
-			</bounds>
+			<bounds x="318" y="190" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="320" y="192" width="38" height="15">
-			</bounds>
+			<bounds x="320" y="192" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="290" y="214" width="54" height="22">
-			</bounds>
+			<bounds x="290" y="214" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="292" y="216" width="50" height="18">
-			</bounds>
+			<bounds x="292" y="216" width="50" height="18"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="677" y="352" width="32" height="19">
-			</bounds>
+			<bounds x="677" y="352" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="679" y="354" width="28" height="15">
-			</bounds>
+			<bounds x="679" y="354" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="578" y="352" width="32" height="19">
-			</bounds>
+			<bounds x="578" y="352" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="580" y="354" width="28" height="15">
-			</bounds>
+			<bounds x="580" y="354" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="612" y="352" width="62" height="19">
-			</bounds>
+			<bounds x="612" y="352" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="614" y="354" width="58" height="15">
-			</bounds>
+			<bounds x="614" y="354" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="552" y="382" width="62" height="19">
-			</bounds>
+			<bounds x="552" y="382" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="554" y="384" width="58" height="15">
-			</bounds>
+			<bounds x="554" y="384" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="691" y="374" width="52" height="32">
-			</bounds>
+			<bounds x="691" y="374" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="693" y="376" width="48" height="28">
-			</bounds>
+			<bounds x="693" y="376" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="637" y="374" width="52" height="32">
-			</bounds>
+			<bounds x="637" y="374" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="639" y="376" width="48" height="28">
-			</bounds>
+			<bounds x="639" y="376" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="582" y="409" width="42" height="42">
-			</bounds>
+			<bounds x="582" y="409" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="584" y="411" width="38" height="38">
-			</bounds>
+			<bounds x="584" y="411" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="542" y="410" width="42" height="42">
-			</bounds>
+			<bounds x="542" y="410" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="544" y="412" width="38" height="38">
-			</bounds>
+			<bounds x="544" y="412" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="623" y="409" width="42" height="42">
-			</bounds>
+			<bounds x="623" y="409" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="625" y="411" width="38" height="38">
-			</bounds>
+			<bounds x="625" y="411" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="702" y="409" width="42" height="42">
-			</bounds>
+			<bounds x="702" y="409" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="704" y="411" width="38" height="38">
-			</bounds>
+			<bounds x="704" y="411" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="702" y="448" width="42" height="42">
-			</bounds>
+			<bounds x="702" y="448" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="704" y="450" width="38" height="38">
-			</bounds>
+			<bounds x="704" y="450" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="702" y="526" width="42" height="42">
-			</bounds>
+			<bounds x="702" y="526" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="704" y="528" width="38" height="38">
-			</bounds>
+			<bounds x="704" y="528" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="663" y="526" width="42" height="42">
-			</bounds>
+			<bounds x="663" y="526" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="665" y="528" width="38" height="38">
-			</bounds>
+			<bounds x="665" y="528" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="623" y="526" width="42" height="42">
-			</bounds>
+			<bounds x="623" y="526" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="625" y="528" width="38" height="38">
-			</bounds>
+			<bounds x="625" y="528" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="583" y="526" width="42" height="42">
-			</bounds>
+			<bounds x="583" y="526" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="585" y="528" width="38" height="38">
-			</bounds>
+			<bounds x="585" y="528" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="542" y="488" width="42" height="42">
-			</bounds>
+			<bounds x="542" y="488" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="544" y="490" width="38" height="38">
-			</bounds>
+			<bounds x="544" y="490" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="543" y="526" width="42" height="42">
-			</bounds>
+			<bounds x="543" y="526" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="545" y="528" width="38" height="38">
-			</bounds>
+			<bounds x="545" y="528" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="543" y="449" width="42" height="42">
-			</bounds>
+			<bounds x="543" y="449" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="545" y="451" width="38" height="38">
-			</bounds>
+			<bounds x="545" y="451" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="582" y="449" width="42" height="42">
-			</bounds>
+			<bounds x="582" y="449" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="584" y="451" width="38" height="38">
-			</bounds>
+			<bounds x="584" y="451" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="623" y="449" width="42" height="42">
-			</bounds>
+			<bounds x="623" y="449" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="625" y="451" width="38" height="38">
-			</bounds>
+			<bounds x="625" y="451" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="662" y="447" width="42" height="42">
-			</bounds>
+			<bounds x="662" y="447" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="664" y="449" width="38" height="38">
-			</bounds>
+			<bounds x="664" y="449" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="702" y="487" width="42" height="42">
-			</bounds>
+			<bounds x="702" y="487" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="704" y="489" width="38" height="38">
-			</bounds>
+			<bounds x="704" y="489" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="663" y="486" width="42" height="42">
-			</bounds>
+			<bounds x="663" y="486" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="665" y="488" width="38" height="38">
-			</bounds>
+			<bounds x="665" y="488" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="623" y="487" width="42" height="42">
-			</bounds>
+			<bounds x="623" y="487" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="625" y="489" width="38" height="38">
-			</bounds>
+			<bounds x="625" y="489" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="583" y="488" width="42" height="42">
-			</bounds>
+			<bounds x="583" y="488" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="585" y="490" width="38" height="38">
-			</bounds>
+			<bounds x="585" y="490" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="663" y="409" width="42" height="42">
-			</bounds>
+			<bounds x="663" y="409" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="665" y="411" width="38" height="38">
-			</bounds>
+			<bounds x="665" y="411" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="544" y="569" width="36" height="19">
-			</bounds>
+			<bounds x="544" y="569" width="36" height="19"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="546" y="571" width="32" height="15">
-			</bounds>
+			<bounds x="546" y="571" width="32" height="15"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="626" y="63" width="32" height="32">
-			</bounds>
+			<bounds x="626" y="63" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="628" y="65" width="28" height="28">
-			</bounds>
+			<bounds x="628" y="65" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="596" y="63" width="32" height="32">
-			</bounds>
+			<bounds x="596" y="63" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="598" y="65" width="28" height="28">
-			</bounds>
+			<bounds x="598" y="65" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="626" y="93" width="32" height="32">
-			</bounds>
+			<bounds x="626" y="93" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="628" y="95" width="28" height="28">
-			</bounds>
+			<bounds x="628" y="95" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="596" y="93" width="32" height="32">
-			</bounds>
+			<bounds x="596" y="93" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="598" y="95" width="28" height="28">
-			</bounds>
+			<bounds x="598" y="95" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="596" y="33" width="32" height="32">
-			</bounds>
+			<bounds x="596" y="33" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="598" y="35" width="28" height="28">
-			</bounds>
+			<bounds x="598" y="35" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="656" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="656" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="658" y="5" width="28" height="28">
-			</bounds>
+			<bounds x="658" y="5" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="656" y="63" width="32" height="32">
-			</bounds>
+			<bounds x="656" y="63" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="658" y="65" width="28" height="28">
-			</bounds>
+			<bounds x="658" y="65" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="656" y="33" width="32" height="32">
-			</bounds>
+			<bounds x="656" y="33" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="658" y="35" width="28" height="28">
-			</bounds>
+			<bounds x="658" y="35" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="626" y="33" width="32" height="32">
-			</bounds>
+			<bounds x="626" y="33" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="628" y="35" width="28" height="28">
-			</bounds>
+			<bounds x="628" y="35" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="596" y="3" width="62" height="32">
-			</bounds>
+			<bounds x="596" y="3" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="598" y="5" width="58" height="28">
-			</bounds>
+			<bounds x="598" y="5" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="656" y="93" width="32" height="32">
-			</bounds>
+			<bounds x="656" y="93" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="658" y="95" width="28" height="28">
-			</bounds>
+			<bounds x="658" y="95" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="595" y="249" width="92" height="32">
-			</bounds>
+			<bounds x="595" y="249" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="597" y="251" width="88" height="28">
-			</bounds>
+			<bounds x="597" y="251" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp11" element="colour_button_184_border" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="345" y="358" width="82" height="27">
-			</bounds>
+			<bounds x="345" y="358" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp11" element="colour_button_184" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="347" y="360" width="78" height="23">
-			</bounds>
+			<bounds x="347" y="360" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_185_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="161" y="359" width="75" height="27">
-			</bounds>
+			<bounds x="161" y="359" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp9" element="colour_button_185" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="163" y="361" width="71" height="23">
-			</bounds>
+			<bounds x="163" y="361" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_186_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="252" y="358" width="75" height="27">
-			</bounds>
+			<bounds x="252" y="358" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp10" element="colour_button_186" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="254" y="360" width="71" height="23">
-			</bounds>
+			<bounds x="254" y="360" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_187_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="57" y="643" width="75" height="27">
-			</bounds>
+			<bounds x="57" y="643" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_187" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="59" y="645" width="71" height="23">
-			</bounds>
+			<bounds x="59" y="645" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_188_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="522" y="643" width="75" height="27">
-			</bounds>
+			<bounds x="522" y="643" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_188" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="524" y="645" width="71" height="23">
-			</bounds>
+			<bounds x="524" y="645" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_189_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="656" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="656" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_189" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="658" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="658" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_190_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="247" y="643" width="75" height="27">
-			</bounds>
+			<bounds x="247" y="643" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_190" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="249" y="645" width="71" height="23">
-			</bounds>
+			<bounds x="249" y="645" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_191_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="328" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="328" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_191" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="330" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="330" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_192_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="163" y="644" width="75" height="27">
-			</bounds>
+			<bounds x="163" y="644" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_192" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="165" y="646" width="71" height="23">
-			</bounds>
+			<bounds x="165" y="646" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_193_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="426" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="426" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_193" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="428" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="428" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp12" element="colour_button_194_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="709" y="33" width="36" height="42">
-			</bounds>
+			<bounds x="709" y="33" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="lamp12" element="colour_button_194" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="711" y="35" width="32" height="38">
-			</bounds>
+			<bounds x="711" y="35" width="32" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="636" y="594" width="24" height="32">
-			</bounds>
+			<bounds x="636" y="594" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="639" y="596" width="17" height="2">
-			</bounds>
+			<bounds x="639" y="596" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="653" y="596" width="3" height="14">
-			</bounds>
+			<bounds x="653" y="596" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="653" y="608" width="3" height="14">
-			</bounds>
+			<bounds x="653" y="608" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="639" y="620" width="17" height="2">
-			</bounds>
+			<bounds x="639" y="620" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="639" y="608" width="3" height="14">
-			</bounds>
+			<bounds x="639" y="608" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="639" y="596" width="3" height="14">
-			</bounds>
+			<bounds x="639" y="596" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="639" y="608" width="17" height="2">
-			</bounds>
+			<bounds x="639" y="608" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="656" y="620" width="3" height="2">
-			</bounds>
+			<bounds x="656" y="620" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="639" y="596" width="17" height="2">
-			</bounds>
+			<bounds x="639" y="596" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="653" y="596" width="3" height="14">
-			</bounds>
+			<bounds x="653" y="596" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="653" y="608" width="3" height="14">
-			</bounds>
+			<bounds x="653" y="608" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="639" y="620" width="17" height="2">
-			</bounds>
+			<bounds x="639" y="620" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="639" y="608" width="3" height="14">
-			</bounds>
+			<bounds x="639" y="608" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="639" y="596" width="3" height="14">
-			</bounds>
+			<bounds x="639" y="596" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="639" y="608" width="17" height="2">
-			</bounds>
+			<bounds x="639" y="608" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="656" y="620" width="3" height="2">
-			</bounds>
+			<bounds x="656" y="620" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="612" y="594" width="24" height="32">
-			</bounds>
+			<bounds x="612" y="594" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="615" y="596" width="17" height="2">
-			</bounds>
+			<bounds x="615" y="596" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="629" y="596" width="3" height="14">
-			</bounds>
+			<bounds x="629" y="596" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="629" y="608" width="3" height="14">
-			</bounds>
+			<bounds x="629" y="608" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="615" y="620" width="17" height="2">
-			</bounds>
+			<bounds x="615" y="620" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="615" y="608" width="3" height="14">
-			</bounds>
+			<bounds x="615" y="608" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="615" y="596" width="3" height="14">
-			</bounds>
+			<bounds x="615" y="596" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="615" y="608" width="17" height="2">
-			</bounds>
+			<bounds x="615" y="608" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="632" y="620" width="3" height="2">
-			</bounds>
+			<bounds x="632" y="620" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="615" y="596" width="17" height="2">
-			</bounds>
+			<bounds x="615" y="596" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="629" y="596" width="3" height="14">
-			</bounds>
+			<bounds x="629" y="596" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="629" y="608" width="3" height="14">
-			</bounds>
+			<bounds x="629" y="608" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="615" y="620" width="17" height="2">
-			</bounds>
+			<bounds x="615" y="620" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="615" y="608" width="3" height="14">
-			</bounds>
+			<bounds x="615" y="608" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="615" y="596" width="3" height="14">
-			</bounds>
+			<bounds x="615" y="596" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="615" y="608" width="17" height="2">
-			</bounds>
+			<bounds x="615" y="608" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="632" y="620" width="3" height="2">
-			</bounds>
+			<bounds x="632" y="620" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="558" y="602" width="44" height="15">
-			</bounds>
+			<bounds x="558" y="602" width="44" height="15"/>
 		</backdrop>
 		<backdrop name="label117" element="label_117">
-			<bounds x="173" y="10" width="54" height="54">
-			</bounds>
+			<bounds x="173" y="10" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="label118" element="label_118">
-			<bounds x="149" y="24" width="14" height="30">
-			</bounds>
+			<bounds x="149" y="24" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="label142" element="label_142">
-			<bounds x="2" y="585" width="105" height="30">
-			</bounds>
+			<bounds x="2" y="585" width="105" height="30"/>
 		</backdrop>
 		<backdrop name="label148" element="label_148">
-			<bounds x="664" y="287" width="46" height="30">
-			</bounds>
+			<bounds x="664" y="287" width="46" height="30"/>
 		</backdrop>
 		<backdrop name="label158" element="label_158">
-			<bounds x="641" y="156" width="5" height="20">
-			</bounds>
+			<bounds x="641" y="156" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="label159" element="label_159">
-			<bounds x="641" y="201" width="5" height="20">
-			</bounds>
+			<bounds x="641" y="201" width="5" height="20"/>
 		</backdrop>
 		<backdrop name="label160" element="label_160">
-			<bounds x="662" y="165" width="12" height="37">
-			</bounds>
+			<bounds x="662" y="165" width="12" height="37"/>
 		</backdrop>
 		<backdrop name="label161" element="label_161">
-			<bounds x="611" y="171" width="12" height="37">
-			</bounds>
+			<bounds x="611" y="171" width="12" height="37"/>
 		</backdrop>
 		<backdrop name="label178" element="label_178">
-			<bounds x="710" y="3" width="35" height="30">
-			</bounds>
+			<bounds x="710" y="3" width="35" height="30"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_button" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1triviax.lay
+++ b/src/mame/layout/m1triviax.lay
@@ -8,17788 +8,9721 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="COLOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="COLOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="777 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HEAVEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="777 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HEAVEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_255_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_255_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="THROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PURSUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PURSUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FALLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FALLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="BIG WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="BIG WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</disk>
 		<text string="MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</disk>
-		<text string="MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="BACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="GO FOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="WEDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="WEDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PURSUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PURSUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CATHERINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WHEEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CATHERINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WHEEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LYNX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LYNX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SKILL SH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SKILL SH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="GOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.08"/>
 		</text>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.13" width="0.90" height="0.08"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.21" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.21" width="0.90" height="0.08"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.30" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.30" width="0.90" height="0.08"/>
 		</text>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.38" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.46" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.38" width="0.90" height="0.08"/>
 		</text>
 		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.54" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.54" width="0.90" height="0.08"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.62" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.62" width="0.90" height="0.08"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.70" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.70" width="0.90" height="0.08"/>
 		</text>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.79" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.79" width="0.90" height="0.08"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.08">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.21" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.30" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.38" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.46" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.54" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.62" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.70" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.79" width="0.90" height="0.08">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.08">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.87" width="0.90" height="0.08"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.07"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.13" width="0.90" height="0.07"/>
 		</text>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.07"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.27" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.27" width="0.90" height="0.07"/>
 		</text>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.07"/>
 		</text>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.42" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.42" width="0.90" height="0.07"/>
 		</text>
 		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.57" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.57" width="0.90" height="0.07"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.07"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.07"/>
 		</text>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.07"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.07">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.13" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.27" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.42" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.57" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.07">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.87" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.87" width="0.90" height="0.07"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LIGHT ALL WEDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FOR BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIGHT ALL WEDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FOR BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WRONG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ANSWER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRIVIAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PURSUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRIVIAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PURSUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="HIGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="HIGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_189_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_189">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_190_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_190">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_191_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_191">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_192_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_192">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_194_border">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
+			<color red="0.00" green="0.03" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_194">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
+			<color red="0.00" green="0.06" blue="0.13"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_195_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_195">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_198_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_198">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_199_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_199">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_200_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_200">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_55">
 		<text string="GOLDEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_72">
 		<text string="GOLD POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_82">
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_95">
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_160">
 		<text string="MIXED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_175">
 		<text string="3 BOXES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_186">
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_188">
 		<text string="With thanks to Gary,Dialtone, ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Andy T, Steveir, Stiffy, Harvey and">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Retrofruit.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1018" height="667">
-			</bounds>
+			<bounds x="0" y="0" width="1018" height="667"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="346" y="449" width="80" height="140">
-			</bounds>
+			<bounds x="346" y="449" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="346.0000" y="449.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="346.0000" y="449.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="349.3333" y="450.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="349.3333" y="450.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="352.6667" y="452.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="352.6667" y="452.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="356.0000" y="454.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="356.0000" y="454.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="359.3333" y="456.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="359.3333" y="456.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="362.6667" y="458.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="362.6667" y="458.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="346.0000" y="495.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="346.0000" y="495.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="349.3333" y="497.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="349.3333" y="497.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="352.6667" y="499.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="352.6667" y="499.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="356.0000" y="501.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="356.0000" y="501.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="359.3333" y="503.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="359.3333" y="503.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="362.6667" y="505.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="362.6667" y="505.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="346.0000" y="542.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="346.0000" y="542.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="349.3333" y="544.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="349.3333" y="544.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="352.6667" y="546.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="352.6667" y="546.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="356.0000" y="548.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="356.0000" y="548.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="359.3333" y="550.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="359.3333" y="550.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="362.6667" y="552.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="362.6667" y="552.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="346" y="449" width="80" height="140">
-			</bounds>
+			<bounds x="346" y="449" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="436" y="449" width="80" height="140">
-			</bounds>
+			<bounds x="436" y="449" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="449.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="449.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="450.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="450.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="452.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="452.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="454.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="454.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="456.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="456.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="458.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="458.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="495.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="495.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="497.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="497.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="499.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="499.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="501.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="501.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="503.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="503.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="505.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="505.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="542.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="542.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="544.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="544.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="546.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="546.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="548.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="548.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="550.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="550.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="552.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="552.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="436" y="449" width="80" height="140">
-			</bounds>
+			<bounds x="436" y="449" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="526" y="449" width="80" height="140">
-			</bounds>
+			<bounds x="526" y="449" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="526.0000" y="449.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="526.0000" y="449.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="529.3333" y="450.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="529.3333" y="450.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="532.6667" y="452.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="532.6667" y="452.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="536.0000" y="454.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="536.0000" y="454.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="539.3333" y="456.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="539.3333" y="456.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="542.6667" y="458.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="542.6667" y="458.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="526.0000" y="495.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="526.0000" y="495.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="529.3333" y="497.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="529.3333" y="497.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="532.6667" y="499.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="532.6667" y="499.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="536.0000" y="501.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="536.0000" y="501.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="539.3333" y="503.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="539.3333" y="503.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="542.6667" y="505.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="542.6667" y="505.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="526.0000" y="542.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="526.0000" y="542.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="529.3333" y="544.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="529.3333" y="544.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="532.6667" y="546.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="532.6667" y="546.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="536.0000" y="548.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="536.0000" y="548.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="539.3333" y="550.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="539.3333" y="550.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="542.6667" y="552.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="542.6667" y="552.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="526" y="449" width="80" height="140">
-			</bounds>
+			<bounds x="526" y="449" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="50" y="213" width="90" height="80">
-			</bounds>
+			<bounds x="50" y="213" width="90" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="50.0000" y="213.0000" width="90.0000" height="80.0000">
-			</bounds>
+			<bounds x="50.0000" y="213.0000" width="90.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="53.7500" y="216.3333" width="82.5000" height="73.3333">
-			</bounds>
+			<bounds x="53.7500" y="216.3333" width="82.5000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="57.5000" y="219.6667" width="75.0000" height="66.6667">
-			</bounds>
+			<bounds x="57.5000" y="219.6667" width="75.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="61.2500" y="223.0000" width="67.5000" height="60.0000">
-			</bounds>
+			<bounds x="61.2500" y="223.0000" width="67.5000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="65.0000" y="226.3333" width="60.0000" height="53.3333">
-			</bounds>
+			<bounds x="65.0000" y="226.3333" width="60.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="68.7500" y="229.6667" width="52.5000" height="46.6667">
-			</bounds>
+			<bounds x="68.7500" y="229.6667" width="52.5000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="50" y="213" width="90" height="80">
-			</bounds>
+			<bounds x="50" y="213" width="90" height="80"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="450" y="386" width="47" height="27">
-			</bounds>
+			<bounds x="450" y="386" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="452" y="388" width="43" height="23">
-			</bounds>
+			<bounds x="452" y="388" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="231" y="170" width="47" height="27">
-			</bounds>
+			<bounds x="231" y="170" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="233" y="172" width="43" height="23">
-			</bounds>
+			<bounds x="233" y="172" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="238" y="146" width="47" height="27">
-			</bounds>
+			<bounds x="238" y="146" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="240" y="148" width="43" height="23">
-			</bounds>
+			<bounds x="240" y="148" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="245" y="122" width="47" height="27">
-			</bounds>
+			<bounds x="245" y="122" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="247" y="124" width="43" height="23">
-			</bounds>
+			<bounds x="247" y="124" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="253" y="98" width="47" height="27">
-			</bounds>
+			<bounds x="253" y="98" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="255" y="100" width="43" height="23">
-			</bounds>
+			<bounds x="255" y="100" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="261" y="74" width="47" height="27">
-			</bounds>
+			<bounds x="261" y="74" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="263" y="76" width="43" height="23">
-			</bounds>
+			<bounds x="263" y="76" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="274" y="50" width="47" height="27">
-			</bounds>
+			<bounds x="274" y="50" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="276" y="52" width="43" height="23">
-			</bounds>
+			<bounds x="276" y="52" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="318" y="40" width="47" height="27">
-			</bounds>
+			<bounds x="318" y="40" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="320" y="42" width="43" height="23">
-			</bounds>
+			<bounds x="320" y="42" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="362" y="34" width="47" height="27">
-			</bounds>
+			<bounds x="362" y="34" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="364" y="36" width="43" height="23">
-			</bounds>
+			<bounds x="364" y="36" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="406" y="25" width="47" height="27">
-			</bounds>
+			<bounds x="406" y="25" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="408" y="27" width="43" height="23">
-			</bounds>
+			<bounds x="408" y="27" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="450" y="18" width="47" height="27">
-			</bounds>
+			<bounds x="450" y="18" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="452" y="20" width="43" height="23">
-			</bounds>
+			<bounds x="452" y="20" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="172" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="172" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="174" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="174" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="398" y="152" width="39" height="27">
-			</bounds>
+			<bounds x="398" y="152" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="400" y="154" width="35" height="23">
-			</bounds>
+			<bounds x="400" y="154" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="362" y="140" width="39" height="27">
-			</bounds>
+			<bounds x="362" y="140" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="364" y="142" width="35" height="23">
-			</bounds>
+			<bounds x="364" y="142" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="326" y="134" width="39" height="27">
-			</bounds>
+			<bounds x="326" y="134" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="328" y="136" width="35" height="23">
-			</bounds>
+			<bounds x="328" y="136" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="226" y="194" width="47" height="27">
-			</bounds>
+			<bounds x="226" y="194" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="228" y="196" width="43" height="23">
-			</bounds>
+			<bounds x="228" y="196" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="226" y="218" width="47" height="27">
-			</bounds>
+			<bounds x="226" y="218" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="228" y="220" width="43" height="23">
-			</bounds>
+			<bounds x="228" y="220" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="230" y="242" width="47" height="27">
-			</bounds>
+			<bounds x="230" y="242" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="232" y="244" width="43" height="23">
-			</bounds>
+			<bounds x="232" y="244" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="238" y="266" width="47" height="27">
-			</bounds>
+			<bounds x="238" y="266" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="240" y="268" width="43" height="23">
-			</bounds>
+			<bounds x="240" y="268" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="245" y="290" width="47" height="27">
-			</bounds>
+			<bounds x="245" y="290" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="247" y="292" width="43" height="23">
-			</bounds>
+			<bounds x="247" y="292" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="254" y="315" width="47" height="27">
-			</bounds>
+			<bounds x="254" y="315" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="256" y="317" width="43" height="23">
-			</bounds>
+			<bounds x="256" y="317" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="264" y="340" width="47" height="27">
-			</bounds>
+			<bounds x="264" y="340" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="266" y="342" width="43" height="23">
-			</bounds>
+			<bounds x="266" y="342" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="274" y="364" width="47" height="27">
-			</bounds>
+			<bounds x="274" y="364" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="276" y="366" width="43" height="23">
-			</bounds>
+			<bounds x="276" y="366" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="318" y="370" width="47" height="27">
-			</bounds>
+			<bounds x="318" y="370" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="320" y="372" width="43" height="23">
-			</bounds>
+			<bounds x="320" y="372" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="362" y="373" width="47" height="27">
-			</bounds>
+			<bounds x="362" y="373" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="364" y="375" width="43" height="23">
-			</bounds>
+			<bounds x="364" y="375" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="406" y="381" width="47" height="27">
-			</bounds>
+			<bounds x="406" y="381" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="408" y="383" width="43" height="23">
-			</bounds>
+			<bounds x="408" y="383" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="398" y="251" width="39" height="27">
-			</bounds>
+			<bounds x="398" y="251" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="400" y="253" width="35" height="23">
-			</bounds>
+			<bounds x="400" y="253" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="361" y="264" width="39" height="27">
-			</bounds>
+			<bounds x="361" y="264" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="363" y="266" width="35" height="23">
-			</bounds>
+			<bounds x="363" y="266" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="325" y="274" width="37" height="27">
-			</bounds>
+			<bounds x="325" y="274" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="327" y="276" width="33" height="23">
-			</bounds>
+			<bounds x="327" y="276" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="289" y="285" width="39" height="27">
-			</bounds>
+			<bounds x="289" y="285" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="291" y="287" width="35" height="23">
-			</bounds>
+			<bounds x="291" y="287" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="652" y="290" width="47" height="27">
-			</bounds>
+			<bounds x="652" y="290" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="654" y="292" width="43" height="23">
-			</bounds>
+			<bounds x="654" y="292" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="657" y="266" width="47" height="27">
-			</bounds>
+			<bounds x="657" y="266" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="659" y="268" width="43" height="23">
-			</bounds>
+			<bounds x="659" y="268" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="665" y="242" width="47" height="27">
-			</bounds>
+			<bounds x="665" y="242" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="667" y="244" width="43" height="23">
-			</bounds>
+			<bounds x="667" y="244" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="658" y="146" width="47" height="27">
-			</bounds>
+			<bounds x="658" y="146" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="660" y="148" width="43" height="23">
-			</bounds>
+			<bounds x="660" y="148" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="653" y="122" width="47" height="27">
-			</bounds>
+			<bounds x="653" y="122" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="655" y="124" width="43" height="23">
-			</bounds>
+			<bounds x="655" y="124" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="645" y="98" width="47" height="27">
-			</bounds>
+			<bounds x="645" y="98" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="647" y="100" width="43" height="23">
-			</bounds>
+			<bounds x="647" y="100" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="636" y="74" width="47" height="27">
-			</bounds>
+			<bounds x="636" y="74" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="638" y="76" width="43" height="23">
-			</bounds>
+			<bounds x="638" y="76" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="626" y="50" width="47" height="27">
-			</bounds>
+			<bounds x="626" y="50" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="628" y="52" width="43" height="23">
-			</bounds>
+			<bounds x="628" y="52" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="582" y="40" width="47" height="27">
-			</bounds>
+			<bounds x="582" y="40" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="584" y="42" width="43" height="23">
-			</bounds>
+			<bounds x="584" y="42" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="538" y="34" width="47" height="27">
-			</bounds>
+			<bounds x="538" y="34" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="540" y="36" width="43" height="23">
-			</bounds>
+			<bounds x="540" y="36" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="494" y="26" width="47" height="27">
-			</bounds>
+			<bounds x="494" y="26" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="496" y="28" width="43" height="23">
-			</bounds>
+			<bounds x="496" y="28" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="494" y="381" width="47" height="27">
-			</bounds>
+			<bounds x="494" y="381" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="496" y="383" width="43" height="23">
-			</bounds>
+			<bounds x="496" y="383" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="538" y="373" width="47" height="27">
-			</bounds>
+			<bounds x="538" y="373" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="540" y="375" width="43" height="23">
-			</bounds>
+			<bounds x="540" y="375" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="582" y="370" width="47" height="27">
-			</bounds>
+			<bounds x="582" y="370" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="584" y="372" width="43" height="23">
-			</bounds>
+			<bounds x="584" y="372" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="626" y="364" width="47" height="27">
-			</bounds>
+			<bounds x="626" y="364" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="628" y="366" width="43" height="23">
-			</bounds>
+			<bounds x="628" y="366" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="636" y="340" width="47" height="27">
-			</bounds>
+			<bounds x="636" y="340" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="638" y="342" width="43" height="23">
-			</bounds>
+			<bounds x="638" y="342" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="645" y="315" width="47" height="27">
-			</bounds>
+			<bounds x="645" y="315" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="647" y="317" width="43" height="23">
-			</bounds>
+			<bounds x="647" y="317" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="455" y="258" width="39" height="27">
-			</bounds>
+			<bounds x="455" y="258" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="457" y="260" width="35" height="23">
-			</bounds>
+			<bounds x="457" y="260" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="455" y="290" width="39" height="27">
-			</bounds>
+			<bounds x="455" y="290" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="457" y="292" width="35" height="23">
-			</bounds>
+			<bounds x="457" y="292" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="455" y="321" width="39" height="27">
-			</bounds>
+			<bounds x="455" y="321" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="457" y="323" width="35" height="23">
-			</bounds>
+			<bounds x="457" y="323" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="455" y="354" width="39" height="27">
-			</bounds>
+			<bounds x="455" y="354" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="457" y="356" width="35" height="23">
-			</bounds>
+			<bounds x="457" y="356" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="552" y="63" width="32" height="32">
-			</bounds>
+			<bounds x="552" y="63" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="554" y="65" width="28" height="28">
-			</bounds>
+			<bounds x="554" y="65" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="522" y="59" width="32" height="32">
-			</bounds>
+			<bounds x="522" y="59" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="524" y="61" width="28" height="28">
-			</bounds>
+			<bounds x="524" y="61" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="605" y="86" width="32" height="32">
-			</bounds>
+			<bounds x="605" y="86" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="607" y="88" width="28" height="28">
-			</bounds>
+			<bounds x="607" y="88" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="579" y="102" width="32" height="32">
-			</bounds>
+			<bounds x="579" y="102" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="581" y="104" width="28" height="28">
-			</bounds>
+			<bounds x="581" y="104" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1_border" state="0">
-			<bounds x="582" y="68" width="32" height="32">
-			</bounds>
+			<bounds x="582" y="68" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp255" element="lamp_255_1" state="0">
-			<bounds x="584" y="70" width="28" height="28">
-			</bounds>
+			<bounds x="584" y="70" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="672" y="218" width="47" height="27">
-			</bounds>
+			<bounds x="672" y="218" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="674" y="220" width="43" height="23">
-			</bounds>
+			<bounds x="674" y="220" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="672" y="194" width="47" height="27">
-			</bounds>
+			<bounds x="672" y="194" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="674" y="196" width="43" height="23">
-			</bounds>
+			<bounds x="674" y="196" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="665" y="170" width="47" height="27">
-			</bounds>
+			<bounds x="665" y="170" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="667" y="172" width="43" height="23">
-			</bounds>
+			<bounds x="667" y="172" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="508" y="150" width="39" height="27">
-			</bounds>
+			<bounds x="508" y="150" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="510" y="152" width="35" height="23">
-			</bounds>
+			<bounds x="510" y="152" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="614" y="284" width="39" height="27">
-			</bounds>
+			<bounds x="614" y="284" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="616" y="286" width="35" height="23">
-			</bounds>
+			<bounds x="616" y="286" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="578" y="272" width="39" height="27">
-			</bounds>
+			<bounds x="578" y="272" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="580" y="274" width="35" height="23">
-			</bounds>
+			<bounds x="580" y="274" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="542" y="263" width="39" height="27">
-			</bounds>
+			<bounds x="542" y="263" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="544" y="265" width="35" height="23">
-			</bounds>
+			<bounds x="544" y="265" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="506" y="254" width="39" height="27">
-			</bounds>
+			<bounds x="506" y="254" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="508" y="256" width="35" height="23">
-			</bounds>
+			<bounds x="508" y="256" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="290" y="125" width="39" height="27">
-			</bounds>
+			<bounds x="290" y="125" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="292" y="127" width="35" height="23">
-			</bounds>
+			<bounds x="292" y="127" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="383" y="220" width="62" height="27">
-			</bounds>
+			<bounds x="383" y="220" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="385" y="222" width="58" height="23">
-			</bounds>
+			<bounds x="385" y="222" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="475" y="176" width="62" height="27">
-			</bounds>
+			<bounds x="475" y="176" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="477" y="178" width="58" height="23">
-			</bounds>
+			<bounds x="477" y="178" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="443" y="221" width="62" height="27">
-			</bounds>
+			<bounds x="443" y="221" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="445" y="223" width="58" height="23">
-			</bounds>
+			<bounds x="445" y="223" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="383" y="196" width="62" height="27">
-			</bounds>
+			<bounds x="383" y="196" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="385" y="198" width="58" height="23">
-			</bounds>
+			<bounds x="385" y="198" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="417" y="176" width="62" height="27">
-			</bounds>
+			<bounds x="417" y="176" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="419" y="178" width="58" height="23">
-			</bounds>
+			<bounds x="419" y="178" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="502" y="221" width="62" height="27">
-			</bounds>
+			<bounds x="502" y="221" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="504" y="223" width="58" height="23">
-			</bounds>
+			<bounds x="504" y="223" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="502" y="197" width="62" height="27">
-			</bounds>
+			<bounds x="502" y="197" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="504" y="199" width="58" height="23">
-			</bounds>
+			<bounds x="504" y="199" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="443" y="197" width="62" height="27">
-			</bounds>
+			<bounds x="443" y="197" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="445" y="199" width="58" height="23">
-			</bounds>
+			<bounds x="445" y="199" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="581" y="134" width="39" height="27">
-			</bounds>
+			<bounds x="581" y="134" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="583" y="136" width="35" height="23">
-			</bounds>
+			<bounds x="583" y="136" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="545" y="140" width="39" height="27">
-			</bounds>
+			<bounds x="545" y="140" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="547" y="142" width="35" height="23">
-			</bounds>
+			<bounds x="547" y="142" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="617" y="128" width="39" height="27">
-			</bounds>
+			<bounds x="617" y="128" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="619" y="130" width="35" height="23">
-			</bounds>
+			<bounds x="619" y="130" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="570" y="316" width="62" height="32">
-			</bounds>
+			<bounds x="570" y="316" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="572" y="318" width="58" height="28">
-			</bounds>
+			<bounds x="572" y="318" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="500" y="330" width="62" height="32">
-			</bounds>
+			<bounds x="500" y="330" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="502" y="332" width="58" height="28">
-			</bounds>
+			<bounds x="502" y="332" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="319" y="315" width="62" height="32">
-			</bounds>
+			<bounds x="319" y="315" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="321" y="317" width="58" height="28">
-			</bounds>
+			<bounds x="321" y="317" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="387" y="294" width="62" height="32">
-			</bounds>
+			<bounds x="387" y="294" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="389" y="296" width="58" height="28">
-			</bounds>
+			<bounds x="389" y="296" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="387" y="331" width="62" height="32">
-			</bounds>
+			<bounds x="387" y="331" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="389" y="333" width="58" height="28">
-			</bounds>
+			<bounds x="389" y="333" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="499" y="295" width="62" height="32">
-			</bounds>
+			<bounds x="499" y="295" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="501" y="297" width="58" height="28">
-			</bounds>
+			<bounds x="501" y="297" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="578" y="203" width="62" height="27">
-			</bounds>
+			<bounds x="578" y="203" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="580" y="205" width="58" height="23">
-			</bounds>
+			<bounds x="580" y="205" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="593" y="167" width="62" height="27">
-			</bounds>
+			<bounds x="593" y="167" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="595" y="169" width="58" height="23">
-			</bounds>
+			<bounds x="595" y="169" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="287" y="167" width="62" height="27">
-			</bounds>
+			<bounds x="287" y="167" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="289" y="169" width="58" height="23">
-			</bounds>
+			<bounds x="289" y="169" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="302" y="203" width="62" height="27">
-			</bounds>
+			<bounds x="302" y="203" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="304" y="205" width="58" height="23">
-			</bounds>
+			<bounds x="304" y="205" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="288" y="238" width="62" height="27">
-			</bounds>
+			<bounds x="288" y="238" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="290" y="240" width="58" height="23">
-			</bounds>
+			<bounds x="290" y="240" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="596" y="242" width="62" height="27">
-			</bounds>
+			<bounds x="596" y="242" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="598" y="244" width="58" height="23">
-			</bounds>
+			<bounds x="598" y="244" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="345" y="82" width="32" height="32">
-			</bounds>
+			<bounds x="345" y="82" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="347" y="84" width="28" height="28">
-			</bounds>
+			<bounds x="347" y="84" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="371" y="100" width="32" height="32">
-			</bounds>
+			<bounds x="371" y="100" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="373" y="102" width="28" height="28">
-			</bounds>
+			<bounds x="373" y="102" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="397" y="116" width="32" height="32">
-			</bounds>
+			<bounds x="397" y="116" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="399" y="118" width="28" height="28">
-			</bounds>
+			<bounds x="399" y="118" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="371" y="67" width="32" height="32">
-			</bounds>
+			<bounds x="371" y="67" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="373" y="69" width="28" height="28">
-			</bounds>
+			<bounds x="373" y="69" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="398" y="85" width="32" height="32">
-			</bounds>
+			<bounds x="398" y="85" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="400" y="87" width="28" height="28">
-			</bounds>
+			<bounds x="400" y="87" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="398" y="55" width="32" height="32">
-			</bounds>
+			<bounds x="398" y="55" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="400" y="57" width="28" height="28">
-			</bounds>
+			<bounds x="400" y="57" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="905" y="323" width="37" height="27">
-			</bounds>
+			<bounds x="905" y="323" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="907" y="325" width="33" height="23">
-			</bounds>
+			<bounds x="907" y="325" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="905" y="299" width="37" height="27">
-			</bounds>
+			<bounds x="905" y="299" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="907" y="301" width="33" height="23">
-			</bounds>
+			<bounds x="907" y="301" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="905" y="275" width="37" height="27">
-			</bounds>
+			<bounds x="905" y="275" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="907" y="277" width="33" height="23">
-			</bounds>
+			<bounds x="907" y="277" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="905" y="251" width="37" height="27">
-			</bounds>
+			<bounds x="905" y="251" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="907" y="253" width="33" height="23">
-			</bounds>
+			<bounds x="907" y="253" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="806" y="299" width="37" height="27">
-			</bounds>
+			<bounds x="806" y="299" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="808" y="301" width="33" height="23">
-			</bounds>
+			<bounds x="808" y="301" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="806" y="323" width="37" height="27">
-			</bounds>
+			<bounds x="806" y="323" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="808" y="325" width="33" height="23">
-			</bounds>
+			<bounds x="808" y="325" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="806" y="275" width="37" height="27">
-			</bounds>
+			<bounds x="806" y="275" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="808" y="277" width="33" height="23">
-			</bounds>
+			<bounds x="808" y="277" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="806" y="251" width="37" height="27">
-			</bounds>
+			<bounds x="806" y="251" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="808" y="253" width="33" height="23">
-			</bounds>
+			<bounds x="808" y="253" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="944" y="243" width="19" height="122">
-			</bounds>
+			<bounds x="944" y="243" width="19" height="122"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="946" y="245" width="15" height="118">
-			</bounds>
+			<bounds x="946" y="245" width="15" height="118"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="785" y="243" width="19" height="122">
-			</bounds>
+			<bounds x="785" y="243" width="19" height="122"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="787" y="245" width="15" height="118">
-			</bounds>
+			<bounds x="787" y="245" width="15" height="118"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="887" y="279" width="19" height="19">
-			</bounds>
+			<bounds x="887" y="279" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="889" y="281" width="15" height="15">
-			</bounds>
+			<bounds x="889" y="281" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="866" y="279" width="19" height="19">
-			</bounds>
+			<bounds x="866" y="279" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="868" y="281" width="15" height="15">
-			</bounds>
+			<bounds x="868" y="281" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="845" y="279" width="19" height="19">
-			</bounds>
+			<bounds x="845" y="279" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="847" y="281" width="15" height="15">
-			</bounds>
+			<bounds x="847" y="281" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="887" y="255" width="19" height="19">
-			</bounds>
+			<bounds x="887" y="255" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="889" y="257" width="15" height="15">
-			</bounds>
+			<bounds x="889" y="257" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="866" y="255" width="19" height="19">
-			</bounds>
+			<bounds x="866" y="255" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="868" y="257" width="15" height="15">
-			</bounds>
+			<bounds x="868" y="257" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="845" y="255" width="19" height="19">
-			</bounds>
+			<bounds x="845" y="255" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="847" y="257" width="15" height="15">
-			</bounds>
+			<bounds x="847" y="257" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="887" y="306" width="19" height="19">
-			</bounds>
+			<bounds x="887" y="306" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="889" y="308" width="15" height="15">
-			</bounds>
+			<bounds x="889" y="308" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="845" y="306" width="19" height="19">
-			</bounds>
+			<bounds x="845" y="306" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="847" y="308" width="15" height="15">
-			</bounds>
+			<bounds x="847" y="308" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="866" y="306" width="19" height="19">
-			</bounds>
+			<bounds x="866" y="306" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="868" y="308" width="15" height="15">
-			</bounds>
+			<bounds x="868" y="308" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="845" y="330" width="19" height="19">
-			</bounds>
+			<bounds x="845" y="330" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="847" y="332" width="15" height="15">
-			</bounds>
+			<bounds x="847" y="332" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="866" y="330" width="19" height="19">
-			</bounds>
+			<bounds x="866" y="330" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="868" y="332" width="15" height="15">
-			</bounds>
+			<bounds x="868" y="332" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="887" y="330" width="19" height="19">
-			</bounds>
+			<bounds x="887" y="330" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="889" y="332" width="15" height="15">
-			</bounds>
+			<bounds x="889" y="332" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="807" y="167" width="132" height="32">
-			</bounds>
+			<bounds x="807" y="167" width="132" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="809" y="169" width="128" height="28">
-			</bounds>
+			<bounds x="809" y="169" width="128" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="882" y="134" width="27" height="27">
-			</bounds>
+			<bounds x="882" y="134" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="884" y="136" width="23" height="23">
-			</bounds>
+			<bounds x="884" y="136" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="857" y="134" width="27" height="27">
-			</bounds>
+			<bounds x="857" y="134" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="859" y="136" width="23" height="23">
-			</bounds>
+			<bounds x="859" y="136" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="833" y="134" width="27" height="27">
-			</bounds>
+			<bounds x="833" y="134" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="835" y="136" width="23" height="23">
-			</bounds>
+			<bounds x="835" y="136" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="857" y="109" width="27" height="27">
-			</bounds>
+			<bounds x="857" y="109" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="859" y="111" width="23" height="23">
-			</bounds>
+			<bounds x="859" y="111" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="833" y="109" width="27" height="27">
-			</bounds>
+			<bounds x="833" y="109" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="835" y="111" width="23" height="23">
-			</bounds>
+			<bounds x="835" y="111" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="882" y="109" width="27" height="27">
-			</bounds>
+			<bounds x="882" y="109" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="884" y="111" width="23" height="23">
-			</bounds>
+			<bounds x="884" y="111" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="829" y="86" width="82" height="19">
-			</bounds>
+			<bounds x="829" y="86" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="831" y="88" width="78" height="15">
-			</bounds>
+			<bounds x="831" y="88" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="454" y="147" width="39" height="27">
-			</bounds>
+			<bounds x="454" y="147" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="456" y="149" width="35" height="23">
-			</bounds>
+			<bounds x="456" y="149" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="454" y="113" width="39" height="27">
-			</bounds>
+			<bounds x="454" y="113" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="456" y="115" width="35" height="23">
-			</bounds>
+			<bounds x="456" y="115" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="454" y="81" width="39" height="27">
-			</bounds>
+			<bounds x="454" y="81" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="456" y="83" width="35" height="23">
-			</bounds>
+			<bounds x="456" y="83" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="454" y="49" width="39" height="27">
-			</bounds>
+			<bounds x="454" y="49" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="456" y="51" width="35" height="23">
-			</bounds>
+			<bounds x="456" y="51" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="785" y="455" width="42" height="42">
-			</bounds>
+			<bounds x="785" y="455" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="787" y="457" width="38" height="38">
-			</bounds>
+			<bounds x="787" y="457" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="863" y="455" width="42" height="42">
-			</bounds>
+			<bounds x="863" y="455" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="865" y="457" width="38" height="38">
-			</bounds>
+			<bounds x="865" y="457" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="902" y="454" width="42" height="42">
-			</bounds>
+			<bounds x="902" y="454" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="904" y="456" width="38" height="38">
-			</bounds>
+			<bounds x="904" y="456" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="941" y="454" width="42" height="42">
-			</bounds>
+			<bounds x="941" y="454" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="943" y="456" width="38" height="38">
-			</bounds>
+			<bounds x="943" y="456" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="746" y="455" width="42" height="42">
-			</bounds>
+			<bounds x="746" y="455" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="748" y="457" width="38" height="38">
-			</bounds>
+			<bounds x="748" y="457" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="824" y="454" width="42" height="42">
-			</bounds>
+			<bounds x="824" y="454" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="826" y="456" width="38" height="38">
-			</bounds>
+			<bounds x="826" y="456" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="863" y="494" width="42" height="42">
-			</bounds>
+			<bounds x="863" y="494" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="865" y="496" width="38" height="38">
-			</bounds>
+			<bounds x="865" y="496" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="941" y="493" width="42" height="42">
-			</bounds>
+			<bounds x="941" y="493" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="943" y="495" width="38" height="38">
-			</bounds>
+			<bounds x="943" y="495" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="902" y="493" width="42" height="42">
-			</bounds>
+			<bounds x="902" y="493" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="904" y="495" width="38" height="38">
-			</bounds>
+			<bounds x="904" y="495" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="785" y="493" width="42" height="42">
-			</bounds>
+			<bounds x="785" y="493" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="787" y="495" width="38" height="38">
-			</bounds>
+			<bounds x="787" y="495" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="746" y="494" width="42" height="42">
-			</bounds>
+			<bounds x="746" y="494" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="748" y="496" width="38" height="38">
-			</bounds>
+			<bounds x="748" y="496" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="824" y="493" width="42" height="42">
-			</bounds>
+			<bounds x="824" y="493" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="826" y="495" width="38" height="38">
-			</bounds>
+			<bounds x="826" y="495" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="941" y="532" width="42" height="42">
-			</bounds>
+			<bounds x="941" y="532" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="943" y="534" width="38" height="38">
-			</bounds>
+			<bounds x="943" y="534" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="746" y="534" width="42" height="42">
-			</bounds>
+			<bounds x="746" y="534" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="748" y="536" width="38" height="38">
-			</bounds>
+			<bounds x="748" y="536" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="902" y="532" width="42" height="42">
-			</bounds>
+			<bounds x="902" y="532" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="904" y="534" width="38" height="38">
-			</bounds>
+			<bounds x="904" y="534" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="863" y="533" width="42" height="42">
-			</bounds>
+			<bounds x="863" y="533" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="865" y="535" width="38" height="38">
-			</bounds>
+			<bounds x="865" y="535" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="824" y="532" width="42" height="42">
-			</bounds>
+			<bounds x="824" y="532" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="826" y="534" width="38" height="38">
-			</bounds>
+			<bounds x="826" y="534" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="785" y="533" width="42" height="42">
-			</bounds>
+			<bounds x="785" y="533" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="787" y="535" width="38" height="38">
-			</bounds>
+			<bounds x="787" y="535" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="902" y="415" width="42" height="42">
-			</bounds>
+			<bounds x="902" y="415" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="904" y="417" width="38" height="38">
-			</bounds>
+			<bounds x="904" y="417" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="941" y="415" width="42" height="42">
-			</bounds>
+			<bounds x="941" y="415" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="943" y="417" width="38" height="38">
-			</bounds>
+			<bounds x="943" y="417" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="785" y="416" width="42" height="42">
-			</bounds>
+			<bounds x="785" y="416" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="787" y="418" width="38" height="38">
-			</bounds>
+			<bounds x="787" y="418" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="824" y="415" width="42" height="42">
-			</bounds>
+			<bounds x="824" y="415" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="826" y="417" width="38" height="38">
-			</bounds>
+			<bounds x="826" y="417" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="746" y="416" width="42" height="42">
-			</bounds>
+			<bounds x="746" y="416" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="748" y="418" width="38" height="38">
-			</bounds>
+			<bounds x="748" y="418" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="863" y="415" width="42" height="42">
-			</bounds>
+			<bounds x="863" y="415" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="865" y="417" width="38" height="38">
-			</bounds>
+			<bounds x="865" y="417" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="922" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="922" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="924" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="924" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="285" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="285" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="287" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="287" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="818" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="818" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="820" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="820" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="717" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="717" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="719" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="719" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="614" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="614" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="616" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="616" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="500" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="500" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="502" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="502" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="386" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="386" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="388" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="388" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="55" y="633" width="52" height="27">
-			</bounds>
+			<bounds x="55" y="633" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="57" y="635" width="48" height="23">
-			</bounds>
+			<bounds x="57" y="635" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="46" y="28" width="102" height="42">
-			</bounds>
+			<bounds x="46" y="28" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="48" y="30" width="98" height="38">
-			</bounds>
+			<bounds x="48" y="30" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="46" y="28" width="102" height="42">
-			</bounds>
+			<bounds x="46" y="28" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="48" y="30" width="98" height="38">
-			</bounds>
+			<bounds x="48" y="30" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="269" y="461" width="42" height="42">
-			</bounds>
+			<bounds x="269" y="461" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="271" y="463" width="38" height="38">
-			</bounds>
+			<bounds x="271" y="463" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="269" y="503" width="42" height="42">
-			</bounds>
+			<bounds x="269" y="503" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="271" y="505" width="38" height="38">
-			</bounds>
+			<bounds x="271" y="505" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="269" y="545" width="42" height="42">
-			</bounds>
+			<bounds x="269" y="545" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="271" y="547" width="38" height="38">
-			</bounds>
+			<bounds x="271" y="547" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="269" y="419" width="42" height="42">
-			</bounds>
+			<bounds x="269" y="419" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="271" y="421" width="38" height="38">
-			</bounds>
+			<bounds x="271" y="421" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="73" y="294" width="42" height="22">
-			</bounds>
+			<bounds x="73" y="294" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="75" y="296" width="38" height="18">
-			</bounds>
+			<bounds x="75" y="296" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="73" y="190" width="42" height="22">
-			</bounds>
+			<bounds x="73" y="190" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="75" y="192" width="38" height="18">
-			</bounds>
+			<bounds x="75" y="192" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_189_border" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="984" y="79" width="34" height="27">
-			</bounds>
+			<bounds x="984" y="79" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_189" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="986" y="81" width="30" height="23">
-			</bounds>
+			<bounds x="986" y="81" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_190_border" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="984" y="53" width="34" height="27">
-			</bounds>
+			<bounds x="984" y="53" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_190" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="986" y="55" width="30" height="23">
-			</bounds>
+			<bounds x="986" y="55" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_191_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="984" y="27" width="34" height="27">
-			</bounds>
+			<bounds x="984" y="27" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_191" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="986" y="29" width="30" height="23">
-			</bounds>
+			<bounds x="986" y="29" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_192_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="984" y="1" width="34" height="27">
-			</bounds>
+			<bounds x="984" y="1" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_192" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="986" y="3" width="30" height="23">
-			</bounds>
+			<bounds x="986" y="3" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_193_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="259" y="593" width="75" height="37">
-			</bounds>
+			<bounds x="259" y="593" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_193" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="261" y="595" width="71" height="33">
-			</bounds>
+			<bounds x="261" y="595" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_194_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="163" y="593" width="75" height="37">
-			</bounds>
+			<bounds x="163" y="593" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_194" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="165" y="595" width="71" height="33">
-			</bounds>
+			<bounds x="165" y="595" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_195_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="68" y="593" width="79" height="37">
-			</bounds>
+			<bounds x="68" y="593" width="79" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_195" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="70" y="595" width="75" height="33">
-			</bounds>
+			<bounds x="70" y="595" width="75" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_196_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="656" y="593" width="75" height="37">
-			</bounds>
+			<bounds x="656" y="593" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_196" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="658" y="595" width="71" height="33">
-			</bounds>
+			<bounds x="658" y="595" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_198_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="348" y="593" width="75" height="37">
-			</bounds>
+			<bounds x="348" y="593" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_198" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="350" y="595" width="71" height="33">
-			</bounds>
+			<bounds x="350" y="595" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_199_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="439" y="593" width="75" height="37">
-			</bounds>
+			<bounds x="439" y="593" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_199" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="441" y="595" width="71" height="33">
-			</bounds>
+			<bounds x="441" y="595" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_200_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="529" y="593" width="75" height="37">
-			</bounds>
+			<bounds x="529" y="593" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_200" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="531" y="595" width="71" height="33">
-			</bounds>
+			<bounds x="531" y="595" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="95" y="112" width="44" height="56">
-			</bounds>
+			<bounds x="95" y="112" width="44" height="56"/>
 		</backdrop>
 		<backdrop name="led_off112" element="led_off">
-			<bounds x="101" y="117" width="31" height="5">
-			</bounds>
+			<bounds x="101" y="117" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="led_off113" element="led_off">
-			<bounds x="126" y="117" width="6" height="25">
-			</bounds>
+			<bounds x="126" y="117" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="led_off114" element="led_off">
-			<bounds x="126" y="137" width="6" height="25">
-			</bounds>
+			<bounds x="126" y="137" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="led_off115" element="led_off">
-			<bounds x="101" y="157" width="31" height="5">
-			</bounds>
+			<bounds x="101" y="157" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="led_off116" element="led_off">
-			<bounds x="101" y="137" width="6" height="25">
-			</bounds>
+			<bounds x="101" y="137" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="led_off117" element="led_off">
-			<bounds x="101" y="117" width="6" height="25">
-			</bounds>
+			<bounds x="101" y="117" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="led_off118" element="led_off">
-			<bounds x="101" y="137" width="31" height="5">
-			</bounds>
+			<bounds x="101" y="137" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="led_off119" element="led_dot_off">
-			<bounds x="132" y="157" width="6" height="5">
-			</bounds>
+			<bounds x="132" y="157" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp112" element="led_on">
-			<bounds x="101" y="117" width="31" height="5">
-			</bounds>
+			<bounds x="101" y="117" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="lamp113" element="led_on">
-			<bounds x="126" y="117" width="6" height="25">
-			</bounds>
+			<bounds x="126" y="117" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="lamp114" element="led_on">
-			<bounds x="126" y="137" width="6" height="25">
-			</bounds>
+			<bounds x="126" y="137" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="lamp115" element="led_on">
-			<bounds x="101" y="157" width="31" height="5">
-			</bounds>
+			<bounds x="101" y="157" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="lamp116" element="led_on">
-			<bounds x="101" y="137" width="6" height="25">
-			</bounds>
+			<bounds x="101" y="137" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="lamp117" element="led_on">
-			<bounds x="101" y="117" width="6" height="25">
-			</bounds>
+			<bounds x="101" y="117" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="lamp118" element="led_on">
-			<bounds x="101" y="137" width="31" height="5">
-			</bounds>
+			<bounds x="101" y="137" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="lamp119" element="led_dot_on">
-			<bounds x="132" y="157" width="6" height="5">
-			</bounds>
+			<bounds x="132" y="157" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="51" y="112" width="44" height="56">
-			</bounds>
+			<bounds x="51" y="112" width="44" height="56"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_off">
-			<bounds x="57" y="117" width="31" height="5">
-			</bounds>
+			<bounds x="57" y="117" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="82" y="117" width="6" height="25">
-			</bounds>
+			<bounds x="82" y="117" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="82" y="137" width="6" height="25">
-			</bounds>
+			<bounds x="82" y="137" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="57" y="157" width="31" height="5">
-			</bounds>
+			<bounds x="57" y="157" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="57" y="137" width="6" height="25">
-			</bounds>
+			<bounds x="57" y="137" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="57" y="117" width="6" height="25">
-			</bounds>
+			<bounds x="57" y="117" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="57" y="137" width="31" height="5">
-			</bounds>
+			<bounds x="57" y="137" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_dot_off">
-			<bounds x="88" y="157" width="6" height="5">
-			</bounds>
+			<bounds x="88" y="157" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_on">
-			<bounds x="57" y="117" width="31" height="5">
-			</bounds>
+			<bounds x="57" y="117" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="82" y="117" width="6" height="25">
-			</bounds>
+			<bounds x="82" y="117" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="82" y="137" width="6" height="25">
-			</bounds>
+			<bounds x="82" y="137" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="57" y="157" width="31" height="5">
-			</bounds>
+			<bounds x="57" y="157" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="57" y="137" width="6" height="25">
-			</bounds>
+			<bounds x="57" y="137" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="57" y="117" width="6" height="25">
-			</bounds>
+			<bounds x="57" y="117" width="6" height="25"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="57" y="137" width="31" height="5">
-			</bounds>
+			<bounds x="57" y="137" width="31" height="5"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_dot_on">
-			<bounds x="88" y="157" width="6" height="5">
-			</bounds>
+			<bounds x="88" y="157" width="6" height="5"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="340" y="414" width="272" height="30">
-			</bounds>
+			<bounds x="340" y="414" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="340" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="340" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="357" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="357" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="374" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="374" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="391" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="391" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="408" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="408" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="425" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="425" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="442" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="442" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="459" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="459" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="476" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="476" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="493" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="493" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="510" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="510" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="527" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="527" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="544" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="544" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="561" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="561" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="578" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="578" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="595" y="414" width="17" height="30">
-			</bounds>
+			<bounds x="595" y="414" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label55" element="label_55">
-			<bounds x="515" y="101" width="52" height="26">
-			</bounds>
+			<bounds x="515" y="101" width="52" height="26"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="448" y="247" width="55" height="11">
-			</bounds>
+			<bounds x="448" y="247" width="55" height="11"/>
 		</backdrop>
 		<backdrop name="label82" element="label_82">
-			<bounds x="382" y="317" width="13" height="27">
-			</bounds>
+			<bounds x="382" y="317" width="13" height="27"/>
 		</backdrop>
 		<backdrop name="label95" element="label_95">
-			<bounds x="557" y="314" width="13" height="27">
-			</bounds>
+			<bounds x="557" y="314" width="13" height="27"/>
 		</backdrop>
 		<backdrop name="label160" element="label_160">
-			<bounds x="132" y="636" width="39" height="22">
-			</bounds>
+			<bounds x="132" y="636" width="39" height="22"/>
 		</backdrop>
 		<backdrop name="label175" element="label_175">
-			<bounds x="14" y="635" width="38" height="22">
-			</bounds>
+			<bounds x="14" y="635" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="label186" element="label_186">
-			<bounds x="60" y="89" width="74" height="19">
-			</bounds>
+			<bounds x="60" y="89" width="74" height="19"/>
 		</backdrop>
 		<backdrop name="label188" element="label_188">
-			<bounds x="43" y="523" width="180" height="39">
-			</bounds>
+			<bounds x="43" y="523" width="180" height="39"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1trtr.lay
+++ b/src/mame/layout/m1trtr.lay
@@ -8,8854 +8,6167 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COUNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="COUNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MYSTERY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MYSTERY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FRUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FRUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SKILL CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SPINNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPINNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="OR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="OR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_123_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_123">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_124_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_124">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_125_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_125">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="TREAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_126_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_126">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TRICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_127_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_127">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_128_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_128">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_129_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_129">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_130_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_130">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="2730" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_55">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_56">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="782" height="775">
-			</bounds>
+			<bounds x="0" y="0" width="782" height="775"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="265" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="265" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="265.0000" y="583.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="265.0000" y="583.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="268.3333" y="584.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="268.3333" y="584.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.6667" y="586.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="271.6667" y="586.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="275.0000" y="588.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="275.0000" y="588.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="278.3333" y="590.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="278.3333" y="590.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="281.6667" y="592.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="281.6667" y="592.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="265.0000" y="629.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="265.0000" y="629.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="268.3333" y="631.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="268.3333" y="631.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.6667" y="633.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="271.6667" y="633.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="275.0000" y="635.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="275.0000" y="635.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="278.3333" y="637.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="278.3333" y="637.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="281.6667" y="639.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="281.6667" y="639.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="265.0000" y="676.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="265.0000" y="676.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="268.3333" y="678.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="268.3333" y="678.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.6667" y="680.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="271.6667" y="680.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="275.0000" y="682.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="275.0000" y="682.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="278.3333" y="684.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="278.3333" y="684.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="281.6667" y="686.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="281.6667" y="686.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="265" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="265" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="351" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="351" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="351.0000" y="583.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="351.0000" y="583.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="354.3333" y="584.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="354.3333" y="584.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="357.6667" y="586.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="357.6667" y="586.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="361.0000" y="588.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="361.0000" y="588.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="364.3333" y="590.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="364.3333" y="590.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="367.6667" y="592.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="367.6667" y="592.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="351.0000" y="629.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="351.0000" y="629.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="354.3333" y="631.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="354.3333" y="631.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="357.6667" y="633.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="357.6667" y="633.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="361.0000" y="635.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="361.0000" y="635.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="364.3333" y="637.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="364.3333" y="637.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="367.6667" y="639.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="367.6667" y="639.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="351.0000" y="676.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="351.0000" y="676.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="354.3333" y="678.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="354.3333" y="678.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="357.6667" y="680.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="357.6667" y="680.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="361.0000" y="682.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="361.0000" y="682.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="364.3333" y="684.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="364.3333" y="684.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="367.6667" y="686.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="367.6667" y="686.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="351" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="351" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="436" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="436" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="583.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="583.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="584.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="584.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="586.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="586.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="588.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="588.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="590.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="590.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="592.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="592.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="629.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="629.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="631.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="631.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="633.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="633.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="635.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="635.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="637.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="637.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="639.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="639.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="676.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="676.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="678.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="678.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="680.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="680.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="682.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="682.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="684.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="684.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="686.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="686.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="436" y="583" width="80" height="140">
-			</bounds>
+			<bounds x="436" y="583" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="132" y="146" width="81" height="76">
-			</bounds>
+			<bounds x="132" y="146" width="81" height="76"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="132.0000" y="146.0000" width="81.0000" height="76.0000">
-			</bounds>
+			<bounds x="132.0000" y="146.0000" width="81.0000" height="76.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="135.3750" y="149.1667" width="74.2500" height="69.6667">
-			</bounds>
+			<bounds x="135.3750" y="149.1667" width="74.2500" height="69.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="138.7500" y="152.3333" width="67.5000" height="63.3333">
-			</bounds>
+			<bounds x="138.7500" y="152.3333" width="67.5000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="142.1250" y="155.5000" width="60.7500" height="57.0000">
-			</bounds>
+			<bounds x="142.1250" y="155.5000" width="60.7500" height="57.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="145.5000" y="158.6667" width="54.0000" height="50.6667">
-			</bounds>
+			<bounds x="145.5000" y="158.6667" width="54.0000" height="50.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="148.8750" y="161.8333" width="47.2500" height="44.3333">
-			</bounds>
+			<bounds x="148.8750" y="161.8333" width="47.2500" height="44.3333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="132" y="146" width="81" height="76">
-			</bounds>
+			<bounds x="132" y="146" width="81" height="76"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="321" y="39" width="142" height="36">
-			</bounds>
+			<bounds x="321" y="39" width="142" height="36"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="323" y="41" width="138" height="32">
-			</bounds>
+			<bounds x="323" y="41" width="138" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="32" y="12" width="78" height="46">
-			</bounds>
+			<bounds x="32" y="12" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="34" y="14" width="74" height="42">
-			</bounds>
+			<bounds x="34" y="14" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="33" y="289" width="78" height="46">
-			</bounds>
+			<bounds x="33" y="289" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="35" y="291" width="74" height="42">
-			</bounds>
+			<bounds x="35" y="291" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="32" y="58" width="78" height="46">
-			</bounds>
+			<bounds x="32" y="58" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="34" y="60" width="74" height="42">
-			</bounds>
+			<bounds x="34" y="60" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="32" y="150" width="78" height="46">
-			</bounds>
+			<bounds x="32" y="150" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="34" y="152" width="74" height="42">
-			</bounds>
+			<bounds x="34" y="152" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="33" y="243" width="78" height="46">
-			</bounds>
+			<bounds x="33" y="243" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="35" y="245" width="74" height="42">
-			</bounds>
+			<bounds x="35" y="245" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="32" y="196" width="78" height="46">
-			</bounds>
+			<bounds x="32" y="196" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="34" y="198" width="74" height="42">
-			</bounds>
+			<bounds x="34" y="198" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="32" y="104" width="78" height="46">
-			</bounds>
+			<bounds x="32" y="104" width="78" height="46"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="34" y="106" width="74" height="42">
-			</bounds>
+			<bounds x="34" y="106" width="74" height="42"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="282" y="1" width="96" height="36">
-			</bounds>
+			<bounds x="282" y="1" width="96" height="36"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="284" y="3" width="92" height="32">
-			</bounds>
+			<bounds x="284" y="3" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="379" y="1" width="122" height="36">
-			</bounds>
+			<bounds x="379" y="1" width="122" height="36"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="381" y="3" width="118" height="32">
-			</bounds>
+			<bounds x="381" y="3" width="118" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="504" y="459" width="46" height="34">
-			</bounds>
+			<bounds x="504" y="459" width="46" height="34"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="506" y="461" width="42" height="30">
-			</bounds>
+			<bounds x="506" y="461" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="19" y="622" width="46" height="36">
-			</bounds>
+			<bounds x="19" y="622" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="21" y="624" width="42" height="32">
-			</bounds>
+			<bounds x="21" y="624" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="360" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="360" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="362" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="362" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="360" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="360" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="362" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="362" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="396" y="537" width="56" height="36">
-			</bounds>
+			<bounds x="396" y="537" width="56" height="36"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="398" y="539" width="52" height="32">
-			</bounds>
+			<bounds x="398" y="539" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="396" y="537" width="56" height="36">
-			</bounds>
+			<bounds x="396" y="537" width="56" height="36"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="398" y="539" width="52" height="32">
-			</bounds>
+			<bounds x="398" y="539" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="327" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="327" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="329" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="329" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="327" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="327" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="329" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="329" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="293" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="293" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="295" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="295" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="293" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="293" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="295" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="295" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="261" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="261" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="263" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="263" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="261" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="261" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="263" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="263" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="226" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="226" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="228" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="228" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="226" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="226" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="228" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="228" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="161" y="537" width="66" height="36">
-			</bounds>
+			<bounds x="161" y="537" width="66" height="36"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="163" y="539" width="62" height="32">
-			</bounds>
+			<bounds x="163" y="539" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="451" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="451" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="453" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="453" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="451" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="451" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="453" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="453" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="485" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="485" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="487" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="487" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="485" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="485" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="487" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="487" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="586" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="586" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="588" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="588" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="586" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="586" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="588" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="588" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="552" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="552" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="554" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="554" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="552" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="552" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="554" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="554" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="519" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="519" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="521" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="521" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="519" y="537" width="36" height="36">
-			</bounds>
+			<bounds x="519" y="537" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="521" y="539" width="32" height="32">
-			</bounds>
+			<bounds x="521" y="539" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="73" y="699" width="60" height="36">
-			</bounds>
+			<bounds x="73" y="699" width="60" height="36"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="75" y="701" width="56" height="32">
-			</bounds>
+			<bounds x="75" y="701" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="73" y="699" width="60" height="36">
-			</bounds>
+			<bounds x="73" y="699" width="60" height="36"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="75" y="701" width="56" height="32">
-			</bounds>
+			<bounds x="75" y="701" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="77" y="586" width="36" height="36">
-			</bounds>
+			<bounds x="77" y="586" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="79" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="79" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="40" y="549" width="36" height="36">
-			</bounds>
+			<bounds x="40" y="549" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="42" y="551" width="32" height="32">
-			</bounds>
+			<bounds x="42" y="551" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="103" y="627" width="34" height="34">
-			</bounds>
+			<bounds x="103" y="627" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="105" y="629" width="30" height="30">
-			</bounds>
+			<bounds x="105" y="629" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="74" y="662" width="36" height="36">
-			</bounds>
+			<bounds x="74" y="662" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="76" y="664" width="32" height="32">
-			</bounds>
+			<bounds x="76" y="664" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="433" y="83" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="83" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="435" y="85" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="85" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="433" y="129" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="129" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="435" y="131" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="131" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="433" y="175" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="175" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="435" y="177" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="177" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="433" y="221" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="221" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="435" y="223" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="223" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="433" y="267" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="267" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="435" y="269" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="269" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="433" y="313" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="313" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="435" y="315" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="315" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="433" y="359" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="359" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="435" y="361" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="361" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="433" y="405" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="405" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="435" y="407" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="407" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="433" y="451" width="54" height="46">
-			</bounds>
+			<bounds x="433" y="451" width="54" height="46"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="435" y="453" width="50" height="42">
-			</bounds>
+			<bounds x="435" y="453" width="50" height="42"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_123_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="745" y="1" width="36" height="36">
-			</bounds>
+			<bounds x="745" y="1" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_123" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="747" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="747" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_124_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="677" y="734" width="75" height="37">
-			</bounds>
+			<bounds x="677" y="734" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_124" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="679" y="736" width="71" height="33">
-			</bounds>
+			<bounds x="679" y="736" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_125_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="593" y="734" width="75" height="37">
-			</bounds>
+			<bounds x="593" y="734" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_125" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="595" y="736" width="71" height="33">
-			</bounds>
+			<bounds x="595" y="736" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_126_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="515" y="734" width="75" height="37">
-			</bounds>
+			<bounds x="515" y="734" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_126" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="517" y="736" width="71" height="33">
-			</bounds>
+			<bounds x="517" y="736" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_127_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="437" y="734" width="75" height="37">
-			</bounds>
+			<bounds x="437" y="734" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_127" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="439" y="736" width="71" height="33">
-			</bounds>
+			<bounds x="439" y="736" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_128_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="358" y="734" width="75" height="37">
-			</bounds>
+			<bounds x="358" y="734" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_128" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="360" y="736" width="71" height="33">
-			</bounds>
+			<bounds x="360" y="736" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_129_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="271" y="734" width="75" height="37">
-			</bounds>
+			<bounds x="271" y="734" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_129" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="273" y="736" width="71" height="33">
-			</bounds>
+			<bounds x="273" y="736" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_130_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="185" y="734" width="75" height="37">
-			</bounds>
+			<bounds x="185" y="734" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_130" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="187" y="736" width="71" height="33">
-			</bounds>
+			<bounds x="187" y="736" width="71" height="33"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="270" y="507" width="245" height="26">
-			</bounds>
+			<bounds x="270" y="507" width="245" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="270" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="270" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="285" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="285" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="300" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="300" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="315" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="315" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="330" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="330" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="345" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="345" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="360" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="360" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="375" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="375" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="390" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="390" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="405" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="405" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="420" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="420" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="435" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="435" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="450" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="450" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="465" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="465" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="480" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="480" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="495" y="507" width="15" height="26">
-			</bounds>
+			<bounds x="495" y="507" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="label55" element="label_55">
-			<bounds x="517" y="641" width="46" height="24">
-			</bounds>
+			<bounds x="517" y="641" width="46" height="24"/>
 		</backdrop>
 		<backdrop name="label56" element="label_56">
-			<bounds x="222" y="641" width="40" height="24">
-			</bounds>
+			<bounds x="222" y="641" width="40" height="24"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1ttcash.lay
+++ b/src/mame/layout/m1ttcash.lay
@@ -6,8962 +6,5972 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png">
-		</image>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Double">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Double">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.46" green="0.40" blue="0.04">
-			</color>
+			<color red="0.46" green="0.40" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
+			<color red="0.11" green="0.10" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.93" green="0.80" blue="0.07">
-			</color>
+			<color red="0.93" green="0.80" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
+			<color red="0.23" green="0.20" blue="0.02"/>
 		</rect>
 		<text string=" Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.46" green="0.40" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.10" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.93" green="0.80" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.23" green="0.20" blue="0.02">
-			</color>
-		</rect>
-		<text string=" Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rewi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_79_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_79">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_80_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_80">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_81_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_81">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_82_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_82">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_83_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_83">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_84_border">
 		<rect state="1">
-			<color red="0.12" green="0.41" blue="0.32">
-			</color>
+			<color red="0.12" green="0.41" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.10" blue="0.08">
-			</color>
+			<color red="0.03" green="0.10" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="colour_button_84">
 		<rect state="1">
-			<color red="0.24" green="0.83" blue="0.64">
-			</color>
+			<color red="0.24" green="0.83" blue="0.64"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.20" blue="0.16">
-			</color>
+			<color red="0.06" green="0.20" blue="0.16"/>
 		</rect>
 		<text string="Rewind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_85_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_85">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_86_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_86">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_50">
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_51">
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_52">
 		<text string="All-Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_60">
 		<text string="Rewind at a cost of 1 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_63">
 		<text string="&#xA3;5+Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_64">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_71">
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_72">
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_73">
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_74">
 		<text string="27 Ways to win &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_75">
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_76">
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
-			<bounds x="0" y="0" width="792" height="510">
-			</bounds>
+		<backdrop element="backdrop_colour">
+			<bounds x="0" y="0" width="792" height="510"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="221" y="326" width="80" height="140">
-			</bounds>
+			<bounds x="221" y="326" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="221.0000" y="326.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="221.0000" y="326.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="224.3333" y="327.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="224.3333" y="327.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="227.6667" y="329.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="227.6667" y="329.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="231.0000" y="331.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="231.0000" y="331.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="234.3333" y="333.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="234.3333" y="333.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.6667" y="335.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="237.6667" y="335.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="221.0000" y="372.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="221.0000" y="372.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="224.3333" y="374.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="224.3333" y="374.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="227.6667" y="376.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="227.6667" y="376.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="231.0000" y="378.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="231.0000" y="378.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="234.3333" y="380.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="234.3333" y="380.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.6667" y="382.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="237.6667" y="382.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="221.0000" y="419.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="221.0000" y="419.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="224.3333" y="421.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="224.3333" y="421.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="227.6667" y="423.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="227.6667" y="423.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="231.0000" y="425.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="231.0000" y="425.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="234.3333" y="427.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="234.3333" y="427.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.6667" y="429.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="237.6667" y="429.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="221" y="326" width="80" height="140">
-			</bounds>
+			<bounds x="221" y="326" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="305" y="326" width="80" height="140">
-			</bounds>
+			<bounds x="305" y="326" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="305.0000" y="326.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="305.0000" y="326.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="308.3333" y="327.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="308.3333" y="327.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="311.6667" y="329.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="311.6667" y="329.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="315.0000" y="331.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="315.0000" y="331.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="318.3333" y="333.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="318.3333" y="333.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="321.6667" y="335.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="321.6667" y="335.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="305.0000" y="372.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="305.0000" y="372.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="308.3333" y="374.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="308.3333" y="374.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="311.6667" y="376.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="311.6667" y="376.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="315.0000" y="378.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="315.0000" y="378.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="318.3333" y="380.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="318.3333" y="380.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="321.6667" y="382.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="321.6667" y="382.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="305.0000" y="419.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="305.0000" y="419.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="308.3333" y="421.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="308.3333" y="421.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="311.6667" y="423.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="311.6667" y="423.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="315.0000" y="425.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="315.0000" y="425.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="318.3333" y="427.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="318.3333" y="427.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="321.6667" y="429.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="321.6667" y="429.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="305" y="326" width="80" height="140">
-			</bounds>
+			<bounds x="305" y="326" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="389" y="326" width="80" height="140">
-			</bounds>
+			<bounds x="389" y="326" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="389.0000" y="326.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="389.0000" y="326.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="392.3333" y="327.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="392.3333" y="327.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.6667" y="329.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="395.6667" y="329.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="399.0000" y="331.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="399.0000" y="331.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="402.3333" y="333.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="402.3333" y="333.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="405.6667" y="335.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="405.6667" y="335.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="389.0000" y="372.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="389.0000" y="372.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="392.3333" y="374.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="392.3333" y="374.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.6667" y="376.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="395.6667" y="376.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="399.0000" y="378.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="399.0000" y="378.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="402.3333" y="380.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="402.3333" y="380.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="405.6667" y="382.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="405.6667" y="382.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="389.0000" y="419.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="389.0000" y="419.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="392.3333" y="421.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="392.3333" y="421.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.6667" y="423.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="395.6667" y="423.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="399.0000" y="425.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="399.0000" y="425.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="402.3333" y="427.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="402.3333" y="427.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="405.6667" y="429.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="405.6667" y="429.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="389" y="326" width="80" height="140">
-			</bounds>
+			<bounds x="389" y="326" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="301" y="92" width="86" height="86">
-			</bounds>
+			<bounds x="301" y="92" width="86" height="86"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="301.0000" y="92.0000" width="86.0000" height="86.0000">
-			</bounds>
+			<bounds x="301.0000" y="92.0000" width="86.0000" height="86.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="304.5833" y="95.5833" width="78.8333" height="78.8333">
-			</bounds>
+			<bounds x="304.5833" y="95.5833" width="78.8333" height="78.8333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="308.1667" y="99.1667" width="71.6667" height="71.6667">
-			</bounds>
+			<bounds x="308.1667" y="99.1667" width="71.6667" height="71.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="311.7500" y="102.7500" width="64.5000" height="64.5000">
-			</bounds>
+			<bounds x="311.7500" y="102.7500" width="64.5000" height="64.5000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="315.3333" y="106.3333" width="57.3333" height="57.3333">
-			</bounds>
+			<bounds x="315.3333" y="106.3333" width="57.3333" height="57.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="318.9167" y="109.9167" width="50.1667" height="50.1667">
-			</bounds>
+			<bounds x="318.9167" y="109.9167" width="50.1667" height="50.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="301" y="92" width="86" height="86">
-			</bounds>
+			<bounds x="301" y="92" width="86" height="86"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="321" y="222" width="47" height="47">
-			</bounds>
+			<bounds x="321" y="222" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="323" y="224" width="43" height="43">
-			</bounds>
+			<bounds x="323" y="224" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="380" y="205" width="47" height="47">
-			</bounds>
+			<bounds x="380" y="205" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="382" y="207" width="43" height="43">
-			</bounds>
+			<bounds x="382" y="207" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="417" y="164" width="47" height="47">
-			</bounds>
+			<bounds x="417" y="164" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="419" y="166" width="43" height="43">
-			</bounds>
+			<bounds x="419" y="166" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="429" y="114" width="47" height="47">
-			</bounds>
+			<bounds x="429" y="114" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="431" y="116" width="43" height="43">
-			</bounds>
+			<bounds x="431" y="116" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="380" y="23" width="47" height="47">
-			</bounds>
+			<bounds x="380" y="23" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="382" y="25" width="43" height="43">
-			</bounds>
+			<bounds x="382" y="25" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="417" y="62" width="47" height="47">
-			</bounds>
+			<bounds x="417" y="62" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="419" y="64" width="43" height="43">
-			</bounds>
+			<bounds x="419" y="64" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="321" y="4" width="47" height="47">
-			</bounds>
+			<bounds x="321" y="4" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="323" y="6" width="43" height="43">
-			</bounds>
+			<bounds x="323" y="6" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="696" y="186" width="72" height="42">
-			</bounds>
+			<bounds x="696" y="186" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="698" y="188" width="68" height="38">
-			</bounds>
+			<bounds x="698" y="188" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="546" y="186" width="72" height="42">
-			</bounds>
+			<bounds x="546" y="186" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="548" y="188" width="68" height="38">
-			</bounds>
+			<bounds x="548" y="188" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="576" y="229" width="72" height="42">
-			</bounds>
+			<bounds x="576" y="229" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="578" y="231" width="68" height="38">
-			</bounds>
+			<bounds x="578" y="231" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="666" y="229" width="72" height="42">
-			</bounds>
+			<bounds x="666" y="229" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="668" y="231" width="68" height="38">
-			</bounds>
+			<bounds x="668" y="231" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="625" y="358" width="64" height="42">
-			</bounds>
+			<bounds x="625" y="358" width="64" height="42"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="627" y="360" width="60" height="38">
-			</bounds>
+			<bounds x="627" y="360" width="60" height="38"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="623" y="315" width="68" height="42">
-			</bounds>
+			<bounds x="623" y="315" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="625" y="317" width="64" height="38">
-			</bounds>
+			<bounds x="625" y="317" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="621" y="272" width="72" height="42">
-			</bounds>
+			<bounds x="621" y="272" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="623" y="274" width="68" height="38">
-			</bounds>
+			<bounds x="623" y="274" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="223" y="164" width="47" height="47">
-			</bounds>
+			<bounds x="223" y="164" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="225" y="166" width="43" height="43">
-			</bounds>
+			<bounds x="225" y="166" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="223" y="62" width="47" height="47">
-			</bounds>
+			<bounds x="223" y="62" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="225" y="64" width="43" height="43">
-			</bounds>
+			<bounds x="225" y="64" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="262" y="23" width="47" height="47">
-			</bounds>
+			<bounds x="262" y="23" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="264" y="25" width="43" height="43">
-			</bounds>
+			<bounds x="264" y="25" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="262" y="205" width="47" height="47">
-			</bounds>
+			<bounds x="262" y="205" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="264" y="207" width="43" height="43">
-			</bounds>
+			<bounds x="264" y="207" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="211" y="114" width="47" height="47">
-			</bounds>
+			<bounds x="211" y="114" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="213" y="116" width="43" height="43">
-			</bounds>
+			<bounds x="213" y="116" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="518" y="378" width="72" height="27">
-			</bounds>
+			<bounds x="518" y="378" width="72" height="27"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="520" y="380" width="68" height="23">
-			</bounds>
+			<bounds x="520" y="380" width="68" height="23"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="520" y="403" width="68" height="27">
-			</bounds>
+			<bounds x="520" y="403" width="68" height="27"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="522" y="405" width="64" height="23">
-			</bounds>
+			<bounds x="522" y="405" width="64" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="197" y="267" width="42" height="27">
-			</bounds>
+			<bounds x="197" y="267" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="199" y="269" width="38" height="23">
-			</bounds>
+			<bounds x="199" y="269" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="170" y="249" width="57" height="18">
-			</bounds>
+			<bounds x="170" y="249" width="57" height="18"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="172" y="251" width="53" height="14">
-			</bounds>
+			<bounds x="172" y="251" width="53" height="14"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="449" y="267" width="42" height="27">
-			</bounds>
+			<bounds x="449" y="267" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="451" y="269" width="38" height="23">
-			</bounds>
+			<bounds x="451" y="269" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="407" y="267" width="42" height="27">
-			</bounds>
+			<bounds x="407" y="267" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="409" y="269" width="38" height="23">
-			</bounds>
+			<bounds x="409" y="269" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="365" y="267" width="42" height="27">
-			</bounds>
+			<bounds x="365" y="267" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="367" y="269" width="38" height="23">
-			</bounds>
+			<bounds x="367" y="269" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="323" y="267" width="42" height="27">
-			</bounds>
+			<bounds x="323" y="267" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="325" y="269" width="38" height="23">
-			</bounds>
+			<bounds x="325" y="269" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="281" y="267" width="42" height="27">
-			</bounds>
+			<bounds x="281" y="267" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="283" y="269" width="38" height="23">
-			</bounds>
+			<bounds x="283" y="269" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="239" y="267" width="42" height="27">
-			</bounds>
+			<bounds x="239" y="267" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="241" y="269" width="38" height="23">
-			</bounds>
+			<bounds x="241" y="269" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="644" y="98" width="76" height="42">
-			</bounds>
+			<bounds x="644" y="98" width="76" height="42"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="646" y="100" width="72" height="38">
-			</bounds>
+			<bounds x="646" y="100" width="72" height="38"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="583" y="98" width="67" height="42">
-			</bounds>
+			<bounds x="583" y="98" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="585" y="100" width="63" height="38">
-			</bounds>
+			<bounds x="585" y="100" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="85" y="438" width="62" height="30">
-			</bounds>
+			<bounds x="85" y="438" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="87" y="440" width="58" height="26">
-			</bounds>
+			<bounds x="87" y="440" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="85" y="410" width="62" height="30">
-			</bounds>
+			<bounds x="85" y="410" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="87" y="412" width="58" height="26">
-			</bounds>
+			<bounds x="87" y="412" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="85" y="382" width="62" height="30">
-			</bounds>
+			<bounds x="85" y="382" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="87" y="384" width="58" height="26">
-			</bounds>
+			<bounds x="87" y="384" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="85" y="354" width="62" height="30">
-			</bounds>
+			<bounds x="85" y="354" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="87" y="356" width="58" height="26">
-			</bounds>
+			<bounds x="87" y="356" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="85" y="326" width="62" height="30">
-			</bounds>
+			<bounds x="85" y="326" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="87" y="328" width="58" height="26">
-			</bounds>
+			<bounds x="87" y="328" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_79_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="625" y="14" width="52" height="32">
-			</bounds>
+			<bounds x="625" y="14" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_79" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="627" y="16" width="48" height="28">
-			</bounds>
+			<bounds x="627" y="16" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_80_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="398" y="470" width="62" height="40">
-			</bounds>
+			<bounds x="398" y="470" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_80" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="400" y="472" width="58" height="36">
-			</bounds>
+			<bounds x="400" y="472" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_81_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="316" y="470" width="62" height="40">
-			</bounds>
+			<bounds x="316" y="470" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_81" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="318" y="472" width="58" height="36">
-			</bounds>
+			<bounds x="318" y="472" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_82_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="230" y="470" width="62" height="40">
-			</bounds>
+			<bounds x="230" y="470" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_82" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="232" y="472" width="58" height="36">
-			</bounds>
+			<bounds x="232" y="472" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_83_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="695" y="470" width="62" height="40">
-			</bounds>
+			<bounds x="695" y="470" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_83" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="697" y="472" width="58" height="36">
-			</bounds>
+			<bounds x="697" y="472" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_84_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="601" y="470" width="62" height="40">
-			</bounds>
+			<bounds x="601" y="470" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_84" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="603" y="472" width="58" height="36">
-			</bounds>
+			<bounds x="603" y="472" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_85_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="507" y="470" width="62" height="40">
-			</bounds>
+			<bounds x="507" y="470" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_85" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="509" y="472" width="58" height="36">
-			</bounds>
+			<bounds x="509" y="472" width="58" height="36"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_86_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="123" y="470" width="62" height="40">
-			</bounds>
+			<bounds x="123" y="470" width="62" height="40"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_86" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="125" y="472" width="58" height="36">
-			</bounds>
+			<bounds x="125" y="472" width="58" height="36"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="214" y="296" width="260" height="26">
-			</bounds>
+			<bounds x="214" y="296" width="260" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="214" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="214" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="230" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="230" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="246" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="246" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="262" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="262" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="278" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="278" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="294" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="294" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="310" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="310" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="326" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="326" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="342" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="342" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="358" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="358" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="374" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="374" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="390" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="390" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="406" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="406" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="422" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="422" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="438" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="438" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="454" y="296" width="16" height="26">
-			</bounds>
+			<bounds x="454" y="296" width="16" height="26"/>
 		</backdrop>
 		<backdrop name="label50" element="label_50">
-			<bounds x="286" y="258" width="30" height="11">
-			</bounds>
+			<bounds x="286" y="258" width="30" height="11"/>
 		</backdrop>
 		<backdrop name="label51" element="label_51">
-			<bounds x="417" y="258" width="22" height="11">
-			</bounds>
+			<bounds x="417" y="258" width="22" height="11"/>
 		</backdrop>
 		<backdrop name="label52" element="label_52">
-			<bounds x="603" y="68" width="95" height="27">
-			</bounds>
+			<bounds x="603" y="68" width="95" height="27"/>
 		</backdrop>
 		<backdrop name="label60" element="label_60">
-			<bounds x="87" y="291" width="58" height="33">
-			</bounds>
+			<bounds x="87" y="291" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="label63" element="label_63">
-			<bounds x="68" y="16" width="56" height="26">
-			</bounds>
+			<bounds x="68" y="16" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="label64" element="label_64">
-			<bounds x="68" y="48" width="21" height="21">
-			</bounds>
+			<bounds x="68" y="48" width="21" height="21"/>
 		</backdrop>
 		<backdrop name="label71" element="label_71">
-			<bounds x="68" y="221" width="32" height="21">
-			</bounds>
+			<bounds x="68" y="221" width="32" height="21"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="68" y="192" width="32" height="21">
-			</bounds>
+			<bounds x="68" y="192" width="32" height="21"/>
 		</backdrop>
 		<backdrop name="label73" element="label_73">
-			<bounds x="68" y="163" width="32" height="21">
-			</bounds>
+			<bounds x="68" y="163" width="32" height="21"/>
 		</backdrop>
 		<backdrop name="label74" element="label_74">
-			<bounds x="68" y="103" width="47" height="26">
-			</bounds>
+			<bounds x="68" y="103" width="47" height="26"/>
 		</backdrop>
 		<backdrop name="label75" element="label_75">
-			<bounds x="68" y="134" width="32" height="21">
-			</bounds>
+			<bounds x="68" y="134" width="32" height="21"/>
 		</backdrop>
 		<backdrop name="label76" element="label_76">
-			<bounds x="68" y="250" width="32" height="21">
-			</bounds>
+			<bounds x="68" y="250" width="32" height="21"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="68" y="77" width="46" height="21">
-			</bounds>
+			<bounds x="68" y="77" width="46" height="21"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1wldzner.lay
+++ b/src/mame/layout/m1wldzner.lay
@@ -8,13892 +8,8175 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</disk>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</disk>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</disk>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</disk>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</disk>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</disk>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</disk>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</disk>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</disk>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</disk>
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</disk>
-		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</disk>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</disk>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</disk>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</disk>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ELIMI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ELIMI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TILT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="TILT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="STOP N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="STOP N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TILT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="TILT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CRAZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CRAZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TO WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TO WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FLIPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WILD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WILD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="BARS OR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SEVENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="BARS OR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SEVENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
+			<color red="0.50" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
+			<color red="1.00" green="0.95" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
+			<color red="0.25" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="ON WINLINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="START FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="ON WINLINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="START FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
+			<color red="0.08" green="0.50" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
+			<color red="0.02" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
+			<color red="0.17" green="1.00" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
+			<color red="0.04" green="0.25" blue="0.04"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
+			<color red="0.16" green="0.50" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
+			<color red="0.04" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
+			<color red="0.33" green="1.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
+			<color red="0.08" green="0.25" blue="0.08"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.50" blue="0.33">
-			</color>
+			<color red="0.33" green="0.50" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.12" blue="0.08">
-			</color>
+			<color red="0.08" green="0.12" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="1.00" blue="0.67">
-			</color>
+			<color red="0.67" green="1.00" blue="0.67"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.25" blue="0.16">
-			</color>
+			<color red="0.16" green="0.25" blue="0.16"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.50" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.12" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="1.00" blue="0.67">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.25" blue="0.16">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
+			<color red="0.50" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
+			<color red="1.00" green="0.95" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
+			<color red="0.25" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="NE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="NE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
+			<color red="0.50" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
+			<color red="1.00" green="0.95" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
+			<color red="0.25" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="LD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="LD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
+			<color red="0.50" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
+			<color red="1.00" green="0.95" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
+			<color red="0.25" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="WI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="WI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
+			<color red="0.50" green="0.47" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
+			<color red="1.00" green="0.95" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
+			<color red="0.25" green="0.24" blue="0.00"/>
 		</rect>
 		<text string="ZO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.47" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.95" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.24" blue="0.00">
-			</color>
-		</rect>
-		<text string="ZO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="300">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="300">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" TO WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string=" TO WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="0.50" blue="0.33">
-			</color>
+			<color red="0.33" green="0.50" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.12" blue="0.08">
-			</color>
+			<color red="0.08" green="0.12" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.67" green="1.00" blue="0.67">
-			</color>
+			<color red="0.67" green="1.00" blue="0.67"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.25" blue="0.16">
-			</color>
+			<color red="0.16" green="0.25" blue="0.16"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="0.50" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.12" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.67" green="1.00" blue="0.67">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.25" blue="0.16">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.50" blue="0.29">
-			</color>
+			<color red="0.29" green="0.50" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.12" blue="0.07">
-			</color>
+			<color red="0.07" green="0.12" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.58" green="1.00" blue="0.58">
-			</color>
+			<color red="0.58" green="1.00" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.25" blue="0.15">
-			</color>
+			<color red="0.15" green="0.25" blue="0.15"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.50" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.12" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.58" green="1.00" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.25" blue="0.15">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.50" blue="0.21">
-			</color>
+			<color red="0.21" green="0.50" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
+			<color red="0.05" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="1.00" blue="0.42">
-			</color>
+			<color red="0.42" green="1.00" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.10">
-			</color>
+			<color red="0.10" green="0.25" blue="0.10"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.50" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="1.00" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.10">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
+			<color red="0.16" green="0.50" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
+			<color red="0.04" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
+			<color red="0.33" green="1.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
+			<color red="0.08" green="0.25" blue="0.08"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
+			<color red="0.13" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
+			<color red="0.25" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
+			<color red="0.08" green="0.50" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
+			<color red="0.02" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
+			<color red="0.17" green="1.00" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
+			<color red="0.04" green="0.25" blue="0.04"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
+			<color red="0.04" green="0.50" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
+			<color red="0.01" green="0.12" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
+			<color red="0.08" green="1.00" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
+			<color red="0.02" green="0.25" blue="0.02"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 MILLION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 MILLION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.46" blue="0.16">
-			</color>
+			<color red="0.50" green="0.46" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
+			<color red="0.12" green="0.11" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.92" blue="0.33">
-			</color>
+			<color red="1.00" green="0.92" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
+			<color red="0.25" green="0.23" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.46" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.92" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.45" blue="0.13">
-			</color>
+			<color red="0.50" green="0.45" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.03">
-			</color>
+			<color red="0.12" green="0.11" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.91" blue="0.25">
-			</color>
+			<color red="1.00" green="0.91" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.06">
-			</color>
+			<color red="0.25" green="0.23" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.45" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.91" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.45" blue="0.08">
-			</color>
+			<color red="0.50" green="0.45" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.02">
-			</color>
+			<color red="0.12" green="0.11" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.89" blue="0.17">
-			</color>
+			<color red="1.00" green="0.89" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.04">
-			</color>
+			<color red="0.25" green="0.22" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.45" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.89" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.04">
-			</color>
+			<color red="0.50" green="0.44" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.01">
-			</color>
+			<color red="0.12" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.89" blue="0.08">
-			</color>
+			<color red="1.00" green="0.89" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.02">
-			</color>
+			<color red="0.25" green="0.22" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.89" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="TARGETS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="TARGETS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="TILT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="TILT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="SPECIAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPECIAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="TARGET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="AGAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
+			<color red="0.50" green="0.38" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
+			<color red="1.00" green="0.77" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.38" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.77" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="RE-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_175_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_175">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_176_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_176">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_177_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_177">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_178_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_178">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_179_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_179">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_180_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_180">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_181_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_181">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_182_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_182">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_191_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_191">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_192_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_192">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SCORE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist=",,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_125">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_169">
 		<text string="INNER PAYS 40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_170">
 		<text string="OUTER PAYS 20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_171">
 		<text string="BULLSEYE PAYS &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_173">
 		<text string="madness.fruitemu.co.uk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_174">
 		<text string="v1.11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="787" height="651">
-			</bounds>
+			<bounds x="0" y="0" width="787" height="651"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="126" y="435" width="80" height="100">
-			</bounds>
+			<bounds x="126" y="435" width="80" height="100"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="126.0000" y="435.0000" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="126.0000" y="435.0000" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="129.3333" y="436.3889" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="129.3333" y="436.3889" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="132.6667" y="437.7778" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="132.6667" y="437.7778" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="136.0000" y="439.1667" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="136.0000" y="439.1667" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="139.3333" y="440.5555" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="139.3333" y="440.5555" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="142.6667" y="441.9445" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="142.6667" y="441.9445" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="126.0000" y="468.3333" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="126.0000" y="468.3333" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="129.3333" y="469.7222" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="129.3333" y="469.7222" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="132.6667" y="471.1111" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="132.6667" y="471.1111" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="136.0000" y="472.5000" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="136.0000" y="472.5000" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="139.3333" y="473.8889" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="139.3333" y="473.8889" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="142.6667" y="475.2778" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="142.6667" y="475.2778" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="126.0000" y="501.6667" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="126.0000" y="501.6667" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="129.3333" y="503.0555" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="129.3333" y="503.0555" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="132.6667" y="504.4444" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="132.6667" y="504.4444" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="136.0000" y="505.8333" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="136.0000" y="505.8333" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="139.3333" y="507.2222" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="139.3333" y="507.2222" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="142.6667" y="508.6111" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="142.6667" y="508.6111" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="126" y="435" width="80" height="100">
-			</bounds>
+			<bounds x="126" y="435" width="80" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="256" y="435" width="80" height="100">
-			</bounds>
+			<bounds x="256" y="435" width="80" height="100"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="256.0000" y="435.0000" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="256.0000" y="435.0000" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="259.3333" y="436.3889" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="259.3333" y="436.3889" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="262.6667" y="437.7778" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="262.6667" y="437.7778" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="266.0000" y="439.1667" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="266.0000" y="439.1667" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="269.3333" y="440.5555" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="269.3333" y="440.5555" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="272.6667" y="441.9445" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="272.6667" y="441.9445" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="256.0000" y="468.3333" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="256.0000" y="468.3333" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="259.3333" y="469.7222" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="259.3333" y="469.7222" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="262.6667" y="471.1111" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="262.6667" y="471.1111" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="266.0000" y="472.5000" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="266.0000" y="472.5000" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="269.3333" y="473.8889" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="269.3333" y="473.8889" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="272.6667" y="475.2778" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="272.6667" y="475.2778" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="256.0000" y="501.6667" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="256.0000" y="501.6667" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="259.3333" y="503.0555" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="259.3333" y="503.0555" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="262.6667" y="504.4444" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="262.6667" y="504.4444" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="266.0000" y="505.8333" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="266.0000" y="505.8333" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="269.3333" y="507.2222" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="269.3333" y="507.2222" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="272.6667" y="508.6111" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="272.6667" y="508.6111" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="256" y="435" width="80" height="100">
-			</bounds>
+			<bounds x="256" y="435" width="80" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="386" y="435" width="80" height="100">
-			</bounds>
+			<bounds x="386" y="435" width="80" height="100"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="435.0000" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="386.0000" y="435.0000" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="436.3889" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="389.3333" y="436.3889" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="437.7778" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="392.6667" y="437.7778" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="439.1667" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="396.0000" y="439.1667" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="440.5555" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="399.3333" y="440.5555" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="441.9445" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="402.6667" y="441.9445" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="468.3333" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="386.0000" y="468.3333" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="469.7222" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="389.3333" y="469.7222" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="471.1111" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="392.6667" y="471.1111" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="472.5000" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="396.0000" y="472.5000" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="473.8889" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="399.3333" y="473.8889" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="475.2778" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="402.6667" y="475.2778" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="501.6667" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="386.0000" y="501.6667" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="503.0555" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="389.3333" y="503.0555" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="504.4444" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="392.6667" y="504.4444" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="505.8333" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="396.0000" y="505.8333" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="507.2222" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="399.3333" y="507.2222" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="508.6111" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="402.6667" y="508.6111" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="386" y="435" width="80" height="100">
-			</bounds>
+			<bounds x="386" y="435" width="80" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="282" y="200" width="50" height="60">
-			</bounds>
+			<bounds x="282" y="200" width="50" height="60"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="282.0000" y="200.0000" width="50.0000" height="60.0000">
-			</bounds>
+			<bounds x="282.0000" y="200.0000" width="50.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="284.0833" y="202.5000" width="45.8333" height="55.0000">
-			</bounds>
+			<bounds x="284.0833" y="202.5000" width="45.8333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="286.1667" y="205.0000" width="41.6667" height="50.0000">
-			</bounds>
+			<bounds x="286.1667" y="205.0000" width="41.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="288.2500" y="207.5000" width="37.5000" height="45.0000">
-			</bounds>
+			<bounds x="288.2500" y="207.5000" width="37.5000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="290.3333" y="210.0000" width="33.3333" height="40.0000">
-			</bounds>
+			<bounds x="290.3333" y="210.0000" width="33.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="292.4167" y="212.5000" width="29.1667" height="35.0000">
-			</bounds>
+			<bounds x="292.4167" y="212.5000" width="29.1667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="282" y="200" width="50" height="60">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="282" y="200" width="50" height="60"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="110" y="232" width="24" height="24">
-			</bounds>
+			<bounds x="110" y="232" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="112" y="234" width="20" height="20">
-			</bounds>
+			<bounds x="112" y="234" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="110" y="257" width="24" height="24">
-			</bounds>
+			<bounds x="110" y="257" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="112" y="259" width="20" height="20">
-			</bounds>
+			<bounds x="112" y="259" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="107" y="282" width="24" height="24">
-			</bounds>
+			<bounds x="107" y="282" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="109" y="284" width="20" height="20">
-			</bounds>
+			<bounds x="109" y="284" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="98" y="306" width="24" height="24">
-			</bounds>
+			<bounds x="98" y="306" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="100" y="308" width="20" height="20">
-			</bounds>
+			<bounds x="100" y="308" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="87" y="329" width="24" height="24">
-			</bounds>
+			<bounds x="87" y="329" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="89" y="331" width="20" height="20">
-			</bounds>
+			<bounds x="89" y="331" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="73" y="351" width="24" height="24">
-			</bounds>
+			<bounds x="73" y="351" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="75" y="353" width="20" height="20">
-			</bounds>
+			<bounds x="75" y="353" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="726" y="395" width="52" height="32">
-			</bounds>
+			<bounds x="726" y="395" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="728" y="397" width="48" height="28">
-			</bounds>
+			<bounds x="728" y="397" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="685" y="416" width="32" height="32">
-			</bounds>
+			<bounds x="685" y="416" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="687" y="418" width="28" height="28">
-			</bounds>
+			<bounds x="687" y="418" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="713" y="438" width="32" height="32">
-			</bounds>
+			<bounds x="713" y="438" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="715" y="440" width="28" height="28">
-			</bounds>
+			<bounds x="715" y="440" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="733" y="468" width="32" height="32">
-			</bounds>
+			<bounds x="733" y="468" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="735" y="470" width="28" height="28">
-			</bounds>
+			<bounds x="735" y="470" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="741" y="503" width="32" height="32">
-			</bounds>
+			<bounds x="741" y="503" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="743" y="505" width="28" height="28">
-			</bounds>
+			<bounds x="743" y="505" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="743" y="538" width="32" height="32">
-			</bounds>
+			<bounds x="743" y="538" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="745" y="540" width="28" height="28">
-			</bounds>
+			<bounds x="745" y="540" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="743" y="572" width="32" height="32">
-			</bounds>
+			<bounds x="743" y="572" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="745" y="574" width="28" height="28">
-			</bounds>
+			<bounds x="745" y="574" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="4" y="376" width="67" height="45">
-			</bounds>
+			<bounds x="4" y="376" width="67" height="45"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="6" y="378" width="63" height="41">
-			</bounds>
+			<bounds x="6" y="378" width="63" height="41"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="69" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="69" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="71" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="71" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="124" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="124" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="126" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="126" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="179" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="179" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="181" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="181" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="5" y="3" width="67" height="45">
-			</bounds>
+			<bounds x="5" y="3" width="67" height="45"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="7" y="5" width="63" height="41">
-			</bounds>
+			<bounds x="7" y="5" width="63" height="41"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="5" y="46" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="46" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="7" y="48" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="48" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="5" y="79" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="79" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="7" y="81" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="81" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="5" y="112" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="112" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="7" y="114" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="114" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="5" y="145" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="145" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="7" y="147" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="147" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="5" y="178" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="178" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="7" y="180" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="180" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="5" y="211" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="211" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="7" y="213" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="213" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="5" y="244" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="244" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="7" y="246" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="246" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="5" y="277" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="277" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="7" y="279" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="279" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="5" y="310" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="310" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="7" y="312" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="312" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="5" y="343" width="57" height="35">
-			</bounds>
+			<bounds x="5" y="343" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="7" y="345" width="53" height="31">
-			</bounds>
+			<bounds x="7" y="345" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="70" y="3" width="57" height="35">
-			</bounds>
+			<bounds x="70" y="3" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="72" y="5" width="53" height="31">
-			</bounds>
+			<bounds x="72" y="5" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="125" y="3" width="57" height="35">
-			</bounds>
+			<bounds x="125" y="3" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="127" y="5" width="53" height="31">
-			</bounds>
+			<bounds x="127" y="5" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="180" y="3" width="57" height="35">
-			</bounds>
+			<bounds x="180" y="3" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="182" y="5" width="53" height="31">
-			</bounds>
+			<bounds x="182" y="5" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="235" y="3" width="57" height="35">
-			</bounds>
+			<bounds x="235" y="3" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="237" y="5" width="53" height="31">
-			</bounds>
+			<bounds x="237" y="5" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="290" y="3" width="57" height="35">
-			</bounds>
+			<bounds x="290" y="3" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="292" y="5" width="53" height="31">
-			</bounds>
+			<bounds x="292" y="5" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="345" y="3" width="57" height="35">
-			</bounds>
+			<bounds x="345" y="3" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="347" y="5" width="53" height="31">
-			</bounds>
+			<bounds x="347" y="5" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="344" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="344" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="346" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="346" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="289" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="289" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="291" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="291" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="234" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="234" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="236" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="236" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="399" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="399" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="401" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="401" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="454" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="454" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="456" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="456" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="509" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="509" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="511" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="511" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="564" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="564" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="566" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="566" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="619" y="386" width="57" height="35">
-			</bounds>
+			<bounds x="619" y="386" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="621" y="388" width="53" height="31">
-			</bounds>
+			<bounds x="621" y="388" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="725" y="302" width="57" height="35">
-			</bounds>
+			<bounds x="725" y="302" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="727" y="304" width="53" height="31">
-			</bounds>
+			<bounds x="727" y="304" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="725" y="269" width="57" height="35">
-			</bounds>
+			<bounds x="725" y="269" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="727" y="271" width="53" height="31">
-			</bounds>
+			<bounds x="727" y="271" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="725" y="236" width="57" height="35">
-			</bounds>
+			<bounds x="725" y="236" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="727" y="238" width="53" height="31">
-			</bounds>
+			<bounds x="727" y="238" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="725" y="203" width="57" height="35">
-			</bounds>
+			<bounds x="725" y="203" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="727" y="205" width="53" height="31">
-			</bounds>
+			<bounds x="727" y="205" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="725" y="170" width="57" height="35">
-			</bounds>
+			<bounds x="725" y="170" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="727" y="172" width="53" height="31">
-			</bounds>
+			<bounds x="727" y="172" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="725" y="137" width="57" height="35">
-			</bounds>
+			<bounds x="725" y="137" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="727" y="139" width="53" height="31">
-			</bounds>
+			<bounds x="727" y="139" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="725" y="104" width="57" height="35">
-			</bounds>
+			<bounds x="725" y="104" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="727" y="106" width="53" height="31">
-			</bounds>
+			<bounds x="727" y="106" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="715" y="335" width="67" height="45">
-			</bounds>
+			<bounds x="715" y="335" width="67" height="45"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="717" y="337" width="63" height="41">
-			</bounds>
+			<bounds x="717" y="337" width="63" height="41"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="715" y="61" width="67" height="45">
-			</bounds>
+			<bounds x="715" y="61" width="67" height="45"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="717" y="63" width="63" height="41">
-			</bounds>
+			<bounds x="717" y="63" width="63" height="41"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="89" y="58" width="30" height="30">
-			</bounds>
+			<bounds x="89" y="58" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="91" y="60" width="26" height="26">
-			</bounds>
+			<bounds x="91" y="60" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="660" y="61" width="57" height="35">
-			</bounds>
+			<bounds x="660" y="61" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="662" y="63" width="53" height="31">
-			</bounds>
+			<bounds x="662" y="63" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="605" y="61" width="57" height="35">
-			</bounds>
+			<bounds x="605" y="61" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="607" y="63" width="53" height="31">
-			</bounds>
+			<bounds x="607" y="63" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="550" y="61" width="57" height="35">
-			</bounds>
+			<bounds x="550" y="61" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="552" y="63" width="53" height="31">
-			</bounds>
+			<bounds x="552" y="63" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="495" y="61" width="57" height="35">
-			</bounds>
+			<bounds x="495" y="61" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="497" y="63" width="53" height="31">
-			</bounds>
+			<bounds x="497" y="63" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="440" y="48" width="57" height="35">
-			</bounds>
+			<bounds x="440" y="48" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="442" y="50" width="53" height="31">
-			</bounds>
+			<bounds x="442" y="50" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="400" y="15" width="57" height="35">
-			</bounds>
+			<bounds x="400" y="15" width="57" height="35"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="402" y="17" width="53" height="31">
-			</bounds>
+			<bounds x="402" y="17" width="53" height="31"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="583" y="574" width="96" height="30">
-			</bounds>
+			<bounds x="583" y="574" width="96" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="585" y="576" width="92" height="26">
-			</bounds>
+			<bounds x="585" y="576" width="92" height="26"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="60" y="436" width="34" height="32">
-			</bounds>
+			<bounds x="60" y="436" width="34" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="62" y="438" width="30" height="28">
-			</bounds>
+			<bounds x="62" y="438" width="30" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="50" y="472" width="34" height="32">
-			</bounds>
+			<bounds x="50" y="472" width="34" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="52" y="474" width="30" height="28">
-			</bounds>
+			<bounds x="52" y="474" width="30" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="40" y="508" width="34" height="32">
-			</bounds>
+			<bounds x="40" y="508" width="34" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="42" y="510" width="30" height="28">
-			</bounds>
+			<bounds x="42" y="510" width="30" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="30" y="544" width="34" height="32">
-			</bounds>
+			<bounds x="30" y="544" width="34" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="32" y="546" width="30" height="28">
-			</bounds>
+			<bounds x="32" y="546" width="30" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="19" y="580" width="56" height="16">
-			</bounds>
+			<bounds x="19" y="580" width="56" height="16"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="21" y="582" width="52" height="12">
-			</bounds>
+			<bounds x="21" y="582" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="212" y="572" width="46" height="32">
-			</bounds>
+			<bounds x="212" y="572" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="214" y="574" width="42" height="28">
-			</bounds>
+			<bounds x="214" y="574" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="212" y="543" width="46" height="32">
-			</bounds>
+			<bounds x="212" y="543" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="214" y="545" width="42" height="28">
-			</bounds>
+			<bounds x="214" y="545" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="169" y="543" width="46" height="32">
-			</bounds>
+			<bounds x="169" y="543" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="171" y="545" width="42" height="28">
-			</bounds>
+			<bounds x="171" y="545" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="169" y="572" width="46" height="32">
-			</bounds>
+			<bounds x="169" y="572" width="46" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="171" y="574" width="42" height="28">
-			</bounds>
+			<bounds x="171" y="574" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="338" y="543" width="152" height="32">
-			</bounds>
+			<bounds x="338" y="543" width="152" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="340" y="545" width="148" height="28">
-			</bounds>
+			<bounds x="340" y="545" width="148" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="292" y="73" width="62" height="18">
-			</bounds>
+			<bounds x="292" y="73" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="294" y="75" width="58" height="14">
-			</bounds>
+			<bounds x="294" y="75" width="58" height="14"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="342" y="41" width="42" height="16">
-			</bounds>
+			<bounds x="342" y="41" width="42" height="16"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="344" y="43" width="38" height="12">
-			</bounds>
+			<bounds x="344" y="43" width="38" height="12"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="352" y="55" width="42" height="16">
-			</bounds>
+			<bounds x="352" y="55" width="42" height="16"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="354" y="57" width="38" height="12">
-			</bounds>
+			<bounds x="354" y="57" width="38" height="12"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="366" y="69" width="42" height="16">
-			</bounds>
+			<bounds x="366" y="69" width="42" height="16"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="368" y="71" width="38" height="12">
-			</bounds>
+			<bounds x="368" y="71" width="38" height="12"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="380" y="83" width="42" height="16">
-			</bounds>
+			<bounds x="380" y="83" width="42" height="16"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="382" y="85" width="38" height="12">
-			</bounds>
+			<bounds x="382" y="85" width="38" height="12"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="390" y="97" width="42" height="16">
-			</bounds>
+			<bounds x="390" y="97" width="42" height="16"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="392" y="99" width="38" height="12">
-			</bounds>
+			<bounds x="392" y="99" width="38" height="12"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="613" y="318" width="62" height="52">
-			</bounds>
+			<bounds x="613" y="318" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="615" y="320" width="58" height="48">
-			</bounds>
+			<bounds x="615" y="320" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="550" y="318" width="62" height="52">
-			</bounds>
+			<bounds x="550" y="318" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="552" y="320" width="58" height="48">
-			</bounds>
+			<bounds x="552" y="320" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="550" y="266" width="62" height="52">
-			</bounds>
+			<bounds x="550" y="266" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="552" y="268" width="58" height="48">
-			</bounds>
+			<bounds x="552" y="268" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="613" y="266" width="62" height="52">
-			</bounds>
+			<bounds x="613" y="266" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="615" y="268" width="58" height="48">
-			</bounds>
+			<bounds x="615" y="268" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="299" y="115" width="62" height="26">
-			</bounds>
+			<bounds x="299" y="115" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="301" y="117" width="58" height="22">
-			</bounds>
+			<bounds x="301" y="117" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="229" y="115" width="62" height="26">
-			</bounds>
+			<bounds x="229" y="115" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="231" y="117" width="58" height="22">
-			</bounds>
+			<bounds x="231" y="117" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="159" y="115" width="62" height="26">
-			</bounds>
+			<bounds x="159" y="115" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="161" y="117" width="58" height="22">
-			</bounds>
+			<bounds x="161" y="117" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="89" y="115" width="62" height="26">
-			</bounds>
+			<bounds x="89" y="115" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="91" y="117" width="58" height="22">
-			</bounds>
+			<bounds x="91" y="117" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="549" y="108" width="54" height="16">
-			</bounds>
+			<bounds x="549" y="108" width="54" height="16"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="551" y="110" width="50" height="12">
-			</bounds>
+			<bounds x="551" y="110" width="50" height="12"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="599" y="108" width="56" height="16">
-			</bounds>
+			<bounds x="599" y="108" width="56" height="16"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="601" y="110" width="52" height="12">
-			</bounds>
+			<bounds x="601" y="110" width="52" height="12"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="624" y="547" width="55" height="28">
-			</bounds>
+			<bounds x="624" y="547" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="626" y="549" width="51" height="24">
-			</bounds>
+			<bounds x="626" y="549" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="624" y="522" width="55" height="28">
-			</bounds>
+			<bounds x="624" y="522" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="626" y="524" width="51" height="24">
-			</bounds>
+			<bounds x="626" y="524" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="624" y="497" width="55" height="28">
-			</bounds>
+			<bounds x="624" y="497" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="626" y="499" width="51" height="24">
-			</bounds>
+			<bounds x="626" y="499" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="624" y="472" width="55" height="28">
-			</bounds>
+			<bounds x="624" y="472" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="626" y="474" width="51" height="24">
-			</bounds>
+			<bounds x="626" y="474" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="624" y="447" width="55" height="28">
-			</bounds>
+			<bounds x="624" y="447" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="626" y="449" width="51" height="24">
-			</bounds>
+			<bounds x="626" y="449" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="624" y="422" width="55" height="28">
-			</bounds>
+			<bounds x="624" y="422" width="55" height="28"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="626" y="424" width="51" height="24">
-			</bounds>
+			<bounds x="626" y="424" width="51" height="24"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="397" y="315" width="37" height="22">
-			</bounds>
+			<bounds x="397" y="315" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="399" y="317" width="33" height="18">
-			</bounds>
+			<bounds x="399" y="317" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="434" y="302" width="37" height="22">
-			</bounds>
+			<bounds x="434" y="302" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="436" y="304" width="33" height="18">
-			</bounds>
+			<bounds x="436" y="304" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="397" y="289" width="37" height="22">
-			</bounds>
+			<bounds x="397" y="289" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="399" y="291" width="33" height="18">
-			</bounds>
+			<bounds x="399" y="291" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="434" y="276" width="37" height="22">
-			</bounds>
+			<bounds x="434" y="276" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="436" y="278" width="33" height="18">
-			</bounds>
+			<bounds x="436" y="278" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="397" y="263" width="37" height="22">
-			</bounds>
+			<bounds x="397" y="263" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="399" y="265" width="33" height="18">
-			</bounds>
+			<bounds x="399" y="265" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="434" y="250" width="37" height="22">
-			</bounds>
+			<bounds x="434" y="250" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="436" y="252" width="33" height="18">
-			</bounds>
+			<bounds x="436" y="252" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="397" y="237" width="37" height="22">
-			</bounds>
+			<bounds x="397" y="237" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="399" y="239" width="33" height="18">
-			</bounds>
+			<bounds x="399" y="239" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="434" y="224" width="37" height="22">
-			</bounds>
+			<bounds x="434" y="224" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="436" y="226" width="33" height="18">
-			</bounds>
+			<bounds x="436" y="226" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="397" y="209" width="73" height="16">
-			</bounds>
+			<bounds x="397" y="209" width="73" height="16"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="399" y="211" width="69" height="12">
-			</bounds>
+			<bounds x="399" y="211" width="69" height="12"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="397" y="196" width="73" height="16">
-			</bounds>
+			<bounds x="397" y="196" width="73" height="16"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="399" y="198" width="69" height="12">
-			</bounds>
+			<bounds x="399" y="198" width="69" height="12"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="172" y="313" width="42" height="24">
-			</bounds>
+			<bounds x="172" y="313" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="174" y="315" width="38" height="20">
-			</bounds>
+			<bounds x="174" y="315" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="165" y="281" width="42" height="24">
-			</bounds>
+			<bounds x="165" y="281" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="167" y="283" width="38" height="20">
-			</bounds>
+			<bounds x="167" y="283" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="165" y="249" width="42" height="24">
-			</bounds>
+			<bounds x="165" y="249" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="167" y="251" width="38" height="20">
-			</bounds>
+			<bounds x="167" y="251" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="172" y="217" width="42" height="24">
-			</bounds>
+			<bounds x="172" y="217" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="174" y="219" width="38" height="20">
-			</bounds>
+			<bounds x="174" y="219" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="155" y="197" width="71" height="18">
-			</bounds>
+			<bounds x="155" y="197" width="71" height="18"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="157" y="199" width="67" height="14">
-			</bounds>
+			<bounds x="157" y="199" width="67" height="14"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="236" y="275" width="52" height="32">
-			</bounds>
+			<bounds x="236" y="275" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="238" y="277" width="48" height="28">
-			</bounds>
+			<bounds x="238" y="277" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="236" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="236" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="238" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="238" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="286" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="286" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="288" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="288" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="336" y="305" width="52" height="32">
-			</bounds>
+			<bounds x="336" y="305" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="338" y="307" width="48" height="28">
-			</bounds>
+			<bounds x="338" y="307" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="336" y="275" width="52" height="32">
-			</bounds>
+			<bounds x="336" y="275" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="338" y="277" width="48" height="28">
-			</bounds>
+			<bounds x="338" y="277" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="286" y="275" width="52" height="32">
-			</bounds>
+			<bounds x="286" y="275" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="288" y="277" width="48" height="28">
-			</bounds>
+			<bounds x="288" y="277" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_175_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="542" y="607" width="68" height="42">
-			</bounds>
+			<bounds x="542" y="607" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_175" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="544" y="609" width="64" height="38">
-			</bounds>
+			<bounds x="544" y="609" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_176_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="9" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="9" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_176" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="11" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="11" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_177_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="102" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="102" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_177" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="104" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="104" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_178_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="254" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="254" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_178" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="256" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="256" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_179_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="403" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="403" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_179" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="405" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="405" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_180_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="630" y="607" width="76" height="42">
-			</bounds>
+			<bounds x="630" y="607" width="76" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_180" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="632" y="609" width="72" height="38">
-			</bounds>
+			<bounds x="632" y="609" width="72" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_181_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="718" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="718" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_181" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="720" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="720" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_182_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="9" y="607" width="62" height="42">
-			</bounds>
+			<bounds x="9" y="607" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_182" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="11" y="609" width="58" height="38">
-			</bounds>
+			<bounds x="11" y="609" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_191_border" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="659" y="10" width="46" height="42">
-			</bounds>
+			<bounds x="659" y="10" width="46" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_191" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="661" y="12" width="42" height="38">
-			</bounds>
+			<bounds x="661" y="12" width="42" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_192_border" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="704" y="10" width="46" height="42">
-			</bounds>
+			<bounds x="704" y="10" width="46" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_192" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="706" y="12" width="42" height="38">
-			</bounds>
+			<bounds x="706" y="12" width="42" height="38"/>
 		</backdrop>
 		<backdrop name="lamp200" element="colour_button_193_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="151" y="77" width="75" height="27">
-			</bounds>
+			<bounds x="151" y="77" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp200" element="colour_button_193" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="153" y="79" width="71" height="23">
-			</bounds>
+			<bounds x="153" y="79" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="153" y="45" width="24" height="32">
-			</bounds>
+			<bounds x="153" y="45" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_off">
-			<bounds x="156" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="156" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="170" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="170" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="170" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="170" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="156" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="156" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="156" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="156" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="156" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="156" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="156" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="156" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_dot_off">
-			<bounds x="173" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="173" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_on">
-			<bounds x="156" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="156" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="170" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="170" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="170" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="170" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="156" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="156" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="156" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="156" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="156" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="156" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="156" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="156" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_dot_on">
-			<bounds x="173" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="173" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="177" y="45" width="24" height="32">
-			</bounds>
+			<bounds x="177" y="45" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off80" element="led_off">
-			<bounds x="180" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="180" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off81" element="led_off">
-			<bounds x="194" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="194" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off82" element="led_off">
-			<bounds x="194" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="194" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off83" element="led_off">
-			<bounds x="180" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="180" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off84" element="led_off">
-			<bounds x="180" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="180" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off85" element="led_off">
-			<bounds x="180" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="180" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off86" element="led_off">
-			<bounds x="180" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="180" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off87" element="led_dot_off">
-			<bounds x="197" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="197" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp80" element="led_on">
-			<bounds x="180" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="180" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp81" element="led_on">
-			<bounds x="194" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="194" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp82" element="led_on">
-			<bounds x="194" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="194" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp83" element="led_on">
-			<bounds x="180" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="180" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp84" element="led_on">
-			<bounds x="180" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="180" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp85" element="led_on">
-			<bounds x="180" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="180" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp86" element="led_on">
-			<bounds x="180" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="180" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp87" element="led_dot_on">
-			<bounds x="197" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="197" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="201" y="45" width="24" height="32">
-			</bounds>
+			<bounds x="201" y="45" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_off">
-			<bounds x="204" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="204" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="218" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="218" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="218" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="218" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="204" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="204" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="204" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="204" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="204" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="204" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="204" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="204" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_dot_off">
-			<bounds x="221" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="221" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_on">
-			<bounds x="204" y="47" width="17" height="2">
-			</bounds>
+			<bounds x="204" y="47" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="218" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="218" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="218" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="218" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="204" y="71" width="17" height="2">
-			</bounds>
+			<bounds x="204" y="71" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="204" y="59" width="3" height="14">
-			</bounds>
+			<bounds x="204" y="59" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="204" y="47" width="3" height="14">
-			</bounds>
+			<bounds x="204" y="47" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="204" y="59" width="17" height="2">
-			</bounds>
+			<bounds x="204" y="59" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_dot_on">
-			<bounds x="221" y="71" width="3" height="2">
-			</bounds>
+			<bounds x="221" y="71" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="176" y="359" width="240" height="26">
-			</bounds>
+			<bounds x="176" y="359" width="240" height="26"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="176" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="176" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="191" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="191" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="206" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="206" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="221" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="221" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="236" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="236" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="251" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="251" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="266" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="266" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="281" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="281" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="296" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="296" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="311" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="311" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="326" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="326" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="341" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="341" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="356" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="356" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="371" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="371" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="386" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="386" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="401" y="359" width="15" height="26">
-			</bounds>
+			<bounds x="401" y="359" width="15" height="26"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="217" y="467" width="29" height="32">
-			</bounds>
+			<bounds x="217" y="467" width="29" height="32"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="347" y="467" width="29" height="32">
-			</bounds>
+			<bounds x="347" y="467" width="29" height="32"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="184" y="343" width="47" height="19">
-			</bounds>
+			<bounds x="184" y="343" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="346" y="343" width="52" height="19">
-			</bounds>
+			<bounds x="346" y="343" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="label169" element="label_169">
-			<bounds x="437" y="143" width="82" height="14">
-			</bounds>
+			<bounds x="437" y="143" width="82" height="14"/>
 		</backdrop>
 		<backdrop name="label170" element="label_170">
-			<bounds x="435" y="134" width="87" height="14">
-			</bounds>
+			<bounds x="435" y="134" width="87" height="14"/>
 		</backdrop>
 		<backdrop name="label171" element="label_171">
-			<bounds x="428" y="152" width="99" height="14">
-			</bounds>
+			<bounds x="428" y="152" width="99" height="14"/>
 		</backdrop>
 		<backdrop name="label173" element="label_173">
-			<bounds x="528" y="45" width="99" height="15">
-			</bounds>
+			<bounds x="528" y="45" width="99" height="15"/>
 		</backdrop>
 		<backdrop name="label174" element="label_174">
-			<bounds x="2" y="423" width="27" height="13">
-			</bounds>
+			<bounds x="2" y="423" width="27" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_button" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m1wotwa.lay
+++ b/src/mame/layout/m1wotwa.lay
@@ -8,13630 +8,7982 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ASTEROID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ASTEROID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" LINE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string=" LINE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CASH REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MULTIPLIER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="             ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MULTIPLIER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="             ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SHOOT OUT   ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="               ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHOOT OUT   ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="               ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WIN  SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN  SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI LO ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI LO ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MEGA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MEGA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="OF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="OF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="RLDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="UP AGAINST TIME         9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="UP AGAINST TIME         9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BLAST ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="      OFF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="BLAST ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="      OFF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string=" HEAVENS             ABOVE     7 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string=" HEAVENS             ABOVE     7 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EVEN ENCOUNTER  6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="EVEN ENCOUNTER  6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="             ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="             ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="STAR RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="           ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="STAR RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="           ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="      STAR              SEARCH     3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="      STAR              SEARCH     3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string=" SUPER        JACKPOT    10 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string=" SUPER        JACKPOT    10 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="YEAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="YEAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LIGHT SPEED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LIGHT SPEED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TIME WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="TIME WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1 WINPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1 WINPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2 FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2 FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string=" +1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string=" +1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BLACK HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BLACK HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string=" 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string=" 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="DO    OR  DIE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="DO    OR  DIE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="LIGHT SPEED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="LIGHT SPEED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string=" WIPED  OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string=" WIPED  OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="YEAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="YEAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BLACK HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BLACK HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1 WINPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1 WINPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="WIN WIPEOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="WIN WIPEOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+2 WINPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+2 WINPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1  NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1  NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TIME WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="TIME WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="YEAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="YEAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+3 WINPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+3 WINPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURE WIPEOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURE WIPEOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2 FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2 FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TIME WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="TIME WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES WIPEOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES WIPEOUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+2 WINPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+2 WINPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TIME WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="TIME WARP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="VORTEX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2000 AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2000 AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1939  AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1939  AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1914 AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1914 AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1805 AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1805 AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="200 BC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="200 BC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BIG WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BIG WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WIN REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIN REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ROMAN EMPIRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROMAN EMPIRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NAPOLEON WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NAPOLEON WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WORLD WAR 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WORLD WAR 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WORLD WAR 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WORLD WAR 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ARMEGEDDON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARMEGEDDON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="YEAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="YEAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3  NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3  NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4  NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4  NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2  NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2  NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MYSTERY WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MYSTERY WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="BLACK  HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="BLACK  HOLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="WAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="FORCE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FIELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="FORCE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FIELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="99 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="99 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="16 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="16 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_253_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_253">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_262_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_262">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_263_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_263">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string=" WINPOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_264_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_264">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_266_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_266">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_267_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_267">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_268_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_268">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_269_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_269">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_270_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_270">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_271_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_271">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_272_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_272">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_132">
 		<text string="ALL THREE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="AWARDS WAR O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_185">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_186">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_206">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_207">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1029" height="839">
-			</bounds>
+			<bounds x="0" y="0" width="1029" height="839"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="327" y="597" width="80" height="140">
-			</bounds>
+			<bounds x="327" y="597" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="327.0000" y="597.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="327.0000" y="597.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.3333" y="598.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="330.3333" y="598.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="333.6667" y="600.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="333.6667" y="600.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="337.0000" y="602.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="337.0000" y="602.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="340.3333" y="604.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="340.3333" y="604.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="343.6667" y="606.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="343.6667" y="606.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="327.0000" y="643.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="327.0000" y="643.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.3333" y="645.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="330.3333" y="645.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="333.6667" y="647.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="333.6667" y="647.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="337.0000" y="649.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="337.0000" y="649.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="340.3333" y="651.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="340.3333" y="651.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="343.6667" y="653.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="343.6667" y="653.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="327.0000" y="690.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="327.0000" y="690.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.3333" y="692.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="330.3333" y="692.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="333.6667" y="694.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="333.6667" y="694.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="337.0000" y="696.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="337.0000" y="696.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="340.3333" y="698.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="340.3333" y="698.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="343.6667" y="700.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="343.6667" y="700.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="327" y="597" width="80" height="140">
-			</bounds>
+			<bounds x="327" y="597" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="408" y="597" width="80" height="140">
-			</bounds>
+			<bounds x="408" y="597" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="408.0000" y="597.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="408.0000" y="597.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="411.3333" y="598.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="411.3333" y="598.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="414.6667" y="600.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="414.6667" y="600.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="418.0000" y="602.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="418.0000" y="602.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="421.3333" y="604.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="421.3333" y="604.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="424.6667" y="606.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="424.6667" y="606.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="408.0000" y="643.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="408.0000" y="643.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="411.3333" y="645.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="411.3333" y="645.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="414.6667" y="647.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="414.6667" y="647.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="418.0000" y="649.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="418.0000" y="649.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="421.3333" y="651.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="421.3333" y="651.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="424.6667" y="653.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="424.6667" y="653.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="408.0000" y="690.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="408.0000" y="690.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="411.3333" y="692.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="411.3333" y="692.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="414.6667" y="694.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="414.6667" y="694.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="418.0000" y="696.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="418.0000" y="696.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="421.3333" y="698.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="421.3333" y="698.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="424.6667" y="700.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="424.6667" y="700.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="408" y="597" width="80" height="140">
-			</bounds>
+			<bounds x="408" y="597" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="491" y="597" width="80" height="140">
-			</bounds>
+			<bounds x="491" y="597" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="491.0000" y="597.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="491.0000" y="597.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="494.3333" y="598.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="494.3333" y="598.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="497.6667" y="600.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="497.6667" y="600.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="501.0000" y="602.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="501.0000" y="602.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="504.3333" y="604.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="504.3333" y="604.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="507.6667" y="606.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="507.6667" y="606.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="491.0000" y="643.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="491.0000" y="643.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="494.3333" y="645.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="494.3333" y="645.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="497.6667" y="647.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="497.6667" y="647.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="501.0000" y="649.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="501.0000" y="649.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="504.3333" y="651.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="504.3333" y="651.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="507.6667" y="653.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="507.6667" y="653.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="491.0000" y="690.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="491.0000" y="690.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="494.3333" y="692.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="494.3333" y="692.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="497.6667" y="694.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="497.6667" y="694.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="501.0000" y="696.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="501.0000" y="696.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="504.3333" y="698.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="504.3333" y="698.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="507.6667" y="700.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="507.6667" y="700.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="491" y="597" width="80" height="140">
-			</bounds>
+			<bounds x="491" y="597" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="402" y="253" width="80" height="80">
-			</bounds>
+			<bounds x="402" y="253" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="402.0000" y="253.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="402.0000" y="253.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="405.3333" y="256.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="405.3333" y="256.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="408.6667" y="259.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="408.6667" y="259.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="412.0000" y="263.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="412.0000" y="263.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="415.3333" y="266.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="415.3333" y="266.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="418.6667" y="269.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="418.6667" y="269.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="402" y="253" width="80" height="80">
-			</bounds>
+			<bounds x="402" y="253" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="907" y="280" width="78" height="20">
-			</bounds>
+			<bounds x="907" y="280" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="909" y="282" width="74" height="16">
-			</bounds>
+			<bounds x="909" y="282" width="74" height="16"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="908" y="260" width="78" height="20">
-			</bounds>
+			<bounds x="908" y="260" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="910" y="262" width="74" height="16">
-			</bounds>
+			<bounds x="910" y="262" width="74" height="16"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="952" y="328" width="68" height="26">
-			</bounds>
+			<bounds x="952" y="328" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="954" y="330" width="64" height="22">
-			</bounds>
+			<bounds x="954" y="330" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="952" y="302" width="68" height="26">
-			</bounds>
+			<bounds x="952" y="302" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="954" y="304" width="64" height="22">
-			</bounds>
+			<bounds x="954" y="304" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="952" y="354" width="68" height="26">
-			</bounds>
+			<bounds x="952" y="354" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="954" y="356" width="64" height="22">
-			</bounds>
+			<bounds x="954" y="356" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="83" y="140" width="84" height="26">
-			</bounds>
+			<bounds x="83" y="140" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="85" y="142" width="80" height="22">
-			</bounds>
+			<bounds x="85" y="142" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="105" y="111" width="84" height="26">
-			</bounds>
+			<bounds x="105" y="111" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="107" y="113" width="80" height="22">
-			</bounds>
+			<bounds x="107" y="113" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="884" y="302" width="68" height="26">
-			</bounds>
+			<bounds x="884" y="302" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="886" y="304" width="64" height="22">
-			</bounds>
+			<bounds x="886" y="304" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="884" y="328" width="68" height="26">
-			</bounds>
+			<bounds x="884" y="328" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="886" y="330" width="64" height="22">
-			</bounds>
+			<bounds x="886" y="330" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="884" y="354" width="68" height="26">
-			</bounds>
+			<bounds x="884" y="354" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="886" y="356" width="64" height="22">
-			</bounds>
+			<bounds x="886" y="356" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="385" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="385" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="387" y="40" width="54" height="34">
-			</bounds>
+			<bounds x="387" y="40" width="54" height="34"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="350" y="1" width="78" height="38">
-			</bounds>
+			<bounds x="350" y="1" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="352" y="3" width="74" height="34">
-			</bounds>
+			<bounds x="352" y="3" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="464" y="1" width="78" height="38">
-			</bounds>
+			<bounds x="464" y="1" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="466" y="3" width="74" height="34">
-			</bounds>
+			<bounds x="466" y="3" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="428" y="1" width="36" height="38">
-			</bounds>
+			<bounds x="428" y="1" width="36" height="38"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="430" y="3" width="32" height="34">
-			</bounds>
+			<bounds x="430" y="3" width="32" height="34"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="443" y="38" width="68" height="38">
-			</bounds>
+			<bounds x="443" y="38" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="445" y="40" width="64" height="34">
-			</bounds>
+			<bounds x="445" y="40" width="64" height="34"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="631" y="80" width="84" height="26">
-			</bounds>
+			<bounds x="631" y="80" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="633" y="82" width="80" height="22">
-			</bounds>
+			<bounds x="633" y="82" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="547" y="80" width="84" height="26">
-			</bounds>
+			<bounds x="547" y="80" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="549" y="82" width="80" height="22">
-			</bounds>
+			<bounds x="549" y="82" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="463" y="80" width="84" height="26">
-			</bounds>
+			<bounds x="463" y="80" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="465" y="82" width="80" height="22">
-			</bounds>
+			<bounds x="465" y="82" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="379" y="80" width="84" height="26">
-			</bounds>
+			<bounds x="379" y="80" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="381" y="82" width="80" height="22">
-			</bounds>
+			<bounds x="381" y="82" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="295" y="80" width="84" height="26">
-			</bounds>
+			<bounds x="295" y="80" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="297" y="82" width="80" height="22">
-			</bounds>
+			<bounds x="297" y="82" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="211" y="80" width="84" height="26">
-			</bounds>
+			<bounds x="211" y="80" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="213" y="82" width="80" height="22">
-			</bounds>
+			<bounds x="213" y="82" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="127" y="80" width="84" height="26">
-			</bounds>
+			<bounds x="127" y="80" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="129" y="82" width="80" height="22">
-			</bounds>
+			<bounds x="129" y="82" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="715" y="80" width="84" height="26">
-			</bounds>
+			<bounds x="715" y="80" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="717" y="82" width="80" height="22">
-			</bounds>
+			<bounds x="717" y="82" width="80" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="147" y="354" width="58" height="28">
-			</bounds>
+			<bounds x="147" y="354" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="149" y="356" width="54" height="24">
-			</bounds>
+			<bounds x="149" y="356" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="151" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="151" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="153" y="325" width="54" height="24">
-			</bounds>
+			<bounds x="153" y="325" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="152" y="384" width="58" height="28">
-			</bounds>
+			<bounds x="152" y="384" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="154" y="386" width="54" height="24">
-			</bounds>
+			<bounds x="154" y="386" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="151" y="290" width="58" height="28">
-			</bounds>
+			<bounds x="151" y="290" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="153" y="292" width="54" height="24">
-			</bounds>
+			<bounds x="153" y="292" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="168" y="414" width="58" height="28">
-			</bounds>
+			<bounds x="168" y="414" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="170" y="416" width="54" height="24">
-			</bounds>
+			<bounds x="170" y="416" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="158" y="261" width="58" height="28">
-			</bounds>
+			<bounds x="158" y="261" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="160" y="263" width="54" height="24">
-			</bounds>
+			<bounds x="160" y="263" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="207" y="474" width="58" height="28">
-			</bounds>
+			<bounds x="207" y="474" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="209" y="476" width="54" height="24">
-			</bounds>
+			<bounds x="209" y="476" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="171" y="231" width="58" height="28">
-			</bounds>
+			<bounds x="171" y="231" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="173" y="233" width="54" height="24">
-			</bounds>
+			<bounds x="173" y="233" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="180" y="201" width="58" height="28">
-			</bounds>
+			<bounds x="180" y="201" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="182" y="203" width="54" height="24">
-			</bounds>
+			<bounds x="182" y="203" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="185" y="444" width="58" height="28">
-			</bounds>
+			<bounds x="185" y="444" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="187" y="446" width="54" height="24">
-			</bounds>
+			<bounds x="187" y="446" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="206" y="171" width="58" height="28">
-			</bounds>
+			<bounds x="206" y="171" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="208" y="173" width="54" height="24">
-			</bounds>
+			<bounds x="208" y="173" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="217" y="367" width="56" height="28">
-			</bounds>
+			<bounds x="217" y="367" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="219" y="369" width="52" height="24">
-			</bounds>
+			<bounds x="219" y="369" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="331" y="357" width="56" height="28">
-			</bounds>
+			<bounds x="331" y="357" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="333" y="359" width="52" height="24">
-			</bounds>
+			<bounds x="333" y="359" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="274" y="363" width="56" height="28">
-			</bounds>
+			<bounds x="274" y="363" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="276" y="365" width="52" height="24">
-			</bounds>
+			<bounds x="276" y="365" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="525" y="475" width="68" height="26">
-			</bounds>
+			<bounds x="525" y="475" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="527" y="477" width="64" height="22">
-			</bounds>
+			<bounds x="527" y="477" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="455" y="475" width="68" height="26">
-			</bounds>
+			<bounds x="455" y="475" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="457" y="477" width="64" height="22">
-			</bounds>
+			<bounds x="457" y="477" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="315" y="475" width="68" height="26">
-			</bounds>
+			<bounds x="315" y="475" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="317" y="477" width="64" height="22">
-			</bounds>
+			<bounds x="317" y="477" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="385" y="475" width="68" height="26">
-			</bounds>
+			<bounds x="385" y="475" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="387" y="477" width="64" height="22">
-			</bounds>
+			<bounds x="387" y="477" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="645" y="231" width="58" height="28">
-			</bounds>
+			<bounds x="645" y="231" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="647" y="233" width="54" height="24">
-			</bounds>
+			<bounds x="647" y="233" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="656" y="384" width="58" height="28">
-			</bounds>
+			<bounds x="656" y="384" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="658" y="386" width="54" height="24">
-			</bounds>
+			<bounds x="658" y="386" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="663" y="354" width="58" height="28">
-			</bounds>
+			<bounds x="663" y="354" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="665" y="356" width="54" height="24">
-			</bounds>
+			<bounds x="665" y="356" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="664" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="664" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="666" y="325" width="54" height="24">
-			</bounds>
+			<bounds x="666" y="325" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="664" y="290" width="58" height="28">
-			</bounds>
+			<bounds x="664" y="290" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="666" y="292" width="54" height="24">
-			</bounds>
+			<bounds x="666" y="292" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="655" y="261" width="58" height="28">
-			</bounds>
+			<bounds x="655" y="261" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="657" y="263" width="54" height="24">
-			</bounds>
+			<bounds x="657" y="263" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="633" y="201" width="58" height="28">
-			</bounds>
+			<bounds x="633" y="201" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="635" y="203" width="54" height="24">
-			</bounds>
+			<bounds x="635" y="203" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="612" y="171" width="58" height="28">
-			</bounds>
+			<bounds x="612" y="171" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="614" y="173" width="54" height="24">
-			</bounds>
+			<bounds x="614" y="173" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="649" y="414" width="58" height="28">
-			</bounds>
+			<bounds x="649" y="414" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="651" y="416" width="54" height="24">
-			</bounds>
+			<bounds x="651" y="416" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="631" y="474" width="54" height="28">
-			</bounds>
+			<bounds x="631" y="474" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="633" y="476" width="50" height="24">
-			</bounds>
+			<bounds x="633" y="476" width="50" height="24"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="644" y="444" width="54" height="28">
-			</bounds>
+			<bounds x="644" y="444" width="54" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="646" y="446" width="50" height="24">
-			</bounds>
+			<bounds x="646" y="446" width="50" height="24"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="599" y="504" width="58" height="28">
-			</bounds>
+			<bounds x="599" y="504" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="601" y="506" width="54" height="24">
-			</bounds>
+			<bounds x="601" y="506" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="226" y="504" width="58" height="28">
-			</bounds>
+			<bounds x="226" y="504" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="228" y="506" width="54" height="24">
-			</bounds>
+			<bounds x="228" y="506" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="324" y="547" width="58" height="28">
-			</bounds>
+			<bounds x="324" y="547" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="326" y="549" width="54" height="24">
-			</bounds>
+			<bounds x="326" y="549" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="566" y="534" width="58" height="28">
-			</bounds>
+			<bounds x="566" y="534" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="568" y="536" width="54" height="24">
-			</bounds>
+			<bounds x="568" y="536" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="506" y="546" width="58" height="28">
-			</bounds>
+			<bounds x="506" y="546" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="508" y="548" width="54" height="24">
-			</bounds>
+			<bounds x="508" y="548" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="445" y="549" width="58" height="28">
-			</bounds>
+			<bounds x="445" y="549" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="447" y="551" width="54" height="24">
-			</bounds>
+			<bounds x="447" y="551" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="385" y="549" width="58" height="28">
-			</bounds>
+			<bounds x="385" y="549" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="387" y="551" width="54" height="24">
-			</bounds>
+			<bounds x="387" y="551" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="264" y="533" width="58" height="28">
-			</bounds>
+			<bounds x="264" y="533" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="266" y="535" width="54" height="24">
-			</bounds>
+			<bounds x="266" y="535" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="506" y="130" width="58" height="28">
-			</bounds>
+			<bounds x="506" y="130" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="508" y="132" width="54" height="24">
-			</bounds>
+			<bounds x="508" y="132" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="324" y="130" width="58" height="28">
-			</bounds>
+			<bounds x="324" y="130" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="326" y="132" width="54" height="24">
-			</bounds>
+			<bounds x="326" y="132" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="264" y="147" width="58" height="28">
-			</bounds>
+			<bounds x="264" y="147" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="266" y="149" width="54" height="24">
-			</bounds>
+			<bounds x="266" y="149" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="385" y="126" width="58" height="28">
-			</bounds>
+			<bounds x="385" y="126" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="387" y="128" width="54" height="24">
-			</bounds>
+			<bounds x="387" y="128" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="445" y="126" width="58" height="28">
-			</bounds>
+			<bounds x="445" y="126" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="447" y="128" width="54" height="24">
-			</bounds>
+			<bounds x="447" y="128" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="566" y="141" width="58" height="28">
-			</bounds>
+			<bounds x="566" y="141" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="568" y="143" width="54" height="24">
-			</bounds>
+			<bounds x="568" y="143" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="411" y="453" width="68" height="19">
-			</bounds>
+			<bounds x="411" y="453" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="413" y="455" width="64" height="15">
-			</bounds>
+			<bounds x="413" y="455" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="694" y="582" width="68" height="26">
-			</bounds>
+			<bounds x="694" y="582" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="696" y="584" width="64" height="22">
-			</bounds>
+			<bounds x="696" y="584" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="694" y="608" width="68" height="26">
-			</bounds>
+			<bounds x="694" y="608" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="696" y="610" width="64" height="22">
-			</bounds>
+			<bounds x="696" y="610" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="694" y="634" width="68" height="26">
-			</bounds>
+			<bounds x="694" y="634" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="696" y="636" width="64" height="22">
-			</bounds>
+			<bounds x="696" y="636" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="694" y="660" width="68" height="26">
-			</bounds>
+			<bounds x="694" y="660" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="696" y="662" width="64" height="22">
-			</bounds>
+			<bounds x="696" y="662" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="694" y="686" width="68" height="26">
-			</bounds>
+			<bounds x="694" y="686" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="696" y="688" width="64" height="22">
-			</bounds>
+			<bounds x="696" y="688" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="762" y="582" width="78" height="26">
-			</bounds>
+			<bounds x="762" y="582" width="78" height="26"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="764" y="584" width="74" height="22">
-			</bounds>
+			<bounds x="764" y="584" width="74" height="22"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="762" y="608" width="78" height="26">
-			</bounds>
+			<bounds x="762" y="608" width="78" height="26"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="764" y="610" width="74" height="22">
-			</bounds>
+			<bounds x="764" y="610" width="74" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="762" y="634" width="78" height="26">
-			</bounds>
+			<bounds x="762" y="634" width="78" height="26"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="764" y="636" width="74" height="22">
-			</bounds>
+			<bounds x="764" y="636" width="74" height="22"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="762" y="660" width="78" height="26">
-			</bounds>
+			<bounds x="762" y="660" width="78" height="26"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="764" y="662" width="74" height="22">
-			</bounds>
+			<bounds x="764" y="662" width="74" height="22"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="762" y="686" width="78" height="26">
-			</bounds>
+			<bounds x="762" y="686" width="78" height="26"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="764" y="688" width="74" height="22">
-			</bounds>
+			<bounds x="764" y="688" width="74" height="22"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="840" y="686" width="96" height="26">
-			</bounds>
+			<bounds x="840" y="686" width="96" height="26"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="842" y="688" width="92" height="22">
-			</bounds>
+			<bounds x="842" y="688" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="840" y="660" width="96" height="26">
-			</bounds>
+			<bounds x="840" y="660" width="96" height="26"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="842" y="662" width="92" height="22">
-			</bounds>
+			<bounds x="842" y="662" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="840" y="634" width="96" height="26">
-			</bounds>
+			<bounds x="840" y="634" width="96" height="26"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="842" y="636" width="92" height="22">
-			</bounds>
+			<bounds x="842" y="636" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="840" y="608" width="96" height="26">
-			</bounds>
+			<bounds x="840" y="608" width="96" height="26"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="842" y="610" width="92" height="22">
-			</bounds>
+			<bounds x="842" y="610" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="840" y="582" width="96" height="26">
-			</bounds>
+			<bounds x="840" y="582" width="96" height="26"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="842" y="584" width="92" height="22">
-			</bounds>
+			<bounds x="842" y="584" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="840" y="556" width="96" height="26">
-			</bounds>
+			<bounds x="840" y="556" width="96" height="26"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="842" y="558" width="92" height="22">
-			</bounds>
+			<bounds x="842" y="558" width="92" height="22"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="694" y="556" width="68" height="26">
-			</bounds>
+			<bounds x="694" y="556" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="696" y="558" width="64" height="22">
-			</bounds>
+			<bounds x="696" y="558" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="762" y="556" width="78" height="26">
-			</bounds>
+			<bounds x="762" y="556" width="78" height="26"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="764" y="558" width="74" height="22">
-			</bounds>
+			<bounds x="764" y="558" width="74" height="22"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="90" y="634" width="62" height="32">
-			</bounds>
+			<bounds x="90" y="634" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="92" y="636" width="58" height="28">
-			</bounds>
+			<bounds x="92" y="636" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0">
-			<bounds x="90" y="602" width="62" height="32">
-			</bounds>
+			<bounds x="90" y="602" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0">
-			<bounds x="92" y="604" width="58" height="28">
-			</bounds>
+			<bounds x="92" y="604" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="90" y="666" width="62" height="32">
-			</bounds>
+			<bounds x="90" y="666" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="92" y="668" width="58" height="28">
-			</bounds>
+			<bounds x="92" y="668" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="90" y="698" width="62" height="32">
-			</bounds>
+			<bounds x="90" y="698" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="92" y="700" width="58" height="28">
-			</bounds>
+			<bounds x="92" y="700" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="185" y="747" width="68" height="24">
-			</bounds>
+			<bounds x="185" y="747" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="187" y="749" width="64" height="20">
-			</bounds>
+			<bounds x="187" y="749" width="64" height="20"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="279" y="747" width="24" height="24">
-			</bounds>
+			<bounds x="279" y="747" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="281" y="749" width="20" height="20">
-			</bounds>
+			<bounds x="281" y="749" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="341" y="747" width="24" height="24">
-			</bounds>
+			<bounds x="341" y="747" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="343" y="749" width="20" height="20">
-			</bounds>
+			<bounds x="343" y="749" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="414" y="747" width="24" height="24">
-			</bounds>
+			<bounds x="414" y="747" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="416" y="749" width="20" height="20">
-			</bounds>
+			<bounds x="416" y="749" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="479" y="747" width="24" height="24">
-			</bounds>
+			<bounds x="479" y="747" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="481" y="749" width="20" height="20">
-			</bounds>
+			<bounds x="481" y="749" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="364" y="285" width="34" height="24">
-			</bounds>
+			<bounds x="364" y="285" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="366" y="287" width="30" height="20">
-			</bounds>
+			<bounds x="366" y="287" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="485" y="285" width="34" height="24">
-			</bounds>
+			<bounds x="485" y="285" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="487" y="287" width="30" height="20">
-			</bounds>
+			<bounds x="487" y="287" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="348" y="505" width="68" height="26">
-			</bounds>
+			<bounds x="348" y="505" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="350" y="507" width="64" height="22">
-			</bounds>
+			<bounds x="350" y="507" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="418" y="505" width="68" height="26">
-			</bounds>
+			<bounds x="418" y="505" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="420" y="507" width="64" height="22">
-			</bounds>
+			<bounds x="420" y="507" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="488" y="505" width="68" height="26">
-			</bounds>
+			<bounds x="488" y="505" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="490" y="507" width="64" height="22">
-			</bounds>
+			<bounds x="490" y="507" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="61" y="171" width="56" height="28">
-			</bounds>
+			<bounds x="61" y="171" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="63" y="173" width="52" height="24">
-			</bounds>
+			<bounds x="63" y="173" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="61" y="199" width="56" height="28">
-			</bounds>
+			<bounds x="61" y="199" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="63" y="201" width="52" height="24">
-			</bounds>
+			<bounds x="63" y="201" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="61" y="227" width="56" height="28">
-			</bounds>
+			<bounds x="61" y="227" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="63" y="229" width="52" height="24">
-			</bounds>
+			<bounds x="63" y="229" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="61" y="255" width="56" height="28">
-			</bounds>
+			<bounds x="61" y="255" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="63" y="257" width="52" height="24">
-			</bounds>
+			<bounds x="63" y="257" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="61" y="283" width="56" height="28">
-			</bounds>
+			<bounds x="61" y="283" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="63" y="285" width="52" height="24">
-			</bounds>
+			<bounds x="63" y="285" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="61" y="311" width="56" height="28">
-			</bounds>
+			<bounds x="61" y="311" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="63" y="313" width="52" height="24">
-			</bounds>
+			<bounds x="63" y="313" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="61" y="339" width="56" height="28">
-			</bounds>
+			<bounds x="61" y="339" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="63" y="341" width="52" height="24">
-			</bounds>
+			<bounds x="63" y="341" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="61" y="367" width="56" height="28">
-			</bounds>
+			<bounds x="61" y="367" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="63" y="369" width="52" height="24">
-			</bounds>
+			<bounds x="63" y="369" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="553" y="747" width="24" height="24">
-			</bounds>
+			<bounds x="553" y="747" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="555" y="749" width="20" height="20">
-			</bounds>
+			<bounds x="555" y="749" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="812" y="730" width="68" height="19">
-			</bounds>
+			<bounds x="812" y="730" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="814" y="732" width="64" height="15">
-			</bounds>
+			<bounds x="814" y="732" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="812" y="747" width="68" height="24">
-			</bounds>
+			<bounds x="812" y="747" width="68" height="24"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="814" y="749" width="64" height="20">
-			</bounds>
+			<bounds x="814" y="749" width="64" height="20"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="625" y="747" width="24" height="24">
-			</bounds>
+			<bounds x="625" y="747" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="627" y="749" width="20" height="20">
-			</bounds>
+			<bounds x="627" y="749" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="757" y="747" width="24" height="24">
-			</bounds>
+			<bounds x="757" y="747" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="759" y="749" width="20" height="20">
-			</bounds>
+			<bounds x="759" y="749" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="688" y="747" width="24" height="24">
-			</bounds>
+			<bounds x="688" y="747" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="690" y="749" width="20" height="20">
-			</bounds>
+			<bounds x="690" y="749" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_253_border" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="842" y="1" width="46" height="27">
-			</bounds>
+			<bounds x="842" y="1" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_253" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="844" y="3" width="42" height="23">
-			</bounds>
+			<bounds x="844" y="3" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="colour_button_262_border" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="29" y="91" width="76" height="32">
-			</bounds>
+			<bounds x="29" y="91" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="colour_button_262" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="31" y="93" width="72" height="28">
-			</bounds>
+			<bounds x="31" y="93" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp226" element="colour_button_263_border" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="550" y="312" width="76" height="32">
-			</bounds>
+			<bounds x="550" y="312" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp226" element="colour_button_263" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="552" y="314" width="72" height="28">
-			</bounds>
+			<bounds x="552" y="314" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="colour_button_264_border" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="248" y="325" width="76" height="32">
-			</bounds>
+			<bounds x="248" y="325" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="colour_button_264" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="250" y="327" width="72" height="28">
-			</bounds>
+			<bounds x="250" y="327" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_266_border" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="765" y="800" width="79" height="37">
-			</bounds>
+			<bounds x="765" y="800" width="79" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_266" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="767" y="802" width="75" height="33">
-			</bounds>
+			<bounds x="767" y="802" width="75" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_267_border" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="674" y="800" width="79" height="37">
-			</bounds>
+			<bounds x="674" y="800" width="79" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_267" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="676" y="802" width="75" height="33">
-			</bounds>
+			<bounds x="676" y="802" width="75" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_268_border" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="586" y="800" width="79" height="37">
-			</bounds>
+			<bounds x="586" y="800" width="79" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_268" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="588" y="802" width="75" height="33">
-			</bounds>
+			<bounds x="588" y="802" width="75" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_269_border" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="176" y="800" width="79" height="37">
-			</bounds>
+			<bounds x="176" y="800" width="79" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_269" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="178" y="802" width="75" height="33">
-			</bounds>
+			<bounds x="178" y="802" width="75" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_270_border" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="496" y="800" width="79" height="37">
-			</bounds>
+			<bounds x="496" y="800" width="79" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_270" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="498" y="802" width="75" height="33">
-			</bounds>
+			<bounds x="498" y="802" width="75" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_271_border" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="411" y="800" width="79" height="37">
-			</bounds>
+			<bounds x="411" y="800" width="79" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_271" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="413" y="802" width="75" height="33">
-			</bounds>
+			<bounds x="413" y="802" width="75" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_272_border" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="326" y="800" width="79" height="37">
-			</bounds>
+			<bounds x="326" y="800" width="79" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_272" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="328" y="802" width="75" height="33">
-			</bounds>
+			<bounds x="328" y="802" width="75" height="33"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="312" y="410" width="272" height="30">
-			</bounds>
+			<bounds x="312" y="410" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="312" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="312" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="329" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="329" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="346" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="346" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="363" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="363" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="380" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="380" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="397" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="397" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="414" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="414" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="431" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="431" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="448" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="448" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="465" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="465" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="482" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="482" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="499" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="499" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="516" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="516" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="533" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="533" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="550" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="550" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="567" y="410" width="17" height="30">
-			</bounds>
+			<bounds x="567" y="410" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="818" y="458" width="172" height="26">
-			</bounds>
+			<bounds x="818" y="458" width="172" height="26"/>
 		</backdrop>
 		<backdrop name="label185" element="label_185">
-			<bounds x="521" y="440" width="53" height="19">
-			</bounds>
+			<bounds x="521" y="440" width="53" height="19"/>
 		</backdrop>
 		<backdrop name="label186" element="label_186">
-			<bounds x="330" y="440" width="46" height="19">
-			</bounds>
+			<bounds x="330" y="440" width="46" height="19"/>
 		</backdrop>
 		<backdrop name="label206" element="label_206">
-			<bounds x="578" y="658" width="27" height="16">
-			</bounds>
+			<bounds x="578" y="658" width="27" height="16"/>
 		</backdrop>
 		<backdrop name="label207" element="label_207">
-			<bounds x="295" y="658" width="26" height="16">
-			</bounds>
+			<bounds x="295" y="658" width="26" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_reel" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_button" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_button" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_button" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_button_standard" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE8" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp12" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp13" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp14" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp15" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp20" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m3circle.lay
+++ b/src/mame/layout/m3circle.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<disk state="1">
@@ -3430,7 +3432,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="835" height="907"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m4aao.lay
+++ b/src/mame/layout/m4aao.lay
@@ -8,1265 +8,5215 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_132_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_132">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_133_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_133">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_135_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_135">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="AUTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Red7,SingleBar,DoubleBar,Blue7,DoubleBar,TripleBar,Red7,DoubleBar,SingleBar,TripleBar,Blue7,SingleBar,DoubleBar,White7,TripleBar,SingleBar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Blue7,SingleBar,DoubleBar,Red7,SingleBar,TripleBar,White7,DoubleBar,SingleBar,TripleBar,Red7,SingleBar,DoubleBar,White7,TripleBar,SingleBar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Red7,TripleBar,DoubleBar,Blue7,DoubleBar,TripleBar,Red7,DoubleBar,SingleBar,TripleBar,Blue7,SingleBar,DoubleBar,White7,TripleBar,SingleBar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="1,2,3,4,5,6,7,8,9,10,11,12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_81">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_115">
 		<text string="7 Steppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="Win Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_backdrop_colour">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_standard">
+		<rect state="0">
+			<color red="0.00" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_reel">
+		<rect state="0">
+			<color red="0.00" green="0.00" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="0.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_segment">
+		<rect state="0">
+			<color red="0.20" green="0.00" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="0.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_button">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_64">
+		<text string="64">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_65">
+		<text string="65">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_66">
+		<text string="66">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_67">
+		<text string="67">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_68">
+		<text string="68">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_69">
+		<text string="69">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_70">
+		<text string="70">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_71">
+		<text string="71">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_72">
+		<text string="72">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_73">
+		<text string="73">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_74">
+		<text string="74">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_75">
+		<text string="75">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_76">
+		<text string="76">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_77">
+		<text string="77">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_78">
+		<text string="78">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_79">
+		<text string="79">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_80">
+		<text string="80">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_81">
+		<text string="81">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_82">
+		<text string="82">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_83">
+		<text string="83">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_84">
+		<text string="84">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_85">
+		<text string="85">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_86">
+		<text string="86">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_87">
+		<text string="87">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_88">
+		<text string="88">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_89">
+		<text string="89">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_90">
+		<text string="90">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_91">
+		<text string="91">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_92">
+		<text string="92">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_93">
+		<text string="93">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_94">
+		<text string="94">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_95">
+		<text string="95">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_96">
+		<text string="96">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_97">
+		<text string="97">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_98">
+		<text string="98">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_99">
+		<text string="99">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_100">
+		<text string="100">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_101">
+		<text string="101">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_102">
+		<text string="102">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_103">
+		<text string="103">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_104">
+		<text string="104">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_105">
+		<text string="105">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_106">
+		<text string="106">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_107">
+		<text string="107">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_108">
+		<text string="108">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_109">
+		<text string="109">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_110">
+		<text string="110">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_111">
+		<text string="111">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_112">
+		<text string="112">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_113">
+		<text string="113">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_114">
+		<text string="114">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_115">
+		<text string="115">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_116">
+		<text string="116">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_117">
+		<text string="117">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_118">
+		<text string="118">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_119">
+		<text string="119">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_120">
+		<text string="120">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_121">
+		<text string="121">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_122">
+		<text string="122">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_123">
+		<text string="123">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_124">
+		<text string="124">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_125">
+		<text string="125">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_126">
+		<text string="126">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_127">
+		<text string="127">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_128">
+		<text string="128">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_129">
+		<text string="129">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_130">
+		<text string="130">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_131">
+		<text string="131">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_132">
+		<text string="132">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_133">
+		<text string="133">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_134">
+		<text string="134">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_135">
+		<text string="135">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_136">
+		<text string="136">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_137">
+		<text string="137">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_138">
+		<text string="138">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_139">
+		<text string="139">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_140">
+		<text string="140">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_141">
+		<text string="141">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_142">
+		<text string="142">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_143">
+		<text string="143">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_144">
+		<text string="144">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_145">
+		<text string="145">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_146">
+		<text string="146">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_147">
+		<text string="147">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_148">
+		<text string="148">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_149">
+		<text string="149">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_150">
+		<text string="150">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_151">
+		<text string="151">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_152">
+		<text string="152">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_153">
+		<text string="153">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_154">
+		<text string="154">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_155">
+		<text string="155">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_156">
+		<text string="156">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_157">
+		<text string="157">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_158">
+		<text string="158">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_159">
+		<text string="159">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_160">
+		<text string="160">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_161">
+		<text string="161">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_162">
+		<text string="162">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_163">
+		<text string="163">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_164">
+		<text string="164">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_165">
+		<text string="165">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_166">
+		<text string="166">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_167">
+		<text string="167">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_168">
+		<text string="168">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_169">
+		<text string="169">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_170">
+		<text string="170">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_171">
+		<text string="171">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_172">
+		<text string="172">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_173">
+		<text string="173">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_174">
+		<text string="174">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_175">
+		<text string="175">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_176">
+		<text string="176">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_177">
+		<text string="177">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_178">
+		<text string="178">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_179">
+		<text string="179">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_180">
+		<text string="180">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_181">
+		<text string="181">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_182">
+		<text string="182">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_183">
+		<text string="183">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_184">
+		<text string="184">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_185">
+		<text string="185">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_186">
+		<text string="186">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_187">
+		<text string="187">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_188">
+		<text string="188">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_189">
+		<text string="189">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_190">
+		<text string="190">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_191">
+		<text string="191">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_192">
+		<text string="192">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_193">
+		<text string="193">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_194">
+		<text string="194">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_195">
+		<text string="195">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_196">
+		<text string="196">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_197">
+		<text string="197">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_198">
+		<text string="198">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_199">
+		<text string="199">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_200">
+		<text string="200">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_201">
+		<text string="201">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_202">
+		<text string="202">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_203">
+		<text string="203">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_204">
+		<text string="204">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_205">
+		<text string="205">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_206">
+		<text string="206">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_207">
+		<text string="207">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_208">
+		<text string="208">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_209">
+		<text string="209">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_210">
+		<text string="210">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_211">
+		<text string="211">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_212">
+		<text string="212">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_213">
+		<text string="213">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_214">
+		<text string="214">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_215">
+		<text string="215">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_216">
+		<text string="216">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_217">
+		<text string="217">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_218">
+		<text string="218">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_219">
+		<text string="219">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_220">
+		<text string="220">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_221">
+		<text string="221">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_222">
+		<text string="222">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_223">
+		<text string="223">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_224">
+		<text string="224">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_225">
+		<text string="225">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_226">
+		<text string="226">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_227">
+		<text string="227">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_228">
+		<text string="228">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_229">
+		<text string="229">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_230">
+		<text string="230">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_231">
+		<text string="231">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_232">
+		<text string="232">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_233">
+		<text string="233">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_234">
+		<text string="234">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_235">
+		<text string="235">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_236">
+		<text string="236">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_237">
+		<text string="237">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_238">
+		<text string="238">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_239">
+		<text string="239">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_240">
+		<text string="240">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_241">
+		<text string="241">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_242">
+		<text string="242">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_243">
+		<text string="243">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_244">
+		<text string="244">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_245">
+		<text string="245">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_246">
+		<text string="246">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_247">
+		<text string="247">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_248">
+		<text string="248">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_249">
+		<text string="249">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_250">
+		<text string="250">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_251">
+		<text string="251">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_252">
+		<text string="252">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_253">
+		<text string="253">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_254">
+		<text string="254">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_255">
+		<text string="255">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_standard">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_vfd">
+		<led16segsc>
+			<color red="0.0" green="1.0" blue="1.0"/>
+		</led16segsc>
+	</element>
+	<element name="debug_stepper_value" defstate="0">
+		<simplecounter maxstate="999" digits="3">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</simplecounter>
+	</element>
+	<element name="debug_reel_symbol_count_0">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_1">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_2">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_3">
+		<text string="12">
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="508" height="574">
-			</bounds>
+			<bounds x="0" y="0" width="508" height="574"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="80" y="382" width="80" height="140">
-			</bounds>
+			<bounds x="80" y="382" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
-			<bounds x="80.0000" y="382.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="80.0000" y="382.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
-			<bounds x="83.3333" y="383.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="83.3333" y="383.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
-			<bounds x="86.6667" y="385.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="86.6667" y="385.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
-			<bounds x="90.0000" y="387.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="387.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
-			<bounds x="93.3333" y="389.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="93.3333" y="389.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
-			<bounds x="96.6667" y="391.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="96.6667" y="391.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
-			<bounds x="80.0000" y="428.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="80.0000" y="428.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
-			<bounds x="83.3333" y="430.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="83.3333" y="430.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
-			<bounds x="86.6667" y="432.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="86.6667" y="432.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
-			<bounds x="90.0000" y="434.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="434.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
-			<bounds x="93.3333" y="436.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="93.3333" y="436.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
-			<bounds x="96.6667" y="438.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="96.6667" y="438.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="80.0000" y="475.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="80.0000" y="475.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="83.3333" y="477.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="83.3333" y="477.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="86.6667" y="479.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="86.6667" y="479.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="90.0000" y="481.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="481.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="93.3333" y="483.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="93.3333" y="483.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="96.6667" y="485.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="96.6667" y="485.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="80" y="382" width="80" height="140">
-			</bounds>
+			<bounds x="80" y="382" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="162" y="382" width="80" height="140">
-			</bounds>
+			<bounds x="162" y="382" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_0" state="0">
-			<bounds x="162.0000" y="382.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="162.0000" y="382.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_1" state="0">
-			<bounds x="165.3333" y="383.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="165.3333" y="383.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_2" state="0">
-			<bounds x="168.6667" y="385.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="168.6667" y="385.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_3" state="0">
-			<bounds x="172.0000" y="387.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="172.0000" y="387.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_4" state="0">
-			<bounds x="175.3333" y="389.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="175.3333" y="389.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_5" state="0">
-			<bounds x="178.6667" y="391.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="178.6667" y="391.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_0" state="0">
-			<bounds x="162.0000" y="428.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="162.0000" y="428.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_1" state="0">
-			<bounds x="165.3333" y="430.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="165.3333" y="430.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_2" state="0">
-			<bounds x="168.6667" y="432.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="168.6667" y="432.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_3" state="0">
-			<bounds x="172.0000" y="434.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="172.0000" y="434.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_4" state="0">
-			<bounds x="175.3333" y="436.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="175.3333" y="436.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_5" state="0">
-			<bounds x="178.6667" y="438.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="178.6667" y="438.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="162.0000" y="475.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="162.0000" y="475.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="165.3333" y="477.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="165.3333" y="477.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="168.6667" y="479.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="168.6667" y="479.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="172.0000" y="481.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="172.0000" y="481.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="175.3333" y="483.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="175.3333" y="483.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="178.6667" y="485.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="178.6667" y="485.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="162" y="382" width="80" height="140">
-			</bounds>
+			<bounds x="162" y="382" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="244" y="382" width="80" height="140">
-			</bounds>
+			<bounds x="244" y="382" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_0" state="0">
-			<bounds x="244.0000" y="382.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="244.0000" y="382.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_1" state="0">
-			<bounds x="247.3333" y="383.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="247.3333" y="383.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_2" state="0">
-			<bounds x="250.6667" y="385.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="250.6667" y="385.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_3" state="0">
-			<bounds x="254.0000" y="387.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="254.0000" y="387.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_4" state="0">
-			<bounds x="257.3333" y="389.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="257.3333" y="389.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_5" state="0">
-			<bounds x="260.6667" y="391.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="260.6667" y="391.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="244.0000" y="428.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="244.0000" y="428.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="247.3333" y="430.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="247.3333" y="430.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="250.6667" y="432.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="250.6667" y="432.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="254.0000" y="434.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="254.0000" y="434.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="257.3333" y="436.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="257.3333" y="436.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="260.6667" y="438.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="260.6667" y="438.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="244.0000" y="475.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="244.0000" y="475.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="247.3333" y="477.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="247.3333" y="477.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="250.6667" y="479.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="250.6667" y="479.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="254.0000" y="481.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="254.0000" y="481.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="257.3333" y="483.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="257.3333" y="483.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="260.6667" y="485.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="260.6667" y="485.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="244" y="382" width="80" height="140">
-			</bounds>
+			<bounds x="244" y="382" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="896" y="87" width="80" height="140">
-			</bounds>
+			<bounds x="896" y="87" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_0" state="0">
-			<bounds x="896.0000" y="87.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="896.0000" y="87.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_1" state="0">
-			<bounds x="899.3333" y="88.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="899.3333" y="88.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_2" state="0">
-			<bounds x="902.6667" y="90.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="902.6667" y="90.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_3" state="0">
-			<bounds x="906.0000" y="92.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="906.0000" y="92.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_4" state="0">
-			<bounds x="909.3333" y="94.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="909.3333" y="94.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_5" state="0">
-			<bounds x="912.6667" y="96.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="912.6667" y="96.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="896.0000" y="133.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="896.0000" y="133.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="899.3333" y="135.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="899.3333" y="135.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="902.6667" y="137.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="902.6667" y="137.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="906.0000" y="139.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="906.0000" y="139.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="909.3333" y="141.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="909.3333" y="141.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="912.6667" y="143.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="912.6667" y="143.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="896.0000" y="180.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="896.0000" y="180.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="899.3333" y="182.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="899.3333" y="182.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="902.6667" y="184.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="902.6667" y="184.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="906.0000" y="186.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="906.0000" y="186.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="909.3333" y="188.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="909.3333" y="188.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="912.6667" y="190.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="912.6667" y="190.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="896" y="87" width="80" height="140">
-			</bounds>
+			<bounds x="896" y="87" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="20" y="447" width="39" height="39">
-			</bounds>
+			<bounds x="20" y="447" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="22" y="449" width="35" height="35">
-			</bounds>
+			<bounds x="22" y="449" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="20" y="411" width="39" height="39">
-			</bounds>
+			<bounds x="20" y="411" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="22" y="413" width="35" height="35">
-			</bounds>
+			<bounds x="22" y="413" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="20" y="375" width="39" height="39">
-			</bounds>
+			<bounds x="20" y="375" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="22" y="377" width="35" height="35">
-			</bounds>
+			<bounds x="22" y="377" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="14" y="486" width="52" height="32">
-			</bounds>
+			<bounds x="14" y="486" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="16" y="488" width="48" height="28">
-			</bounds>
+			<bounds x="16" y="488" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="232" y="338" width="102" height="39">
-			</bounds>
+			<bounds x="232" y="338" width="102" height="39"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="234" y="340" width="98" height="35">
-			</bounds>
+			<bounds x="234" y="340" width="98" height="35"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="232" y="86" width="102" height="39">
-			</bounds>
+			<bounds x="232" y="86" width="102" height="39"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="234" y="88" width="98" height="35">
-			</bounds>
+			<bounds x="234" y="88" width="98" height="35"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="232" y="122" width="102" height="39">
-			</bounds>
+			<bounds x="232" y="122" width="102" height="39"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="234" y="124" width="98" height="35">
-			</bounds>
+			<bounds x="234" y="124" width="98" height="35"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="232" y="158" width="102" height="39">
-			</bounds>
+			<bounds x="232" y="158" width="102" height="39"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="234" y="160" width="98" height="35">
-			</bounds>
+			<bounds x="234" y="160" width="98" height="35"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="232" y="194" width="102" height="39">
-			</bounds>
+			<bounds x="232" y="194" width="102" height="39"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="234" y="196" width="98" height="35">
-			</bounds>
+			<bounds x="234" y="196" width="98" height="35"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="232" y="230" width="102" height="39">
-			</bounds>
+			<bounds x="232" y="230" width="102" height="39"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="234" y="232" width="98" height="35">
-			</bounds>
+			<bounds x="234" y="232" width="98" height="35"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="232" y="266" width="102" height="39">
-			</bounds>
+			<bounds x="232" y="266" width="102" height="39"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="234" y="268" width="98" height="35">
-			</bounds>
+			<bounds x="234" y="268" width="98" height="35"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="232" y="302" width="102" height="39">
-			</bounds>
+			<bounds x="232" y="302" width="102" height="39"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="234" y="304" width="98" height="35">
-			</bounds>
+			<bounds x="234" y="304" width="98" height="35"/>
 		</backdrop>
 		<backdrop name="lamp14" element="colour_button_132_border" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="429" y="3" width="47" height="62">
-			</bounds>
+			<bounds x="429" y="3" width="47" height="62"/>
 		</backdrop>
 		<backdrop name="lamp14" element="colour_button_132" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="431" y="5" width="43" height="58">
-			</bounds>
+			<bounds x="431" y="5" width="43" height="58"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_133_border" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="83" y="525" width="75" height="39">
-			</bounds>
+			<bounds x="83" y="525" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_133" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="85" y="527" width="71" height="35">
-			</bounds>
+			<bounds x="85" y="527" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_134_border" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="167" y="525" width="75" height="39">
-			</bounds>
+			<bounds x="167" y="525" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_134" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="169" y="527" width="71" height="35">
-			</bounds>
+			<bounds x="169" y="527" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_135_border" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="247" y="525" width="75" height="39">
-			</bounds>
+			<bounds x="247" y="525" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_135" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="249" y="527" width="71" height="35">
-			</bounds>
+			<bounds x="249" y="527" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_136_border" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="328" y="525" width="75" height="39">
-			</bounds>
+			<bounds x="328" y="525" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_136" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="330" y="527" width="71" height="35">
-			</bounds>
+			<bounds x="330" y="527" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_137_border" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="410" y="525" width="75" height="39">
-			</bounds>
+			<bounds x="410" y="525" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_137" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="412" y="527" width="71" height="35">
-			</bounds>
+			<bounds x="412" y="527" width="71" height="35"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_138_border" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="3" y="525" width="75" height="39">
-			</bounds>
+			<bounds x="3" y="525" width="75" height="39"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_138" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="5" y="527" width="71" height="35">
-			</bounds>
+			<bounds x="5" y="527" width="71" height="35"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="229" y="7" width="50" height="75">
-			</bounds>
+			<bounds x="229" y="7" width="50" height="75"/>
 		</backdrop>
 		<backdrop name="digit7" element="led_digit_red">
-			<bounds x="229" y="7" width="50" height="75">
-			</bounds>
+			<bounds x="229" y="7" width="50" height="75"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="229" y="7" width="50" height="75">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="229" y="7" width="50" height="75"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="179" y="7" width="50" height="75">
-			</bounds>
+			<bounds x="179" y="7" width="50" height="75"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="179" y="7" width="50" height="75">
-			</bounds>
+			<bounds x="179" y="7" width="50" height="75"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="179" y="7" width="50" height="75">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="179" y="7" width="50" height="75"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="129" y="7" width="50" height="75">
-			</bounds>
+			<bounds x="129" y="7" width="50" height="75"/>
 		</backdrop>
 		<backdrop name="digit5" element="led_digit_red">
-			<bounds x="129" y="7" width="50" height="75">
-			</bounds>
+			<bounds x="129" y="7" width="50" height="75"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="129" y="7" width="50" height="75">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="129" y="7" width="50" height="75"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="445" y="488" width="24" height="32">
-			</bounds>
+			<bounds x="445" y="488" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit4" element="led_digit_red">
-			<bounds x="445" y="488" width="24" height="32">
-			</bounds>
+			<bounds x="445" y="488" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="445" y="488" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="445" y="488" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="421" y="488" width="24" height="32">
-			</bounds>
+			<bounds x="421" y="488" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit3" element="led_digit_red">
-			<bounds x="421" y="488" width="24" height="32">
-			</bounds>
+			<bounds x="421" y="488" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="421" y="488" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="421" y="488" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop name="label81" element="label_81">
-			<bounds x="91" y="7" width="36" height="75">
-			</bounds>
+			<bounds x="91" y="7" width="36" height="75"/>
 		</backdrop>
 		<backdrop name="label115" element="label_115">
-			<bounds x="394" y="284" width="54" height="38">
-			</bounds>
+			<bounds x="394" y="284" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="396" y="141" width="48" height="38">
-			</bounds>
+			<bounds x="396" y="141" width="48" height="38"/>
+		</backdrop>
+	</view>
+
+	<view name="MFME2MAME Debug">
+		<backdrop element="debug_backdrop_colour">
+			<bounds x="0" y="0" width="1920" height="1080"/>
+		</backdrop>
+		<backdrop name="lamp0" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
+			<bounds x="47" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp1" element="debug_lamp_reel" state="0">
+			<bounds x="96" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
+			<bounds x="111" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp2" element="debug_lamp_reel" state="0">
+			<bounds x="160" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
+			<bounds x="175" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp3" element="debug_lamp_reel" state="0">
+			<bounds x="224" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
+			<bounds x="239" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
+			<bounds x="303" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
+			<bounds x="367" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
+			<bounds x="431" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
+			<bounds x="495" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp8" element="debug_lamp_reel" state="0">
+			<bounds x="544" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
+			<bounds x="559" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp9" element="debug_lamp_reel" state="0">
+			<bounds x="608" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
+			<bounds x="623" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
+			<bounds x="672" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
+			<bounds x="687" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
+			<bounds x="736" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
+			<bounds x="751" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
+			<bounds x="815" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
+			<bounds x="879" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp14" element="debug_lamp_button" state="0">
+			<bounds x="928" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
+			<bounds x="943" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
+			<bounds x="1007" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
+			<bounds x="47" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
+			<bounds x="96" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
+			<bounds x="111" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
+			<bounds x="160" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
+			<bounds x="175" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
+			<bounds x="224" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
+			<bounds x="239" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
+			<bounds x="303" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
+			<bounds x="367" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
+			<bounds x="431" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
+			<bounds x="495" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
+			<bounds x="559" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
+			<bounds x="623" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_lamp_button" state="0">
+			<bounds x="672" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
+			<bounds x="687" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
+			<bounds x="751" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
+			<bounds x="815" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
+			<bounds x="879" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
+			<bounds x="943" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp31" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
+			<bounds x="1007" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_lamp_button" state="0">
+			<bounds x="32" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
+			<bounds x="47" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_lamp_button" state="0">
+			<bounds x="96" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
+			<bounds x="111" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_lamp_button" state="0">
+			<bounds x="160" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
+			<bounds x="175" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
+			<bounds x="239" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
+			<bounds x="303" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
+			<bounds x="367" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
+			<bounds x="431" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
+			<bounds x="495" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_lamp_button" state="0">
+			<bounds x="544" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
+			<bounds x="559" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_lamp_button" state="0">
+			<bounds x="608" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
+			<bounds x="623" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
+			<bounds x="687" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
+			<bounds x="751" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
+			<bounds x="815" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
+			<bounds x="879" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
+			<bounds x="943" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
+			<bounds x="1007" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
+			<bounds x="47" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
+			<bounds x="111" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
+			<bounds x="175" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
+			<bounds x="239" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
+			<bounds x="303" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
+			<bounds x="367" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
+			<bounds x="431" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
+			<bounds x="495" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
+			<bounds x="559" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
+			<bounds x="623" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
+			<bounds x="687" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
+			<bounds x="751" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
+			<bounds x="815" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
+			<bounds x="879" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
+			<bounds x="943" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
+			<bounds x="1007" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
+			<bounds x="47" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
+			<bounds x="111" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
+			<bounds x="175" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
+			<bounds x="239" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
+			<bounds x="303" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
+			<bounds x="367" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
+			<bounds x="431" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
+			<bounds x="495" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
+			<bounds x="559" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
+			<bounds x="623" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
+			<bounds x="687" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
+			<bounds x="751" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
+			<bounds x="815" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
+			<bounds x="879" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
+			<bounds x="943" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
+			<bounds x="1007" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
+			<bounds x="47" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
+			<bounds x="111" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
+			<bounds x="175" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
+			<bounds x="239" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
+			<bounds x="303" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
+			<bounds x="367" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
+			<bounds x="431" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
+			<bounds x="495" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
+			<bounds x="559" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
+			<bounds x="623" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
+			<bounds x="687" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
+			<bounds x="751" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
+			<bounds x="815" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
+			<bounds x="879" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
+			<bounds x="943" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
+			<bounds x="1007" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
+			<bounds x="47" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
+			<bounds x="111" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
+			<bounds x="175" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
+			<bounds x="239" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
+			<bounds x="303" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
+			<bounds x="367" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
+			<bounds x="431" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
+			<bounds x="495" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
+			<bounds x="559" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
+			<bounds x="623" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
+			<bounds x="687" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
+			<bounds x="751" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
+			<bounds x="815" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
+			<bounds x="879" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
+			<bounds x="943" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
+			<bounds x="1007" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
+			<bounds x="47" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
+			<bounds x="111" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
+			<bounds x="175" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
+			<bounds x="239" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
+			<bounds x="303" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
+			<bounds x="367" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
+			<bounds x="431" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
+			<bounds x="495" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
+			<bounds x="559" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
+			<bounds x="623" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
+			<bounds x="687" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
+			<bounds x="751" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
+			<bounds x="815" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
+			<bounds x="879" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
+			<bounds x="943" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
+			<bounds x="1007" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
+			<bounds x="47" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
+			<bounds x="111" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
+			<bounds x="175" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
+			<bounds x="239" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
+			<bounds x="303" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
+			<bounds x="367" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
+			<bounds x="431" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
+			<bounds x="495" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
+			<bounds x="559" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
+			<bounds x="623" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
+			<bounds x="687" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
+			<bounds x="751" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
+			<bounds x="815" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
+			<bounds x="879" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
+			<bounds x="943" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
+			<bounds x="1007" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
+			<bounds x="47" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
+			<bounds x="111" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
+			<bounds x="175" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
+			<bounds x="239" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
+			<bounds x="303" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
+			<bounds x="367" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
+			<bounds x="431" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
+			<bounds x="495" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
+			<bounds x="559" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
+			<bounds x="623" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
+			<bounds x="687" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
+			<bounds x="751" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
+			<bounds x="815" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
+			<bounds x="879" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
+			<bounds x="943" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
+			<bounds x="1007" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
+			<bounds x="47" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
+			<bounds x="111" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
+			<bounds x="175" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
+			<bounds x="239" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
+			<bounds x="303" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
+			<bounds x="367" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
+			<bounds x="431" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
+			<bounds x="495" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
+			<bounds x="559" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
+			<bounds x="623" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
+			<bounds x="687" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
+			<bounds x="751" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
+			<bounds x="815" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
+			<bounds x="879" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
+			<bounds x="943" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
+			<bounds x="1007" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
+			<bounds x="47" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
+			<bounds x="111" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
+			<bounds x="175" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
+			<bounds x="239" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
+			<bounds x="303" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
+			<bounds x="367" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
+			<bounds x="431" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
+			<bounds x="495" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
+			<bounds x="559" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
+			<bounds x="623" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
+			<bounds x="687" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
+			<bounds x="751" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
+			<bounds x="815" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
+			<bounds x="879" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
+			<bounds x="943" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
+			<bounds x="1007" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
+			<bounds x="47" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
+			<bounds x="111" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
+			<bounds x="175" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
+			<bounds x="239" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
+			<bounds x="303" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
+			<bounds x="367" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
+			<bounds x="431" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
+			<bounds x="495" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
+			<bounds x="559" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
+			<bounds x="623" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
+			<bounds x="687" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
+			<bounds x="751" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
+			<bounds x="815" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
+			<bounds x="879" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
+			<bounds x="943" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
+			<bounds x="1007" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
+			<bounds x="47" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
+			<bounds x="111" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
+			<bounds x="175" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
+			<bounds x="239" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
+			<bounds x="303" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
+			<bounds x="367" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
+			<bounds x="431" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
+			<bounds x="495" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
+			<bounds x="559" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
+			<bounds x="623" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
+			<bounds x="687" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
+			<bounds x="751" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
+			<bounds x="815" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
+			<bounds x="879" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
+			<bounds x="943" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
+			<bounds x="1007" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
+			<bounds x="47" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
+			<bounds x="111" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
+			<bounds x="175" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
+			<bounds x="239" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
+			<bounds x="303" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
+			<bounds x="367" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
+			<bounds x="431" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
+			<bounds x="495" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
+			<bounds x="559" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
+			<bounds x="623" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
+			<bounds x="687" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
+			<bounds x="751" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
+			<bounds x="815" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
+			<bounds x="879" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
+			<bounds x="943" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
+			<bounds x="1007" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
+			<bounds x="47" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
+			<bounds x="111" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
+			<bounds x="175" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
+			<bounds x="239" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
+			<bounds x="303" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
+			<bounds x="367" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
+			<bounds x="431" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
+			<bounds x="495" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
+			<bounds x="559" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
+			<bounds x="623" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
+			<bounds x="687" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
+			<bounds x="751" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
+			<bounds x="815" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
+			<bounds x="879" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
+			<bounds x="943" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
+			<bounds x="1007" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x01">
+			<bounds x="1100" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_0" element="debug_button_label_0">
+			<bounds x="1120" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x02">
+			<bounds x="1184" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_1" element="debug_button_label_1">
+			<bounds x="1204" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x04">
+			<bounds x="1268" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_2" element="debug_button_label_2">
+			<bounds x="1288" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x08">
+			<bounds x="1352" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_3" element="debug_button_label_3">
+			<bounds x="1372" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x10">
+			<bounds x="1436" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_4" element="debug_button_label_4">
+			<bounds x="1456" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x20">
+			<bounds x="1520" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_5" element="debug_button_label_5">
+			<bounds x="1540" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x40">
+			<bounds x="1604" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_6" element="debug_button_label_6">
+			<bounds x="1624" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x80">
+			<bounds x="1688" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_7" element="debug_button_label_7">
+			<bounds x="1708" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x01">
+			<bounds x="1100" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_8" element="debug_button_label_8">
+			<bounds x="1120" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x02">
+			<bounds x="1184" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_9" element="debug_button_label_9">
+			<bounds x="1204" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x04">
+			<bounds x="1268" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_10" element="debug_button_label_10">
+			<bounds x="1288" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x08">
+			<bounds x="1352" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_11" element="debug_button_label_11">
+			<bounds x="1372" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x10">
+			<bounds x="1436" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_12" element="debug_button_label_12">
+			<bounds x="1456" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x20">
+			<bounds x="1520" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_13" element="debug_button_label_13">
+			<bounds x="1540" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x40">
+			<bounds x="1604" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_14" element="debug_button_label_14">
+			<bounds x="1624" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x80">
+			<bounds x="1688" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_15" element="debug_button_label_15">
+			<bounds x="1708" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x01">
+			<bounds x="1100" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_16" element="debug_button_label_16">
+			<bounds x="1120" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x02">
+			<bounds x="1184" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_17" element="debug_button_label_17">
+			<bounds x="1204" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x04">
+			<bounds x="1268" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_18" element="debug_button_label_18">
+			<bounds x="1288" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x08">
+			<bounds x="1352" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_19" element="debug_button_label_19">
+			<bounds x="1372" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x10">
+			<bounds x="1436" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_20" element="debug_button_label_20">
+			<bounds x="1456" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x20">
+			<bounds x="1520" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_21" element="debug_button_label_21">
+			<bounds x="1540" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x40">
+			<bounds x="1604" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_22" element="debug_button_label_22">
+			<bounds x="1624" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x80">
+			<bounds x="1688" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_23" element="debug_button_label_23">
+			<bounds x="1708" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="BLACK2" inputmask="0x01">
+			<bounds x="1100" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_24" element="debug_button_label_24">
+			<bounds x="1120" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="BLACK2" inputmask="0x02">
+			<bounds x="1184" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_25" element="debug_button_label_25">
+			<bounds x="1204" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x04">
+			<bounds x="1268" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_26" element="debug_button_label_26">
+			<bounds x="1288" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x08">
+			<bounds x="1352" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_27" element="debug_button_label_27">
+			<bounds x="1372" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x10">
+			<bounds x="1436" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_28" element="debug_button_label_28">
+			<bounds x="1456" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x20">
+			<bounds x="1520" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_29" element="debug_button_label_29">
+			<bounds x="1540" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x40">
+			<bounds x="1604" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_30" element="debug_button_label_30">
+			<bounds x="1624" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x80">
+			<bounds x="1688" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_31" element="debug_button_label_31">
+			<bounds x="1708" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x01">
+			<bounds x="1100" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_32" element="debug_button_label_32">
+			<bounds x="1120" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x02">
+			<bounds x="1184" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_33" element="debug_button_label_33">
+			<bounds x="1204" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x04">
+			<bounds x="1268" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_34" element="debug_button_label_34">
+			<bounds x="1288" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x08">
+			<bounds x="1352" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_35" element="debug_button_label_35">
+			<bounds x="1372" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x10">
+			<bounds x="1436" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_36" element="debug_button_label_36">
+			<bounds x="1456" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x20">
+			<bounds x="1520" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_37" element="debug_button_label_37">
+			<bounds x="1540" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x40">
+			<bounds x="1604" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_38" element="debug_button_label_38">
+			<bounds x="1624" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x80">
+			<bounds x="1688" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_39" element="debug_button_label_39">
+			<bounds x="1708" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x01">
+			<bounds x="1100" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_40" element="debug_button_label_40">
+			<bounds x="1120" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x02">
+			<bounds x="1184" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_41" element="debug_button_label_41">
+			<bounds x="1204" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x04">
+			<bounds x="1268" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_42" element="debug_button_label_42">
+			<bounds x="1288" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x08">
+			<bounds x="1352" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_43" element="debug_button_label_43">
+			<bounds x="1372" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x10">
+			<bounds x="1436" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_44" element="debug_button_label_44">
+			<bounds x="1456" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x20">
+			<bounds x="1520" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_45" element="debug_button_label_45">
+			<bounds x="1540" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x40">
+			<bounds x="1604" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_46" element="debug_button_label_46">
+			<bounds x="1624" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x80">
+			<bounds x="1688" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_47" element="debug_button_label_47">
+			<bounds x="1708" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x01">
+			<bounds x="1100" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_48" element="debug_button_label_48">
+			<bounds x="1120" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x02">
+			<bounds x="1184" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_49" element="debug_button_label_49">
+			<bounds x="1204" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x04">
+			<bounds x="1268" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_50" element="debug_button_label_50">
+			<bounds x="1288" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x08">
+			<bounds x="1352" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_51" element="debug_button_label_51">
+			<bounds x="1372" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x10">
+			<bounds x="1436" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_52" element="debug_button_label_52">
+			<bounds x="1456" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x20">
+			<bounds x="1520" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_53" element="debug_button_label_53">
+			<bounds x="1540" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x40">
+			<bounds x="1604" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_54" element="debug_button_label_54">
+			<bounds x="1624" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x80">
+			<bounds x="1688" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_55" element="debug_button_label_55">
+			<bounds x="1708" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x01">
+			<bounds x="1100" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_56" element="debug_button_label_56">
+			<bounds x="1120" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x02">
+			<bounds x="1184" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_57" element="debug_button_label_57">
+			<bounds x="1204" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x04">
+			<bounds x="1268" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_58" element="debug_button_label_58">
+			<bounds x="1288" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x08">
+			<bounds x="1352" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_59" element="debug_button_label_59">
+			<bounds x="1372" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x10">
+			<bounds x="1436" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_60" element="debug_button_label_60">
+			<bounds x="1456" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x20">
+			<bounds x="1520" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_61" element="debug_button_label_61">
+			<bounds x="1540" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x40">
+			<bounds x="1604" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_62" element="debug_button_label_62">
+			<bounds x="1624" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp14" element="debug_button_standard" state="0" inputtag="AUX2" inputmask="0x80">
+			<bounds x="1688" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_63" element="debug_button_label_63">
+			<bounds x="1708" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="vfd15" element="debug_vfd" state="0">
+			<bounds x="1150" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd14" element="debug_vfd" state="0">
+			<bounds x="1182" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd13" element="debug_vfd" state="0">
+			<bounds x="1214" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd12" element="debug_vfd" state="0">
+			<bounds x="1246" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd11" element="debug_vfd" state="0">
+			<bounds x="1278" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd10" element="debug_vfd" state="0">
+			<bounds x="1310" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd9" element="debug_vfd" state="0">
+			<bounds x="1342" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd8" element="debug_vfd" state="0">
+			<bounds x="1374" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd7" element="debug_vfd" state="0">
+			<bounds x="1406" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd6" element="debug_vfd" state="0">
+			<bounds x="1438" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd5" element="debug_vfd" state="0">
+			<bounds x="1470" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd4" element="debug_vfd" state="0">
+			<bounds x="1502" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd3" element="debug_vfd" state="0">
+			<bounds x="1534" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd2" element="debug_vfd" state="0">
+			<bounds x="1566" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd1" element="debug_vfd" state="0">
+			<bounds x="1598" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd0" element="debug_vfd" state="0">
+			<bounds x="1630" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel1" element="reel0" state="0">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel2" element="reel1" state="0">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel3" element="reel2" state="0">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1520" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_0" state="0">
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_1" state="0">
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_2" state="0">
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_3" state="0">
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_4" state="0">
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_5" state="0">
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel4" element="reel3" state="0">
+			<bounds x="1520" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="reel1" element="debug_stepper_value">
+			<bounds x="1100" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel2" element="debug_stepper_value">
+			<bounds x="1240" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel3" element="debug_stepper_value">
+			<bounds x="1380" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel4" element="debug_stepper_value">
+			<bounds x="1520" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
+			<bounds x="1180" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
+			<bounds x="1320" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
+			<bounds x="1460" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m4actclb.lay
+++ b/src/mame/layout/m4actclb.lay
@@ -8,4025 +8,7310 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MINI POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MINOR POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MAjor pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Take Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Or Leave">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="For Later.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Skillstop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60%">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40%">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20%">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80%">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_7_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_7_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_5_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_5_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_6_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_6_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_4_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_4_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Link">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Criss Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Coin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string=" START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="ACTION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_170_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_170">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SAVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_171_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_171">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="GEORGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Orange(1),Plum,Pear,SingleBar,Bell,DoubleBar,Melon,TripleBar,Grape,Cherry,Lemon,Apple(2),Orange(R),Plum,Lemon(1),CashPot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Apple,Melon,SingleBar,Bell,TripleBar,Grape,DoubleBar,Plum,Lemon,Pear,Orange(1),Lemon(3),Cherry,Orange(?),CashPot,Lemon(2)">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Lemon,Apple,Orange(1),Plum,DoubleBar,Bell,SingleBar,Grape,TripleBar,Melon,Cherry,Orange(2),CashPot,Lemon,Orange(3),Pear">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Orange,CashPot,Pear,SingleBar,Bell,DoubleBar,Melon,TripleBar,Grape,Cherry,Lemon(1),Apple,Orange(R),Plum(1),Lemon,Grape(2)">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_8">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_17">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_41">
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_42">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_43">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_44">
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_45">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_46">
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_47">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_48">
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_49">
 		<text string="pays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Note">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Climb">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="label_50">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_51">
 		<text string="&#xA3;3.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_52">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_57">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_58">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_59">
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_60">
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_61">
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_62">
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_63">
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_92">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_93">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_120">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_121">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="PAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_backdrop_colour">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_standard">
+		<rect state="0">
+			<color red="0.00" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_reel">
+		<rect state="0">
+			<color red="0.00" green="0.00" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="0.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_segment">
+		<rect state="0">
+			<color red="0.20" green="0.00" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="0.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_button">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_64">
+		<text string="64">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_65">
+		<text string="65">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_66">
+		<text string="66">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_67">
+		<text string="67">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_68">
+		<text string="68">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_69">
+		<text string="69">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_70">
+		<text string="70">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_71">
+		<text string="71">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_72">
+		<text string="72">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_73">
+		<text string="73">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_74">
+		<text string="74">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_75">
+		<text string="75">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_76">
+		<text string="76">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_77">
+		<text string="77">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_78">
+		<text string="78">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_79">
+		<text string="79">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_80">
+		<text string="80">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_81">
+		<text string="81">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_82">
+		<text string="82">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_83">
+		<text string="83">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_84">
+		<text string="84">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_85">
+		<text string="85">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_86">
+		<text string="86">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_87">
+		<text string="87">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_88">
+		<text string="88">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_89">
+		<text string="89">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_90">
+		<text string="90">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_91">
+		<text string="91">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_92">
+		<text string="92">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_93">
+		<text string="93">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_94">
+		<text string="94">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_95">
+		<text string="95">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_96">
+		<text string="96">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_97">
+		<text string="97">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_98">
+		<text string="98">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_99">
+		<text string="99">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_100">
+		<text string="100">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_101">
+		<text string="101">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_102">
+		<text string="102">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_103">
+		<text string="103">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_104">
+		<text string="104">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_105">
+		<text string="105">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_106">
+		<text string="106">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_107">
+		<text string="107">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_108">
+		<text string="108">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_109">
+		<text string="109">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_110">
+		<text string="110">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_111">
+		<text string="111">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_112">
+		<text string="112">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_113">
+		<text string="113">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_114">
+		<text string="114">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_115">
+		<text string="115">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_116">
+		<text string="116">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_117">
+		<text string="117">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_118">
+		<text string="118">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_119">
+		<text string="119">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_120">
+		<text string="120">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_121">
+		<text string="121">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_122">
+		<text string="122">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_123">
+		<text string="123">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_124">
+		<text string="124">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_125">
+		<text string="125">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_126">
+		<text string="126">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_127">
+		<text string="127">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_128">
+		<text string="128">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_129">
+		<text string="129">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_130">
+		<text string="130">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_131">
+		<text string="131">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_132">
+		<text string="132">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_133">
+		<text string="133">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_134">
+		<text string="134">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_135">
+		<text string="135">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_136">
+		<text string="136">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_137">
+		<text string="137">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_138">
+		<text string="138">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_139">
+		<text string="139">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_140">
+		<text string="140">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_141">
+		<text string="141">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_142">
+		<text string="142">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_143">
+		<text string="143">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_144">
+		<text string="144">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_145">
+		<text string="145">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_146">
+		<text string="146">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_147">
+		<text string="147">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_148">
+		<text string="148">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_149">
+		<text string="149">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_150">
+		<text string="150">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_151">
+		<text string="151">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_152">
+		<text string="152">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_153">
+		<text string="153">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_154">
+		<text string="154">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_155">
+		<text string="155">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_156">
+		<text string="156">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_157">
+		<text string="157">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_158">
+		<text string="158">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_159">
+		<text string="159">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_160">
+		<text string="160">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_161">
+		<text string="161">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_162">
+		<text string="162">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_163">
+		<text string="163">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_164">
+		<text string="164">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_165">
+		<text string="165">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_166">
+		<text string="166">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_167">
+		<text string="167">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_168">
+		<text string="168">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_169">
+		<text string="169">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_170">
+		<text string="170">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_171">
+		<text string="171">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_172">
+		<text string="172">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_173">
+		<text string="173">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_174">
+		<text string="174">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_175">
+		<text string="175">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_176">
+		<text string="176">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_177">
+		<text string="177">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_178">
+		<text string="178">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_179">
+		<text string="179">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_180">
+		<text string="180">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_181">
+		<text string="181">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_182">
+		<text string="182">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_183">
+		<text string="183">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_184">
+		<text string="184">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_185">
+		<text string="185">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_186">
+		<text string="186">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_187">
+		<text string="187">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_188">
+		<text string="188">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_189">
+		<text string="189">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_190">
+		<text string="190">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_191">
+		<text string="191">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_192">
+		<text string="192">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_193">
+		<text string="193">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_194">
+		<text string="194">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_195">
+		<text string="195">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_196">
+		<text string="196">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_197">
+		<text string="197">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_198">
+		<text string="198">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_199">
+		<text string="199">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_200">
+		<text string="200">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_201">
+		<text string="201">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_202">
+		<text string="202">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_203">
+		<text string="203">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_204">
+		<text string="204">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_205">
+		<text string="205">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_206">
+		<text string="206">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_207">
+		<text string="207">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_208">
+		<text string="208">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_209">
+		<text string="209">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_210">
+		<text string="210">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_211">
+		<text string="211">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_212">
+		<text string="212">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_213">
+		<text string="213">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_214">
+		<text string="214">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_215">
+		<text string="215">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_216">
+		<text string="216">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_217">
+		<text string="217">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_218">
+		<text string="218">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_219">
+		<text string="219">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_220">
+		<text string="220">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_221">
+		<text string="221">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_222">
+		<text string="222">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_223">
+		<text string="223">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_224">
+		<text string="224">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_225">
+		<text string="225">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_226">
+		<text string="226">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_227">
+		<text string="227">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_228">
+		<text string="228">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_229">
+		<text string="229">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_230">
+		<text string="230">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_231">
+		<text string="231">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_232">
+		<text string="232">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_233">
+		<text string="233">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_234">
+		<text string="234">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_235">
+		<text string="235">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_236">
+		<text string="236">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_237">
+		<text string="237">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_238">
+		<text string="238">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_239">
+		<text string="239">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_240">
+		<text string="240">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_241">
+		<text string="241">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_242">
+		<text string="242">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_243">
+		<text string="243">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_244">
+		<text string="244">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_245">
+		<text string="245">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_246">
+		<text string="246">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_247">
+		<text string="247">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_248">
+		<text string="248">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_249">
+		<text string="249">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_250">
+		<text string="250">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_251">
+		<text string="251">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_252">
+		<text string="252">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_253">
+		<text string="253">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_254">
+		<text string="254">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_255">
+		<text string="255">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_standard">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_vfd">
+		<led16segsc>
+			<color red="0.0" green="1.0" blue="1.0"/>
+		</led16segsc>
+	</element>
+	<element name="debug_stepper_value" defstate="0">
+		<simplecounter maxstate="999" digits="3">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</simplecounter>
+	</element>
+	<element name="debug_reel_symbol_count_0">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_1">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_2">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_3">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="646">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="646"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="241" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="241" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="241.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="244.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
-			<bounds x="247.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="247.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
-			<bounds x="251.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="251.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
-			<bounds x="254.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="254.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
-			<bounds x="257.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="257.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="241.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="244.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
-			<bounds x="247.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="247.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
-			<bounds x="251.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="251.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
-			<bounds x="254.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="254.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
-			<bounds x="257.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="257.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="241.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="244.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="247.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="247.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="251.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="251.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="254.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="254.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="257.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="257.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="241" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="241" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="323" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="323" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_0" state="0">
-			<bounds x="323.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="323.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_1" state="0">
-			<bounds x="326.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="326.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_2" state="0">
-			<bounds x="329.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="329.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_3" state="0">
-			<bounds x="333.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="333.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_4" state="0">
-			<bounds x="336.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="336.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_5" state="0">
-			<bounds x="339.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="339.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_0" state="0">
-			<bounds x="323.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="323.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_1" state="0">
-			<bounds x="326.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="326.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_2" state="0">
-			<bounds x="329.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="329.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_3" state="0">
-			<bounds x="333.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="333.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_4" state="0">
-			<bounds x="336.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="336.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_5" state="0">
-			<bounds x="339.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="339.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="323.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="323.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="326.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="326.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="329.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="329.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="333.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="333.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="336.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="336.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="339.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="339.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="323" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="323" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="405" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="405" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_0" state="0">
-			<bounds x="405.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="405.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_1" state="0">
-			<bounds x="408.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="408.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_2" state="0">
-			<bounds x="411.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="411.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_3" state="0">
-			<bounds x="415.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="415.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_4" state="0">
-			<bounds x="418.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="418.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_5" state="0">
-			<bounds x="421.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="421.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="405.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="405.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="408.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="408.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="411.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="411.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="415.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="415.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="418.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="418.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="421.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="421.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="405.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="405.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="408.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="408.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="411.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="411.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="415.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="415.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="418.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="418.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="421.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="421.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="405" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="405" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="487" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="487" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_0" state="0">
-			<bounds x="487.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="487.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_1" state="0">
-			<bounds x="490.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="490.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_2" state="0">
-			<bounds x="493.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="493.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_3" state="0">
-			<bounds x="497.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="497.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_4" state="0">
-			<bounds x="500.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="500.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp3" element="reel_lamp_layer_5" state="0">
-			<bounds x="503.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="503.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="487.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="487.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="490.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="490.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="493.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="493.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="497.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="497.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="500.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="500.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="503.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="503.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
-			<bounds x="487.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="487.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
-			<bounds x="490.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="490.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
-			<bounds x="493.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="493.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
-			<bounds x="497.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="497.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
-			<bounds x="500.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="500.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
-			<bounds x="503.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="503.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="487" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="487" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="218" y="188" width="122" height="24">
-			</bounds>
+			<bounds x="218" y="188" width="122" height="24"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="220" y="190" width="118" height="20">
-			</bounds>
+			<bounds x="220" y="190" width="118" height="20"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="219" y="98" width="122" height="24">
-			</bounds>
+			<bounds x="219" y="98" width="122" height="24"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="221" y="100" width="118" height="20">
-			</bounds>
+			<bounds x="221" y="100" width="118" height="20"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="219" y="3" width="122" height="24">
-			</bounds>
+			<bounds x="219" y="3" width="122" height="24"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="221" y="5" width="118" height="20">
-			</bounds>
+			<bounds x="221" y="5" width="118" height="20"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="355" y="4" width="68" height="46">
-			</bounds>
+			<bounds x="355" y="4" width="68" height="46"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="357" y="6" width="64" height="42">
-			</bounds>
+			<bounds x="357" y="6" width="64" height="42"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="239" y="248" width="50" height="19">
-			</bounds>
+			<bounds x="239" y="248" width="50" height="19"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="241" y="250" width="46" height="15">
-			</bounds>
+			<bounds x="241" y="250" width="46" height="15"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="210" y="162" width="50" height="19">
-			</bounds>
+			<bounds x="210" y="162" width="50" height="19"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="212" y="164" width="46" height="15">
-			</bounds>
+			<bounds x="212" y="164" width="46" height="15"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="179" y="72" width="50" height="19">
-			</bounds>
+			<bounds x="179" y="72" width="50" height="19"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="181" y="74" width="46" height="15">
-			</bounds>
+			<bounds x="181" y="74" width="46" height="15"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="287" y="352" width="62" height="20">
-			</bounds>
+			<bounds x="287" y="352" width="62" height="20"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="289" y="354" width="58" height="16">
-			</bounds>
+			<bounds x="289" y="354" width="58" height="16"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="532" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="532" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="534" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="534" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="500" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="500" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="502" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="502" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="468" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="468" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="470" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="470" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="436" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="436" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="438" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="438" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="404" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="404" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="406" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="406" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="372" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="372" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="374" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="374" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="340" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="340" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="342" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="342" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="308" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="308" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="310" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="310" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="276" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="276" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="278" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="278" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="244" y="372" width="32" height="37">
-			</bounds>
+			<bounds x="244" y="372" width="32" height="37"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="246" y="374" width="28" height="33">
-			</bounds>
+			<bounds x="246" y="374" width="28" height="33"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="244" y="340" width="42" height="32">
-			</bounds>
+			<bounds x="244" y="340" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="246" y="342" width="38" height="28">
-			</bounds>
+			<bounds x="246" y="342" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="613" y="365" width="32" height="32">
-			</bounds>
+			<bounds x="613" y="365" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="615" y="367" width="28" height="28">
-			</bounds>
+			<bounds x="615" y="367" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="741" y="365" width="32" height="32">
-			</bounds>
+			<bounds x="741" y="365" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="743" y="367" width="28" height="28">
-			</bounds>
+			<bounds x="743" y="367" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="709" y="365" width="32" height="32">
-			</bounds>
+			<bounds x="709" y="365" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="711" y="367" width="28" height="28">
-			</bounds>
+			<bounds x="711" y="367" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="677" y="365" width="32" height="32">
-			</bounds>
+			<bounds x="677" y="365" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="679" y="367" width="28" height="28">
-			</bounds>
+			<bounds x="679" y="367" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="645" y="365" width="32" height="32">
-			</bounds>
+			<bounds x="645" y="365" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="647" y="367" width="28" height="28">
-			</bounds>
+			<bounds x="647" y="367" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="613" y="429" width="32" height="32">
-			</bounds>
+			<bounds x="613" y="429" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="615" y="431" width="28" height="28">
-			</bounds>
+			<bounds x="615" y="431" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="645" y="429" width="32" height="32">
-			</bounds>
+			<bounds x="645" y="429" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="647" y="431" width="28" height="28">
-			</bounds>
+			<bounds x="647" y="431" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="677" y="429" width="32" height="32">
-			</bounds>
+			<bounds x="677" y="429" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="679" y="431" width="28" height="28">
-			</bounds>
+			<bounds x="679" y="431" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="709" y="429" width="32" height="32">
-			</bounds>
+			<bounds x="709" y="429" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="711" y="431" width="28" height="28">
-			</bounds>
+			<bounds x="711" y="431" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="741" y="429" width="32" height="32">
-			</bounds>
+			<bounds x="741" y="429" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="743" y="431" width="28" height="28">
-			</bounds>
+			<bounds x="743" y="431" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="741" y="461" width="32" height="32">
-			</bounds>
+			<bounds x="741" y="461" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="743" y="463" width="28" height="28">
-			</bounds>
+			<bounds x="743" y="463" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="709" y="461" width="32" height="32">
-			</bounds>
+			<bounds x="709" y="461" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="711" y="463" width="28" height="28">
-			</bounds>
+			<bounds x="711" y="463" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="677" y="461" width="32" height="32">
-			</bounds>
+			<bounds x="677" y="461" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="679" y="463" width="28" height="28">
-			</bounds>
+			<bounds x="679" y="463" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="645" y="461" width="32" height="32">
-			</bounds>
+			<bounds x="645" y="461" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="647" y="463" width="28" height="28">
-			</bounds>
+			<bounds x="647" y="463" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="613" y="461" width="32" height="32">
-			</bounds>
+			<bounds x="613" y="461" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="615" y="463" width="28" height="28">
-			</bounds>
+			<bounds x="615" y="463" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="613" y="493" width="32" height="32">
-			</bounds>
+			<bounds x="613" y="493" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="615" y="495" width="28" height="28">
-			</bounds>
+			<bounds x="615" y="495" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="741" y="397" width="32" height="32">
-			</bounds>
+			<bounds x="741" y="397" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="743" y="399" width="28" height="28">
-			</bounds>
+			<bounds x="743" y="399" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="709" y="397" width="32" height="32">
-			</bounds>
+			<bounds x="709" y="397" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="711" y="399" width="28" height="28">
-			</bounds>
+			<bounds x="711" y="399" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="677" y="397" width="32" height="32">
-			</bounds>
+			<bounds x="677" y="397" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="679" y="399" width="28" height="28">
-			</bounds>
+			<bounds x="679" y="399" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="645" y="397" width="32" height="32">
-			</bounds>
+			<bounds x="645" y="397" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="647" y="399" width="28" height="28">
-			</bounds>
+			<bounds x="647" y="399" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="613" y="397" width="32" height="32">
-			</bounds>
+			<bounds x="613" y="397" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="615" y="399" width="28" height="28">
-			</bounds>
+			<bounds x="615" y="399" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="709" y="493" width="32" height="32">
-			</bounds>
+			<bounds x="709" y="493" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="711" y="495" width="28" height="28">
-			</bounds>
+			<bounds x="711" y="495" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="677" y="493" width="32" height="32">
-			</bounds>
+			<bounds x="677" y="493" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="679" y="495" width="28" height="28">
-			</bounds>
+			<bounds x="679" y="495" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="645" y="493" width="32" height="32">
-			</bounds>
+			<bounds x="645" y="493" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="647" y="495" width="28" height="28">
-			</bounds>
+			<bounds x="647" y="495" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="741" y="493" width="32" height="32">
-			</bounds>
+			<bounds x="741" y="493" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="743" y="495" width="28" height="28">
-			</bounds>
+			<bounds x="743" y="495" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="357" y="176" width="60" height="28">
-			</bounds>
+			<bounds x="357" y="176" width="60" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="359" y="178" width="56" height="24">
-			</bounds>
+			<bounds x="359" y="178" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="357" y="204" width="60" height="28">
-			</bounds>
+			<bounds x="357" y="204" width="60" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="359" y="206" width="56" height="24">
-			</bounds>
+			<bounds x="359" y="206" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="357" y="232" width="60" height="28">
-			</bounds>
+			<bounds x="357" y="232" width="60" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="359" y="234" width="56" height="24">
-			</bounds>
+			<bounds x="359" y="234" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="357" y="148" width="60" height="28">
-			</bounds>
+			<bounds x="357" y="148" width="60" height="28"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="359" y="150" width="56" height="24">
-			</bounds>
+			<bounds x="359" y="150" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="357" y="120" width="60" height="28">
-			</bounds>
+			<bounds x="357" y="120" width="60" height="28"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="359" y="122" width="56" height="24">
-			</bounds>
+			<bounds x="359" y="122" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="432" y="92" width="32" height="32">
-			</bounds>
+			<bounds x="432" y="92" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="434" y="94" width="28" height="28">
-			</bounds>
+			<bounds x="434" y="94" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp7" element="lamp_7_1_border" state="0">
-			<bounds x="432" y="124" width="32" height="32">
-			</bounds>
+			<bounds x="432" y="124" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="lamp_7_1" state="0">
-			<bounds x="434" y="126" width="28" height="28">
-			</bounds>
+			<bounds x="434" y="126" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1_border" state="0">
-			<bounds x="432" y="156" width="32" height="32">
-			</bounds>
+			<bounds x="432" y="156" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1" state="0">
-			<bounds x="434" y="158" width="28" height="28">
-			</bounds>
+			<bounds x="434" y="158" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp5" element="lamp_5_1_border" state="0">
-			<bounds x="432" y="188" width="32" height="32">
-			</bounds>
+			<bounds x="432" y="188" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp5" element="lamp_5_1" state="0">
-			<bounds x="434" y="190" width="28" height="28">
-			</bounds>
+			<bounds x="434" y="190" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="432" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="432" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="434" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="434" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="460" y="76" width="32" height="32">
-			</bounds>
+			<bounds x="460" y="76" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="462" y="78" width="28" height="28">
-			</bounds>
+			<bounds x="462" y="78" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0">
-			<bounds x="460" y="108" width="32" height="32">
-			</bounds>
+			<bounds x="460" y="108" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0">
-			<bounds x="462" y="110" width="28" height="28">
-			</bounds>
+			<bounds x="462" y="110" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1_border" state="0">
-			<bounds x="460" y="140" width="32" height="32">
-			</bounds>
+			<bounds x="460" y="140" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1" state="0">
-			<bounds x="462" y="142" width="28" height="28">
-			</bounds>
+			<bounds x="462" y="142" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="460" y="172" width="32" height="32">
-			</bounds>
+			<bounds x="460" y="172" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="462" y="174" width="28" height="28">
-			</bounds>
+			<bounds x="462" y="174" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1_border" state="0">
-			<bounds x="460" y="204" width="32" height="32">
-			</bounds>
+			<bounds x="460" y="204" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1" state="0">
-			<bounds x="462" y="206" width="28" height="28">
-			</bounds>
+			<bounds x="462" y="206" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="434" y="41" width="56" height="30">
-			</bounds>
+			<bounds x="434" y="41" width="56" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="436" y="43" width="52" height="26">
-			</bounds>
+			<bounds x="436" y="43" width="52" height="26"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="624" y="286" width="42" height="28">
-			</bounds>
+			<bounds x="624" y="286" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="626" y="288" width="38" height="24">
-			</bounds>
+			<bounds x="626" y="288" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="666" y="286" width="52" height="28">
-			</bounds>
+			<bounds x="666" y="286" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="668" y="288" width="48" height="24">
-			</bounds>
+			<bounds x="668" y="288" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="718" y="286" width="42" height="28">
-			</bounds>
+			<bounds x="718" y="286" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="720" y="288" width="38" height="24">
-			</bounds>
+			<bounds x="720" y="288" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="655" y="214" width="72" height="33">
-			</bounds>
+			<bounds x="655" y="214" width="72" height="33"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="657" y="216" width="68" height="29">
-			</bounds>
+			<bounds x="657" y="216" width="68" height="29"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="655" y="181" width="72" height="33">
-			</bounds>
+			<bounds x="655" y="181" width="72" height="33"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="657" y="183" width="68" height="29">
-			</bounds>
+			<bounds x="657" y="183" width="68" height="29"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="655" y="148" width="72" height="33">
-			</bounds>
+			<bounds x="655" y="148" width="72" height="33"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="657" y="150" width="68" height="29">
-			</bounds>
+			<bounds x="657" y="150" width="68" height="29"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="655" y="115" width="72" height="33">
-			</bounds>
+			<bounds x="655" y="115" width="72" height="33"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="657" y="117" width="68" height="29">
-			</bounds>
+			<bounds x="657" y="117" width="68" height="29"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="655" y="82" width="72" height="33">
-			</bounds>
+			<bounds x="655" y="82" width="72" height="33"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="657" y="84" width="68" height="29">
-			</bounds>
+			<bounds x="657" y="84" width="68" height="29"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="655" y="247" width="72" height="33">
-			</bounds>
+			<bounds x="655" y="247" width="72" height="33"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="657" y="249" width="68" height="29">
-			</bounds>
+			<bounds x="657" y="249" width="68" height="29"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="655" y="49" width="72" height="33">
-			</bounds>
+			<bounds x="655" y="49" width="72" height="33"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="657" y="51" width="68" height="29">
-			</bounds>
+			<bounds x="657" y="51" width="68" height="29"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="526" y="75" width="96" height="36">
-			</bounds>
+			<bounds x="526" y="75" width="96" height="36"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="528" y="77" width="92" height="32">
-			</bounds>
+			<bounds x="528" y="77" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="526" y="111" width="96" height="36">
-			</bounds>
+			<bounds x="526" y="111" width="96" height="36"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="528" y="113" width="92" height="32">
-			</bounds>
+			<bounds x="528" y="113" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="526" y="147" width="96" height="36">
-			</bounds>
+			<bounds x="526" y="147" width="96" height="36"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="528" y="149" width="92" height="32">
-			</bounds>
+			<bounds x="528" y="149" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="526" y="183" width="96" height="36">
-			</bounds>
+			<bounds x="526" y="183" width="96" height="36"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="528" y="185" width="92" height="32">
-			</bounds>
+			<bounds x="528" y="185" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="colour_button_160_border" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="745" y="609" width="42" height="27">
-			</bounds>
+			<bounds x="745" y="609" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp56" element="colour_button_160" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="747" y="611" width="38" height="23">
-			</bounds>
+			<bounds x="747" y="611" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_161_border" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="658" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="658" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_161" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="660" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="660" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp24" element="colour_button_162_border" state="0" inputtag="BLACK2" inputmask="0x01">
-			<bounds x="575" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="575" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp24" element="colour_button_162" state="0" inputtag="BLACK2" inputmask="0x01">
-			<bounds x="577" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="577" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp50" element="colour_button_163_border" state="0" inputtag="BLACK1" inputmask="0x08">
-			<bounds x="154" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="154" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp50" element="colour_button_163" state="0" inputtag="BLACK1" inputmask="0x08">
-			<bounds x="156" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="156" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp48" element="colour_button_164_border" state="0" inputtag="BLACK1" inputmask="0x02">
-			<bounds x="349" y="51" width="78" height="38">
-			</bounds>
+			<bounds x="349" y="51" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp48" element="colour_button_164" state="0" inputtag="BLACK1" inputmask="0x02">
-			<bounds x="351" y="53" width="74" height="34">
-			</bounds>
+			<bounds x="351" y="53" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_165_border" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="486" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="486" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_165" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="488" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="488" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_166_border" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="404" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="404" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_166" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="406" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="406" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_167_border" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="322" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="322" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_167" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="324" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="324" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp25" element="colour_button_168_border" state="0" inputtag="BLACK2" inputmask="0x02">
-			<bounds x="240" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="240" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp25" element="colour_button_168" state="0" inputtag="BLACK2" inputmask="0x02">
-			<bounds x="242" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="242" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_169_border" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="578" y="555" width="72" height="38">
-			</bounds>
+			<bounds x="578" y="555" width="72" height="38"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_169" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="580" y="557" width="68" height="34">
-			</bounds>
+			<bounds x="580" y="557" width="68" height="34"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_170_border" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="650" y="555" width="58" height="38">
-			</bounds>
+			<bounds x="650" y="555" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_170" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="652" y="557" width="54" height="34">
-			</bounds>
+			<bounds x="652" y="557" width="54" height="34"/>
 		</backdrop>
 		<backdrop name="lamp49" element="colour_button_171_border" state="0" inputtag="BLACK1" inputmask="0x04">
-			<bounds x="708" y="555" width="72" height="38">
-			</bounds>
+			<bounds x="708" y="555" width="72" height="38"/>
 		</backdrop>
 		<backdrop name="lamp49" element="colour_button_171" state="0" inputtag="BLACK1" inputmask="0x04">
-			<bounds x="710" y="557" width="68" height="34">
-			</bounds>
+			<bounds x="710" y="557" width="68" height="34"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="258" y="124" width="27" height="36">
-			</bounds>
+			<bounds x="258" y="124" width="27" height="36"/>
 		</backdrop>
 		<backdrop name="digit8" element="led_digit_red">
-			<bounds x="258" y="124" width="27" height="36">
-			</bounds>
+			<bounds x="258" y="124" width="27" height="36"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="258" y="124" width="27" height="36">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="258" y="124" width="27" height="36"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="285" y="124" width="27" height="36">
-			</bounds>
+			<bounds x="285" y="124" width="27" height="36"/>
 		</backdrop>
 		<backdrop name="digit9" element="led_digit_red">
-			<bounds x="285" y="124" width="27" height="36">
-			</bounds>
+			<bounds x="285" y="124" width="27" height="36"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="285" y="124" width="27" height="36">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="285" y="124" width="27" height="36"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="312" y="124" width="27" height="36">
-			</bounds>
+			<bounds x="312" y="124" width="27" height="36"/>
 		</backdrop>
 		<backdrop name="digit10" element="led_digit_red">
-			<bounds x="312" y="124" width="27" height="36">
-			</bounds>
+			<bounds x="312" y="124" width="27" height="36"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="312" y="124" width="27" height="36">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="312" y="124" width="27" height="36"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="220" y="29" width="30" height="40">
-			</bounds>
+			<bounds x="220" y="29" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit12" element="led_digit_red">
-			<bounds x="220" y="29" width="30" height="40">
-			</bounds>
+			<bounds x="220" y="29" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="220" y="29" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="220" y="29" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="250" y="29" width="30" height="40">
-			</bounds>
+			<bounds x="250" y="29" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit13" element="led_digit_red">
-			<bounds x="250" y="29" width="30" height="40">
-			</bounds>
+			<bounds x="250" y="29" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="250" y="29" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="250" y="29" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="280" y="29" width="30" height="40">
-			</bounds>
+			<bounds x="280" y="29" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit14" element="led_digit_red">
-			<bounds x="280" y="29" width="30" height="40">
-			</bounds>
+			<bounds x="280" y="29" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="280" y="29" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="280" y="29" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="310" y="29" width="30" height="40">
-			</bounds>
+			<bounds x="310" y="29" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit15" element="led_digit_red">
-			<bounds x="310" y="29" width="30" height="40">
-			</bounds>
+			<bounds x="310" y="29" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="310" y="29" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="310" y="29" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="315" y="214" width="24" height="32">
-			</bounds>
+			<bounds x="315" y="214" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit5" element="led_digit_green">
-			<bounds x="315" y="214" width="24" height="32">
-			</bounds>
+			<bounds x="315" y="214" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_green">
-			<bounds x="315" y="214" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="315" y="214" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="291" y="214" width="24" height="32">
-			</bounds>
+			<bounds x="291" y="214" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit4" element="led_digit_green">
-			<bounds x="291" y="214" width="24" height="32">
-			</bounds>
+			<bounds x="291" y="214" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_green">
-			<bounds x="291" y="214" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="291" y="214" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="474" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="474" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="474" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="474" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="474" y="318" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="474" y="318" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="504" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="504" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit1" element="led_digit_red">
-			<bounds x="504" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="504" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="504" y="318" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="504" y="318" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="534" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="534" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="534" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="534" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="534" y="318" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="534" y="318" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="564" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="564" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit3" element="led_digit_red">
-			<bounds x="564" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="564" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="564" y="318" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="564" y="318" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="385" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="385" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit7" element="led_digit_red">
-			<bounds x="385" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="385" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="385" y="318" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="385" y="318" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="355" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="355" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="355" y="318" width="30" height="40">
-			</bounds>
+			<bounds x="355" y="318" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="355" y="318" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="355" y="318" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop name="label8" element="label_8">
-			<bounds x="262" y="203" width="29" height="51">
-			</bounds>
+			<bounds x="262" y="203" width="29" height="51"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="227" y="112" width="32" height="55">
-			</bounds>
+			<bounds x="227" y="112" width="32" height="55"/>
 		</backdrop>
 		<backdrop name="label17" element="label_17">
-			<bounds x="183" y="13" width="38" height="67">
-			</bounds>
+			<bounds x="183" y="13" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label41" element="label_41">
-			<bounds x="109" y="173" width="22" height="22">
-			</bounds>
+			<bounds x="109" y="173" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label42" element="label_42">
-			<bounds x="108" y="116" width="33" height="22">
-			</bounds>
+			<bounds x="108" y="116" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label43" element="label_43">
-			<bounds x="109" y="143" width="33" height="22">
-			</bounds>
+			<bounds x="109" y="143" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label44" element="label_44">
-			<bounds x="109" y="89" width="33" height="22">
-			</bounds>
+			<bounds x="109" y="89" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label45" element="label_45">
-			<bounds x="109" y="71" width="33" height="22">
-			</bounds>
+			<bounds x="109" y="71" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label46" element="label_46">
-			<bounds x="109" y="35" width="44" height="22">
-			</bounds>
+			<bounds x="109" y="35" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="label47" element="label_47">
-			<bounds x="109" y="53" width="33" height="22">
-			</bounds>
+			<bounds x="109" y="53" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label48" element="label_48">
-			<bounds x="109" y="17" width="44" height="22">
-			</bounds>
+			<bounds x="109" y="17" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="label49" element="label_49">
-			<bounds x="148" y="93" width="32" height="42">
-			</bounds>
+			<bounds x="148" y="93" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="label50" element="label_50">
-			<bounds x="107" y="208" width="22" height="22">
-			</bounds>
+			<bounds x="107" y="208" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label51" element="label_51">
-			<bounds x="108" y="246" width="40" height="19">
-			</bounds>
+			<bounds x="108" y="246" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label52" element="label_52">
-			<bounds x="107" y="280" width="22" height="22">
-			</bounds>
+			<bounds x="107" y="280" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label57" element="label_57">
-			<bounds x="108" y="335" width="40" height="19">
-			</bounds>
+			<bounds x="108" y="335" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label58" element="label_58">
-			<bounds x="106" y="308" width="40" height="19">
-			</bounds>
+			<bounds x="106" y="308" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label59" element="label_59">
-			<bounds x="96" y="373" width="40" height="19">
-			</bounds>
+			<bounds x="96" y="373" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label60" element="label_60">
-			<bounds x="96" y="406" width="28" height="19">
-			</bounds>
+			<bounds x="96" y="406" width="28" height="19"/>
 		</backdrop>
 		<backdrop name="label61" element="label_61">
-			<bounds x="96" y="435" width="40" height="19">
-			</bounds>
+			<bounds x="96" y="435" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label62" element="label_62">
-			<bounds x="94" y="453" width="28" height="19">
-			</bounds>
+			<bounds x="94" y="453" width="28" height="19"/>
 		</backdrop>
 		<backdrop name="label63" element="label_63">
-			<bounds x="92" y="471" width="28" height="19">
-			</bounds>
+			<bounds x="92" y="471" width="28" height="19"/>
 		</backdrop>
 		<backdrop name="label92" element="label_92">
-			<bounds x="569" y="496" width="25" height="26">
-			</bounds>
+			<bounds x="569" y="496" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label93" element="label_93">
-			<bounds x="214" y="496" width="25" height="26">
-			</bounds>
+			<bounds x="214" y="496" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="436" y="302" width="38" height="67">
-			</bounds>
+			<bounds x="436" y="302" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label120" element="label_120">
-			<bounds x="473" y="278" width="108" height="44">
-			</bounds>
+			<bounds x="473" y="278" width="108" height="44"/>
 		</backdrop>
 		<backdrop name="label121" element="label_121">
-			<bounds x="353" y="296" width="62" height="22">
-			</bounds>
+			<bounds x="353" y="296" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="360" y="95" width="44" height="29">
-			</bounds>
+			<bounds x="360" y="95" width="44" height="29"/>
+		</backdrop>
+	</view>
+
+	<view name="MFME2MAME Debug">
+		<backdrop element="debug_backdrop_colour">
+			<bounds x="0" y="0" width="1920" height="1080"/>
+		</backdrop>
+		<backdrop name="lamp0" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
+			<bounds x="47" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp1" element="debug_lamp_reel" state="0">
+			<bounds x="96" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
+			<bounds x="111" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp2" element="debug_lamp_reel" state="0">
+			<bounds x="160" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
+			<bounds x="175" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp3" element="debug_lamp_reel" state="0">
+			<bounds x="224" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
+			<bounds x="239" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp4" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
+			<bounds x="303" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp5" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
+			<bounds x="367" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp6" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
+			<bounds x="431" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp7" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
+			<bounds x="495" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp8" element="debug_lamp_reel" state="0">
+			<bounds x="544" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
+			<bounds x="559" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp9" element="debug_lamp_reel" state="0">
+			<bounds x="608" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
+			<bounds x="623" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
+			<bounds x="672" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
+			<bounds x="687" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
+			<bounds x="736" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
+			<bounds x="751" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
+			<bounds x="815" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
+			<bounds x="879" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp14" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
+			<bounds x="943" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp15" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
+			<bounds x="1007" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
+			<bounds x="47" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
+			<bounds x="96" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
+			<bounds x="111" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
+			<bounds x="160" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
+			<bounds x="175" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
+			<bounds x="224" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
+			<bounds x="239" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
+			<bounds x="303" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
+			<bounds x="367" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
+			<bounds x="431" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
+			<bounds x="495" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp24" element="debug_lamp_button" state="0">
+			<bounds x="544" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
+			<bounds x="559" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_lamp_button" state="0">
+			<bounds x="608" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
+			<bounds x="623" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_lamp_button" state="0">
+			<bounds x="672" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
+			<bounds x="687" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
+			<bounds x="751" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
+			<bounds x="815" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
+			<bounds x="879" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
+			<bounds x="943" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp31" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
+			<bounds x="1007" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_lamp_button" state="0">
+			<bounds x="32" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
+			<bounds x="47" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_lamp_button" state="0">
+			<bounds x="96" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
+			<bounds x="111" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_lamp_button" state="0">
+			<bounds x="160" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
+			<bounds x="175" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
+			<bounds x="239" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
+			<bounds x="303" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
+			<bounds x="367" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
+			<bounds x="431" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
+			<bounds x="495" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_lamp_button" state="0">
+			<bounds x="544" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
+			<bounds x="559" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_lamp_button" state="0">
+			<bounds x="608" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
+			<bounds x="623" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
+			<bounds x="687" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
+			<bounds x="751" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
+			<bounds x="815" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
+			<bounds x="879" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
+			<bounds x="943" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
+			<bounds x="1007" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp48" element="debug_lamp_button" state="0">
+			<bounds x="32" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
+			<bounds x="47" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp49" element="debug_lamp_button" state="0">
+			<bounds x="96" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
+			<bounds x="111" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp50" element="debug_lamp_button" state="0">
+			<bounds x="160" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
+			<bounds x="175" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
+			<bounds x="239" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
+			<bounds x="303" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
+			<bounds x="367" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
+			<bounds x="431" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
+			<bounds x="495" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp56" element="debug_lamp_button" state="0">
+			<bounds x="544" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
+			<bounds x="559" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
+			<bounds x="623" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
+			<bounds x="687" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
+			<bounds x="751" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
+			<bounds x="815" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
+			<bounds x="879" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
+			<bounds x="943" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
+			<bounds x="1007" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
+			<bounds x="47" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
+			<bounds x="111" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
+			<bounds x="175" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
+			<bounds x="239" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
+			<bounds x="303" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
+			<bounds x="367" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
+			<bounds x="431" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
+			<bounds x="495" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
+			<bounds x="559" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
+			<bounds x="623" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
+			<bounds x="687" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
+			<bounds x="751" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
+			<bounds x="815" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
+			<bounds x="879" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
+			<bounds x="943" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
+			<bounds x="1007" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
+			<bounds x="47" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
+			<bounds x="111" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
+			<bounds x="175" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
+			<bounds x="239" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
+			<bounds x="303" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
+			<bounds x="367" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
+			<bounds x="431" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
+			<bounds x="495" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
+			<bounds x="559" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
+			<bounds x="623" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
+			<bounds x="687" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
+			<bounds x="751" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
+			<bounds x="815" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
+			<bounds x="879" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
+			<bounds x="943" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
+			<bounds x="1007" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
+			<bounds x="47" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
+			<bounds x="111" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
+			<bounds x="175" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
+			<bounds x="239" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
+			<bounds x="303" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
+			<bounds x="367" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
+			<bounds x="431" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
+			<bounds x="495" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
+			<bounds x="559" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
+			<bounds x="623" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
+			<bounds x="687" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
+			<bounds x="751" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
+			<bounds x="815" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
+			<bounds x="879" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
+			<bounds x="943" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
+			<bounds x="1007" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
+			<bounds x="47" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
+			<bounds x="111" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
+			<bounds x="175" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
+			<bounds x="239" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
+			<bounds x="303" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
+			<bounds x="367" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
+			<bounds x="431" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
+			<bounds x="495" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
+			<bounds x="559" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
+			<bounds x="623" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
+			<bounds x="687" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
+			<bounds x="751" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
+			<bounds x="815" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
+			<bounds x="879" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
+			<bounds x="943" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
+			<bounds x="1007" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
+			<bounds x="47" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
+			<bounds x="111" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
+			<bounds x="175" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
+			<bounds x="239" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
+			<bounds x="303" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
+			<bounds x="367" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
+			<bounds x="431" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
+			<bounds x="495" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
+			<bounds x="559" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
+			<bounds x="623" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
+			<bounds x="687" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
+			<bounds x="751" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
+			<bounds x="815" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
+			<bounds x="879" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
+			<bounds x="943" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
+			<bounds x="1007" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
+			<bounds x="47" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
+			<bounds x="111" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
+			<bounds x="175" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
+			<bounds x="239" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
+			<bounds x="303" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
+			<bounds x="367" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
+			<bounds x="431" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
+			<bounds x="495" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
+			<bounds x="559" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
+			<bounds x="623" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
+			<bounds x="687" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
+			<bounds x="751" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
+			<bounds x="815" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
+			<bounds x="879" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
+			<bounds x="943" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
+			<bounds x="1007" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
+			<bounds x="47" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
+			<bounds x="111" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
+			<bounds x="175" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
+			<bounds x="239" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
+			<bounds x="303" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
+			<bounds x="367" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
+			<bounds x="431" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
+			<bounds x="495" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
+			<bounds x="559" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
+			<bounds x="623" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
+			<bounds x="687" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
+			<bounds x="751" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
+			<bounds x="815" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
+			<bounds x="879" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
+			<bounds x="943" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
+			<bounds x="1007" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
+			<bounds x="47" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
+			<bounds x="111" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
+			<bounds x="175" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
+			<bounds x="239" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
+			<bounds x="303" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
+			<bounds x="367" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
+			<bounds x="431" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
+			<bounds x="495" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
+			<bounds x="559" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
+			<bounds x="623" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
+			<bounds x="687" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
+			<bounds x="751" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
+			<bounds x="815" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
+			<bounds x="879" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
+			<bounds x="943" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
+			<bounds x="1007" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
+			<bounds x="47" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
+			<bounds x="111" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
+			<bounds x="175" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
+			<bounds x="239" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
+			<bounds x="303" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
+			<bounds x="367" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
+			<bounds x="431" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
+			<bounds x="495" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
+			<bounds x="559" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
+			<bounds x="623" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
+			<bounds x="687" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
+			<bounds x="751" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
+			<bounds x="815" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
+			<bounds x="879" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
+			<bounds x="943" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
+			<bounds x="1007" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
+			<bounds x="47" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
+			<bounds x="111" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
+			<bounds x="175" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
+			<bounds x="239" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
+			<bounds x="303" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
+			<bounds x="367" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
+			<bounds x="431" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
+			<bounds x="495" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
+			<bounds x="559" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
+			<bounds x="623" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
+			<bounds x="687" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
+			<bounds x="751" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
+			<bounds x="815" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
+			<bounds x="879" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
+			<bounds x="943" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
+			<bounds x="1007" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
+			<bounds x="47" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
+			<bounds x="111" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
+			<bounds x="175" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
+			<bounds x="239" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
+			<bounds x="303" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
+			<bounds x="367" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
+			<bounds x="431" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
+			<bounds x="495" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
+			<bounds x="559" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
+			<bounds x="623" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
+			<bounds x="687" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
+			<bounds x="751" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
+			<bounds x="815" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
+			<bounds x="879" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
+			<bounds x="943" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
+			<bounds x="1007" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
+			<bounds x="47" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
+			<bounds x="111" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
+			<bounds x="175" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
+			<bounds x="239" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
+			<bounds x="303" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
+			<bounds x="367" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
+			<bounds x="431" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
+			<bounds x="495" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
+			<bounds x="559" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
+			<bounds x="623" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
+			<bounds x="687" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
+			<bounds x="751" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
+			<bounds x="815" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
+			<bounds x="879" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
+			<bounds x="943" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
+			<bounds x="1007" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x01">
+			<bounds x="1100" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_0" element="debug_button_label_0">
+			<bounds x="1120" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x02">
+			<bounds x="1184" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_1" element="debug_button_label_1">
+			<bounds x="1204" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x04">
+			<bounds x="1268" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_2" element="debug_button_label_2">
+			<bounds x="1288" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x08">
+			<bounds x="1352" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_3" element="debug_button_label_3">
+			<bounds x="1372" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x10">
+			<bounds x="1436" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_4" element="debug_button_label_4">
+			<bounds x="1456" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x20">
+			<bounds x="1520" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_5" element="debug_button_label_5">
+			<bounds x="1540" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x40">
+			<bounds x="1604" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_6" element="debug_button_label_6">
+			<bounds x="1624" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x80">
+			<bounds x="1688" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_7" element="debug_button_label_7">
+			<bounds x="1708" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x01">
+			<bounds x="1100" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_8" element="debug_button_label_8">
+			<bounds x="1120" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x02">
+			<bounds x="1184" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_9" element="debug_button_label_9">
+			<bounds x="1204" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x04">
+			<bounds x="1268" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_10" element="debug_button_label_10">
+			<bounds x="1288" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x08">
+			<bounds x="1352" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_11" element="debug_button_label_11">
+			<bounds x="1372" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x10">
+			<bounds x="1436" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_12" element="debug_button_label_12">
+			<bounds x="1456" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x20">
+			<bounds x="1520" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_13" element="debug_button_label_13">
+			<bounds x="1540" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x40">
+			<bounds x="1604" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_14" element="debug_button_label_14">
+			<bounds x="1624" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x80">
+			<bounds x="1688" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_15" element="debug_button_label_15">
+			<bounds x="1708" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x01">
+			<bounds x="1100" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_16" element="debug_button_label_16">
+			<bounds x="1120" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp48" element="debug_button_standard" state="0" inputtag="BLACK1" inputmask="0x02">
+			<bounds x="1184" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_17" element="debug_button_label_17">
+			<bounds x="1204" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp49" element="debug_button_standard" state="0" inputtag="BLACK1" inputmask="0x04">
+			<bounds x="1268" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_18" element="debug_button_label_18">
+			<bounds x="1288" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp50" element="debug_button_standard" state="0" inputtag="BLACK1" inputmask="0x08">
+			<bounds x="1352" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_19" element="debug_button_label_19">
+			<bounds x="1372" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x10">
+			<bounds x="1436" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_20" element="debug_button_label_20">
+			<bounds x="1456" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x20">
+			<bounds x="1520" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_21" element="debug_button_label_21">
+			<bounds x="1540" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x40">
+			<bounds x="1604" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_22" element="debug_button_label_22">
+			<bounds x="1624" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x80">
+			<bounds x="1688" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_23" element="debug_button_label_23">
+			<bounds x="1708" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp24" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x01">
+			<bounds x="1100" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_24" element="debug_button_label_24">
+			<bounds x="1120" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x02">
+			<bounds x="1184" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_25" element="debug_button_label_25">
+			<bounds x="1204" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x04">
+			<bounds x="1268" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_26" element="debug_button_label_26">
+			<bounds x="1288" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x08">
+			<bounds x="1352" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_27" element="debug_button_label_27">
+			<bounds x="1372" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x10">
+			<bounds x="1436" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_28" element="debug_button_label_28">
+			<bounds x="1456" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x20">
+			<bounds x="1520" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_29" element="debug_button_label_29">
+			<bounds x="1540" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x40">
+			<bounds x="1604" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_30" element="debug_button_label_30">
+			<bounds x="1624" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x80">
+			<bounds x="1688" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_31" element="debug_button_label_31">
+			<bounds x="1708" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x01">
+			<bounds x="1100" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_32" element="debug_button_label_32">
+			<bounds x="1120" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x02">
+			<bounds x="1184" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_33" element="debug_button_label_33">
+			<bounds x="1204" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x04">
+			<bounds x="1268" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_34" element="debug_button_label_34">
+			<bounds x="1288" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x08">
+			<bounds x="1352" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_35" element="debug_button_label_35">
+			<bounds x="1372" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x10">
+			<bounds x="1436" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_36" element="debug_button_label_36">
+			<bounds x="1456" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x20">
+			<bounds x="1520" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_37" element="debug_button_label_37">
+			<bounds x="1540" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x40">
+			<bounds x="1604" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_38" element="debug_button_label_38">
+			<bounds x="1624" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x80">
+			<bounds x="1688" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_39" element="debug_button_label_39">
+			<bounds x="1708" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x01">
+			<bounds x="1100" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_40" element="debug_button_label_40">
+			<bounds x="1120" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x02">
+			<bounds x="1184" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_41" element="debug_button_label_41">
+			<bounds x="1204" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x04">
+			<bounds x="1268" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_42" element="debug_button_label_42">
+			<bounds x="1288" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x08">
+			<bounds x="1352" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_43" element="debug_button_label_43">
+			<bounds x="1372" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x10">
+			<bounds x="1436" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_44" element="debug_button_label_44">
+			<bounds x="1456" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x20">
+			<bounds x="1520" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_45" element="debug_button_label_45">
+			<bounds x="1540" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x40">
+			<bounds x="1604" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_46" element="debug_button_label_46">
+			<bounds x="1624" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x80">
+			<bounds x="1688" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_47" element="debug_button_label_47">
+			<bounds x="1708" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x01">
+			<bounds x="1100" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_48" element="debug_button_label_48">
+			<bounds x="1120" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x02">
+			<bounds x="1184" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_49" element="debug_button_label_49">
+			<bounds x="1204" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x04">
+			<bounds x="1268" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_50" element="debug_button_label_50">
+			<bounds x="1288" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x08">
+			<bounds x="1352" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_51" element="debug_button_label_51">
+			<bounds x="1372" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x10">
+			<bounds x="1436" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_52" element="debug_button_label_52">
+			<bounds x="1456" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x20">
+			<bounds x="1520" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_53" element="debug_button_label_53">
+			<bounds x="1540" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x40">
+			<bounds x="1604" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_54" element="debug_button_label_54">
+			<bounds x="1624" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x80">
+			<bounds x="1688" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_55" element="debug_button_label_55">
+			<bounds x="1708" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x01">
+			<bounds x="1100" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_56" element="debug_button_label_56">
+			<bounds x="1120" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x02">
+			<bounds x="1184" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_57" element="debug_button_label_57">
+			<bounds x="1204" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x04">
+			<bounds x="1268" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_58" element="debug_button_label_58">
+			<bounds x="1288" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x08">
+			<bounds x="1352" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_59" element="debug_button_label_59">
+			<bounds x="1372" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x10">
+			<bounds x="1436" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_60" element="debug_button_label_60">
+			<bounds x="1456" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x20">
+			<bounds x="1520" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_61" element="debug_button_label_61">
+			<bounds x="1540" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x40">
+			<bounds x="1604" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_62" element="debug_button_label_62">
+			<bounds x="1624" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp56" element="debug_button_standard" state="0" inputtag="AUX2" inputmask="0x80">
+			<bounds x="1688" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_63" element="debug_button_label_63">
+			<bounds x="1708" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="vfd15" element="debug_vfd" state="0">
+			<bounds x="1150" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd14" element="debug_vfd" state="0">
+			<bounds x="1182" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd13" element="debug_vfd" state="0">
+			<bounds x="1214" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd12" element="debug_vfd" state="0">
+			<bounds x="1246" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd11" element="debug_vfd" state="0">
+			<bounds x="1278" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd10" element="debug_vfd" state="0">
+			<bounds x="1310" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd9" element="debug_vfd" state="0">
+			<bounds x="1342" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd8" element="debug_vfd" state="0">
+			<bounds x="1374" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd7" element="debug_vfd" state="0">
+			<bounds x="1406" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd6" element="debug_vfd" state="0">
+			<bounds x="1438" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd5" element="debug_vfd" state="0">
+			<bounds x="1470" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd4" element="debug_vfd" state="0">
+			<bounds x="1502" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd3" element="debug_vfd" state="0">
+			<bounds x="1534" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd2" element="debug_vfd" state="0">
+			<bounds x="1566" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd1" element="debug_vfd" state="0">
+			<bounds x="1598" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd0" element="debug_vfd" state="0">
+			<bounds x="1630" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel1" element="reel0" state="0">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel2" element="reel1" state="0">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel3" element="reel2" state="0">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1520" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_0" state="0">
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_1" state="0">
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_2" state="0">
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_3" state="0">
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_4" state="0">
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp3" element="reel_lamp_layer_5" state="0">
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_0" state="0">
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_1" state="0">
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_2" state="0">
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_3" state="0">
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_4" state="0">
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp19" element="reel_lamp_layer_5" state="0">
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel4" element="reel3" state="0">
+			<bounds x="1520" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="reel1" element="debug_stepper_value">
+			<bounds x="1100" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel2" element="debug_stepper_value">
+			<bounds x="1240" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel3" element="debug_stepper_value">
+			<bounds x="1380" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel4" element="debug_stepper_value">
+			<bounds x="1520" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
+			<bounds x="1180" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
+			<bounds x="1320" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
+			<bounds x="1460" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m4addr.lay
+++ b/src/mame/layout/m4addr.lay
@@ -8,4405 +8,7586 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.39" green="0.49" blue="0.38">
-			</color>
+			<color red="0.39" green="0.49" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.12" blue="0.09">
-			</color>
+			<color red="0.10" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.99" blue="0.76">
-			</color>
+			<color red="0.79" green="0.99" blue="0.76"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.25" blue="0.19">
-			</color>
+			<color red="0.20" green="0.25" blue="0.19"/>
 		</rect>
 		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.41" blue="0.50">
-			</color>
+			<color red="0.50" green="0.41" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.12">
-			</color>
+			<color red="0.12" green="0.10" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.82" blue="1.00">
-			</color>
+			<color red="1.00" green="0.82" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.25">
-			</color>
+			<color red="0.25" green="0.20" blue="0.25"/>
 		</rect>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUDGE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MONEY TRAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUDGE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUDGE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="ADDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_4_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_4_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPA STEPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ADDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MONEY TRAP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUDGE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.41" blue="0.50">
-			</color>
+			<color red="0.50" green="0.41" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.12">
-			</color>
+			<color red="0.12" green="0.10" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.82" blue="1.00">
-			</color>
+			<color red="1.00" green="0.82" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.25">
-			</color>
+			<color red="0.25" green="0.20" blue="0.25"/>
 		</rect>
 		<text string="LADDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NICE DICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUDGE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="ADDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6 JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_3_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_3_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CASH ATTACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PICK A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SKILL CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.41" blue="0.50">
-			</color>
+			<color red="0.50" green="0.41" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.12">
-			</color>
+			<color red="0.12" green="0.10" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.82" blue="1.00">
-			</color>
+			<color red="1.00" green="0.82" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.25">
-			</color>
+			<color red="0.25" green="0.20" blue="0.25"/>
 		</rect>
 		<text string="LADDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ADDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LADDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CASH CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT RESTART">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_7_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_7_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="RATTLER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="ADDERS N LADDERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_6_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_6_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="SNAKE BITE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="BACK 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="SNAKE BITE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="ROLL EVEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="ADVANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="UP AND OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="SNAKE BITE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.16" blue="0.16">
-			</color>
+			<color red="0.32" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.04" blue="0.04">
-			</color>
+			<color red="0.08" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.32" blue="0.32">
-			</color>
+			<color red="0.64" green="0.32" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.08" blue="0.08">
-			</color>
+			<color red="0.16" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.42" blue="0.00">
-			</color>
+			<color red="0.42" green="0.42" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.11" blue="0.00">
-			</color>
+			<color red="0.11" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.85" blue="0.00">
-			</color>
+			<color red="0.85" green="0.85" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.21" blue="0.00">
-			</color>
+			<color red="0.21" green="0.21" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_5_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_5_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUDGE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.41" blue="0.50">
-			</color>
+			<color red="0.50" green="0.41" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.12">
-			</color>
+			<color red="0.12" green="0.10" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.82" blue="1.00">
-			</color>
+			<color red="1.00" green="0.82" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.20" blue="0.25">
-			</color>
+			<color red="0.25" green="0.20" blue="0.25"/>
 		</rect>
 		<text string="LADDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FEATURE RESTART">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_33_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FEATURE RESTART">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FEATURE RESTART">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FEATURE RESTART">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED   7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BLUE  7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BLUE  7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BLUE  7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED   7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED   7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1 BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1 BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1 BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7'S MIX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="7'S MIX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7'S MIX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_119_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_119">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CAN/COLL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_120_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_120">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_121_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_121">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_122_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_122">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_123_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_123">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_124_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_124">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_125_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_125">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_126_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_126">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_127_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_127">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_128_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_128">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="TripleBar(*),SingleBar,DoubleBar,Red7(*),TripleBar,DoubleBar,Blue7,DoubleBar,SingleBar(*),Red7,SingleBar,TripleBar,Blue7,DoubleBar(*),SingleBar,Blue7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Red7,TripleBar,SingleBar,DoubleBar(*),Blue7,TripleBar,DoubleBar,Red7,DoubleBar,SingleBar(*),Blue7,SingleBar,TripleBar,Red7,DoubleBar(*),SingleBar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Red7,TripleBar,DoubleBar,Blue7(*),DoubleBar,SingleBar,Red7(*),SingleBar,TripleBar(*),Blue7,DoubleBar,SingleBar,Blue7,TripleBar(*),SingleBar,DoubleBar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="9,8,7,6,5,4,3,2,1,12,11,10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_11">
 		<text string="Any 3 Symbols On Pay Line Starts Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_backdrop_colour">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_standard">
+		<rect state="0">
+			<color red="0.00" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_reel">
+		<rect state="0">
+			<color red="0.00" green="0.00" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="0.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_segment">
+		<rect state="0">
+			<color red="0.20" green="0.00" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="0.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_button">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_64">
+		<text string="64">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_65">
+		<text string="65">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_66">
+		<text string="66">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_67">
+		<text string="67">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_68">
+		<text string="68">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_69">
+		<text string="69">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_70">
+		<text string="70">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_71">
+		<text string="71">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_72">
+		<text string="72">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_73">
+		<text string="73">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_74">
+		<text string="74">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_75">
+		<text string="75">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_76">
+		<text string="76">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_77">
+		<text string="77">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_78">
+		<text string="78">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_79">
+		<text string="79">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_80">
+		<text string="80">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_81">
+		<text string="81">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_82">
+		<text string="82">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_83">
+		<text string="83">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_84">
+		<text string="84">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_85">
+		<text string="85">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_86">
+		<text string="86">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_87">
+		<text string="87">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_88">
+		<text string="88">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_89">
+		<text string="89">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_90">
+		<text string="90">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_91">
+		<text string="91">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_92">
+		<text string="92">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_93">
+		<text string="93">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_94">
+		<text string="94">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_95">
+		<text string="95">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_96">
+		<text string="96">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_97">
+		<text string="97">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_98">
+		<text string="98">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_99">
+		<text string="99">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_100">
+		<text string="100">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_101">
+		<text string="101">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_102">
+		<text string="102">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_103">
+		<text string="103">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_104">
+		<text string="104">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_105">
+		<text string="105">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_106">
+		<text string="106">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_107">
+		<text string="107">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_108">
+		<text string="108">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_109">
+		<text string="109">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_110">
+		<text string="110">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_111">
+		<text string="111">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_112">
+		<text string="112">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_113">
+		<text string="113">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_114">
+		<text string="114">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_115">
+		<text string="115">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_116">
+		<text string="116">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_117">
+		<text string="117">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_118">
+		<text string="118">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_119">
+		<text string="119">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_120">
+		<text string="120">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_121">
+		<text string="121">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_122">
+		<text string="122">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_123">
+		<text string="123">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_124">
+		<text string="124">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_125">
+		<text string="125">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_126">
+		<text string="126">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_127">
+		<text string="127">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_128">
+		<text string="128">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_129">
+		<text string="129">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_130">
+		<text string="130">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_131">
+		<text string="131">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_132">
+		<text string="132">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_133">
+		<text string="133">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_134">
+		<text string="134">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_135">
+		<text string="135">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_136">
+		<text string="136">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_137">
+		<text string="137">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_138">
+		<text string="138">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_139">
+		<text string="139">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_140">
+		<text string="140">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_141">
+		<text string="141">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_142">
+		<text string="142">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_143">
+		<text string="143">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_144">
+		<text string="144">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_145">
+		<text string="145">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_146">
+		<text string="146">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_147">
+		<text string="147">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_148">
+		<text string="148">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_149">
+		<text string="149">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_150">
+		<text string="150">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_151">
+		<text string="151">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_152">
+		<text string="152">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_153">
+		<text string="153">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_154">
+		<text string="154">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_155">
+		<text string="155">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_156">
+		<text string="156">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_157">
+		<text string="157">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_158">
+		<text string="158">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_159">
+		<text string="159">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_160">
+		<text string="160">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_161">
+		<text string="161">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_162">
+		<text string="162">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_163">
+		<text string="163">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_164">
+		<text string="164">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_165">
+		<text string="165">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_166">
+		<text string="166">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_167">
+		<text string="167">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_168">
+		<text string="168">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_169">
+		<text string="169">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_170">
+		<text string="170">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_171">
+		<text string="171">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_172">
+		<text string="172">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_173">
+		<text string="173">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_174">
+		<text string="174">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_175">
+		<text string="175">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_176">
+		<text string="176">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_177">
+		<text string="177">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_178">
+		<text string="178">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_179">
+		<text string="179">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_180">
+		<text string="180">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_181">
+		<text string="181">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_182">
+		<text string="182">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_183">
+		<text string="183">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_184">
+		<text string="184">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_185">
+		<text string="185">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_186">
+		<text string="186">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_187">
+		<text string="187">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_188">
+		<text string="188">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_189">
+		<text string="189">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_190">
+		<text string="190">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_191">
+		<text string="191">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_192">
+		<text string="192">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_193">
+		<text string="193">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_194">
+		<text string="194">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_195">
+		<text string="195">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_196">
+		<text string="196">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_197">
+		<text string="197">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_198">
+		<text string="198">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_199">
+		<text string="199">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_200">
+		<text string="200">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_201">
+		<text string="201">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_202">
+		<text string="202">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_203">
+		<text string="203">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_204">
+		<text string="204">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_205">
+		<text string="205">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_206">
+		<text string="206">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_207">
+		<text string="207">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_208">
+		<text string="208">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_209">
+		<text string="209">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_210">
+		<text string="210">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_211">
+		<text string="211">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_212">
+		<text string="212">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_213">
+		<text string="213">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_214">
+		<text string="214">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_215">
+		<text string="215">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_216">
+		<text string="216">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_217">
+		<text string="217">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_218">
+		<text string="218">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_219">
+		<text string="219">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_220">
+		<text string="220">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_221">
+		<text string="221">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_222">
+		<text string="222">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_223">
+		<text string="223">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_224">
+		<text string="224">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_225">
+		<text string="225">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_226">
+		<text string="226">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_227">
+		<text string="227">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_228">
+		<text string="228">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_229">
+		<text string="229">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_230">
+		<text string="230">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_231">
+		<text string="231">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_232">
+		<text string="232">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_233">
+		<text string="233">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_234">
+		<text string="234">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_235">
+		<text string="235">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_236">
+		<text string="236">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_237">
+		<text string="237">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_238">
+		<text string="238">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_239">
+		<text string="239">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_240">
+		<text string="240">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_241">
+		<text string="241">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_242">
+		<text string="242">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_243">
+		<text string="243">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_244">
+		<text string="244">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_245">
+		<text string="245">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_246">
+		<text string="246">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_247">
+		<text string="247">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_248">
+		<text string="248">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_249">
+		<text string="249">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_250">
+		<text string="250">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_251">
+		<text string="251">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_252">
+		<text string="252">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_253">
+		<text string="253">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_254">
+		<text string="254">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_255">
+		<text string="255">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_standard">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_vfd">
+		<led16segsc>
+			<color red="0.0" green="1.0" blue="1.0"/>
+		</led16segsc>
+	</element>
+	<element name="debug_stepper_value" defstate="0">
+		<simplecounter maxstate="999" digits="3">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</simplecounter>
+	</element>
+	<element name="debug_reel_symbol_count_0">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_1">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_2">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_3">
+		<text string="12">
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="794" height="535">
-			</bounds>
+			<bounds x="0" y="0" width="794" height="535"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="97" y="340" width="90" height="150">
-			</bounds>
+			<bounds x="97" y="340" width="90" height="150"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
-			<bounds x="97.0000" y="340.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="97.0000" y="340.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
-			<bounds x="100.7500" y="342.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="100.7500" y="342.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
-			<bounds x="104.5000" y="344.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="104.5000" y="344.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
-			<bounds x="108.2500" y="346.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="108.2500" y="346.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
-			<bounds x="112.0000" y="348.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="112.0000" y="348.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
-			<bounds x="115.7500" y="350.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="115.7500" y="350.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
-			<bounds x="97.0000" y="390.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="97.0000" y="390.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
-			<bounds x="100.7500" y="392.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="100.7500" y="392.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
-			<bounds x="104.5000" y="394.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="104.5000" y="394.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
-			<bounds x="108.2500" y="396.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="108.2500" y="396.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
-			<bounds x="112.0000" y="398.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="112.0000" y="398.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
-			<bounds x="115.7500" y="400.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="115.7500" y="400.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="97.0000" y="440.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="97.0000" y="440.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="100.7500" y="442.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="100.7500" y="442.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="104.5000" y="444.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="104.5000" y="444.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="108.2500" y="446.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="108.2500" y="446.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="112.0000" y="448.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="112.0000" y="448.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="115.7500" y="450.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="115.7500" y="450.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="97" y="340" width="90" height="150">
-			</bounds>
+			<bounds x="97" y="340" width="90" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="199" y="339" width="90" height="150">
-			</bounds>
+			<bounds x="199" y="339" width="90" height="150"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_0" state="0">
-			<bounds x="199.0000" y="339.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="199.0000" y="339.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_1" state="0">
-			<bounds x="202.7500" y="341.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="202.7500" y="341.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_2" state="0">
-			<bounds x="206.5000" y="343.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="206.5000" y="343.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_3" state="0">
-			<bounds x="210.2500" y="345.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="210.2500" y="345.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_4" state="0">
-			<bounds x="214.0000" y="347.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="214.0000" y="347.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_5" state="0">
-			<bounds x="217.7500" y="349.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="217.7500" y="349.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_0" state="0">
-			<bounds x="199.0000" y="389.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="199.0000" y="389.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_1" state="0">
-			<bounds x="202.7500" y="391.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="202.7500" y="391.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_2" state="0">
-			<bounds x="206.5000" y="393.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="206.5000" y="393.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_3" state="0">
-			<bounds x="210.2500" y="395.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="210.2500" y="395.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_4" state="0">
-			<bounds x="214.0000" y="397.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="214.0000" y="397.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_5" state="0">
-			<bounds x="217.7500" y="399.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="217.7500" y="399.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="199.0000" y="439.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="199.0000" y="439.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="202.7500" y="441.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="202.7500" y="441.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="206.5000" y="443.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="206.5000" y="443.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="210.2500" y="445.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="210.2500" y="445.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="214.0000" y="447.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="214.0000" y="447.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="217.7500" y="449.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="217.7500" y="449.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="199" y="339" width="90" height="150">
-			</bounds>
+			<bounds x="199" y="339" width="90" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="298" y="339" width="90" height="150">
-			</bounds>
+			<bounds x="298" y="339" width="90" height="150"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_0" state="0">
-			<bounds x="298.0000" y="339.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="298.0000" y="339.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_1" state="0">
-			<bounds x="301.7500" y="341.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="301.7500" y="341.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_2" state="0">
-			<bounds x="305.5000" y="343.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="305.5000" y="343.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_3" state="0">
-			<bounds x="309.2500" y="345.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="309.2500" y="345.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_4" state="0">
-			<bounds x="313.0000" y="347.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="313.0000" y="347.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_5" state="0">
-			<bounds x="316.7500" y="349.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="316.7500" y="349.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="298.0000" y="389.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="298.0000" y="389.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="301.7500" y="391.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="301.7500" y="391.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="305.5000" y="393.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="305.5000" y="393.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="309.2500" y="395.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="309.2500" y="395.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="313.0000" y="397.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="313.0000" y="397.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="316.7500" y="399.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="316.7500" y="399.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="298.0000" y="439.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="298.0000" y="439.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="301.7500" y="441.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="301.7500" y="441.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="305.5000" y="443.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="305.5000" y="443.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="309.2500" y="445.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="309.2500" y="445.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="313.0000" y="447.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="313.0000" y="447.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="316.7500" y="449.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="316.7500" y="449.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="298" y="339" width="90" height="150">
-			</bounds>
+			<bounds x="298" y="339" width="90" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="397" y="370" width="80" height="80">
-			</bounds>
+			<bounds x="397" y="370" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
-			<bounds x="397.0000" y="370.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="397.0000" y="370.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
-			<bounds x="400.3333" y="373.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="400.3333" y="373.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
-			<bounds x="403.6667" y="376.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="403.6667" y="376.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
-			<bounds x="407.0000" y="380.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="407.0000" y="380.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
-			<bounds x="410.3333" y="383.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="410.3333" y="383.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
-			<bounds x="413.6667" y="386.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="413.6667" y="386.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="397" y="370" width="80" height="80">
-			</bounds>
+			<bounds x="397" y="370" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="5" y="461" width="85" height="22">
-			</bounds>
+			<bounds x="5" y="461" width="85" height="22"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="7" y="463" width="81" height="18">
-			</bounds>
+			<bounds x="7" y="463" width="81" height="18"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="82" y="257" width="67" height="37">
-			</bounds>
+			<bounds x="82" y="257" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="84" y="259" width="63" height="33">
-			</bounds>
+			<bounds x="84" y="259" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="214" y="257" width="67" height="37">
-			</bounds>
+			<bounds x="214" y="257" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="216" y="259" width="63" height="33">
-			</bounds>
+			<bounds x="216" y="259" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="280" y="257" width="67" height="37">
-			</bounds>
+			<bounds x="280" y="257" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="282" y="259" width="63" height="33">
-			</bounds>
+			<bounds x="282" y="259" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="148" y="257" width="67" height="37">
-			</bounds>
+			<bounds x="148" y="257" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="150" y="259" width="63" height="33">
-			</bounds>
+			<bounds x="150" y="259" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="346" y="257" width="67" height="37">
-			</bounds>
+			<bounds x="346" y="257" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="348" y="259" width="63" height="33">
-			</bounds>
+			<bounds x="348" y="259" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="1" y="411" width="52" height="27">
-			</bounds>
+			<bounds x="1" y="411" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="3" y="413" width="48" height="23">
-			</bounds>
+			<bounds x="3" y="413" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="33" y="367" width="52" height="27">
-			</bounds>
+			<bounds x="33" y="367" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="35" y="369" width="48" height="23">
-			</bounds>
+			<bounds x="35" y="369" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="1" y="326" width="52" height="27">
-			</bounds>
+			<bounds x="1" y="326" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="3" y="328" width="48" height="23">
-			</bounds>
+			<bounds x="3" y="328" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="413" y="77" width="67" height="37">
-			</bounds>
+			<bounds x="413" y="77" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="415" y="79" width="63" height="33">
-			</bounds>
+			<bounds x="415" y="79" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="347" y="77" width="67" height="37">
-			</bounds>
+			<bounds x="347" y="77" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="349" y="79" width="63" height="33">
-			</bounds>
+			<bounds x="349" y="79" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="413" y="113" width="67" height="37">
-			</bounds>
+			<bounds x="413" y="113" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="415" y="115" width="63" height="33">
-			</bounds>
+			<bounds x="415" y="115" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="347" y="113" width="67" height="37">
-			</bounds>
+			<bounds x="347" y="113" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="349" y="115" width="63" height="33">
-			</bounds>
+			<bounds x="349" y="115" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="413" y="41" width="67" height="37">
-			</bounds>
+			<bounds x="413" y="41" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="415" y="43" width="63" height="33">
-			</bounds>
+			<bounds x="415" y="43" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="347" y="41" width="67" height="37">
-			</bounds>
+			<bounds x="347" y="41" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="349" y="43" width="63" height="33">
-			</bounds>
+			<bounds x="349" y="43" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1_border" state="0">
-			<bounds x="347" y="5" width="67" height="37">
-			</bounds>
+			<bounds x="347" y="5" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1" state="0">
-			<bounds x="349" y="7" width="63" height="33">
-			</bounds>
+			<bounds x="349" y="7" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="413" y="5" width="67" height="37">
-			</bounds>
+			<bounds x="413" y="5" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="415" y="7" width="63" height="33">
-			</bounds>
+			<bounds x="415" y="7" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="346" y="221" width="67" height="37">
-			</bounds>
+			<bounds x="346" y="221" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="348" y="223" width="63" height="33">
-			</bounds>
+			<bounds x="348" y="223" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="346" y="185" width="67" height="37">
-			</bounds>
+			<bounds x="346" y="185" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="348" y="187" width="63" height="33">
-			</bounds>
+			<bounds x="348" y="187" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="346" y="149" width="67" height="37">
-			</bounds>
+			<bounds x="346" y="149" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="348" y="151" width="63" height="33">
-			</bounds>
+			<bounds x="348" y="151" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="214" y="149" width="67" height="37">
-			</bounds>
+			<bounds x="214" y="149" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="216" y="151" width="63" height="33">
-			</bounds>
+			<bounds x="216" y="151" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="280" y="149" width="67" height="37">
-			</bounds>
+			<bounds x="280" y="149" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="282" y="151" width="63" height="33">
-			</bounds>
+			<bounds x="282" y="151" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="148" y="185" width="67" height="37">
-			</bounds>
+			<bounds x="148" y="185" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="150" y="187" width="63" height="33">
-			</bounds>
+			<bounds x="150" y="187" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="148" y="149" width="67" height="37">
-			</bounds>
+			<bounds x="148" y="149" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="150" y="151" width="63" height="33">
-			</bounds>
+			<bounds x="150" y="151" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="280" y="185" width="67" height="37">
-			</bounds>
+			<bounds x="280" y="185" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="282" y="187" width="63" height="33">
-			</bounds>
+			<bounds x="282" y="187" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="214" y="185" width="67" height="37">
-			</bounds>
+			<bounds x="214" y="185" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="216" y="187" width="63" height="33">
-			</bounds>
+			<bounds x="216" y="187" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="148" y="221" width="67" height="37">
-			</bounds>
+			<bounds x="148" y="221" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="150" y="223" width="63" height="33">
-			</bounds>
+			<bounds x="150" y="223" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="214" y="221" width="67" height="37">
-			</bounds>
+			<bounds x="214" y="221" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="216" y="223" width="63" height="33">
-			</bounds>
+			<bounds x="216" y="223" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="280" y="221" width="67" height="37">
-			</bounds>
+			<bounds x="280" y="221" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="282" y="223" width="63" height="33">
-			</bounds>
+			<bounds x="282" y="223" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="148" y="5" width="67" height="37">
-			</bounds>
+			<bounds x="148" y="5" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="150" y="7" width="63" height="33">
-			</bounds>
+			<bounds x="150" y="7" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="214" y="5" width="67" height="37">
-			</bounds>
+			<bounds x="214" y="5" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="216" y="7" width="63" height="33">
-			</bounds>
+			<bounds x="216" y="7" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="lamp_3_1_border" state="0">
-			<bounds x="280" y="5" width="67" height="37">
-			</bounds>
+			<bounds x="280" y="5" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="lamp_3_1" state="0">
-			<bounds x="282" y="7" width="63" height="33">
-			</bounds>
+			<bounds x="282" y="7" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="149" y="41" width="67" height="37">
-			</bounds>
+			<bounds x="149" y="41" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="151" y="43" width="63" height="33">
-			</bounds>
+			<bounds x="151" y="43" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="215" y="41" width="67" height="37">
-			</bounds>
+			<bounds x="215" y="41" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="217" y="43" width="63" height="33">
-			</bounds>
+			<bounds x="217" y="43" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="281" y="41" width="67" height="37">
-			</bounds>
+			<bounds x="281" y="41" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="283" y="43" width="63" height="33">
-			</bounds>
+			<bounds x="283" y="43" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="149" y="113" width="67" height="37">
-			</bounds>
+			<bounds x="149" y="113" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="151" y="115" width="63" height="33">
-			</bounds>
+			<bounds x="151" y="115" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="215" y="113" width="67" height="37">
-			</bounds>
+			<bounds x="215" y="113" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="217" y="115" width="63" height="33">
-			</bounds>
+			<bounds x="217" y="115" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="281" y="113" width="67" height="37">
-			</bounds>
+			<bounds x="281" y="113" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="283" y="115" width="63" height="33">
-			</bounds>
+			<bounds x="283" y="115" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="149" y="77" width="67" height="37">
-			</bounds>
+			<bounds x="149" y="77" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="151" y="79" width="63" height="33">
-			</bounds>
+			<bounds x="151" y="79" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="215" y="77" width="67" height="37">
-			</bounds>
+			<bounds x="215" y="77" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="217" y="79" width="63" height="33">
-			</bounds>
+			<bounds x="217" y="79" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="281" y="77" width="67" height="37">
-			</bounds>
+			<bounds x="281" y="77" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="283" y="79" width="63" height="33">
-			</bounds>
+			<bounds x="283" y="79" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="83" y="77" width="67" height="37">
-			</bounds>
+			<bounds x="83" y="77" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="85" y="79" width="63" height="33">
-			</bounds>
+			<bounds x="85" y="79" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="83" y="113" width="67" height="37">
-			</bounds>
+			<bounds x="83" y="113" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="85" y="115" width="63" height="33">
-			</bounds>
+			<bounds x="85" y="115" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="83" y="41" width="67" height="37">
-			</bounds>
+			<bounds x="83" y="41" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="85" y="43" width="63" height="33">
-			</bounds>
+			<bounds x="85" y="43" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="82" y="221" width="67" height="37">
-			</bounds>
+			<bounds x="82" y="221" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="84" y="223" width="63" height="33">
-			</bounds>
+			<bounds x="84" y="223" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="82" y="149" width="67" height="37">
-			</bounds>
+			<bounds x="82" y="149" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="84" y="151" width="63" height="33">
-			</bounds>
+			<bounds x="84" y="151" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="82" y="185" width="67" height="37">
-			</bounds>
+			<bounds x="82" y="185" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="84" y="187" width="63" height="33">
-			</bounds>
+			<bounds x="84" y="187" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="82" y="5" width="67" height="37">
-			</bounds>
+			<bounds x="82" y="5" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="84" y="7" width="63" height="33">
-			</bounds>
+			<bounds x="84" y="7" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="lamp_7_1_border" state="0">
-			<bounds x="487" y="7" width="90" height="37">
-			</bounds>
+			<bounds x="487" y="7" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="lamp_7_1" state="0">
-			<bounds x="489" y="9" width="86" height="33">
-			</bounds>
+			<bounds x="489" y="9" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="576" y="115" width="90" height="37">
-			</bounds>
+			<bounds x="576" y="115" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="578" y="117" width="86" height="33">
-			</bounds>
+			<bounds x="578" y="117" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1_border" state="0">
-			<bounds x="577" y="151" width="90" height="37">
-			</bounds>
+			<bounds x="577" y="151" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1" state="0">
-			<bounds x="579" y="153" width="86" height="33">
-			</bounds>
+			<bounds x="579" y="153" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="576" y="79" width="90" height="37">
-			</bounds>
+			<bounds x="576" y="79" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="578" y="81" width="86" height="33">
-			</bounds>
+			<bounds x="578" y="81" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="576" y="43" width="90" height="37">
-			</bounds>
+			<bounds x="576" y="43" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="578" y="45" width="86" height="33">
-			</bounds>
+			<bounds x="578" y="45" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="576" y="7" width="90" height="37">
-			</bounds>
+			<bounds x="576" y="7" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="578" y="9" width="86" height="33">
-			</bounds>
+			<bounds x="578" y="9" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="488" y="151" width="90" height="37">
-			</bounds>
+			<bounds x="488" y="151" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="490" y="153" width="86" height="33">
-			</bounds>
+			<bounds x="490" y="153" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0">
-			<bounds x="487" y="115" width="90" height="37">
-			</bounds>
+			<bounds x="487" y="115" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0">
-			<bounds x="489" y="117" width="86" height="33">
-			</bounds>
+			<bounds x="489" y="117" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="487" y="79" width="90" height="37">
-			</bounds>
+			<bounds x="487" y="79" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="489" y="81" width="86" height="33">
-			</bounds>
+			<bounds x="489" y="81" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="487" y="43" width="90" height="37">
-			</bounds>
+			<bounds x="487" y="43" width="90" height="37"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="489" y="45" width="86" height="33">
-			</bounds>
+			<bounds x="489" y="45" width="86" height="33"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="412" y="185" width="67" height="37">
-			</bounds>
+			<bounds x="412" y="185" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="414" y="187" width="63" height="33">
-			</bounds>
+			<bounds x="414" y="187" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="lamp_5_1_border" state="0">
-			<bounds x="412" y="149" width="67" height="37">
-			</bounds>
+			<bounds x="412" y="149" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="lamp_5_1" state="0">
-			<bounds x="414" y="151" width="63" height="33">
-			</bounds>
+			<bounds x="414" y="151" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="412" y="221" width="67" height="37">
-			</bounds>
+			<bounds x="412" y="221" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="414" y="223" width="63" height="33">
-			</bounds>
+			<bounds x="414" y="223" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="412" y="257" width="67" height="37">
-			</bounds>
+			<bounds x="412" y="257" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="414" y="259" width="63" height="33">
-			</bounds>
+			<bounds x="414" y="259" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="5" y="256" width="67" height="37">
-			</bounds>
+			<bounds x="5" y="256" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="7" y="258" width="63" height="33">
-			</bounds>
+			<bounds x="7" y="258" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="396" y="451" width="82" height="22">
-			</bounds>
+			<bounds x="396" y="451" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="398" y="453" width="78" height="18">
-			</bounds>
+			<bounds x="398" y="453" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_2_border" state="0">
-			<bounds x="396" y="347" width="82" height="22">
-			</bounds>
+			<bounds x="396" y="347" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_2" state="0">
-			<bounds x="398" y="349" width="78" height="18">
-			</bounds>
+			<bounds x="398" y="349" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="5" y="220" width="67" height="37">
-			</bounds>
+			<bounds x="5" y="220" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="7" y="222" width="63" height="33">
-			</bounds>
+			<bounds x="7" y="222" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="5" y="184" width="67" height="37">
-			</bounds>
+			<bounds x="5" y="184" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="7" y="186" width="63" height="33">
-			</bounds>
+			<bounds x="7" y="186" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="5" y="148" width="67" height="37">
-			</bounds>
+			<bounds x="5" y="148" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="7" y="150" width="63" height="33">
-			</bounds>
+			<bounds x="7" y="150" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="5" y="112" width="67" height="37">
-			</bounds>
+			<bounds x="5" y="112" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="7" y="114" width="63" height="33">
-			</bounds>
+			<bounds x="7" y="114" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="5" y="76" width="67" height="37">
-			</bounds>
+			<bounds x="5" y="76" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="7" y="78" width="63" height="33">
-			</bounds>
+			<bounds x="7" y="78" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="5" y="4" width="67" height="37">
-			</bounds>
+			<bounds x="5" y="4" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="7" y="6" width="63" height="33">
-			</bounds>
+			<bounds x="7" y="6" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="5" y="40" width="67" height="37">
-			</bounds>
+			<bounds x="5" y="40" width="67" height="37"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="7" y="42" width="63" height="33">
-			</bounds>
+			<bounds x="7" y="42" width="63" height="33"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="695" y="126" width="82" height="22">
-			</bounds>
+			<bounds x="695" y="126" width="82" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="697" y="128" width="78" height="18">
-			</bounds>
+			<bounds x="697" y="128" width="78" height="18"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="697" y="372" width="72" height="19">
-			</bounds>
+			<bounds x="697" y="372" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="699" y="374" width="68" height="15">
-			</bounds>
+			<bounds x="699" y="374" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="697" y="432" width="72" height="19">
-			</bounds>
+			<bounds x="697" y="432" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="699" y="434" width="68" height="15">
-			</bounds>
+			<bounds x="699" y="434" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="697" y="344" width="72" height="19">
-			</bounds>
+			<bounds x="697" y="344" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="699" y="346" width="68" height="15">
-			</bounds>
+			<bounds x="699" y="346" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="697" y="400" width="72" height="19">
-			</bounds>
+			<bounds x="697" y="400" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="699" y="402" width="68" height="15">
-			</bounds>
+			<bounds x="699" y="402" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="697" y="312" width="72" height="19">
-			</bounds>
+			<bounds x="697" y="312" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="699" y="314" width="68" height="15">
-			</bounds>
+			<bounds x="699" y="314" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="701" y="463" width="65" height="18">
-			</bounds>
+			<bounds x="701" y="463" width="65" height="18"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="703" y="465" width="61" height="14">
-			</bounds>
+			<bounds x="703" y="465" width="61" height="14"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="647" y="307" width="42" height="32">
-			</bounds>
+			<bounds x="647" y="307" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="649" y="309" width="38" height="28">
-			</bounds>
+			<bounds x="649" y="309" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="647" y="336" width="42" height="32">
-			</bounds>
+			<bounds x="647" y="336" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="649" y="338" width="38" height="28">
-			</bounds>
+			<bounds x="649" y="338" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="647" y="278" width="42" height="32">
-			</bounds>
+			<bounds x="647" y="278" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="649" y="280" width="38" height="28">
-			</bounds>
+			<bounds x="649" y="280" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="647" y="365" width="42" height="32">
-			</bounds>
+			<bounds x="647" y="365" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="649" y="367" width="38" height="28">
-			</bounds>
+			<bounds x="649" y="367" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="647" y="394" width="42" height="32">
-			</bounds>
+			<bounds x="647" y="394" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="649" y="396" width="38" height="28">
-			</bounds>
+			<bounds x="649" y="396" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="647" y="423" width="42" height="32">
-			</bounds>
+			<bounds x="647" y="423" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="649" y="425" width="38" height="28">
-			</bounds>
+			<bounds x="649" y="425" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="534" y="278" width="38" height="32">
-			</bounds>
+			<bounds x="534" y="278" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="536" y="280" width="34" height="28">
-			</bounds>
+			<bounds x="536" y="280" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="534" y="307" width="38" height="32">
-			</bounds>
+			<bounds x="534" y="307" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="536" y="309" width="34" height="28">
-			</bounds>
+			<bounds x="536" y="309" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="534" y="336" width="38" height="32">
-			</bounds>
+			<bounds x="534" y="336" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="536" y="338" width="34" height="28">
-			</bounds>
+			<bounds x="536" y="338" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="534" y="365" width="38" height="32">
-			</bounds>
+			<bounds x="534" y="365" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="536" y="367" width="34" height="28">
-			</bounds>
+			<bounds x="536" y="367" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="569" y="365" width="38" height="32">
-			</bounds>
+			<bounds x="569" y="365" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="571" y="367" width="34" height="28">
-			</bounds>
+			<bounds x="571" y="367" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="604" y="365" width="38" height="32">
-			</bounds>
+			<bounds x="604" y="365" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="606" y="367" width="34" height="28">
-			</bounds>
+			<bounds x="606" y="367" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="604" y="336" width="38" height="32">
-			</bounds>
+			<bounds x="604" y="336" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="606" y="338" width="34" height="28">
-			</bounds>
+			<bounds x="606" y="338" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="569" y="336" width="38" height="32">
-			</bounds>
+			<bounds x="569" y="336" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="571" y="338" width="34" height="28">
-			</bounds>
+			<bounds x="571" y="338" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="569" y="307" width="38" height="32">
-			</bounds>
+			<bounds x="569" y="307" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="571" y="309" width="34" height="28">
-			</bounds>
+			<bounds x="571" y="309" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="604" y="307" width="38" height="32">
-			</bounds>
+			<bounds x="604" y="307" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="606" y="309" width="34" height="28">
-			</bounds>
+			<bounds x="606" y="309" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="604" y="278" width="38" height="32">
-			</bounds>
+			<bounds x="604" y="278" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="606" y="280" width="34" height="28">
-			</bounds>
+			<bounds x="606" y="280" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="569" y="278" width="38" height="32">
-			</bounds>
+			<bounds x="569" y="278" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="571" y="280" width="34" height="28">
-			</bounds>
+			<bounds x="571" y="280" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="604" y="394" width="38" height="32">
-			</bounds>
+			<bounds x="604" y="394" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="606" y="396" width="34" height="28">
-			</bounds>
+			<bounds x="606" y="396" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="569" y="394" width="38" height="32">
-			</bounds>
+			<bounds x="569" y="394" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="571" y="396" width="34" height="28">
-			</bounds>
+			<bounds x="571" y="396" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="534" y="394" width="38" height="32">
-			</bounds>
+			<bounds x="534" y="394" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="536" y="396" width="34" height="28">
-			</bounds>
+			<bounds x="536" y="396" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="534" y="423" width="38" height="32">
-			</bounds>
+			<bounds x="534" y="423" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="536" y="425" width="34" height="28">
-			</bounds>
+			<bounds x="536" y="425" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="569" y="423" width="38" height="32">
-			</bounds>
+			<bounds x="569" y="423" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="571" y="425" width="34" height="28">
-			</bounds>
+			<bounds x="571" y="425" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="604" y="423" width="38" height="32">
-			</bounds>
+			<bounds x="604" y="423" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="606" y="425" width="34" height="28">
-			</bounds>
+			<bounds x="606" y="425" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp24" element="colour_button_119_border" state="0" inputtag="BLACK2" inputmask="0x01">
-			<bounds x="1" y="496" width="92" height="32">
-			</bounds>
+			<bounds x="1" y="496" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp24" element="colour_button_119" state="0" inputtag="BLACK2" inputmask="0x01">
-			<bounds x="3" y="498" width="88" height="28">
-			</bounds>
+			<bounds x="3" y="498" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_120_border" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="702" y="33" width="92" height="32">
-			</bounds>
+			<bounds x="702" y="33" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_120" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="704" y="35" width="88" height="28">
-			</bounds>
+			<bounds x="704" y="35" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_121_border" state="0" inputtag="AUX2" inputmask="0x20">
-			<bounds x="702" y="1" width="92" height="32">
-			</bounds>
+			<bounds x="702" y="1" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_121" state="0" inputtag="AUX2" inputmask="0x20">
-			<bounds x="704" y="3" width="88" height="28">
-			</bounds>
+			<bounds x="704" y="3" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_122_border" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="702" y="491" width="92" height="32">
-			</bounds>
+			<bounds x="702" y="491" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_122" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="704" y="493" width="88" height="28">
-			</bounds>
+			<bounds x="704" y="493" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_123_border" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="594" y="492" width="92" height="32">
-			</bounds>
+			<bounds x="594" y="492" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_123" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="596" y="494" width="88" height="28">
-			</bounds>
+			<bounds x="596" y="494" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_124_border" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="491" y="493" width="92" height="32">
-			</bounds>
+			<bounds x="491" y="493" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_124" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="493" y="495" width="88" height="28">
-			</bounds>
+			<bounds x="493" y="495" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_125_border" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="398" y="493" width="92" height="32">
-			</bounds>
+			<bounds x="398" y="493" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_125" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="400" y="495" width="88" height="28">
-			</bounds>
+			<bounds x="400" y="495" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_126_border" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="296" y="494" width="92" height="32">
-			</bounds>
+			<bounds x="296" y="494" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_126" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="298" y="496" width="88" height="28">
-			</bounds>
+			<bounds x="298" y="496" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_127_border" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="197" y="495" width="92" height="32">
-			</bounds>
+			<bounds x="197" y="495" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_127" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="199" y="497" width="88" height="28">
-			</bounds>
+			<bounds x="199" y="497" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp25" element="colour_button_128_border" state="0" inputtag="BLACK2" inputmask="0x02">
-			<bounds x="96" y="496" width="92" height="32">
-			</bounds>
+			<bounds x="96" y="496" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp25" element="colour_button_128" state="0" inputtag="BLACK2" inputmask="0x02">
-			<bounds x="98" y="498" width="88" height="28">
-			</bounds>
+			<bounds x="98" y="498" width="88" height="28"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="724" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="724" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit4" element="led_digit_red">
-			<bounds x="724" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="724" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="724" y="153" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="724" y="153" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="746" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="746" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit7" element="led_digit_red">
-			<bounds x="746" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="746" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="746" y="153" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="746" y="153" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="702" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="702" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="702" y="153" width="24" height="32">
-			</bounds>
+			<bounds x="702" y="153" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="702" y="153" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="702" y="153" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="105" y="305" width="272" height="30">
-			</bounds>
+			<bounds x="105" y="305" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="105" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="105" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="122" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="122" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="139" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="139" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="156" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="156" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="173" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="173" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="190" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="190" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="207" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="207" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="224" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="224" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="241" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="241" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="258" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="258" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="275" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="275" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="292" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="292" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="309" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="309" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="326" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="326" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="343" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="343" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="360" y="305" width="17" height="30">
-			</bounds>
+			<bounds x="360" y="305" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="507" y="199" width="184" height="28">
-			</bounds>
+			<bounds x="507" y="199" width="184" height="28"/>
+		</backdrop>
+	</view>
+
+	<view name="MFME2MAME Debug">
+		<backdrop element="debug_backdrop_colour">
+			<bounds x="0" y="0" width="1920" height="1080"/>
+		</backdrop>
+		<backdrop name="lamp0" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
+			<bounds x="47" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp1" element="debug_lamp_reel" state="0">
+			<bounds x="96" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
+			<bounds x="111" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp2" element="debug_lamp_reel" state="0">
+			<bounds x="160" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
+			<bounds x="175" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp3" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
+			<bounds x="239" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp4" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
+			<bounds x="303" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp5" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
+			<bounds x="367" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp6" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
+			<bounds x="431" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp7" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
+			<bounds x="495" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp8" element="debug_lamp_reel" state="0">
+			<bounds x="544" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
+			<bounds x="559" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp9" element="debug_lamp_reel" state="0">
+			<bounds x="608" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
+			<bounds x="623" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
+			<bounds x="672" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
+			<bounds x="687" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
+			<bounds x="736" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
+			<bounds x="751" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
+			<bounds x="815" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
+			<bounds x="879" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
+			<bounds x="943" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp15" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
+			<bounds x="1007" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
+			<bounds x="47" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
+			<bounds x="96" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
+			<bounds x="111" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
+			<bounds x="160" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
+			<bounds x="175" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
+			<bounds x="239" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
+			<bounds x="303" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
+			<bounds x="367" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
+			<bounds x="431" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
+			<bounds x="495" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp24" element="debug_lamp_button" state="0">
+			<bounds x="544" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
+			<bounds x="559" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_lamp_button" state="0">
+			<bounds x="608" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
+			<bounds x="623" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_lamp_button" state="0">
+			<bounds x="672" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
+			<bounds x="687" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
+			<bounds x="751" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
+			<bounds x="815" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
+			<bounds x="879" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
+			<bounds x="943" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp31" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
+			<bounds x="1007" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_lamp_button" state="0">
+			<bounds x="32" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
+			<bounds x="47" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_lamp_button" state="0">
+			<bounds x="96" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
+			<bounds x="111" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_lamp_button" state="0">
+			<bounds x="160" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
+			<bounds x="175" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
+			<bounds x="239" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
+			<bounds x="303" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
+			<bounds x="367" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
+			<bounds x="431" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
+			<bounds x="495" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_lamp_button" state="0">
+			<bounds x="544" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
+			<bounds x="559" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_lamp_button" state="0">
+			<bounds x="608" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
+			<bounds x="623" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
+			<bounds x="687" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
+			<bounds x="751" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
+			<bounds x="815" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
+			<bounds x="879" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
+			<bounds x="943" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
+			<bounds x="1007" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
+			<bounds x="47" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
+			<bounds x="111" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
+			<bounds x="175" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
+			<bounds x="239" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
+			<bounds x="303" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
+			<bounds x="367" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
+			<bounds x="431" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
+			<bounds x="495" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
+			<bounds x="559" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
+			<bounds x="623" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
+			<bounds x="687" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
+			<bounds x="751" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
+			<bounds x="815" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
+			<bounds x="879" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
+			<bounds x="943" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
+			<bounds x="1007" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
+			<bounds x="47" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
+			<bounds x="111" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
+			<bounds x="175" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
+			<bounds x="239" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
+			<bounds x="303" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
+			<bounds x="367" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
+			<bounds x="431" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
+			<bounds x="495" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
+			<bounds x="559" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
+			<bounds x="623" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
+			<bounds x="687" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
+			<bounds x="751" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
+			<bounds x="815" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
+			<bounds x="879" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
+			<bounds x="943" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
+			<bounds x="1007" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
+			<bounds x="47" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
+			<bounds x="111" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
+			<bounds x="175" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
+			<bounds x="239" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
+			<bounds x="303" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
+			<bounds x="367" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
+			<bounds x="431" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
+			<bounds x="495" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
+			<bounds x="559" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
+			<bounds x="623" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
+			<bounds x="687" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
+			<bounds x="751" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
+			<bounds x="815" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
+			<bounds x="879" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
+			<bounds x="943" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
+			<bounds x="1007" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
+			<bounds x="47" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
+			<bounds x="111" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
+			<bounds x="175" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
+			<bounds x="239" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
+			<bounds x="303" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
+			<bounds x="367" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
+			<bounds x="431" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
+			<bounds x="495" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
+			<bounds x="559" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
+			<bounds x="623" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
+			<bounds x="687" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
+			<bounds x="751" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
+			<bounds x="815" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
+			<bounds x="879" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
+			<bounds x="943" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
+			<bounds x="1007" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
+			<bounds x="47" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
+			<bounds x="111" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
+			<bounds x="175" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
+			<bounds x="239" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
+			<bounds x="303" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
+			<bounds x="367" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
+			<bounds x="431" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
+			<bounds x="495" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
+			<bounds x="559" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
+			<bounds x="623" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
+			<bounds x="687" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
+			<bounds x="751" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
+			<bounds x="815" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
+			<bounds x="879" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
+			<bounds x="943" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
+			<bounds x="1007" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
+			<bounds x="47" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
+			<bounds x="111" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
+			<bounds x="175" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
+			<bounds x="239" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
+			<bounds x="303" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
+			<bounds x="367" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
+			<bounds x="431" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
+			<bounds x="495" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
+			<bounds x="559" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
+			<bounds x="623" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
+			<bounds x="687" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
+			<bounds x="751" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
+			<bounds x="815" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
+			<bounds x="879" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
+			<bounds x="943" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
+			<bounds x="1007" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
+			<bounds x="47" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
+			<bounds x="111" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
+			<bounds x="175" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
+			<bounds x="239" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
+			<bounds x="303" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
+			<bounds x="367" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
+			<bounds x="431" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
+			<bounds x="495" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
+			<bounds x="559" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
+			<bounds x="623" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
+			<bounds x="687" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
+			<bounds x="751" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
+			<bounds x="815" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
+			<bounds x="879" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
+			<bounds x="943" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
+			<bounds x="1007" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
+			<bounds x="47" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
+			<bounds x="111" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
+			<bounds x="175" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
+			<bounds x="239" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
+			<bounds x="303" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
+			<bounds x="367" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
+			<bounds x="431" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
+			<bounds x="495" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
+			<bounds x="559" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
+			<bounds x="623" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
+			<bounds x="687" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
+			<bounds x="751" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
+			<bounds x="815" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
+			<bounds x="879" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
+			<bounds x="943" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
+			<bounds x="1007" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
+			<bounds x="47" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
+			<bounds x="111" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
+			<bounds x="175" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
+			<bounds x="239" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
+			<bounds x="303" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
+			<bounds x="367" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
+			<bounds x="431" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
+			<bounds x="495" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
+			<bounds x="559" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
+			<bounds x="623" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
+			<bounds x="687" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
+			<bounds x="751" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
+			<bounds x="815" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
+			<bounds x="879" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
+			<bounds x="943" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
+			<bounds x="1007" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
+			<bounds x="47" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
+			<bounds x="111" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
+			<bounds x="175" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
+			<bounds x="239" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
+			<bounds x="303" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
+			<bounds x="367" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
+			<bounds x="431" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
+			<bounds x="495" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
+			<bounds x="559" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
+			<bounds x="623" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
+			<bounds x="687" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
+			<bounds x="751" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
+			<bounds x="815" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
+			<bounds x="879" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
+			<bounds x="943" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
+			<bounds x="1007" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
+			<bounds x="47" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
+			<bounds x="111" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
+			<bounds x="175" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
+			<bounds x="239" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
+			<bounds x="303" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
+			<bounds x="367" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
+			<bounds x="431" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
+			<bounds x="495" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
+			<bounds x="559" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
+			<bounds x="623" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
+			<bounds x="687" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
+			<bounds x="751" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
+			<bounds x="815" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
+			<bounds x="879" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
+			<bounds x="943" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
+			<bounds x="1007" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
+			<bounds x="47" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
+			<bounds x="111" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
+			<bounds x="175" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
+			<bounds x="239" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
+			<bounds x="303" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
+			<bounds x="367" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
+			<bounds x="431" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
+			<bounds x="495" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
+			<bounds x="559" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
+			<bounds x="623" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
+			<bounds x="687" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
+			<bounds x="751" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
+			<bounds x="815" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
+			<bounds x="879" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
+			<bounds x="943" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
+			<bounds x="1007" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
+			<bounds x="47" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
+			<bounds x="111" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
+			<bounds x="175" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
+			<bounds x="239" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
+			<bounds x="303" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
+			<bounds x="367" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
+			<bounds x="431" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
+			<bounds x="495" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
+			<bounds x="559" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
+			<bounds x="623" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
+			<bounds x="687" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
+			<bounds x="751" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
+			<bounds x="815" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
+			<bounds x="879" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
+			<bounds x="943" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
+			<bounds x="992" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
+			<bounds x="1007" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x01">
+			<bounds x="1100" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_0" element="debug_button_label_0">
+			<bounds x="1120" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x02">
+			<bounds x="1184" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_1" element="debug_button_label_1">
+			<bounds x="1204" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x04">
+			<bounds x="1268" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_2" element="debug_button_label_2">
+			<bounds x="1288" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x08">
+			<bounds x="1352" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_3" element="debug_button_label_3">
+			<bounds x="1372" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x10">
+			<bounds x="1436" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_4" element="debug_button_label_4">
+			<bounds x="1456" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x20">
+			<bounds x="1520" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_5" element="debug_button_label_5">
+			<bounds x="1540" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x40">
+			<bounds x="1604" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_6" element="debug_button_label_6">
+			<bounds x="1624" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x80">
+			<bounds x="1688" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_7" element="debug_button_label_7">
+			<bounds x="1708" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x01">
+			<bounds x="1100" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_8" element="debug_button_label_8">
+			<bounds x="1120" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x02">
+			<bounds x="1184" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_9" element="debug_button_label_9">
+			<bounds x="1204" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x04">
+			<bounds x="1268" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_10" element="debug_button_label_10">
+			<bounds x="1288" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x08">
+			<bounds x="1352" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_11" element="debug_button_label_11">
+			<bounds x="1372" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x10">
+			<bounds x="1436" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_12" element="debug_button_label_12">
+			<bounds x="1456" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x20">
+			<bounds x="1520" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_13" element="debug_button_label_13">
+			<bounds x="1540" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x40">
+			<bounds x="1604" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_14" element="debug_button_label_14">
+			<bounds x="1624" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x80">
+			<bounds x="1688" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_15" element="debug_button_label_15">
+			<bounds x="1708" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x01">
+			<bounds x="1100" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_16" element="debug_button_label_16">
+			<bounds x="1120" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x02">
+			<bounds x="1184" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_17" element="debug_button_label_17">
+			<bounds x="1204" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x04">
+			<bounds x="1268" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_18" element="debug_button_label_18">
+			<bounds x="1288" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x08">
+			<bounds x="1352" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_19" element="debug_button_label_19">
+			<bounds x="1372" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x10">
+			<bounds x="1436" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_20" element="debug_button_label_20">
+			<bounds x="1456" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x20">
+			<bounds x="1520" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_21" element="debug_button_label_21">
+			<bounds x="1540" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x40">
+			<bounds x="1604" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_22" element="debug_button_label_22">
+			<bounds x="1624" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x80">
+			<bounds x="1688" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_23" element="debug_button_label_23">
+			<bounds x="1708" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp24" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x01">
+			<bounds x="1100" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_24" element="debug_button_label_24">
+			<bounds x="1120" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x02">
+			<bounds x="1184" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_25" element="debug_button_label_25">
+			<bounds x="1204" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x04">
+			<bounds x="1268" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_26" element="debug_button_label_26">
+			<bounds x="1288" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x08">
+			<bounds x="1352" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_27" element="debug_button_label_27">
+			<bounds x="1372" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x10">
+			<bounds x="1436" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_28" element="debug_button_label_28">
+			<bounds x="1456" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x20">
+			<bounds x="1520" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_29" element="debug_button_label_29">
+			<bounds x="1540" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x40">
+			<bounds x="1604" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_30" element="debug_button_label_30">
+			<bounds x="1624" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x80">
+			<bounds x="1688" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_31" element="debug_button_label_31">
+			<bounds x="1708" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x01">
+			<bounds x="1100" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_32" element="debug_button_label_32">
+			<bounds x="1120" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x02">
+			<bounds x="1184" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_33" element="debug_button_label_33">
+			<bounds x="1204" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x04">
+			<bounds x="1268" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_34" element="debug_button_label_34">
+			<bounds x="1288" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x08">
+			<bounds x="1352" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_35" element="debug_button_label_35">
+			<bounds x="1372" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x10">
+			<bounds x="1436" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_36" element="debug_button_label_36">
+			<bounds x="1456" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x20">
+			<bounds x="1520" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_37" element="debug_button_label_37">
+			<bounds x="1540" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x40">
+			<bounds x="1604" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_38" element="debug_button_label_38">
+			<bounds x="1624" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x80">
+			<bounds x="1688" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_39" element="debug_button_label_39">
+			<bounds x="1708" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x01">
+			<bounds x="1100" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_40" element="debug_button_label_40">
+			<bounds x="1120" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x02">
+			<bounds x="1184" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_41" element="debug_button_label_41">
+			<bounds x="1204" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x04">
+			<bounds x="1268" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_42" element="debug_button_label_42">
+			<bounds x="1288" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x08">
+			<bounds x="1352" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_43" element="debug_button_label_43">
+			<bounds x="1372" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x10">
+			<bounds x="1436" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_44" element="debug_button_label_44">
+			<bounds x="1456" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x20">
+			<bounds x="1520" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_45" element="debug_button_label_45">
+			<bounds x="1540" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x40">
+			<bounds x="1604" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_46" element="debug_button_label_46">
+			<bounds x="1624" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x80">
+			<bounds x="1688" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_47" element="debug_button_label_47">
+			<bounds x="1708" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x01">
+			<bounds x="1100" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_48" element="debug_button_label_48">
+			<bounds x="1120" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x02">
+			<bounds x="1184" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_49" element="debug_button_label_49">
+			<bounds x="1204" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x04">
+			<bounds x="1268" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_50" element="debug_button_label_50">
+			<bounds x="1288" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x08">
+			<bounds x="1352" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_51" element="debug_button_label_51">
+			<bounds x="1372" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x10">
+			<bounds x="1436" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_52" element="debug_button_label_52">
+			<bounds x="1456" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x20">
+			<bounds x="1520" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_53" element="debug_button_label_53">
+			<bounds x="1540" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x40">
+			<bounds x="1604" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_54" element="debug_button_label_54">
+			<bounds x="1624" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x80">
+			<bounds x="1688" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_55" element="debug_button_label_55">
+			<bounds x="1708" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x01">
+			<bounds x="1100" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_56" element="debug_button_label_56">
+			<bounds x="1120" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x02">
+			<bounds x="1184" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_57" element="debug_button_label_57">
+			<bounds x="1204" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x04">
+			<bounds x="1268" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_58" element="debug_button_label_58">
+			<bounds x="1288" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x08">
+			<bounds x="1352" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_59" element="debug_button_label_59">
+			<bounds x="1372" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x10">
+			<bounds x="1436" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_60" element="debug_button_label_60">
+			<bounds x="1456" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_61" element="debug_button_standard" state="0" inputtag="AUX2" inputmask="0x20">
+			<bounds x="1520" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_61" element="debug_button_label_61">
+			<bounds x="1540" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x40">
+			<bounds x="1604" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_62" element="debug_button_label_62">
+			<bounds x="1624" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_63" element="debug_button_standard" state="0" inputtag="AUX2" inputmask="0x80">
+			<bounds x="1688" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_63" element="debug_button_label_63">
+			<bounds x="1708" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="vfd15" element="debug_vfd" state="0">
+			<bounds x="1150" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd14" element="debug_vfd" state="0">
+			<bounds x="1182" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd13" element="debug_vfd" state="0">
+			<bounds x="1214" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd12" element="debug_vfd" state="0">
+			<bounds x="1246" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd11" element="debug_vfd" state="0">
+			<bounds x="1278" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd10" element="debug_vfd" state="0">
+			<bounds x="1310" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd9" element="debug_vfd" state="0">
+			<bounds x="1342" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd8" element="debug_vfd" state="0">
+			<bounds x="1374" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd7" element="debug_vfd" state="0">
+			<bounds x="1406" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd6" element="debug_vfd" state="0">
+			<bounds x="1438" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd5" element="debug_vfd" state="0">
+			<bounds x="1470" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd4" element="debug_vfd" state="0">
+			<bounds x="1502" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd3" element="debug_vfd" state="0">
+			<bounds x="1534" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd2" element="debug_vfd" state="0">
+			<bounds x="1566" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd1" element="debug_vfd" state="0">
+			<bounds x="1598" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd0" element="debug_vfd" state="0">
+			<bounds x="1630" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel1" element="reel0" state="0">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel2" element="reel1" state="0">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel3" element="reel2" state="0">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1520" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_0" state="0">
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_1" state="0">
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_2" state="0">
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_3" state="0">
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_4" state="0">
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
+		</backdrop>
+		<backdrop name="lamp11" element="reel_lamp_layer_5" state="0">
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
+		</backdrop>
+		<backdrop name="sreel4" element="reel3" state="0">
+			<bounds x="1520" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="reel1" element="debug_stepper_value">
+			<bounds x="1100" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel2" element="debug_stepper_value">
+			<bounds x="1240" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel3" element="debug_stepper_value">
+			<bounds x="1380" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel4" element="debug_stepper_value">
+			<bounds x="1520" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
+			<bounds x="1180" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
+			<bounds x="1320" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
+			<bounds x="1460" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m4alladv.lay
+++ b/src/mame/layout/m4alladv.lay
@@ -8,1985 +8,5696 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SuperWin Active">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_7_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_7_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="All Cash Advance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_4_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_4_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Al">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="l">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="VAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Credit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_53_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_53">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SUPERWI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_54_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_54">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_55_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_55">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_56_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_56">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_57_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_57">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_58_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_58">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_59_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_59">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_60_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_60">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_61_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_61">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Cherry,Grape,Cashpot,Orange,Bar,Cashpot,Cherry,Orange,Bell,SuperWin,Lemon,Jackpot,Cashpot,Cherry,Lemon,Pound">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Orange,Cashpot,Jackpot,Lemon,Grape,Cherry,Bell,Lemon,Orange,Cherry,Pound,Lemon,Grape,Cashpot,Bar,Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Cherry,Bar,Orange,Cashpot,Grape,Lemon,Cherry,Jackpot,SuperWin,Grape,Cherry,Pound,Cashpot,Orange,Bell,Lemon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_3">
 		<text string="Trys">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_13">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_14">
 		<text string="27 Ways to win &#xA3;1!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_18">
 		<text string="&#xA3;4 Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_19">
 		<text string="All Cash Advace">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="(C) Barcrest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="MPU Layout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="by Steveir">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
+		</text>
+	</element>
+	<element name="debug_backdrop_colour">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_standard">
+		<rect state="0">
+			<color red="0.00" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_reel">
+		<rect state="0">
+			<color red="0.00" green="0.00" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="0.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_segment">
+		<rect state="0">
+			<color red="0.20" green="0.00" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="0.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_button">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_64">
+		<text string="64">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_65">
+		<text string="65">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_66">
+		<text string="66">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_67">
+		<text string="67">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_68">
+		<text string="68">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_69">
+		<text string="69">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_70">
+		<text string="70">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_71">
+		<text string="71">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_72">
+		<text string="72">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_73">
+		<text string="73">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_74">
+		<text string="74">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_75">
+		<text string="75">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_76">
+		<text string="76">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_77">
+		<text string="77">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_78">
+		<text string="78">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_79">
+		<text string="79">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_80">
+		<text string="80">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_81">
+		<text string="81">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_82">
+		<text string="82">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_83">
+		<text string="83">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_84">
+		<text string="84">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_85">
+		<text string="85">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_86">
+		<text string="86">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_87">
+		<text string="87">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_88">
+		<text string="88">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_89">
+		<text string="89">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_90">
+		<text string="90">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_91">
+		<text string="91">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_92">
+		<text string="92">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_93">
+		<text string="93">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_94">
+		<text string="94">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_95">
+		<text string="95">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_96">
+		<text string="96">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_97">
+		<text string="97">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_98">
+		<text string="98">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_99">
+		<text string="99">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_100">
+		<text string="100">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_101">
+		<text string="101">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_102">
+		<text string="102">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_103">
+		<text string="103">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_104">
+		<text string="104">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_105">
+		<text string="105">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_106">
+		<text string="106">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_107">
+		<text string="107">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_108">
+		<text string="108">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_109">
+		<text string="109">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_110">
+		<text string="110">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_111">
+		<text string="111">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_112">
+		<text string="112">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_113">
+		<text string="113">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_114">
+		<text string="114">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_115">
+		<text string="115">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_116">
+		<text string="116">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_117">
+		<text string="117">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_118">
+		<text string="118">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_119">
+		<text string="119">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_120">
+		<text string="120">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_121">
+		<text string="121">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_122">
+		<text string="122">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_123">
+		<text string="123">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_124">
+		<text string="124">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_125">
+		<text string="125">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_126">
+		<text string="126">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_127">
+		<text string="127">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_128">
+		<text string="128">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_129">
+		<text string="129">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_130">
+		<text string="130">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_131">
+		<text string="131">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_132">
+		<text string="132">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_133">
+		<text string="133">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_134">
+		<text string="134">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_135">
+		<text string="135">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_136">
+		<text string="136">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_137">
+		<text string="137">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_138">
+		<text string="138">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_139">
+		<text string="139">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_140">
+		<text string="140">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_141">
+		<text string="141">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_142">
+		<text string="142">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_143">
+		<text string="143">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_144">
+		<text string="144">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_145">
+		<text string="145">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_146">
+		<text string="146">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_147">
+		<text string="147">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_148">
+		<text string="148">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_149">
+		<text string="149">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_150">
+		<text string="150">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_151">
+		<text string="151">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_152">
+		<text string="152">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_153">
+		<text string="153">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_154">
+		<text string="154">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_155">
+		<text string="155">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_156">
+		<text string="156">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_157">
+		<text string="157">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_158">
+		<text string="158">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_159">
+		<text string="159">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_160">
+		<text string="160">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_161">
+		<text string="161">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_162">
+		<text string="162">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_163">
+		<text string="163">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_164">
+		<text string="164">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_165">
+		<text string="165">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_166">
+		<text string="166">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_167">
+		<text string="167">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_168">
+		<text string="168">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_169">
+		<text string="169">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_170">
+		<text string="170">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_171">
+		<text string="171">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_172">
+		<text string="172">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_173">
+		<text string="173">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_174">
+		<text string="174">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_175">
+		<text string="175">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_176">
+		<text string="176">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_177">
+		<text string="177">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_178">
+		<text string="178">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_179">
+		<text string="179">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_180">
+		<text string="180">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_181">
+		<text string="181">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_182">
+		<text string="182">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_183">
+		<text string="183">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_184">
+		<text string="184">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_185">
+		<text string="185">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_186">
+		<text string="186">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_187">
+		<text string="187">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_188">
+		<text string="188">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_189">
+		<text string="189">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_190">
+		<text string="190">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_191">
+		<text string="191">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_192">
+		<text string="192">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_193">
+		<text string="193">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_194">
+		<text string="194">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_195">
+		<text string="195">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_196">
+		<text string="196">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_197">
+		<text string="197">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_198">
+		<text string="198">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_199">
+		<text string="199">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_200">
+		<text string="200">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_201">
+		<text string="201">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_202">
+		<text string="202">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_203">
+		<text string="203">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_204">
+		<text string="204">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_205">
+		<text string="205">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_206">
+		<text string="206">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_207">
+		<text string="207">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_208">
+		<text string="208">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_209">
+		<text string="209">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_210">
+		<text string="210">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_211">
+		<text string="211">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_212">
+		<text string="212">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_213">
+		<text string="213">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_214">
+		<text string="214">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_215">
+		<text string="215">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_216">
+		<text string="216">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_217">
+		<text string="217">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_218">
+		<text string="218">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_219">
+		<text string="219">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_220">
+		<text string="220">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_221">
+		<text string="221">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_222">
+		<text string="222">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_223">
+		<text string="223">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_224">
+		<text string="224">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_225">
+		<text string="225">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_226">
+		<text string="226">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_227">
+		<text string="227">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_228">
+		<text string="228">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_229">
+		<text string="229">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_230">
+		<text string="230">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_231">
+		<text string="231">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_232">
+		<text string="232">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_233">
+		<text string="233">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_234">
+		<text string="234">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_235">
+		<text string="235">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_236">
+		<text string="236">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_237">
+		<text string="237">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_238">
+		<text string="238">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_239">
+		<text string="239">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_240">
+		<text string="240">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_241">
+		<text string="241">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_242">
+		<text string="242">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_243">
+		<text string="243">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_244">
+		<text string="244">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_245">
+		<text string="245">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_246">
+		<text string="246">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_247">
+		<text string="247">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_248">
+		<text string="248">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_249">
+		<text string="249">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_250">
+		<text string="250">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_251">
+		<text string="251">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_252">
+		<text string="252">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_253">
+		<text string="253">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_254">
+		<text string="254">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_255">
+		<text string="255">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_standard">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_vfd">
+		<led16segsc>
+			<color red="0.0" green="1.0" blue="1.0"/>
+		</led16segsc>
+	</element>
+	<element name="debug_stepper_value" defstate="0">
+		<simplecounter maxstate="999" digits="3">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</simplecounter>
+	</element>
+	<element name="debug_reel_symbol_count_0">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_1">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_2">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="521">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="521"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="241" y="332" width="80" height="140">
-			</bounds>
+			<bounds x="241" y="332" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="332.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="241.0000" y="332.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.3333" y="333.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="244.3333" y="333.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
-			<bounds x="247.6667" y="335.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="247.6667" y="335.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
-			<bounds x="251.0000" y="337.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="251.0000" y="337.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
-			<bounds x="254.3333" y="339.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="254.3333" y="339.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
-			<bounds x="257.6667" y="341.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="257.6667" y="341.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="378.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="241.0000" y="378.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.3333" y="380.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="244.3333" y="380.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
-			<bounds x="247.6667" y="382.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="247.6667" y="382.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
-			<bounds x="251.0000" y="384.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="251.0000" y="384.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
-			<bounds x="254.3333" y="386.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="254.3333" y="386.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
-			<bounds x="257.6667" y="388.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="257.6667" y="388.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="425.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="241.0000" y="425.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.3333" y="427.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="244.3333" y="427.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="247.6667" y="429.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="247.6667" y="429.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="251.0000" y="431.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="251.0000" y="431.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="254.3333" y="433.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="254.3333" y="433.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="257.6667" y="435.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="257.6667" y="435.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="241" y="332" width="80" height="140">
-			</bounds>
+			<bounds x="241" y="332" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="323" y="332" width="80" height="140">
-			</bounds>
+			<bounds x="323" y="332" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_0" state="0">
-			<bounds x="323.0000" y="332.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="323.0000" y="332.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_1" state="0">
-			<bounds x="326.3333" y="333.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="326.3333" y="333.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_2" state="0">
-			<bounds x="329.6667" y="335.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="329.6667" y="335.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_3" state="0">
-			<bounds x="333.0000" y="337.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="333.0000" y="337.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_4" state="0">
-			<bounds x="336.3333" y="339.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="336.3333" y="339.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp1" element="reel_lamp_layer_5" state="0">
-			<bounds x="339.6667" y="341.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="339.6667" y="341.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_0" state="0">
-			<bounds x="323.0000" y="378.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="323.0000" y="378.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_1" state="0">
-			<bounds x="326.3333" y="380.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="326.3333" y="380.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_2" state="0">
-			<bounds x="329.6667" y="382.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="329.6667" y="382.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_3" state="0">
-			<bounds x="333.0000" y="384.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="333.0000" y="384.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_4" state="0">
-			<bounds x="336.3333" y="386.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="336.3333" y="386.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp9" element="reel_lamp_layer_5" state="0">
-			<bounds x="339.6667" y="388.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="339.6667" y="388.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
-			<bounds x="323.0000" y="425.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="323.0000" y="425.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
-			<bounds x="326.3333" y="427.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="326.3333" y="427.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
-			<bounds x="329.6667" y="429.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="329.6667" y="429.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
-			<bounds x="333.0000" y="431.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="333.0000" y="431.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
-			<bounds x="336.3333" y="433.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="336.3333" y="433.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
-			<bounds x="339.6667" y="435.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="339.6667" y="435.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="323" y="332" width="80" height="140">
-			</bounds>
+			<bounds x="323" y="332" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="405" y="332" width="80" height="140">
-			</bounds>
+			<bounds x="405" y="332" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_0" state="0">
-			<bounds x="405.0000" y="332.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="405.0000" y="332.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_1" state="0">
-			<bounds x="408.3333" y="333.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="408.3333" y="333.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_2" state="0">
-			<bounds x="411.6667" y="335.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="411.6667" y="335.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_3" state="0">
-			<bounds x="415.0000" y="337.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="415.0000" y="337.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_4" state="0">
-			<bounds x="418.3333" y="339.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="418.3333" y="339.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp2" element="reel_lamp_layer_5" state="0">
-			<bounds x="421.6667" y="341.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="421.6667" y="341.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
-			<bounds x="405.0000" y="378.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="405.0000" y="378.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
-			<bounds x="408.3333" y="380.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="408.3333" y="380.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
-			<bounds x="411.6667" y="382.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="411.6667" y="382.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
-			<bounds x="415.0000" y="384.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="415.0000" y="384.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
-			<bounds x="418.3333" y="386.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="418.3333" y="386.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
-			<bounds x="421.6667" y="388.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="421.6667" y="388.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
-			<bounds x="405.0000" y="425.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="405.0000" y="425.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
-			<bounds x="408.3333" y="427.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="408.3333" y="427.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
-			<bounds x="411.6667" y="429.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="411.6667" y="429.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
-			<bounds x="415.0000" y="431.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="415.0000" y="431.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
-			<bounds x="418.3333" y="433.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="418.3333" y="433.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
-			<bounds x="421.6667" y="435.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="421.6667" y="435.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="405" y="332" width="80" height="140">
-			</bounds>
+			<bounds x="405" y="332" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="10" y="264" width="52" height="44">
-			</bounds>
+			<bounds x="10" y="264" width="52" height="44"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="12" y="266" width="48" height="40">
-			</bounds>
+			<bounds x="12" y="266" width="48" height="40"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="10" y="315" width="52" height="42">
-			</bounds>
+			<bounds x="10" y="315" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="12" y="317" width="48" height="38">
-			</bounds>
+			<bounds x="12" y="317" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="10" y="361" width="52" height="42">
-			</bounds>
+			<bounds x="10" y="361" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="12" y="363" width="48" height="38">
-			</bounds>
+			<bounds x="12" y="363" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="10" y="407" width="52" height="42">
-			</bounds>
+			<bounds x="10" y="407" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="12" y="409" width="48" height="38">
-			</bounds>
+			<bounds x="12" y="409" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="77" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="77" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="79" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="79" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="116" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="116" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="118" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="118" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="156" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="156" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="158" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="158" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="7" y="215" width="72" height="42">
-			</bounds>
+			<bounds x="7" y="215" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="9" y="217" width="68" height="38">
-			</bounds>
+			<bounds x="9" y="217" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="lamp_7_1_border" state="0">
-			<bounds x="152" y="262" width="72" height="52">
-			</bounds>
+			<bounds x="152" y="262" width="72" height="52"/>
 		</backdrop>
 		<backdrop name="lamp7" element="lamp_7_1" state="0">
-			<bounds x="154" y="264" width="68" height="48">
-			</bounds>
+			<bounds x="154" y="264" width="68" height="48"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1_border" state="0">
-			<bounds x="79" y="264" width="62" height="47">
-			</bounds>
+			<bounds x="79" y="264" width="62" height="47"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1" state="0">
-			<bounds x="81" y="266" width="58" height="43">
-			</bounds>
+			<bounds x="81" y="266" width="58" height="43"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="340" y="277" width="52" height="42">
-			</bounds>
+			<bounds x="340" y="277" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="342" y="279" width="48" height="38">
-			</bounds>
+			<bounds x="342" y="279" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="288" y="277" width="52" height="42">
-			</bounds>
+			<bounds x="288" y="277" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="290" y="279" width="48" height="38">
-			</bounds>
+			<bounds x="290" y="279" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="237" y="278" width="52" height="42">
-			</bounds>
+			<bounds x="237" y="278" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="239" y="280" width="48" height="38">
-			</bounds>
+			<bounds x="239" y="280" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0">
-			<bounds x="392" y="276" width="52" height="42">
-			</bounds>
+			<bounds x="392" y="276" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0">
-			<bounds x="394" y="278" width="48" height="38">
-			</bounds>
+			<bounds x="394" y="278" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1_border" state="0">
-			<bounds x="443" y="276" width="52" height="42">
-			</bounds>
+			<bounds x="443" y="276" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1" state="0">
-			<bounds x="445" y="278" width="48" height="38">
-			</bounds>
+			<bounds x="445" y="278" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="336" y="231" width="62" height="42">
-			</bounds>
+			<bounds x="336" y="231" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="338" y="233" width="58" height="38">
-			</bounds>
+			<bounds x="338" y="233" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="325" y="183" width="82" height="42">
-			</bounds>
+			<bounds x="325" y="183" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="327" y="185" width="78" height="38">
-			</bounds>
+			<bounds x="327" y="185" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="316" y="137" width="102" height="42">
-			</bounds>
+			<bounds x="316" y="137" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="318" y="139" width="98" height="38">
-			</bounds>
+			<bounds x="318" y="139" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="305" y="92" width="122" height="42">
-			</bounds>
+			<bounds x="305" y="92" width="122" height="42"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="307" y="94" width="118" height="38">
-			</bounds>
+			<bounds x="307" y="94" width="118" height="38"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="294" y="46" width="142" height="42">
-			</bounds>
+			<bounds x="294" y="46" width="142" height="42"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="296" y="48" width="138" height="38">
-			</bounds>
+			<bounds x="296" y="48" width="138" height="38"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="236" y="3" width="27" height="37">
-			</bounds>
+			<bounds x="236" y="3" width="27" height="37"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="238" y="5" width="23" height="33">
-			</bounds>
+			<bounds x="238" y="5" width="23" height="33"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="260" y="3" width="22" height="37">
-			</bounds>
+			<bounds x="260" y="3" width="22" height="37"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="262" y="5" width="18" height="33">
-			</bounds>
+			<bounds x="262" y="5" width="18" height="33"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="303" y="3" width="37" height="37">
-			</bounds>
+			<bounds x="303" y="3" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="305" y="5" width="33" height="33">
-			</bounds>
+			<bounds x="305" y="5" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="338" y="3" width="37" height="37">
-			</bounds>
+			<bounds x="338" y="3" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="340" y="5" width="33" height="33">
-			</bounds>
+			<bounds x="340" y="5" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="478" y="3" width="37" height="37">
-			</bounds>
+			<bounds x="478" y="3" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="480" y="5" width="33" height="33">
-			</bounds>
+			<bounds x="480" y="5" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="428" y="3" width="52" height="37">
-			</bounds>
+			<bounds x="428" y="3" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="430" y="5" width="48" height="33">
-			</bounds>
+			<bounds x="430" y="5" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="394" y="3" width="37" height="37">
-			</bounds>
+			<bounds x="394" y="3" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="396" y="5" width="33" height="33">
-			</bounds>
+			<bounds x="396" y="5" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="68" y="407" width="52" height="42">
-			</bounds>
+			<bounds x="68" y="407" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="70" y="409" width="48" height="38">
-			</bounds>
+			<bounds x="70" y="409" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="124" y="407" width="52" height="42">
-			</bounds>
+			<bounds x="124" y="407" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="126" y="409" width="48" height="38">
-			</bounds>
+			<bounds x="126" y="409" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="182" y="407" width="52" height="42">
-			</bounds>
+			<bounds x="182" y="407" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="184" y="409" width="48" height="38">
-			</bounds>
+			<bounds x="184" y="409" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="491" y="87" width="102" height="32">
-			</bounds>
+			<bounds x="491" y="87" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="493" y="89" width="98" height="28">
-			</bounds>
+			<bounds x="493" y="89" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="505" y="172" width="82" height="32">
-			</bounds>
+			<bounds x="505" y="172" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="507" y="174" width="78" height="28">
-			</bounds>
+			<bounds x="507" y="174" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="651" y="85" width="102" height="32">
-			</bounds>
+			<bounds x="651" y="85" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="653" y="87" width="98" height="28">
-			</bounds>
+			<bounds x="653" y="87" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="colour_button_53_border" state="0" inputtag="BLACK1" inputmask="0x08">
-			<bounds x="15" y="477" width="82" height="37">
-			</bounds>
+			<bounds x="15" y="477" width="82" height="37"/>
 		</backdrop>
 		<backdrop name="lamp50" element="colour_button_53" state="0" inputtag="BLACK1" inputmask="0x08">
-			<bounds x="17" y="479" width="78" height="33">
-			</bounds>
+			<bounds x="17" y="479" width="78" height="33"/>
 		</backdrop>
 		<backdrop name="lamp25" element="colour_button_54_border" state="0" inputtag="BLACK2" inputmask="0x02">
-			<bounds x="507" y="477" width="75" height="37">
-			</bounds>
+			<bounds x="507" y="477" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp25" element="colour_button_54" state="0" inputtag="BLACK2" inputmask="0x02">
-			<bounds x="509" y="479" width="71" height="33">
-			</bounds>
+			<bounds x="509" y="479" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_55_border" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="116" y="477" width="82" height="37">
-			</bounds>
+			<bounds x="116" y="477" width="82" height="37"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_55" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="118" y="479" width="78" height="33">
-			</bounds>
+			<bounds x="118" y="479" width="78" height="33"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_56_border" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="241" y="477" width="75" height="37">
-			</bounds>
+			<bounds x="241" y="477" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_56" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="243" y="479" width="71" height="33">
-			</bounds>
+			<bounds x="243" y="479" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_57_border" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="326" y="477" width="75" height="37">
-			</bounds>
+			<bounds x="326" y="477" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_57" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="328" y="479" width="71" height="33">
-			</bounds>
+			<bounds x="328" y="479" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_58_border" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="408" y="477" width="75" height="37">
-			</bounds>
+			<bounds x="408" y="477" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_58" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="410" y="479" width="71" height="33">
-			</bounds>
+			<bounds x="410" y="479" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_59_border" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="609" y="477" width="75" height="37">
-			</bounds>
+			<bounds x="609" y="477" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_59" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="611" y="479" width="71" height="33">
-			</bounds>
+			<bounds x="611" y="479" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_60_border" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="707" y="477" width="75" height="37">
-			</bounds>
+			<bounds x="707" y="477" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_60" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="709" y="479" width="71" height="33">
-			</bounds>
+			<bounds x="709" y="479" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp56" element="colour_button_61_border" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="745" y="11" width="37" height="27">
-			</bounds>
+			<bounds x="745" y="11" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp56" element="colour_button_61" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="747" y="13" width="33" height="23">
-			</bounds>
+			<bounds x="747" y="13" width="33" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="469" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="469" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="469" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="469" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="469" y="120" width="48" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="469" y="120" width="48" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="515" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="515" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop name="digit1" element="led_digit_red">
-			<bounds x="515" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="515" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="515" y="120" width="48" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="515" y="120" width="48" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="562" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="562" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="562" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="562" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="562" y="120" width="48" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="562" y="120" width="48" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="702" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="702" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop name="digit7" element="led_digit_red">
-			<bounds x="702" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="702" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="702" y="120" width="48" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="702" y="120" width="48" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="655" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="655" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="655" y="120" width="48" height="50">
-			</bounds>
+			<bounds x="655" y="120" width="48" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="655" y="120" width="48" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="655" y="120" width="48" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop name="label3" element="label_3">
-			<bounds x="111" y="327" width="41" height="24">
-			</bounds>
+			<bounds x="111" y="327" width="41" height="24"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="569" y="376" width="10" height="16">
-			</bounds>
+			<bounds x="569" y="376" width="10" height="16"/>
 		</backdrop>
 		<backdrop name="label13" element="label_13">
-			<bounds x="634" y="377" width="10" height="16">
-			</bounds>
+			<bounds x="634" y="377" width="10" height="16"/>
 		</backdrop>
 		<backdrop name="label14" element="label_14">
-			<bounds x="694" y="358" width="69" height="26">
-			</bounds>
+			<bounds x="694" y="358" width="69" height="26"/>
 		</backdrop>
 		<backdrop name="label18" element="label_18">
-			<bounds x="59" y="77" width="72" height="48">
-			</bounds>
+			<bounds x="59" y="77" width="72" height="48"/>
 		</backdrop>
 		<backdrop name="label19" element="label_19">
-			<bounds x="704" y="410" width="78" height="52">
-			</bounds>
+			<bounds x="704" y="410" width="78" height="52"/>
+		</backdrop>
+	</view>
+
+	<view name="MFME2MAME Debug">
+		<backdrop element="debug_backdrop_colour">
+			<bounds x="0" y="0" width="1920" height="1080"/>
+		</backdrop>
+		<backdrop name="lamp0" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
+			<bounds x="47" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp1" element="debug_lamp_reel" state="0">
+			<bounds x="96" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
+			<bounds x="111" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp2" element="debug_lamp_reel" state="0">
+			<bounds x="160" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
+			<bounds x="175" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp3" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
+			<bounds x="239" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp4" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
+			<bounds x="303" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
+			<bounds x="367" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
+			<bounds x="431" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp7" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
+			<bounds x="495" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp8" element="debug_lamp_reel" state="0">
+			<bounds x="544" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
+			<bounds x="559" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp9" element="debug_lamp_reel" state="0">
+			<bounds x="608" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
+			<bounds x="623" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
+			<bounds x="672" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
+			<bounds x="687" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
+			<bounds x="751" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
+			<bounds x="815" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
+			<bounds x="879" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp14" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
+			<bounds x="943" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp15" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
+			<bounds x="1007" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
+			<bounds x="47" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
+			<bounds x="96" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
+			<bounds x="111" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
+			<bounds x="160" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
+			<bounds x="175" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
+			<bounds x="239" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
+			<bounds x="303" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
+			<bounds x="367" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
+			<bounds x="431" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
+			<bounds x="495" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
+			<bounds x="559" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_lamp_button" state="0">
+			<bounds x="608" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
+			<bounds x="623" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_lamp_button" state="0">
+			<bounds x="672" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
+			<bounds x="687" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
+			<bounds x="751" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
+			<bounds x="815" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
+			<bounds x="879" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
+			<bounds x="943" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp31" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
+			<bounds x="1007" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_lamp_button" state="0">
+			<bounds x="32" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
+			<bounds x="47" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_lamp_button" state="0">
+			<bounds x="96" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
+			<bounds x="111" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_lamp_button" state="0">
+			<bounds x="160" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
+			<bounds x="175" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
+			<bounds x="239" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
+			<bounds x="303" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
+			<bounds x="367" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
+			<bounds x="431" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
+			<bounds x="495" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_lamp_button" state="0">
+			<bounds x="544" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
+			<bounds x="559" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_lamp_button" state="0">
+			<bounds x="608" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
+			<bounds x="623" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
+			<bounds x="687" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
+			<bounds x="751" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
+			<bounds x="815" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
+			<bounds x="879" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
+			<bounds x="943" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
+			<bounds x="1007" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
+			<bounds x="47" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
+			<bounds x="111" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp50" element="debug_lamp_button" state="0">
+			<bounds x="160" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
+			<bounds x="175" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
+			<bounds x="239" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
+			<bounds x="303" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
+			<bounds x="367" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
+			<bounds x="431" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
+			<bounds x="495" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp56" element="debug_lamp_button" state="0">
+			<bounds x="544" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
+			<bounds x="559" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
+			<bounds x="623" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
+			<bounds x="687" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
+			<bounds x="751" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
+			<bounds x="815" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
+			<bounds x="879" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
+			<bounds x="943" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
+			<bounds x="1007" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
+			<bounds x="47" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
+			<bounds x="111" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
+			<bounds x="175" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
+			<bounds x="239" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
+			<bounds x="303" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
+			<bounds x="367" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
+			<bounds x="431" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
+			<bounds x="495" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
+			<bounds x="559" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
+			<bounds x="623" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
+			<bounds x="687" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
+			<bounds x="751" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
+			<bounds x="815" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
+			<bounds x="879" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
+			<bounds x="943" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
+			<bounds x="1007" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
+			<bounds x="47" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
+			<bounds x="111" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
+			<bounds x="175" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
+			<bounds x="239" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
+			<bounds x="303" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
+			<bounds x="367" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
+			<bounds x="431" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
+			<bounds x="495" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
+			<bounds x="559" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
+			<bounds x="623" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
+			<bounds x="687" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
+			<bounds x="751" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
+			<bounds x="815" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
+			<bounds x="879" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
+			<bounds x="943" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
+			<bounds x="1007" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
+			<bounds x="47" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
+			<bounds x="111" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
+			<bounds x="175" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
+			<bounds x="239" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
+			<bounds x="303" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
+			<bounds x="367" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
+			<bounds x="431" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
+			<bounds x="495" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
+			<bounds x="559" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
+			<bounds x="623" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
+			<bounds x="687" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
+			<bounds x="751" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
+			<bounds x="815" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
+			<bounds x="879" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
+			<bounds x="943" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
+			<bounds x="1007" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
+			<bounds x="47" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
+			<bounds x="111" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
+			<bounds x="175" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
+			<bounds x="239" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
+			<bounds x="303" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
+			<bounds x="367" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
+			<bounds x="431" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
+			<bounds x="495" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
+			<bounds x="559" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
+			<bounds x="623" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
+			<bounds x="687" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
+			<bounds x="751" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
+			<bounds x="815" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
+			<bounds x="879" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
+			<bounds x="943" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
+			<bounds x="1007" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
+			<bounds x="47" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
+			<bounds x="111" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
+			<bounds x="175" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
+			<bounds x="239" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
+			<bounds x="303" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
+			<bounds x="367" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
+			<bounds x="431" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
+			<bounds x="495" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
+			<bounds x="559" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
+			<bounds x="623" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
+			<bounds x="687" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
+			<bounds x="751" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
+			<bounds x="815" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
+			<bounds x="879" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
+			<bounds x="943" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
+			<bounds x="1007" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
+			<bounds x="47" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
+			<bounds x="111" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
+			<bounds x="175" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
+			<bounds x="239" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
+			<bounds x="303" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
+			<bounds x="367" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
+			<bounds x="431" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
+			<bounds x="495" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
+			<bounds x="559" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
+			<bounds x="623" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
+			<bounds x="687" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
+			<bounds x="751" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
+			<bounds x="815" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
+			<bounds x="879" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
+			<bounds x="943" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
+			<bounds x="1007" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
+			<bounds x="47" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
+			<bounds x="111" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
+			<bounds x="175" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
+			<bounds x="239" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
+			<bounds x="303" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
+			<bounds x="367" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
+			<bounds x="431" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
+			<bounds x="495" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
+			<bounds x="559" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
+			<bounds x="623" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
+			<bounds x="687" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
+			<bounds x="751" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
+			<bounds x="815" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
+			<bounds x="879" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
+			<bounds x="943" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
+			<bounds x="1007" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
+			<bounds x="47" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
+			<bounds x="111" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
+			<bounds x="175" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
+			<bounds x="239" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
+			<bounds x="303" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
+			<bounds x="367" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
+			<bounds x="431" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
+			<bounds x="495" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
+			<bounds x="559" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
+			<bounds x="623" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
+			<bounds x="687" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
+			<bounds x="751" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
+			<bounds x="815" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
+			<bounds x="879" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
+			<bounds x="943" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
+			<bounds x="1007" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
+			<bounds x="47" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
+			<bounds x="111" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
+			<bounds x="175" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
+			<bounds x="239" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
+			<bounds x="303" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
+			<bounds x="367" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
+			<bounds x="431" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
+			<bounds x="495" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
+			<bounds x="559" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
+			<bounds x="623" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
+			<bounds x="687" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
+			<bounds x="751" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
+			<bounds x="815" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
+			<bounds x="879" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
+			<bounds x="943" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
+			<bounds x="1007" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
+			<bounds x="47" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
+			<bounds x="111" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
+			<bounds x="175" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
+			<bounds x="239" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
+			<bounds x="303" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
+			<bounds x="367" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
+			<bounds x="431" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
+			<bounds x="495" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
+			<bounds x="559" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
+			<bounds x="623" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
+			<bounds x="687" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
+			<bounds x="751" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
+			<bounds x="815" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
+			<bounds x="879" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
+			<bounds x="943" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
+			<bounds x="1007" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
+			<bounds x="47" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
+			<bounds x="111" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
+			<bounds x="175" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
+			<bounds x="239" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
+			<bounds x="303" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
+			<bounds x="367" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
+			<bounds x="431" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
+			<bounds x="495" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
+			<bounds x="559" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
+			<bounds x="623" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
+			<bounds x="687" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
+			<bounds x="751" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
+			<bounds x="815" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
+			<bounds x="879" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
+			<bounds x="943" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
+			<bounds x="1007" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
+			<bounds x="47" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
+			<bounds x="111" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
+			<bounds x="175" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
+			<bounds x="239" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
+			<bounds x="303" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
+			<bounds x="367" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
+			<bounds x="431" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
+			<bounds x="495" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
+			<bounds x="559" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
+			<bounds x="623" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
+			<bounds x="687" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
+			<bounds x="751" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
+			<bounds x="815" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
+			<bounds x="879" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
+			<bounds x="943" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
+			<bounds x="1007" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x01">
+			<bounds x="1100" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_0" element="debug_button_label_0">
+			<bounds x="1120" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x02">
+			<bounds x="1184" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_1" element="debug_button_label_1">
+			<bounds x="1204" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x04">
+			<bounds x="1268" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_2" element="debug_button_label_2">
+			<bounds x="1288" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x08">
+			<bounds x="1352" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_3" element="debug_button_label_3">
+			<bounds x="1372" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x10">
+			<bounds x="1436" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_4" element="debug_button_label_4">
+			<bounds x="1456" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x20">
+			<bounds x="1520" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_5" element="debug_button_label_5">
+			<bounds x="1540" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x40">
+			<bounds x="1604" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_6" element="debug_button_label_6">
+			<bounds x="1624" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x80">
+			<bounds x="1688" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_7" element="debug_button_label_7">
+			<bounds x="1708" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x01">
+			<bounds x="1100" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_8" element="debug_button_label_8">
+			<bounds x="1120" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x02">
+			<bounds x="1184" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_9" element="debug_button_label_9">
+			<bounds x="1204" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x04">
+			<bounds x="1268" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_10" element="debug_button_label_10">
+			<bounds x="1288" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x08">
+			<bounds x="1352" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_11" element="debug_button_label_11">
+			<bounds x="1372" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x10">
+			<bounds x="1436" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_12" element="debug_button_label_12">
+			<bounds x="1456" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x20">
+			<bounds x="1520" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_13" element="debug_button_label_13">
+			<bounds x="1540" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x40">
+			<bounds x="1604" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_14" element="debug_button_label_14">
+			<bounds x="1624" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x80">
+			<bounds x="1688" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_15" element="debug_button_label_15">
+			<bounds x="1708" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x01">
+			<bounds x="1100" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_16" element="debug_button_label_16">
+			<bounds x="1120" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x02">
+			<bounds x="1184" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_17" element="debug_button_label_17">
+			<bounds x="1204" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x04">
+			<bounds x="1268" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_18" element="debug_button_label_18">
+			<bounds x="1288" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp50" element="debug_button_standard" state="0" inputtag="BLACK1" inputmask="0x08">
+			<bounds x="1352" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_19" element="debug_button_label_19">
+			<bounds x="1372" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x10">
+			<bounds x="1436" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_20" element="debug_button_label_20">
+			<bounds x="1456" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x20">
+			<bounds x="1520" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_21" element="debug_button_label_21">
+			<bounds x="1540" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x40">
+			<bounds x="1604" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_22" element="debug_button_label_22">
+			<bounds x="1624" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x80">
+			<bounds x="1688" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_23" element="debug_button_label_23">
+			<bounds x="1708" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="BLACK2" inputmask="0x01">
+			<bounds x="1100" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_24" element="debug_button_label_24">
+			<bounds x="1120" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x02">
+			<bounds x="1184" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_25" element="debug_button_label_25">
+			<bounds x="1204" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x04">
+			<bounds x="1268" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_26" element="debug_button_label_26">
+			<bounds x="1288" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x08">
+			<bounds x="1352" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_27" element="debug_button_label_27">
+			<bounds x="1372" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x10">
+			<bounds x="1436" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_28" element="debug_button_label_28">
+			<bounds x="1456" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x20">
+			<bounds x="1520" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_29" element="debug_button_label_29">
+			<bounds x="1540" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x40">
+			<bounds x="1604" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_30" element="debug_button_label_30">
+			<bounds x="1624" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x80">
+			<bounds x="1688" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_31" element="debug_button_label_31">
+			<bounds x="1708" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x01">
+			<bounds x="1100" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_32" element="debug_button_label_32">
+			<bounds x="1120" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x02">
+			<bounds x="1184" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_33" element="debug_button_label_33">
+			<bounds x="1204" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x04">
+			<bounds x="1268" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_34" element="debug_button_label_34">
+			<bounds x="1288" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x08">
+			<bounds x="1352" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_35" element="debug_button_label_35">
+			<bounds x="1372" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x10">
+			<bounds x="1436" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_36" element="debug_button_label_36">
+			<bounds x="1456" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x20">
+			<bounds x="1520" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_37" element="debug_button_label_37">
+			<bounds x="1540" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x40">
+			<bounds x="1604" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_38" element="debug_button_label_38">
+			<bounds x="1624" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x80">
+			<bounds x="1688" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_39" element="debug_button_label_39">
+			<bounds x="1708" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x01">
+			<bounds x="1100" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_40" element="debug_button_label_40">
+			<bounds x="1120" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x02">
+			<bounds x="1184" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_41" element="debug_button_label_41">
+			<bounds x="1204" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x04">
+			<bounds x="1268" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_42" element="debug_button_label_42">
+			<bounds x="1288" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x08">
+			<bounds x="1352" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_43" element="debug_button_label_43">
+			<bounds x="1372" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x10">
+			<bounds x="1436" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_44" element="debug_button_label_44">
+			<bounds x="1456" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x20">
+			<bounds x="1520" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_45" element="debug_button_label_45">
+			<bounds x="1540" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x40">
+			<bounds x="1604" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_46" element="debug_button_label_46">
+			<bounds x="1624" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x80">
+			<bounds x="1688" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_47" element="debug_button_label_47">
+			<bounds x="1708" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x01">
+			<bounds x="1100" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_48" element="debug_button_label_48">
+			<bounds x="1120" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x02">
+			<bounds x="1184" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_49" element="debug_button_label_49">
+			<bounds x="1204" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x04">
+			<bounds x="1268" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_50" element="debug_button_label_50">
+			<bounds x="1288" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x08">
+			<bounds x="1352" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_51" element="debug_button_label_51">
+			<bounds x="1372" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x10">
+			<bounds x="1436" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_52" element="debug_button_label_52">
+			<bounds x="1456" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x20">
+			<bounds x="1520" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_53" element="debug_button_label_53">
+			<bounds x="1540" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x40">
+			<bounds x="1604" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_54" element="debug_button_label_54">
+			<bounds x="1624" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x80">
+			<bounds x="1688" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_55" element="debug_button_label_55">
+			<bounds x="1708" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x01">
+			<bounds x="1100" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_56" element="debug_button_label_56">
+			<bounds x="1120" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x02">
+			<bounds x="1184" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_57" element="debug_button_label_57">
+			<bounds x="1204" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x04">
+			<bounds x="1268" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_58" element="debug_button_label_58">
+			<bounds x="1288" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x08">
+			<bounds x="1352" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_59" element="debug_button_label_59">
+			<bounds x="1372" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x10">
+			<bounds x="1436" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_60" element="debug_button_label_60">
+			<bounds x="1456" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x20">
+			<bounds x="1520" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_61" element="debug_button_label_61">
+			<bounds x="1540" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x40">
+			<bounds x="1604" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_62" element="debug_button_label_62">
+			<bounds x="1624" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp56" element="debug_button_standard" state="0" inputtag="AUX2" inputmask="0x80">
+			<bounds x="1688" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_63" element="debug_button_label_63">
+			<bounds x="1708" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="vfd15" element="debug_vfd" state="0">
+			<bounds x="1150" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd14" element="debug_vfd" state="0">
+			<bounds x="1182" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd13" element="debug_vfd" state="0">
+			<bounds x="1214" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd12" element="debug_vfd" state="0">
+			<bounds x="1246" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd11" element="debug_vfd" state="0">
+			<bounds x="1278" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd10" element="debug_vfd" state="0">
+			<bounds x="1310" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd9" element="debug_vfd" state="0">
+			<bounds x="1342" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd8" element="debug_vfd" state="0">
+			<bounds x="1374" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd7" element="debug_vfd" state="0">
+			<bounds x="1406" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd6" element="debug_vfd" state="0">
+			<bounds x="1438" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd5" element="debug_vfd" state="0">
+			<bounds x="1470" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd4" element="debug_vfd" state="0">
+			<bounds x="1502" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd3" element="debug_vfd" state="0">
+			<bounds x="1534" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd2" element="debug_vfd" state="0">
+			<bounds x="1566" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd1" element="debug_vfd" state="0">
+			<bounds x="1598" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd0" element="debug_vfd" state="0">
+			<bounds x="1630" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel1" element="reel0" state="0">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp1" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp9" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_0" state="0">
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_1" state="0">
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_2" state="0">
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_3" state="0">
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_4" state="0">
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp17" element="reel_lamp_layer_5" state="0">
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel2" element="reel1" state="0">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp2" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp10" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_0" state="0">
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_1" state="0">
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_2" state="0">
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_3" state="0">
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_4" state="0">
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp18" element="reel_lamp_layer_5" state="0">
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel3" element="reel2" state="0">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="reel1" element="debug_stepper_value">
+			<bounds x="1100" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel2" element="debug_stepper_value">
+			<bounds x="1240" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel3" element="debug_stepper_value">
+			<bounds x="1380" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
+			<bounds x="1180" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
+			<bounds x="1320" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m4alpha.lay
+++ b/src/mame/layout/m4alpha.lay
@@ -8,4469 +8,7490 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_5_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_5_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Best">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_7_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_7_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="70p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="Press Gamble to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="Select A Random">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="CASH Prize??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_48_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_48_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Letters">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_49_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pays &#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_50_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_50_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="POUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pays &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TOKENS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="J">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Letters">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SILVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudge Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Auto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.46" green="0.28" blue="0.03">
-			</color>
+			<color red="0.46" green="0.28" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.07" blue="0.01">
-			</color>
+			<color red="0.11" green="0.07" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="0.93" green="0.56" blue="0.06">
-			</color>
+			<color red="0.93" green="0.56" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.23" green="0.14" blue="0.02">
-			</color>
+			<color red="0.23" green="0.14" blue="0.02"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Save It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="3" symbollist="Cherry(3),Grape,Orange,Lemon(1),Plum,Orange,Cherry(3),Grape,Orange(2),Pound,Plum,Cherry(1),Pear,Grape,Plum(1),Lemon,Alphabet,Plum,Melon(1),Lemon,Grape,Cherry(2),Bell,Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="3" symbollist="Grape,Lemon(1),Plum,Cherry,Lemon(!),Orange,Pound(1),Cherry,Lemon(2),Pear,Orange,Lemon(1),Bell,Grape,Pound(2),Orange,Melon,Cherry,Alphabet,Lemon(1),Bell,Plum,Pound(!),Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="3" symbollist="Orange(2),Grape,Cherry,Plum(1),Lemon,Orange(2),Cherry,Pound,Grape(3),Cherry,Pear,Plum(1),Melon,Cherry,Lemon(1),Alphabet,Orange,Melon,Grape(1),Bell,Orange,Plum(3),Lemon,Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="1" symbollist="ExtraLetters,U-D,J-O,A-T,L-R,BoostBoard,V-I,S-E,P-D,N-K,G-U,BoostBoard,I-R,A-L,E-V,G-N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led16segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_105">
 		<text string="Letters">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_108">
 		<text string="Any Pair">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_112">
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_116">
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_120">
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_124">
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="70p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_136">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_140">
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_144">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_148">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_149">
 		<text string="Credit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_150">
 		<text string="Savings">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_151">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_backdrop_colour">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_standard">
+		<rect state="0">
+			<color red="0.00" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_reel">
+		<rect state="0">
+			<color red="0.00" green="0.00" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="0.00" green="0.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_segment">
+		<rect state="0">
+			<color red="0.20" green="0.00" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="0.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_button">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_lamp_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_64">
+		<text string="64">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_65">
+		<text string="65">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_66">
+		<text string="66">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_67">
+		<text string="67">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_68">
+		<text string="68">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_69">
+		<text string="69">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_70">
+		<text string="70">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_71">
+		<text string="71">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_72">
+		<text string="72">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_73">
+		<text string="73">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_74">
+		<text string="74">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_75">
+		<text string="75">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_76">
+		<text string="76">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_77">
+		<text string="77">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_78">
+		<text string="78">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_79">
+		<text string="79">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_80">
+		<text string="80">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_81">
+		<text string="81">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_82">
+		<text string="82">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_83">
+		<text string="83">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_84">
+		<text string="84">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_85">
+		<text string="85">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_86">
+		<text string="86">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_87">
+		<text string="87">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_88">
+		<text string="88">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_89">
+		<text string="89">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_90">
+		<text string="90">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_91">
+		<text string="91">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_92">
+		<text string="92">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_93">
+		<text string="93">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_94">
+		<text string="94">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_95">
+		<text string="95">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_96">
+		<text string="96">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_97">
+		<text string="97">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_98">
+		<text string="98">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_99">
+		<text string="99">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_100">
+		<text string="100">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_101">
+		<text string="101">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_102">
+		<text string="102">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_103">
+		<text string="103">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_104">
+		<text string="104">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_105">
+		<text string="105">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_106">
+		<text string="106">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_107">
+		<text string="107">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_108">
+		<text string="108">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_109">
+		<text string="109">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_110">
+		<text string="110">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_111">
+		<text string="111">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_112">
+		<text string="112">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_113">
+		<text string="113">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_114">
+		<text string="114">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_115">
+		<text string="115">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_116">
+		<text string="116">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_117">
+		<text string="117">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_118">
+		<text string="118">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_119">
+		<text string="119">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_120">
+		<text string="120">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_121">
+		<text string="121">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_122">
+		<text string="122">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_123">
+		<text string="123">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_124">
+		<text string="124">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_125">
+		<text string="125">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_126">
+		<text string="126">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_127">
+		<text string="127">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_128">
+		<text string="128">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_129">
+		<text string="129">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_130">
+		<text string="130">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_131">
+		<text string="131">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_132">
+		<text string="132">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_133">
+		<text string="133">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_134">
+		<text string="134">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_135">
+		<text string="135">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_136">
+		<text string="136">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_137">
+		<text string="137">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_138">
+		<text string="138">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_139">
+		<text string="139">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_140">
+		<text string="140">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_141">
+		<text string="141">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_142">
+		<text string="142">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_143">
+		<text string="143">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_144">
+		<text string="144">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_145">
+		<text string="145">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_146">
+		<text string="146">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_147">
+		<text string="147">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_148">
+		<text string="148">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_149">
+		<text string="149">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_150">
+		<text string="150">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_151">
+		<text string="151">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_152">
+		<text string="152">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_153">
+		<text string="153">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_154">
+		<text string="154">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_155">
+		<text string="155">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_156">
+		<text string="156">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_157">
+		<text string="157">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_158">
+		<text string="158">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_159">
+		<text string="159">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_160">
+		<text string="160">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_161">
+		<text string="161">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_162">
+		<text string="162">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_163">
+		<text string="163">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_164">
+		<text string="164">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_165">
+		<text string="165">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_166">
+		<text string="166">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_167">
+		<text string="167">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_168">
+		<text string="168">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_169">
+		<text string="169">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_170">
+		<text string="170">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_171">
+		<text string="171">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_172">
+		<text string="172">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_173">
+		<text string="173">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_174">
+		<text string="174">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_175">
+		<text string="175">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_176">
+		<text string="176">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_177">
+		<text string="177">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_178">
+		<text string="178">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_179">
+		<text string="179">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_180">
+		<text string="180">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_181">
+		<text string="181">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_182">
+		<text string="182">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_183">
+		<text string="183">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_184">
+		<text string="184">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_185">
+		<text string="185">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_186">
+		<text string="186">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_187">
+		<text string="187">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_188">
+		<text string="188">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_189">
+		<text string="189">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_190">
+		<text string="190">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_191">
+		<text string="191">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_192">
+		<text string="192">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_193">
+		<text string="193">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_194">
+		<text string="194">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_195">
+		<text string="195">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_196">
+		<text string="196">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_197">
+		<text string="197">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_198">
+		<text string="198">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_199">
+		<text string="199">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_200">
+		<text string="200">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_201">
+		<text string="201">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_202">
+		<text string="202">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_203">
+		<text string="203">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_204">
+		<text string="204">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_205">
+		<text string="205">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_206">
+		<text string="206">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_207">
+		<text string="207">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_208">
+		<text string="208">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_209">
+		<text string="209">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_210">
+		<text string="210">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_211">
+		<text string="211">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_212">
+		<text string="212">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_213">
+		<text string="213">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_214">
+		<text string="214">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_215">
+		<text string="215">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_216">
+		<text string="216">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_217">
+		<text string="217">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_218">
+		<text string="218">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_219">
+		<text string="219">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_220">
+		<text string="220">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_221">
+		<text string="221">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_222">
+		<text string="222">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_223">
+		<text string="223">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_224">
+		<text string="224">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_225">
+		<text string="225">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_226">
+		<text string="226">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_227">
+		<text string="227">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_228">
+		<text string="228">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_229">
+		<text string="229">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_230">
+		<text string="230">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_231">
+		<text string="231">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_232">
+		<text string="232">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_233">
+		<text string="233">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_234">
+		<text string="234">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_235">
+		<text string="235">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_236">
+		<text string="236">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_237">
+		<text string="237">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_238">
+		<text string="238">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_239">
+		<text string="239">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_240">
+		<text string="240">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_241">
+		<text string="241">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_242">
+		<text string="242">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_243">
+		<text string="243">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_244">
+		<text string="244">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_245">
+		<text string="245">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_246">
+		<text string="246">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_247">
+		<text string="247">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_248">
+		<text string="248">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_249">
+		<text string="249">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_250">
+		<text string="250">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_251">
+		<text string="251">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_252">
+		<text string="252">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_253">
+		<text string="253">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_254">
+		<text string="254">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_lamp_label_255">
+		<text string="255">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_standard">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.00"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="0.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_unreferenced">
+		<rect state="0">
+			<color red="0.20" green="0.20" blue="0.20"/>
+		</rect>
+		<rect state="1">
+			<color red="1.00" green="1.00" blue="1.00"/>
+		</rect>
+	</element>
+	<element name="debug_button_label_0">
+		<text string="0">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_1">
+		<text string="1">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_2">
+		<text string="2">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_3">
+		<text string="3">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_4">
+		<text string="4">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_5">
+		<text string="5">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_6">
+		<text string="6">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_7">
+		<text string="7">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_8">
+		<text string="8">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_9">
+		<text string="9">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_10">
+		<text string="10">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_11">
+		<text string="11">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_12">
+		<text string="12">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_13">
+		<text string="13">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_14">
+		<text string="14">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_15">
+		<text string="15">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_16">
+		<text string="16">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_17">
+		<text string="17">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_18">
+		<text string="18">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_19">
+		<text string="19">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_20">
+		<text string="20">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_21">
+		<text string="21">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_22">
+		<text string="22">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_23">
+		<text string="23">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_24">
+		<text string="24">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_25">
+		<text string="25">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_26">
+		<text string="26">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_27">
+		<text string="27">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_28">
+		<text string="28">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_29">
+		<text string="29">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_30">
+		<text string="30">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_31">
+		<text string="31">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_32">
+		<text string="32">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_33">
+		<text string="33">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_34">
+		<text string="34">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_35">
+		<text string="35">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_36">
+		<text string="36">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_37">
+		<text string="37">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_38">
+		<text string="38">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_39">
+		<text string="39">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_40">
+		<text string="40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_41">
+		<text string="41">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_42">
+		<text string="42">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_43">
+		<text string="43">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_44">
+		<text string="44">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_45">
+		<text string="45">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_46">
+		<text string="46">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_47">
+		<text string="47">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_48">
+		<text string="48">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_49">
+		<text string="49">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_50">
+		<text string="50">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_51">
+		<text string="51">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_52">
+		<text string="52">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_53">
+		<text string="53">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_54">
+		<text string="54">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_55">
+		<text string="55">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_56">
+		<text string="56">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_57">
+		<text string="57">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_58">
+		<text string="58">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_59">
+		<text string="59">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_60">
+		<text string="60">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_61">
+		<text string="61">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_62">
+		<text string="62">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_button_label_63">
+		<text string="63">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
+	<element name="debug_vfd">
+		<led16segsc>
+			<color red="0.0" green="1.0" blue="1.0"/>
+		</led16segsc>
+	</element>
+	<element name="debug_stepper_value" defstate="0">
+		<simplecounter maxstate="999" digits="3">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</simplecounter>
+	</element>
+	<element name="debug_reel_symbol_count_0">
+		<text string="24">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_1">
+		<text string="24">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_2">
+		<text string="24">
+			<color red="1.0" green="1.0" blue="1.0"/>
+		</text>
+	</element>
+	<element name="debug_reel_symbol_count_3">
+		<text string="16">
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="700" height="714">
-			</bounds>
+			<bounds x="0" y="0" width="700" height="714"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="80" y="513" width="80" height="140">
-			</bounds>
+			<bounds x="80" y="513" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
-			<bounds x="80.0000" y="513.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="80.0000" y="513.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
-			<bounds x="83.3333" y="514.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="83.3333" y="514.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
-			<bounds x="86.6667" y="516.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="86.6667" y="516.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
-			<bounds x="90.0000" y="518.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="518.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
-			<bounds x="93.3333" y="520.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="93.3333" y="520.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
-			<bounds x="96.6667" y="522.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="96.6667" y="522.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
-			<bounds x="80.0000" y="559.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="80.0000" y="559.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
-			<bounds x="83.3333" y="561.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="83.3333" y="561.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
-			<bounds x="86.6667" y="563.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="86.6667" y="563.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
-			<bounds x="90.0000" y="565.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="565.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
-			<bounds x="93.3333" y="567.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="93.3333" y="567.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
-			<bounds x="96.6667" y="569.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="96.6667" y="569.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="80.0000" y="606.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="80.0000" y="606.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="83.3333" y="608.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="83.3333" y="608.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="86.6667" y="610.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="86.6667" y="610.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="90.0000" y="612.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="612.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="93.3333" y="614.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="93.3333" y="614.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="96.6667" y="616.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="96.6667" y="616.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="80" y="513" width="80" height="140">
-			</bounds>
+			<bounds x="80" y="513" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="165" y="513" width="80" height="140">
-			</bounds>
+			<bounds x="165" y="513" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="165" y="513" width="80" height="140">
-			</bounds>
+			<bounds x="165" y="513" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="247" y="513" width="80" height="140">
-			</bounds>
+			<bounds x="247" y="513" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="247" y="513" width="80" height="140">
-			</bounds>
+			<bounds x="247" y="513" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="340" y="564" width="80" height="40">
-			</bounds>
+			<bounds x="340" y="564" width="80" height="40"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="340" y="564" width="80" height="40">
-			</bounds>
+			<bounds x="340" y="564" width="80" height="40"/>
 		</backdrop>
 		<backdrop name="lamp5" element="lamp_5_1_border" state="0">
-			<bounds x="469" y="509" width="40" height="42">
-			</bounds>
+			<bounds x="469" y="509" width="40" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="lamp_5_1" state="0">
-			<bounds x="471" y="511" width="36" height="38">
-			</bounds>
+			<bounds x="471" y="511" width="36" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="lamp_7_1_border" state="0">
-			<bounds x="242" y="14" width="92" height="32">
-			</bounds>
+			<bounds x="242" y="14" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="lamp_7_1" state="0">
-			<bounds x="244" y="16" width="88" height="28">
-			</bounds>
+			<bounds x="244" y="16" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="563" y="528" width="47" height="37">
-			</bounds>
+			<bounds x="563" y="528" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="565" y="530" width="43" height="33">
-			</bounds>
+			<bounds x="565" y="530" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="616" y="526" width="72" height="42">
-			</bounds>
+			<bounds x="616" y="526" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="618" y="528" width="68" height="38">
-			</bounds>
+			<bounds x="618" y="528" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1_border" state="0">
-			<bounds x="362" y="49" width="27" height="27">
-			</bounds>
+			<bounds x="362" y="49" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1" state="0">
-			<bounds x="364" y="51" width="23" height="23">
-			</bounds>
+			<bounds x="364" y="51" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0">
-			<bounds x="341" y="76" width="27" height="27">
-			</bounds>
+			<bounds x="341" y="76" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0">
-			<bounds x="343" y="78" width="23" height="23">
-			</bounds>
+			<bounds x="343" y="78" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="516" y="529" width="47" height="37">
-			</bounds>
+			<bounds x="516" y="529" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="518" y="531" width="43" height="33">
-			</bounds>
+			<bounds x="518" y="531" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="493" y="571" width="47" height="37">
-			</bounds>
+			<bounds x="493" y="571" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="495" y="573" width="43" height="33">
-			</bounds>
+			<bounds x="495" y="573" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="314" y="76" width="27" height="27">
-			</bounds>
+			<bounds x="314" y="76" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="316" y="78" width="23" height="23">
-			</bounds>
+			<bounds x="316" y="78" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="324" y="49" width="27" height="27">
-			</bounds>
+			<bounds x="324" y="49" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="326" y="51" width="23" height="23">
-			</bounds>
+			<bounds x="326" y="51" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="587" y="576" width="47" height="37">
-			</bounds>
+			<bounds x="587" y="576" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="589" y="578" width="43" height="33">
-			</bounds>
+			<bounds x="589" y="578" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="538" y="574" width="47" height="37">
-			</bounds>
+			<bounds x="538" y="574" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="540" y="576" width="43" height="33">
-			</bounds>
+			<bounds x="540" y="576" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="297" y="49" width="27" height="27">
-			</bounds>
+			<bounds x="297" y="49" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="299" y="51" width="23" height="23">
-			</bounds>
+			<bounds x="299" y="51" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="287" y="76" width="27" height="27">
-			</bounds>
+			<bounds x="287" y="76" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="289" y="78" width="23" height="23">
-			</bounds>
+			<bounds x="289" y="78" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="260" y="76" width="27" height="27">
-			</bounds>
+			<bounds x="260" y="76" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="262" y="78" width="23" height="23">
-			</bounds>
+			<bounds x="262" y="78" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="270" y="49" width="27" height="27">
-			</bounds>
+			<bounds x="270" y="49" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="272" y="51" width="23" height="23">
-			</bounds>
+			<bounds x="272" y="51" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="533" y="345" width="102" height="67">
-			</bounds>
+			<bounds x="533" y="345" width="102" height="67"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="535" y="347" width="98" height="63">
-			</bounds>
+			<bounds x="535" y="347" width="98" height="63"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="242" y="49" width="27" height="27">
-			</bounds>
+			<bounds x="242" y="49" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="244" y="51" width="23" height="23">
-			</bounds>
+			<bounds x="244" y="51" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="233" y="76" width="27" height="27">
-			</bounds>
+			<bounds x="233" y="76" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="235" y="78" width="23" height="23">
-			</bounds>
+			<bounds x="235" y="78" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1_border" state="0">
-			<bounds x="16" y="462" width="52" height="42">
-			</bounds>
+			<bounds x="16" y="462" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp48" element="lamp_48_1" state="0">
-			<bounds x="18" y="464" width="48" height="38">
-			</bounds>
+			<bounds x="18" y="464" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1_border" state="0">
-			<bounds x="570" y="276" width="62" height="32">
-			</bounds>
+			<bounds x="570" y="276" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp49" element="lamp_49_1" state="0">
-			<bounds x="572" y="278" width="58" height="28">
-			</bounds>
+			<bounds x="572" y="278" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1_border" state="0">
-			<bounds x="571" y="310" width="62" height="32">
-			</bounds>
+			<bounds x="571" y="310" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp50" element="lamp_50_1" state="0">
-			<bounds x="573" y="312" width="58" height="28">
-			</bounds>
+			<bounds x="573" y="312" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="426" y="535" width="32" height="32">
-			</bounds>
+			<bounds x="426" y="535" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="428" y="537" width="28" height="28">
-			</bounds>
+			<bounds x="428" y="537" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="426" y="594" width="32" height="32">
-			</bounds>
+			<bounds x="426" y="594" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="428" y="596" width="28" height="28">
-			</bounds>
+			<bounds x="428" y="596" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="188" y="83" width="37" height="19">
-			</bounds>
+			<bounds x="188" y="83" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="190" y="85" width="33" height="15">
-			</bounds>
+			<bounds x="190" y="85" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="214" y="49" width="27" height="27">
-			</bounds>
+			<bounds x="214" y="49" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="216" y="51" width="23" height="23">
-			</bounds>
+			<bounds x="216" y="51" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="14" y="429" width="27" height="27">
-			</bounds>
+			<bounds x="14" y="429" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="16" y="431" width="23" height="23">
-			</bounds>
+			<bounds x="16" y="431" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="49" y="429" width="27" height="27">
-			</bounds>
+			<bounds x="49" y="429" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="51" y="431" width="23" height="23">
-			</bounds>
+			<bounds x="51" y="431" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="85" y="429" width="27" height="27">
-			</bounds>
+			<bounds x="85" y="429" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="87" y="431" width="23" height="23">
-			</bounds>
+			<bounds x="87" y="431" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="120" y="429" width="27" height="27">
-			</bounds>
+			<bounds x="120" y="429" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="122" y="431" width="23" height="23">
-			</bounds>
+			<bounds x="122" y="431" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="155" y="430" width="27" height="27">
-			</bounds>
+			<bounds x="155" y="430" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="157" y="432" width="23" height="23">
-			</bounds>
+			<bounds x="157" y="432" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="189" y="430" width="27" height="27">
-			</bounds>
+			<bounds x="189" y="430" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="191" y="432" width="23" height="23">
-			</bounds>
+			<bounds x="191" y="432" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="224" y="430" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="430" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="226" y="432" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="432" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="258" y="431" width="27" height="27">
-			</bounds>
+			<bounds x="258" y="431" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="260" y="433" width="23" height="23">
-			</bounds>
+			<bounds x="260" y="433" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="43" y="51" width="37" height="37">
-			</bounds>
+			<bounds x="43" y="51" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="45" y="53" width="33" height="33">
-			</bounds>
+			<bounds x="45" y="53" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="7" y="50" width="37" height="37">
-			</bounds>
+			<bounds x="7" y="50" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="9" y="52" width="33" height="33">
-			</bounds>
+			<bounds x="9" y="52" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="78" y="51" width="37" height="37">
-			</bounds>
+			<bounds x="78" y="51" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="80" y="53" width="33" height="33">
-			</bounds>
+			<bounds x="80" y="53" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="114" y="51" width="37" height="37">
-			</bounds>
+			<bounds x="114" y="51" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="116" y="53" width="33" height="33">
-			</bounds>
+			<bounds x="116" y="53" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="465" y="54" width="37" height="37">
-			</bounds>
+			<bounds x="465" y="54" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="467" y="56" width="33" height="33">
-			</bounds>
+			<bounds x="467" y="56" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="500" y="54" width="37" height="37">
-			</bounds>
+			<bounds x="500" y="54" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="502" y="56" width="33" height="33">
-			</bounds>
+			<bounds x="502" y="56" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="569" y="54" width="37" height="37">
-			</bounds>
+			<bounds x="569" y="54" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="571" y="56" width="33" height="33">
-			</bounds>
+			<bounds x="571" y="56" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="535" y="54" width="37" height="37">
-			</bounds>
+			<bounds x="535" y="54" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="537" y="56" width="33" height="33">
-			</bounds>
+			<bounds x="537" y="56" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="6" y="85" width="37" height="37">
-			</bounds>
+			<bounds x="6" y="85" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="8" y="87" width="33" height="33">
-			</bounds>
+			<bounds x="8" y="87" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="78" y="86" width="37" height="37">
-			</bounds>
+			<bounds x="78" y="86" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="80" y="88" width="33" height="33">
-			</bounds>
+			<bounds x="80" y="88" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="42" y="86" width="37" height="37">
-			</bounds>
+			<bounds x="42" y="86" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="44" y="88" width="33" height="33">
-			</bounds>
+			<bounds x="44" y="88" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="76" y="121" width="37" height="37">
-			</bounds>
+			<bounds x="76" y="121" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="78" y="123" width="33" height="33">
-			</bounds>
+			<bounds x="78" y="123" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="502" y="125" width="37" height="37">
-			</bounds>
+			<bounds x="502" y="125" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="504" y="127" width="33" height="33">
-			</bounds>
+			<bounds x="504" y="127" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="535" y="90" width="37" height="37">
-			</bounds>
+			<bounds x="535" y="90" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="537" y="92" width="33" height="33">
-			</bounds>
+			<bounds x="537" y="92" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="500" y="90" width="37" height="37">
-			</bounds>
+			<bounds x="500" y="90" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="502" y="92" width="33" height="33">
-			</bounds>
+			<bounds x="502" y="92" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="570" y="90" width="37" height="37">
-			</bounds>
+			<bounds x="570" y="90" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="572" y="92" width="33" height="33">
-			</bounds>
+			<bounds x="572" y="92" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="40" y="156" width="37" height="37">
-			</bounds>
+			<bounds x="40" y="156" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="42" y="158" width="33" height="33">
-			</bounds>
+			<bounds x="42" y="158" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="5" y="155" width="37" height="37">
-			</bounds>
+			<bounds x="5" y="155" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="7" y="157" width="33" height="33">
-			</bounds>
+			<bounds x="7" y="157" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="6" y="120" width="37" height="37">
-			</bounds>
+			<bounds x="6" y="120" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="8" y="122" width="33" height="33">
-			</bounds>
+			<bounds x="8" y="122" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="41" y="121" width="37" height="37">
-			</bounds>
+			<bounds x="41" y="121" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="43" y="123" width="33" height="33">
-			</bounds>
+			<bounds x="43" y="123" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="536" y="125" width="37" height="37">
-			</bounds>
+			<bounds x="536" y="125" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="538" y="127" width="33" height="33">
-			</bounds>
+			<bounds x="538" y="127" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="571" y="125" width="37" height="37">
-			</bounds>
+			<bounds x="571" y="125" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="573" y="127" width="33" height="33">
-			</bounds>
+			<bounds x="573" y="127" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="571" y="160" width="37" height="37">
-			</bounds>
+			<bounds x="571" y="160" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="573" y="162" width="33" height="33">
-			</bounds>
+			<bounds x="573" y="162" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="536" y="160" width="37" height="37">
-			</bounds>
+			<bounds x="536" y="160" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="538" y="162" width="33" height="33">
-			</bounds>
+			<bounds x="538" y="162" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="39" y="191" width="37" height="37">
-			</bounds>
+			<bounds x="39" y="191" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="41" y="193" width="33" height="33">
-			</bounds>
+			<bounds x="41" y="193" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="4" y="190" width="37" height="37">
-			</bounds>
+			<bounds x="4" y="190" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="6" y="192" width="33" height="33">
-			</bounds>
+			<bounds x="6" y="192" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="4" y="225" width="37" height="37">
-			</bounds>
+			<bounds x="4" y="225" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="6" y="227" width="33" height="33">
-			</bounds>
+			<bounds x="6" y="227" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="24" y="14" width="92" height="32">
-			</bounds>
+			<bounds x="24" y="14" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="26" y="16" width="88" height="28">
-			</bounds>
+			<bounds x="26" y="16" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="572" y="230" width="37" height="37">
-			</bounds>
+			<bounds x="572" y="230" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="574" y="232" width="33" height="33">
-			</bounds>
+			<bounds x="574" y="232" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="572" y="195" width="37" height="37">
-			</bounds>
+			<bounds x="572" y="195" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="574" y="197" width="33" height="33">
-			</bounds>
+			<bounds x="574" y="197" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="537" y="195" width="37" height="37">
-			</bounds>
+			<bounds x="537" y="195" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="539" y="197" width="33" height="33">
-			</bounds>
+			<bounds x="539" y="197" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="169" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="169" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="171" y="168" width="23" height="23">
-			</bounds>
+			<bounds x="171" y="168" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="196" y="139" width="27" height="27">
-			</bounds>
+			<bounds x="196" y="139" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="198" y="141" width="23" height="23">
-			</bounds>
+			<bounds x="198" y="141" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="196" y="112" width="27" height="27">
-			</bounds>
+			<bounds x="196" y="112" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="198" y="114" width="23" height="23">
-			</bounds>
+			<bounds x="198" y="114" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="223" y="112" width="27" height="27">
-			</bounds>
+			<bounds x="223" y="112" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="225" y="114" width="23" height="23">
-			</bounds>
+			<bounds x="225" y="114" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="250" y="112" width="27" height="27">
-			</bounds>
+			<bounds x="250" y="112" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="252" y="114" width="23" height="23">
-			</bounds>
+			<bounds x="252" y="114" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="277" y="112" width="27" height="27">
-			</bounds>
+			<bounds x="277" y="112" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="279" y="114" width="23" height="23">
-			</bounds>
+			<bounds x="279" y="114" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="304" y="112" width="27" height="27">
-			</bounds>
+			<bounds x="304" y="112" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="306" y="114" width="23" height="23">
-			</bounds>
+			<bounds x="306" y="114" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="331" y="112" width="27" height="27">
-			</bounds>
+			<bounds x="331" y="112" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="333" y="114" width="23" height="23">
-			</bounds>
+			<bounds x="333" y="114" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="196" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="196" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="198" y="168" width="23" height="23">
-			</bounds>
+			<bounds x="198" y="168" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="223" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="223" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="225" y="168" width="23" height="23">
-			</bounds>
+			<bounds x="225" y="168" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="250" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="250" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="252" y="168" width="23" height="23">
-			</bounds>
+			<bounds x="252" y="168" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="277" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="277" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="279" y="168" width="23" height="23">
-			</bounds>
+			<bounds x="279" y="168" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="304" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="304" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="306" y="168" width="23" height="23">
-			</bounds>
+			<bounds x="306" y="168" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="331" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="331" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="333" y="168" width="23" height="23">
-			</bounds>
+			<bounds x="333" y="168" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="385" y="166" width="27" height="27">
-			</bounds>
+			<bounds x="385" y="166" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="387" y="168" width="23" height="23">
-			</bounds>
+			<bounds x="387" y="168" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="385" y="193" width="27" height="27">
-			</bounds>
+			<bounds x="385" y="193" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="387" y="195" width="23" height="23">
-			</bounds>
+			<bounds x="387" y="195" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="196" y="193" width="27" height="27">
-			</bounds>
+			<bounds x="196" y="193" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="198" y="195" width="23" height="23">
-			</bounds>
+			<bounds x="198" y="195" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="321" y="199" width="52" height="42">
-			</bounds>
+			<bounds x="321" y="199" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="323" y="201" width="48" height="38">
-			</bounds>
+			<bounds x="323" y="201" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="277" y="220" width="27" height="27">
-			</bounds>
+			<bounds x="277" y="220" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="279" y="222" width="23" height="23">
-			</bounds>
+			<bounds x="279" y="222" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="277" y="193" width="27" height="27">
-			</bounds>
+			<bounds x="277" y="193" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="279" y="195" width="23" height="23">
-			</bounds>
+			<bounds x="279" y="195" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="503" y="14" width="92" height="32">
-			</bounds>
+			<bounds x="503" y="14" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="505" y="16" width="88" height="28">
-			</bounds>
+			<bounds x="505" y="16" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="385" y="139" width="27" height="27">
-			</bounds>
+			<bounds x="385" y="139" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="387" y="141" width="23" height="23">
-			</bounds>
+			<bounds x="387" y="141" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="385" y="220" width="27" height="27">
-			</bounds>
+			<bounds x="385" y="220" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="387" y="222" width="23" height="23">
-			</bounds>
+			<bounds x="387" y="222" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="196" y="220" width="27" height="27">
-			</bounds>
+			<bounds x="196" y="220" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="198" y="222" width="23" height="23">
-			</bounds>
+			<bounds x="198" y="222" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="277" y="274" width="27" height="27">
-			</bounds>
+			<bounds x="277" y="274" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="279" y="276" width="23" height="23">
-			</bounds>
+			<bounds x="279" y="276" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="277" y="247" width="27" height="27">
-			</bounds>
+			<bounds x="277" y="247" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="279" y="249" width="23" height="23">
-			</bounds>
+			<bounds x="279" y="249" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="304" y="247" width="27" height="27">
-			</bounds>
+			<bounds x="304" y="247" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="306" y="249" width="23" height="23">
-			</bounds>
+			<bounds x="306" y="249" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="331" y="247" width="27" height="27">
-			</bounds>
+			<bounds x="331" y="247" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="333" y="249" width="23" height="23">
-			</bounds>
+			<bounds x="333" y="249" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="358" y="247" width="27" height="27">
-			</bounds>
+			<bounds x="358" y="247" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="360" y="249" width="23" height="23">
-			</bounds>
+			<bounds x="360" y="249" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="385" y="247" width="27" height="27">
-			</bounds>
+			<bounds x="385" y="247" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="387" y="249" width="23" height="23">
-			</bounds>
+			<bounds x="387" y="249" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="385" y="274" width="27" height="27">
-			</bounds>
+			<bounds x="385" y="274" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="387" y="276" width="23" height="23">
-			</bounds>
+			<bounds x="387" y="276" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="515" y="617" width="47" height="37">
-			</bounds>
+			<bounds x="515" y="617" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="517" y="619" width="43" height="33">
-			</bounds>
+			<bounds x="517" y="619" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="459" y="635" width="47" height="22">
-			</bounds>
+			<bounds x="459" y="635" width="47" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="461" y="637" width="43" height="18">
-			</bounds>
+			<bounds x="461" y="637" width="43" height="18"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="563" y="618" width="47" height="37">
-			</bounds>
+			<bounds x="563" y="618" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="565" y="620" width="43" height="33">
-			</bounds>
+			<bounds x="565" y="620" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="608" y="617" width="47" height="37">
-			</bounds>
+			<bounds x="608" y="617" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="610" y="619" width="43" height="33">
-			</bounds>
+			<bounds x="610" y="619" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_153_border" state="0" inputtag="ORANGE2" inputmask="0x01">
-			<bounds x="658" y="41" width="32" height="32">
-			</bounds>
+			<bounds x="658" y="41" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_153" state="0" inputtag="ORANGE2" inputmask="0x01">
-			<bounds x="660" y="43" width="28" height="28">
-			</bounds>
+			<bounds x="660" y="43" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_154_border" state="0" inputtag="ORANGE2" inputmask="0x02">
-			<bounds x="630" y="41" width="32" height="32">
-			</bounds>
+			<bounds x="630" y="41" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_154" state="0" inputtag="ORANGE2" inputmask="0x02">
-			<bounds x="632" y="43" width="28" height="28">
-			</bounds>
+			<bounds x="632" y="43" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_156_border" state="0" inputtag="BLACK2" inputmask="0x01">
-			<bounds x="2" y="661" width="75" height="40">
-			</bounds>
+			<bounds x="2" y="661" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_156" state="0" inputtag="BLACK2" inputmask="0x01">
-			<bounds x="4" y="663" width="71" height="36">
-			</bounds>
+			<bounds x="4" y="663" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp25" element="colour_button_157_border" state="0" inputtag="BLACK2" inputmask="0x02">
-			<bounds x="81" y="661" width="75" height="40">
-			</bounds>
+			<bounds x="81" y="661" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp25" element="colour_button_157" state="0" inputtag="BLACK2" inputmask="0x02">
-			<bounds x="83" y="663" width="71" height="36">
-			</bounds>
+			<bounds x="83" y="663" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_158_border" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="163" y="661" width="75" height="40">
-			</bounds>
+			<bounds x="163" y="661" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp26" element="colour_button_158" state="0" inputtag="BLACK2" inputmask="0x04">
-			<bounds x="165" y="663" width="71" height="36">
-			</bounds>
+			<bounds x="165" y="663" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_159_border" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="247" y="661" width="75" height="40">
-			</bounds>
+			<bounds x="247" y="661" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_159" state="0" inputtag="BLACK2" inputmask="0x08">
-			<bounds x="249" y="663" width="71" height="36">
-			</bounds>
+			<bounds x="249" y="663" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_160_border" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="333" y="661" width="75" height="40">
-			</bounds>
+			<bounds x="333" y="661" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp33" element="colour_button_160" state="0" inputtag="BLACK2" inputmask="0x10">
-			<bounds x="335" y="663" width="71" height="36">
-			</bounds>
+			<bounds x="335" y="663" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_161_border" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="416" y="661" width="75" height="40">
-			</bounds>
+			<bounds x="416" y="661" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp34" element="colour_button_161" state="0" inputtag="BLACK2" inputmask="0x20">
-			<bounds x="418" y="663" width="71" height="36">
-			</bounds>
+			<bounds x="418" y="663" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_162_border" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="497" y="661" width="75" height="40">
-			</bounds>
+			<bounds x="497" y="661" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp40" element="colour_button_162" state="0" inputtag="BLACK2" inputmask="0x40">
-			<bounds x="499" y="663" width="71" height="36">
-			</bounds>
+			<bounds x="499" y="663" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_163_border" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="577" y="661" width="75" height="40">
-			</bounds>
+			<bounds x="577" y="661" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp41" element="colour_button_163" state="0" inputtag="BLACK2" inputmask="0x80">
-			<bounds x="579" y="663" width="71" height="36">
-			</bounds>
+			<bounds x="579" y="663" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_164_border" state="0" inputtag="AUX2" inputmask="0x40">
-			<bounds x="658" y="12" width="32" height="32">
-			</bounds>
+			<bounds x="658" y="12" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_164" state="0" inputtag="AUX2" inputmask="0x40">
-			<bounds x="660" y="14" width="28" height="28">
-			</bounds>
+			<bounds x="660" y="14" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_165_border" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="630" y="12" width="32" height="32">
-			</bounds>
+			<bounds x="630" y="12" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_165" state="0" inputtag="AUX2" inputmask="0x80">
-			<bounds x="632" y="14" width="28" height="28">
-			</bounds>
+			<bounds x="632" y="14" width="28" height="28"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="364" y="488" width="30" height="40">
-			</bounds>
+			<bounds x="364" y="488" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="digit3" element="led_digit_red">
-			<bounds x="364" y="488" width="30" height="40">
-			</bounds>
+			<bounds x="364" y="488" width="30" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="364" y="488" width="30" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="364" y="488" width="30" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="413" y="433" width="272" height="30">
-			</bounds>
+			<bounds x="413" y="433" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="413" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="413" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="430" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="430" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="447" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="447" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="464" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="464" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="481" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="481" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="498" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="498" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="515" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="515" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="532" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="532" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="549" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="549" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="566" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="566" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="583" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="583" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="600" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="600" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="617" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="617" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="634" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="634" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="651" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="651" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="668" y="433" width="17" height="30">
-			</bounds>
+			<bounds x="668" y="433" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label105" element="label_105">
-			<bounds x="349" y="532" width="58" height="20">
-			</bounds>
+			<bounds x="349" y="532" width="58" height="20"/>
 		</backdrop>
 		<backdrop name="label108" element="label_108">
-			<bounds x="18" y="608" width="39" height="26">
-			</bounds>
+			<bounds x="18" y="608" width="39" height="26"/>
 		</backdrop>
 		<backdrop name="label112" element="label_112">
-			<bounds x="230" y="388" width="22" height="13">
-			</bounds>
+			<bounds x="230" y="388" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label116" element="label_116">
-			<bounds x="230" y="364" width="22" height="13">
-			</bounds>
+			<bounds x="230" y="364" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label120" element="label_120">
-			<bounds x="231" y="339" width="22" height="13">
-			</bounds>
+			<bounds x="231" y="339" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="232" y="315" width="22" height="13">
-			</bounds>
+			<bounds x="232" y="315" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="232" y="291" width="22" height="13">
-			</bounds>
+			<bounds x="232" y="291" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="233" y="265" width="22" height="13">
-			</bounds>
+			<bounds x="233" y="265" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label136" element="label_136">
-			<bounds x="102" y="396" width="15" height="13">
-			</bounds>
+			<bounds x="102" y="396" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label140" element="label_140">
-			<bounds x="99" y="369" width="33" height="13">
-			</bounds>
+			<bounds x="99" y="369" width="33" height="13"/>
 		</backdrop>
 		<backdrop name="label144" element="label_144">
-			<bounds x="100" y="339" width="15" height="13">
-			</bounds>
+			<bounds x="100" y="339" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label148" element="label_148">
-			<bounds x="53" y="304" width="17" height="16">
-			</bounds>
+			<bounds x="53" y="304" width="17" height="16"/>
 		</backdrop>
 		<backdrop name="label149" element="label_149">
-			<bounds x="437" y="466" width="27" height="13">
-			</bounds>
+			<bounds x="437" y="466" width="27" height="13"/>
 		</backdrop>
 		<backdrop name="label150" element="label_150">
-			<bounds x="623" y="467" width="38" height="13">
-			</bounds>
+			<bounds x="623" y="467" width="38" height="13"/>
 		</backdrop>
 		<backdrop name="label151" element="label_151">
-			<bounds x="543" y="467" width="19" height="13">
-			</bounds>
+			<bounds x="543" y="467" width="19" height="13"/>
+		</backdrop>
+	</view>
+
+	<view name="MFME2MAME Debug">
+		<backdrop element="debug_backdrop_colour">
+			<bounds x="0" y="0" width="1920" height="1080"/>
+		</backdrop>
+		<backdrop name="lamp0" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
+			<bounds x="47" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp1" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
+			<bounds x="111" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp2" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
+			<bounds x="175" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp3" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
+			<bounds x="239" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
+			<bounds x="303" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp5" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
+			<bounds x="367" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
+			<bounds x="431" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp7" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
+			<bounds x="495" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp8" element="debug_lamp_reel" state="0">
+			<bounds x="544" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
+			<bounds x="559" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
+			<bounds x="623" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
+			<bounds x="687" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
+			<bounds x="751" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
+			<bounds x="815" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
+			<bounds x="879" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp14" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
+			<bounds x="943" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp15" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="32" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
+			<bounds x="1007" y="47" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
+			<bounds x="32" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
+			<bounds x="47" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
+			<bounds x="111" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
+			<bounds x="175" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
+			<bounds x="239" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
+			<bounds x="303" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
+			<bounds x="367" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
+			<bounds x="431" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
+			<bounds x="495" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
+			<bounds x="559" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_lamp_button" state="0">
+			<bounds x="608" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
+			<bounds x="623" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_lamp_button" state="0">
+			<bounds x="672" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
+			<bounds x="687" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
+			<bounds x="751" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
+			<bounds x="815" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
+			<bounds x="879" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
+			<bounds x="943" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp31" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="96" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
+			<bounds x="1007" y="111" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_lamp_button" state="0">
+			<bounds x="32" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
+			<bounds x="47" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_lamp_button" state="0">
+			<bounds x="96" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
+			<bounds x="111" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_lamp_button" state="0">
+			<bounds x="160" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
+			<bounds x="175" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
+			<bounds x="239" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
+			<bounds x="303" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
+			<bounds x="367" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
+			<bounds x="431" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
+			<bounds x="495" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_lamp_button" state="0">
+			<bounds x="544" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
+			<bounds x="559" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_lamp_button" state="0">
+			<bounds x="608" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
+			<bounds x="623" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
+			<bounds x="687" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
+			<bounds x="751" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
+			<bounds x="815" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
+			<bounds x="879" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
+			<bounds x="943" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="160" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
+			<bounds x="1007" y="175" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp48" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
+			<bounds x="47" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp49" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
+			<bounds x="111" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp50" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
+			<bounds x="175" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
+			<bounds x="239" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
+			<bounds x="303" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
+			<bounds x="367" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
+			<bounds x="431" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
+			<bounds x="495" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
+			<bounds x="559" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
+			<bounds x="623" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
+			<bounds x="687" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
+			<bounds x="751" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
+			<bounds x="815" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
+			<bounds x="879" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
+			<bounds x="943" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="224" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
+			<bounds x="1007" y="239" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
+			<bounds x="47" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
+			<bounds x="111" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
+			<bounds x="175" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
+			<bounds x="239" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
+			<bounds x="303" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
+			<bounds x="367" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
+			<bounds x="431" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
+			<bounds x="495" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
+			<bounds x="559" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
+			<bounds x="623" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
+			<bounds x="687" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
+			<bounds x="751" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
+			<bounds x="815" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
+			<bounds x="879" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
+			<bounds x="943" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="288" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
+			<bounds x="1007" y="303" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
+			<bounds x="47" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
+			<bounds x="111" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
+			<bounds x="175" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
+			<bounds x="239" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
+			<bounds x="303" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
+			<bounds x="367" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
+			<bounds x="431" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
+			<bounds x="495" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
+			<bounds x="559" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
+			<bounds x="623" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
+			<bounds x="687" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
+			<bounds x="751" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
+			<bounds x="815" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
+			<bounds x="879" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
+			<bounds x="943" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="352" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
+			<bounds x="1007" y="367" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
+			<bounds x="47" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
+			<bounds x="111" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
+			<bounds x="175" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
+			<bounds x="239" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
+			<bounds x="288" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
+			<bounds x="303" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
+			<bounds x="367" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
+			<bounds x="431" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
+			<bounds x="495" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
+			<bounds x="559" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
+			<bounds x="623" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
+			<bounds x="687" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
+			<bounds x="751" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
+			<bounds x="815" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
+			<bounds x="879" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
+			<bounds x="943" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="416" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
+			<bounds x="1007" y="431" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
+			<bounds x="32" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
+			<bounds x="47" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
+			<bounds x="96" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
+			<bounds x="111" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
+			<bounds x="160" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
+			<bounds x="175" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
+			<bounds x="224" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
+			<bounds x="239" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
+			<bounds x="303" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
+			<bounds x="352" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
+			<bounds x="367" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
+			<bounds x="416" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
+			<bounds x="431" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
+			<bounds x="480" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
+			<bounds x="495" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
+			<bounds x="544" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
+			<bounds x="559" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
+			<bounds x="608" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
+			<bounds x="623" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
+			<bounds x="672" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
+			<bounds x="687" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
+			<bounds x="736" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
+			<bounds x="751" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
+			<bounds x="800" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
+			<bounds x="815" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
+			<bounds x="864" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
+			<bounds x="879" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
+			<bounds x="928" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
+			<bounds x="943" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
+			<bounds x="992" y="480" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
+			<bounds x="1007" y="495" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
+			<bounds x="47" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
+			<bounds x="111" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
+			<bounds x="175" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
+			<bounds x="239" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
+			<bounds x="303" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
+			<bounds x="367" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
+			<bounds x="431" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
+			<bounds x="495" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
+			<bounds x="559" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
+			<bounds x="623" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
+			<bounds x="687" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
+			<bounds x="751" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
+			<bounds x="815" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
+			<bounds x="879" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
+			<bounds x="943" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="544" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
+			<bounds x="1007" y="559" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
+			<bounds x="47" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
+			<bounds x="111" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
+			<bounds x="175" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
+			<bounds x="239" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
+			<bounds x="303" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
+			<bounds x="367" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
+			<bounds x="431" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
+			<bounds x="495" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
+			<bounds x="559" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
+			<bounds x="623" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
+			<bounds x="687" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
+			<bounds x="751" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
+			<bounds x="815" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
+			<bounds x="879" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
+			<bounds x="943" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="608" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
+			<bounds x="1007" y="623" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
+			<bounds x="47" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
+			<bounds x="111" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
+			<bounds x="175" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
+			<bounds x="239" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
+			<bounds x="303" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
+			<bounds x="367" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
+			<bounds x="431" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
+			<bounds x="495" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
+			<bounds x="559" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
+			<bounds x="623" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
+			<bounds x="687" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
+			<bounds x="751" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
+			<bounds x="815" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
+			<bounds x="879" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
+			<bounds x="943" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="672" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
+			<bounds x="1007" y="687" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
+			<bounds x="47" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
+			<bounds x="111" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
+			<bounds x="175" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
+			<bounds x="239" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
+			<bounds x="303" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
+			<bounds x="367" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
+			<bounds x="431" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
+			<bounds x="495" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
+			<bounds x="559" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
+			<bounds x="623" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
+			<bounds x="687" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
+			<bounds x="751" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
+			<bounds x="815" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
+			<bounds x="879" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
+			<bounds x="943" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="736" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
+			<bounds x="1007" y="751" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
+			<bounds x="47" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
+			<bounds x="111" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
+			<bounds x="175" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
+			<bounds x="239" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
+			<bounds x="303" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
+			<bounds x="367" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
+			<bounds x="431" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
+			<bounds x="495" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
+			<bounds x="559" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
+			<bounds x="623" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
+			<bounds x="687" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
+			<bounds x="751" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
+			<bounds x="815" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
+			<bounds x="879" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
+			<bounds x="943" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="800" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
+			<bounds x="1007" y="815" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
+			<bounds x="47" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
+			<bounds x="111" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
+			<bounds x="175" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
+			<bounds x="239" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
+			<bounds x="303" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
+			<bounds x="367" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
+			<bounds x="431" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
+			<bounds x="495" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
+			<bounds x="559" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
+			<bounds x="623" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
+			<bounds x="687" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
+			<bounds x="751" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
+			<bounds x="815" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
+			<bounds x="879" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
+			<bounds x="943" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="864" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
+			<bounds x="1007" y="879" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
+			<bounds x="47" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
+			<bounds x="111" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
+			<bounds x="175" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
+			<bounds x="239" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
+			<bounds x="303" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
+			<bounds x="367" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
+			<bounds x="431" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
+			<bounds x="495" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
+			<bounds x="559" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
+			<bounds x="623" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
+			<bounds x="687" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
+			<bounds x="751" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
+			<bounds x="815" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
+			<bounds x="879" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
+			<bounds x="943" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
+			<bounds x="992" y="928" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
+			<bounds x="1007" y="943" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
+			<bounds x="32" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
+			<bounds x="47" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
+			<bounds x="96" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
+			<bounds x="111" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
+			<bounds x="160" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
+			<bounds x="175" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
+			<bounds x="224" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
+			<bounds x="239" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
+			<bounds x="288" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
+			<bounds x="303" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
+			<bounds x="352" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
+			<bounds x="367" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
+			<bounds x="416" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
+			<bounds x="431" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
+			<bounds x="480" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
+			<bounds x="495" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
+			<bounds x="544" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
+			<bounds x="559" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
+			<bounds x="608" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
+			<bounds x="623" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
+			<bounds x="672" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
+			<bounds x="687" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
+			<bounds x="736" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
+			<bounds x="751" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
+			<bounds x="800" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
+			<bounds x="815" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
+			<bounds x="864" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
+			<bounds x="879" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
+			<bounds x="928" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
+			<bounds x="943" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
+			<bounds x="992" y="992" width="60" height="60"/>
+		</backdrop>
+		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
+			<bounds x="1007" y="1007" width="30" height="30"/>
+		</backdrop>
+		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x01">
+			<bounds x="1100" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_0" element="debug_button_label_0">
+			<bounds x="1120" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x02">
+			<bounds x="1184" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_1" element="debug_button_label_1">
+			<bounds x="1204" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x04">
+			<bounds x="1268" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_2" element="debug_button_label_2">
+			<bounds x="1288" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x08">
+			<bounds x="1352" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_3" element="debug_button_label_3">
+			<bounds x="1372" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x10">
+			<bounds x="1436" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_4" element="debug_button_label_4">
+			<bounds x="1456" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x20">
+			<bounds x="1520" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_5" element="debug_button_label_5">
+			<bounds x="1540" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x40">
+			<bounds x="1604" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_6" element="debug_button_label_6">
+			<bounds x="1624" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="ORANGE1" inputmask="0x80">
+			<bounds x="1688" y="660" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_7" element="debug_button_label_7">
+			<bounds x="1708" y="671" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_8" element="debug_button_standard" state="0" inputtag="ORANGE2" inputmask="0x01">
+			<bounds x="1100" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_8" element="debug_button_label_8">
+			<bounds x="1120" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_9" element="debug_button_standard" state="0" inputtag="ORANGE2" inputmask="0x02">
+			<bounds x="1184" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_9" element="debug_button_label_9">
+			<bounds x="1204" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x04">
+			<bounds x="1268" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_10" element="debug_button_label_10">
+			<bounds x="1288" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x08">
+			<bounds x="1352" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_11" element="debug_button_label_11">
+			<bounds x="1372" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x10">
+			<bounds x="1436" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_12" element="debug_button_label_12">
+			<bounds x="1456" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x20">
+			<bounds x="1520" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_13" element="debug_button_label_13">
+			<bounds x="1540" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x40">
+			<bounds x="1604" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_14" element="debug_button_label_14">
+			<bounds x="1624" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="ORANGE2" inputmask="0x80">
+			<bounds x="1688" y="708" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_15" element="debug_button_label_15">
+			<bounds x="1708" y="719" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x01">
+			<bounds x="1100" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_16" element="debug_button_label_16">
+			<bounds x="1120" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x02">
+			<bounds x="1184" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_17" element="debug_button_label_17">
+			<bounds x="1204" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x04">
+			<bounds x="1268" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_18" element="debug_button_label_18">
+			<bounds x="1288" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x08">
+			<bounds x="1352" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_19" element="debug_button_label_19">
+			<bounds x="1372" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x10">
+			<bounds x="1436" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_20" element="debug_button_label_20">
+			<bounds x="1456" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x20">
+			<bounds x="1520" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_21" element="debug_button_label_21">
+			<bounds x="1540" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x40">
+			<bounds x="1604" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_22" element="debug_button_label_22">
+			<bounds x="1624" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="BLACK1" inputmask="0x80">
+			<bounds x="1688" y="756" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_23" element="debug_button_label_23">
+			<bounds x="1708" y="767" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_24" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x01">
+			<bounds x="1100" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_24" element="debug_button_label_24">
+			<bounds x="1120" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp25" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x02">
+			<bounds x="1184" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_25" element="debug_button_label_25">
+			<bounds x="1204" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp26" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x04">
+			<bounds x="1268" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_26" element="debug_button_label_26">
+			<bounds x="1288" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x08">
+			<bounds x="1352" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_27" element="debug_button_label_27">
+			<bounds x="1372" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp33" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x10">
+			<bounds x="1436" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_28" element="debug_button_label_28">
+			<bounds x="1456" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp34" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x20">
+			<bounds x="1520" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_29" element="debug_button_label_29">
+			<bounds x="1540" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp40" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x40">
+			<bounds x="1604" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_30" element="debug_button_label_30">
+			<bounds x="1624" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="lamp41" element="debug_button_standard" state="0" inputtag="BLACK2" inputmask="0x80">
+			<bounds x="1688" y="804" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_31" element="debug_button_label_31">
+			<bounds x="1708" y="815" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x01">
+			<bounds x="1100" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_32" element="debug_button_label_32">
+			<bounds x="1120" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x02">
+			<bounds x="1184" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_33" element="debug_button_label_33">
+			<bounds x="1204" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x04">
+			<bounds x="1268" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_34" element="debug_button_label_34">
+			<bounds x="1288" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x08">
+			<bounds x="1352" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_35" element="debug_button_label_35">
+			<bounds x="1372" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x10">
+			<bounds x="1436" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_36" element="debug_button_label_36">
+			<bounds x="1456" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x20">
+			<bounds x="1520" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_37" element="debug_button_label_37">
+			<bounds x="1540" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x40">
+			<bounds x="1604" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_38" element="debug_button_label_38">
+			<bounds x="1624" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="DIL1" inputmask="0x80">
+			<bounds x="1688" y="852" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_39" element="debug_button_label_39">
+			<bounds x="1708" y="863" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x01">
+			<bounds x="1100" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_40" element="debug_button_label_40">
+			<bounds x="1120" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x02">
+			<bounds x="1184" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_41" element="debug_button_label_41">
+			<bounds x="1204" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x04">
+			<bounds x="1268" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_42" element="debug_button_label_42">
+			<bounds x="1288" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x08">
+			<bounds x="1352" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_43" element="debug_button_label_43">
+			<bounds x="1372" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x10">
+			<bounds x="1436" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_44" element="debug_button_label_44">
+			<bounds x="1456" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x20">
+			<bounds x="1520" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_45" element="debug_button_label_45">
+			<bounds x="1540" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x40">
+			<bounds x="1604" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_46" element="debug_button_label_46">
+			<bounds x="1624" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="DIL2" inputmask="0x80">
+			<bounds x="1688" y="900" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_47" element="debug_button_label_47">
+			<bounds x="1708" y="911" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x01">
+			<bounds x="1100" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_48" element="debug_button_label_48">
+			<bounds x="1120" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x02">
+			<bounds x="1184" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_49" element="debug_button_label_49">
+			<bounds x="1204" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x04">
+			<bounds x="1268" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_50" element="debug_button_label_50">
+			<bounds x="1288" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x08">
+			<bounds x="1352" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_51" element="debug_button_label_51">
+			<bounds x="1372" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x10">
+			<bounds x="1436" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_52" element="debug_button_label_52">
+			<bounds x="1456" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x20">
+			<bounds x="1520" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_53" element="debug_button_label_53">
+			<bounds x="1540" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x40">
+			<bounds x="1604" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_54" element="debug_button_label_54">
+			<bounds x="1624" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="AUX1" inputmask="0x80">
+			<bounds x="1688" y="948" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_55" element="debug_button_label_55">
+			<bounds x="1708" y="959" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x01">
+			<bounds x="1100" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_56" element="debug_button_label_56">
+			<bounds x="1120" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x02">
+			<bounds x="1184" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_57" element="debug_button_label_57">
+			<bounds x="1204" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x04">
+			<bounds x="1268" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_58" element="debug_button_label_58">
+			<bounds x="1288" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x08">
+			<bounds x="1352" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_59" element="debug_button_label_59">
+			<bounds x="1372" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x10">
+			<bounds x="1436" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_60" element="debug_button_label_60">
+			<bounds x="1456" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="AUX2" inputmask="0x20">
+			<bounds x="1520" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_61" element="debug_button_label_61">
+			<bounds x="1540" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_62" element="debug_button_standard" state="0" inputtag="AUX2" inputmask="0x40">
+			<bounds x="1604" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_62" element="debug_button_label_62">
+			<bounds x="1624" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="debug_button_63" element="debug_button_standard" state="0" inputtag="AUX2" inputmask="0x80">
+			<bounds x="1688" y="996" width="80" height="44"/>
+		</backdrop>
+		<backdrop name="debug_button_label_63" element="debug_button_label_63">
+			<bounds x="1708" y="1007" width="40" height="22"/>
+		</backdrop>
+		<backdrop name="vfd15" element="debug_vfd" state="0">
+			<bounds x="1150" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd14" element="debug_vfd" state="0">
+			<bounds x="1182" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd13" element="debug_vfd" state="0">
+			<bounds x="1214" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd12" element="debug_vfd" state="0">
+			<bounds x="1246" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd11" element="debug_vfd" state="0">
+			<bounds x="1278" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd10" element="debug_vfd" state="0">
+			<bounds x="1310" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd9" element="debug_vfd" state="0">
+			<bounds x="1342" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd8" element="debug_vfd" state="0">
+			<bounds x="1374" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd7" element="debug_vfd" state="0">
+			<bounds x="1406" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd6" element="debug_vfd" state="0">
+			<bounds x="1438" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd5" element="debug_vfd" state="0">
+			<bounds x="1470" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd4" element="debug_vfd" state="0">
+			<bounds x="1502" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd3" element="debug_vfd" state="0">
+			<bounds x="1534" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd2" element="debug_vfd" state="0">
+			<bounds x="1566" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd1" element="debug_vfd" state="0">
+			<bounds x="1598" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop name="vfd0" element="debug_vfd" state="0">
+			<bounds x="1630" y="600" width="32" height="48"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
+		</backdrop>
+		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
+		</backdrop>
+		<backdrop name="sreel1" element="reel0" state="0">
+			<bounds x="1100" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="sreel2" element="reel1" state="0">
+			<bounds x="1240" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="sreel3" element="reel2" state="0">
+			<bounds x="1380" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop element="reel_background">
+			<bounds x="1520" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="sreel4" element="reel3" state="0">
+			<bounds x="1520" y="32" width="120" height="240"/>
+		</backdrop>
+		<backdrop name="reel1" element="debug_stepper_value">
+			<bounds x="1100" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel2" element="debug_stepper_value">
+			<bounds x="1240" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel3" element="debug_stepper_value">
+			<bounds x="1380" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="reel4" element="debug_stepper_value">
+			<bounds x="1520" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
+			<bounds x="1180" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
+			<bounds x="1320" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
+			<bounds x="1460" y="272" width="50" height="30"/>
+		</backdrop>
+		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/m5barkng.lay
+++ b/src/mame/layout/m5barkng.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
@@ -3602,7 +3604,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="677"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5baxe04.lay
+++ b/src/mame/layout/m5baxe04.lay
@@ -779,6 +779,26 @@
 			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
+	<element name="lamp_0_1_border" defstate="0">
+		<rect state="1">
+			<color red="0.16" green="0.50" blue="0.50"/>
+		</rect>
+		<rect state="0">
+			<color red="0.04" green="0.12" blue="0.12"/>
+		</rect>
+	</element>
+	<element name="lamp_0_1" defstate="0">
+		<rect state="1">
+			<color red="0.33" green="1.00" blue="1.00"/>
+		</rect>
+		<rect state="0">
+			<color red="0.08" green="0.25" blue="0.25"/>
+		</rect>
+		<text string="&#xA3;2.40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
 			<color red="0.19" green="0.50" blue="0.50"/>
@@ -5127,6 +5147,12 @@
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
 			<bounds x="19" y="308" width="68" height="28"/>
 		</backdrop>
+		<backdrop name="lamp0" element="lamp_0_1_border" state="0">
+			<bounds x="17" y="306" width="72" height="32"/>
+		</backdrop>
+		<backdrop name="lamp0" element="lamp_0_1" state="0">
+			<bounds x="19" y="308" width="68" height="28"/>
+		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
 			<bounds x="17" y="338" width="72" height="32"/>
 		</backdrop>
@@ -5714,7 +5740,7 @@
 		<backdrop element="debug_backdrop_colour">
 			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
-		<backdrop name="lamp0" element="debug_lamp_unreferenced" state="0">
+		<backdrop name="lamp0" element="debug_lamp_standard" state="0">
 			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">

--- a/src/mame/layout/m5circlb33.lay
+++ b/src/mame/layout/m5circlb33.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_256_1_border" defstate="0">
 		<rect state="1">
@@ -2420,7 +2422,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="665"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5fiddle.lay
+++ b/src/mame/layout/m5fiddle.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
@@ -3086,7 +3088,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="677"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5hotslt.lay
+++ b/src/mame/layout/m5hotslt.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_316_1_border" defstate="0">
 		<rect state="1">
@@ -2872,7 +2874,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="842" height="747"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5nnww.lay
+++ b/src/mame/layout/m5nnww.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
@@ -2996,7 +2998,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="668"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5qshot04.lay
+++ b/src/mame/layout/m5qshot04.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
@@ -2892,7 +2894,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="677"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5revo13.lay
+++ b/src/mame/layout/m5revo13.lay
@@ -1267,6 +1267,26 @@
 			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
+	<element name="lamp_0_1_border" defstate="0">
+		<rect state="1">
+			<color red="0.16" green="0.50" blue="0.50"/>
+		</rect>
+		<rect state="0">
+			<color red="0.04" green="0.12" blue="0.12"/>
+		</rect>
+	</element>
+	<element name="lamp_0_1" defstate="0">
+		<rect state="1">
+			<color red="0.33" green="1.00" blue="1.00"/>
+		</rect>
+		<rect state="0">
+			<color red="0.08" green="0.25" blue="0.25"/>
+		</rect>
+		<text string="&#xA3;2.40">
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
+		</text>
+	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
 			<color red="0.19" green="0.50" blue="0.50"/>
@@ -5349,6 +5369,12 @@
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
 			<bounds x="19" y="308" width="68" height="28"/>
 		</backdrop>
+		<backdrop name="lamp0" element="lamp_0_1_border" state="0">
+			<bounds x="17" y="306" width="72" height="32"/>
+		</backdrop>
+		<backdrop name="lamp0" element="lamp_0_1" state="0">
+			<bounds x="19" y="308" width="68" height="28"/>
+		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
 			<bounds x="17" y="338" width="72" height="32"/>
 		</backdrop>
@@ -5825,7 +5851,7 @@
 		<backdrop element="debug_backdrop_colour">
 			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
-		<backdrop name="lamp0" element="debug_lamp_unreferenced" state="0">
+		<backdrop name="lamp0" element="debug_lamp_standard" state="0">
 			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">

--- a/src/mame/layout/m5starcl.lay
+++ b/src/mame/layout/m5starcl.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
@@ -2548,7 +2550,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="929" height="688"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5stars26.lay
+++ b/src/mame/layout/m5stars26.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
@@ -2520,7 +2522,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="677"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5supro.lay
+++ b/src/mame/layout/m5supro.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_49_1_border" defstate="0">
 		<disk state="1">
@@ -2352,7 +2354,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="665"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/m5wking05.lay
+++ b/src/mame/layout/m5wking05.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
@@ -2658,7 +2660,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="688"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/sc1barcd.lay
+++ b/src/mame/layout/sc1barcd.lay
@@ -8,9680 +8,6348 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="c">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="c">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="UL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="UL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_84_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_84">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_91_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_91">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_92_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_92">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_93_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_93">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_94_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_94">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_95_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_95">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_96_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_96">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_97_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_97">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_76">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_79">
 		<text string="BANK &#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_82">
 		<text string="BARCODE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_83">
 		<text string="WITH THANKS TO BUGS BUNNY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="762" height="539">
-			</bounds>
+			<bounds x="0" y="0" width="762" height="539"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="230" y="298" width="80" height="140">
-			</bounds>
+			<bounds x="230" y="298" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="298.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="230.0000" y="298.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="299.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="233.3333" y="299.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="301.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="236.6667" y="301.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="303.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="240.0000" y="303.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="305.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="243.3333" y="305.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="307.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="246.6667" y="307.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="344.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="230.0000" y="344.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="346.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="233.3333" y="346.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="348.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="236.6667" y="348.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="350.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="240.0000" y="350.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="352.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="243.3333" y="352.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="354.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="246.6667" y="354.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="391.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="230.0000" y="391.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="393.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="233.3333" y="393.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="395.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="236.6667" y="395.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="397.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="240.0000" y="397.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="399.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="243.3333" y="399.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="401.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="246.6667" y="401.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="230" y="298" width="80" height="140">
-			</bounds>
+			<bounds x="230" y="298" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="322" y="298" width="80" height="140">
-			</bounds>
+			<bounds x="322" y="298" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="298.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="298.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="299.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="299.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="301.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="301.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="303.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="303.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="305.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="305.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="307.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="307.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="344.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="344.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="346.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="346.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="348.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="348.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="350.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="350.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="352.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="352.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="354.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="354.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="322.0000" y="391.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="322.0000" y="391.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="325.3333" y="393.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="325.3333" y="393.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="328.6667" y="395.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="328.6667" y="395.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="332.0000" y="397.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="332.0000" y="397.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="335.3333" y="399.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="335.3333" y="399.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.6667" y="401.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="338.6667" y="401.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="322" y="298" width="80" height="140">
-			</bounds>
+			<bounds x="322" y="298" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="414" y="298" width="80" height="140">
-			</bounds>
+			<bounds x="414" y="298" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="414.0000" y="298.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="414.0000" y="298.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="299.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="417.3333" y="299.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="420.6667" y="301.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="420.6667" y="301.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="424.0000" y="303.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="424.0000" y="303.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="305.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="427.3333" y="305.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="430.6667" y="307.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="430.6667" y="307.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="414.0000" y="344.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="414.0000" y="344.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="346.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="417.3333" y="346.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="420.6667" y="348.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="420.6667" y="348.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="424.0000" y="350.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="424.0000" y="350.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="352.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="427.3333" y="352.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="430.6667" y="354.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="430.6667" y="354.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="414.0000" y="391.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="414.0000" y="391.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="393.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="417.3333" y="393.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="420.6667" y="395.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="420.6667" y="395.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="424.0000" y="397.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="424.0000" y="397.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="399.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="427.3333" y="399.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="430.6667" y="401.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="430.6667" y="401.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="414" y="298" width="80" height="140">
-			</bounds>
+			<bounds x="414" y="298" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="74" y="118" width="60" height="60">
-			</bounds>
+			<bounds x="74" y="118" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="74" y="118" width="60" height="60">
-			</bounds>
+			<bounds x="74" y="118" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="411" y="31" width="92" height="37">
-			</bounds>
+			<bounds x="411" y="31" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="413" y="33" width="88" height="33">
-			</bounds>
+			<bounds x="413" y="33" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="294" y="6" width="52" height="19">
-			</bounds>
+			<bounds x="294" y="6" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="296" y="8" width="48" height="15">
-			</bounds>
+			<bounds x="296" y="8" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="411" y="67" width="92" height="37">
-			</bounds>
+			<bounds x="411" y="67" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="413" y="69" width="88" height="33">
-			</bounds>
+			<bounds x="413" y="69" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="376" y="6" width="52" height="19">
-			</bounds>
+			<bounds x="376" y="6" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="378" y="8" width="48" height="15">
-			</bounds>
+			<bounds x="378" y="8" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="411" y="103" width="92" height="37">
-			</bounds>
+			<bounds x="411" y="103" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="413" y="105" width="88" height="33">
-			</bounds>
+			<bounds x="413" y="105" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="411" y="139" width="92" height="37">
-			</bounds>
+			<bounds x="411" y="139" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="413" y="141" width="88" height="33">
-			</bounds>
+			<bounds x="413" y="141" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="411" y="175" width="92" height="37">
-			</bounds>
+			<bounds x="411" y="175" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="413" y="177" width="88" height="33">
-			</bounds>
+			<bounds x="413" y="177" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="411" y="211" width="92" height="37">
-			</bounds>
+			<bounds x="411" y="211" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="413" y="213" width="88" height="33">
-			</bounds>
+			<bounds x="413" y="213" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="411" y="247" width="92" height="37">
-			</bounds>
+			<bounds x="411" y="247" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="413" y="249" width="88" height="33">
-			</bounds>
+			<bounds x="413" y="249" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="229" y="449" width="37" height="37">
-			</bounds>
+			<bounds x="229" y="449" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="231" y="451" width="33" height="33">
-			</bounds>
+			<bounds x="231" y="451" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="267" y="449" width="37" height="37">
-			</bounds>
+			<bounds x="267" y="449" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="269" y="451" width="33" height="33">
-			</bounds>
+			<bounds x="269" y="451" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="305" y="449" width="37" height="37">
-			</bounds>
+			<bounds x="305" y="449" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="307" y="451" width="33" height="33">
-			</bounds>
+			<bounds x="307" y="451" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="343" y="449" width="37" height="37">
-			</bounds>
+			<bounds x="343" y="449" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="345" y="451" width="33" height="33">
-			</bounds>
+			<bounds x="345" y="451" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="381" y="449" width="37" height="37">
-			</bounds>
+			<bounds x="381" y="449" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="383" y="451" width="33" height="33">
-			</bounds>
+			<bounds x="383" y="451" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="419" y="449" width="37" height="37">
-			</bounds>
+			<bounds x="419" y="449" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="421" y="451" width="33" height="33">
-			</bounds>
+			<bounds x="421" y="451" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="457" y="449" width="37" height="37">
-			</bounds>
+			<bounds x="457" y="449" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="459" y="451" width="33" height="33">
-			</bounds>
+			<bounds x="459" y="451" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="623" y="392" width="27" height="27">
-			</bounds>
+			<bounds x="623" y="392" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="625" y="394" width="23" height="23">
-			</bounds>
+			<bounds x="625" y="394" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="653" y="393" width="27" height="27">
-			</bounds>
+			<bounds x="653" y="393" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="655" y="395" width="23" height="23">
-			</bounds>
+			<bounds x="655" y="395" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="684" y="393" width="27" height="27">
-			</bounds>
+			<bounds x="684" y="393" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="686" y="395" width="23" height="23">
-			</bounds>
+			<bounds x="686" y="395" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="714" y="393" width="27" height="27">
-			</bounds>
+			<bounds x="714" y="393" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="716" y="395" width="23" height="23">
-			</bounds>
+			<bounds x="716" y="395" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="623" y="366" width="27" height="27">
-			</bounds>
+			<bounds x="623" y="366" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="625" y="368" width="23" height="23">
-			</bounds>
+			<bounds x="625" y="368" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="653" y="365" width="27" height="27">
-			</bounds>
+			<bounds x="653" y="365" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="655" y="367" width="23" height="23">
-			</bounds>
+			<bounds x="655" y="367" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="684" y="366" width="27" height="27">
-			</bounds>
+			<bounds x="684" y="366" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="686" y="368" width="23" height="23">
-			</bounds>
+			<bounds x="686" y="368" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="713" y="366" width="27" height="27">
-			</bounds>
+			<bounds x="713" y="366" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="715" y="368" width="23" height="23">
-			</bounds>
+			<bounds x="715" y="368" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="623" y="339" width="27" height="27">
-			</bounds>
+			<bounds x="623" y="339" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="625" y="341" width="23" height="23">
-			</bounds>
+			<bounds x="625" y="341" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="654" y="339" width="27" height="27">
-			</bounds>
+			<bounds x="654" y="339" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="656" y="341" width="23" height="23">
-			</bounds>
+			<bounds x="656" y="341" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="683" y="339" width="27" height="27">
-			</bounds>
+			<bounds x="683" y="339" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="685" y="341" width="23" height="23">
-			</bounds>
+			<bounds x="685" y="341" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="714" y="338" width="27" height="27">
-			</bounds>
+			<bounds x="714" y="338" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="716" y="340" width="23" height="23">
-			</bounds>
+			<bounds x="716" y="340" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="624" y="312" width="27" height="27">
-			</bounds>
+			<bounds x="624" y="312" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="626" y="314" width="23" height="23">
-			</bounds>
+			<bounds x="626" y="314" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="654" y="312" width="27" height="27">
-			</bounds>
+			<bounds x="654" y="312" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="656" y="314" width="23" height="23">
-			</bounds>
+			<bounds x="656" y="314" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="684" y="312" width="27" height="27">
-			</bounds>
+			<bounds x="684" y="312" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="686" y="314" width="23" height="23">
-			</bounds>
+			<bounds x="686" y="314" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="714" y="312" width="27" height="27">
-			</bounds>
+			<bounds x="714" y="312" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="716" y="314" width="23" height="23">
-			</bounds>
+			<bounds x="716" y="314" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="714" y="285" width="27" height="27">
-			</bounds>
+			<bounds x="714" y="285" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="716" y="287" width="23" height="23">
-			</bounds>
+			<bounds x="716" y="287" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="684" y="284" width="27" height="27">
-			</bounds>
+			<bounds x="684" y="284" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="686" y="286" width="23" height="23">
-			</bounds>
+			<bounds x="686" y="286" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="654" y="284" width="27" height="27">
-			</bounds>
+			<bounds x="654" y="284" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="656" y="286" width="23" height="23">
-			</bounds>
+			<bounds x="656" y="286" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="624" y="284" width="27" height="27">
-			</bounds>
+			<bounds x="624" y="284" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="626" y="286" width="23" height="23">
-			</bounds>
+			<bounds x="626" y="286" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="714" y="258" width="27" height="27">
-			</bounds>
+			<bounds x="714" y="258" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="716" y="260" width="23" height="23">
-			</bounds>
+			<bounds x="716" y="260" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="684" y="258" width="27" height="27">
-			</bounds>
+			<bounds x="684" y="258" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="686" y="260" width="23" height="23">
-			</bounds>
+			<bounds x="686" y="260" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="654" y="257" width="27" height="27">
-			</bounds>
+			<bounds x="654" y="257" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="656" y="259" width="23" height="23">
-			</bounds>
+			<bounds x="656" y="259" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="624" y="257" width="27" height="27">
-			</bounds>
+			<bounds x="624" y="257" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="626" y="259" width="23" height="23">
-			</bounds>
+			<bounds x="626" y="259" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="521" y="245" width="72" height="19">
-			</bounds>
+			<bounds x="521" y="245" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="523" y="247" width="68" height="15">
-			</bounds>
+			<bounds x="523" y="247" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="539" y="267" width="37" height="37">
-			</bounds>
+			<bounds x="539" y="267" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="541" y="269" width="33" height="33">
-			</bounds>
+			<bounds x="541" y="269" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="539" y="411" width="37" height="37">
-			</bounds>
+			<bounds x="539" y="411" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="541" y="413" width="33" height="33">
-			</bounds>
+			<bounds x="541" y="413" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="539" y="375" width="37" height="37">
-			</bounds>
+			<bounds x="539" y="375" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="541" y="377" width="33" height="33">
-			</bounds>
+			<bounds x="541" y="377" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="539" y="339" width="37" height="37">
-			</bounds>
+			<bounds x="539" y="339" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="541" y="341" width="33" height="33">
-			</bounds>
+			<bounds x="541" y="341" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="539" y="303" width="37" height="37">
-			</bounds>
+			<bounds x="539" y="303" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="541" y="305" width="33" height="33">
-			</bounds>
+			<bounds x="541" y="305" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="533" y="449" width="52" height="19">
-			</bounds>
+			<bounds x="533" y="449" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="535" y="451" width="48" height="15">
-			</bounds>
+			<bounds x="535" y="451" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="85" y="180" width="37" height="27">
-			</bounds>
+			<bounds x="85" y="180" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="87" y="182" width="33" height="23">
-			</bounds>
+			<bounds x="87" y="182" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="86" y="89" width="37" height="27">
-			</bounds>
+			<bounds x="86" y="89" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="88" y="91" width="33" height="23">
-			</bounds>
+			<bounds x="88" y="91" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_84_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="758" y="1" width="34" height="27">
-			</bounds>
+			<bounds x="758" y="1" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_84" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="760" y="3" width="30" height="23">
-			</bounds>
+			<bounds x="760" y="3" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_91_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="138" y="495" width="75" height="37">
-			</bounds>
+			<bounds x="138" y="495" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_91" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="140" y="497" width="71" height="33">
-			</bounds>
+			<bounds x="140" y="497" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_92_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="234" y="495" width="75" height="37">
-			</bounds>
+			<bounds x="234" y="495" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_92" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="236" y="497" width="71" height="33">
-			</bounds>
+			<bounds x="236" y="497" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_93_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="327" y="495" width="75" height="37">
-			</bounds>
+			<bounds x="327" y="495" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_93" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="329" y="497" width="71" height="33">
-			</bounds>
+			<bounds x="329" y="497" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_94_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="419" y="495" width="75" height="37">
-			</bounds>
+			<bounds x="419" y="495" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_94" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="421" y="497" width="71" height="33">
-			</bounds>
+			<bounds x="421" y="497" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_95_border" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="591" y="495" width="75" height="37">
-			</bounds>
+			<bounds x="591" y="495" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_95" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="593" y="497" width="71" height="33">
-			</bounds>
+			<bounds x="593" y="497" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_96_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="677" y="495" width="75" height="37">
-			</bounds>
+			<bounds x="677" y="495" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_96" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="679" y="497" width="71" height="33">
-			</bounds>
+			<bounds x="679" y="497" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_97_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="511" y="495" width="75" height="37">
-			</bounds>
+			<bounds x="511" y="495" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_97" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="513" y="497" width="71" height="33">
-			</bounds>
+			<bounds x="513" y="497" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="174" y="20" width="24" height="32">
-			</bounds>
+			<bounds x="174" y="20" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="177" y="22" width="17" height="2">
-			</bounds>
+			<bounds x="177" y="22" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="191" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="191" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="191" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="191" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="177" y="46" width="17" height="2">
-			</bounds>
+			<bounds x="177" y="46" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="177" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="177" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="177" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="177" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="177" y="34" width="17" height="2">
-			</bounds>
+			<bounds x="177" y="34" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="194" y="46" width="3" height="2">
-			</bounds>
+			<bounds x="194" y="46" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="177" y="22" width="17" height="2">
-			</bounds>
+			<bounds x="177" y="22" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="191" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="191" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="191" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="191" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="177" y="46" width="17" height="2">
-			</bounds>
+			<bounds x="177" y="46" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="177" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="177" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="177" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="177" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="177" y="34" width="17" height="2">
-			</bounds>
+			<bounds x="177" y="34" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="194" y="46" width="3" height="2">
-			</bounds>
+			<bounds x="194" y="46" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="150" y="20" width="24" height="32">
-			</bounds>
+			<bounds x="150" y="20" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="153" y="22" width="17" height="2">
-			</bounds>
+			<bounds x="153" y="22" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="167" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="167" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="167" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="167" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="153" y="46" width="17" height="2">
-			</bounds>
+			<bounds x="153" y="46" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="153" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="153" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="153" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="153" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="153" y="34" width="17" height="2">
-			</bounds>
+			<bounds x="153" y="34" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="170" y="46" width="3" height="2">
-			</bounds>
+			<bounds x="170" y="46" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="153" y="22" width="17" height="2">
-			</bounds>
+			<bounds x="153" y="22" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="167" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="167" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="167" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="167" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="153" y="46" width="17" height="2">
-			</bounds>
+			<bounds x="153" y="46" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="153" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="153" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="153" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="153" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="153" y="34" width="17" height="2">
-			</bounds>
+			<bounds x="153" y="34" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="170" y="46" width="3" height="2">
-			</bounds>
+			<bounds x="170" y="46" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="102" y="20" width="24" height="32">
-			</bounds>
+			<bounds x="102" y="20" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="105" y="22" width="17" height="2">
-			</bounds>
+			<bounds x="105" y="22" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="119" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="119" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="119" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="119" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="105" y="46" width="17" height="2">
-			</bounds>
+			<bounds x="105" y="46" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="105" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="105" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="105" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="105" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="105" y="34" width="17" height="2">
-			</bounds>
+			<bounds x="105" y="34" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="122" y="46" width="3" height="2">
-			</bounds>
+			<bounds x="122" y="46" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="105" y="22" width="17" height="2">
-			</bounds>
+			<bounds x="105" y="22" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="119" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="119" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="119" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="119" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="105" y="46" width="17" height="2">
-			</bounds>
+			<bounds x="105" y="46" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="105" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="105" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="105" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="105" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="105" y="34" width="17" height="2">
-			</bounds>
+			<bounds x="105" y="34" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="122" y="46" width="3" height="2">
-			</bounds>
+			<bounds x="122" y="46" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="126" y="20" width="24" height="32">
-			</bounds>
+			<bounds x="126" y="20" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="129" y="22" width="17" height="2">
-			</bounds>
+			<bounds x="129" y="22" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="143" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="143" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="143" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="143" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="129" y="46" width="17" height="2">
-			</bounds>
+			<bounds x="129" y="46" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="129" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="129" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="129" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="129" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="129" y="34" width="17" height="2">
-			</bounds>
+			<bounds x="129" y="34" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="146" y="46" width="3" height="2">
-			</bounds>
+			<bounds x="146" y="46" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="129" y="22" width="17" height="2">
-			</bounds>
+			<bounds x="129" y="22" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="143" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="143" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="143" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="143" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="129" y="46" width="17" height="2">
-			</bounds>
+			<bounds x="129" y="46" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="129" y="34" width="3" height="14">
-			</bounds>
+			<bounds x="129" y="34" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="129" y="22" width="3" height="14">
-			</bounds>
+			<bounds x="129" y="22" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="129" y="34" width="17" height="2">
-			</bounds>
+			<bounds x="129" y="34" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="146" y="46" width="3" height="2">
-			</bounds>
+			<bounds x="146" y="46" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="658" y="428" width="24" height="32">
-			</bounds>
+			<bounds x="658" y="428" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="661" y="430" width="17" height="2">
-			</bounds>
+			<bounds x="661" y="430" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="675" y="430" width="3" height="14">
-			</bounds>
+			<bounds x="675" y="430" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="675" y="442" width="3" height="14">
-			</bounds>
+			<bounds x="675" y="442" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="661" y="454" width="17" height="2">
-			</bounds>
+			<bounds x="661" y="454" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="661" y="442" width="3" height="14">
-			</bounds>
+			<bounds x="661" y="442" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="661" y="430" width="3" height="14">
-			</bounds>
+			<bounds x="661" y="430" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="661" y="442" width="17" height="2">
-			</bounds>
+			<bounds x="661" y="442" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="678" y="454" width="3" height="2">
-			</bounds>
+			<bounds x="678" y="454" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="661" y="430" width="17" height="2">
-			</bounds>
+			<bounds x="661" y="430" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="675" y="430" width="3" height="14">
-			</bounds>
+			<bounds x="675" y="430" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="675" y="442" width="3" height="14">
-			</bounds>
+			<bounds x="675" y="442" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="661" y="454" width="17" height="2">
-			</bounds>
+			<bounds x="661" y="454" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="661" y="442" width="3" height="14">
-			</bounds>
+			<bounds x="661" y="442" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="661" y="430" width="3" height="14">
-			</bounds>
+			<bounds x="661" y="430" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="661" y="442" width="17" height="2">
-			</bounds>
+			<bounds x="661" y="442" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="678" y="454" width="3" height="2">
-			</bounds>
+			<bounds x="678" y="454" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="682" y="428" width="24" height="32">
-			</bounds>
+			<bounds x="682" y="428" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="685" y="430" width="17" height="2">
-			</bounds>
+			<bounds x="685" y="430" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="699" y="430" width="3" height="14">
-			</bounds>
+			<bounds x="699" y="430" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="699" y="442" width="3" height="14">
-			</bounds>
+			<bounds x="699" y="442" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="685" y="454" width="17" height="2">
-			</bounds>
+			<bounds x="685" y="454" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="685" y="442" width="3" height="14">
-			</bounds>
+			<bounds x="685" y="442" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="685" y="430" width="3" height="14">
-			</bounds>
+			<bounds x="685" y="430" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="685" y="442" width="17" height="2">
-			</bounds>
+			<bounds x="685" y="442" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="702" y="454" width="3" height="2">
-			</bounds>
+			<bounds x="702" y="454" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="685" y="430" width="17" height="2">
-			</bounds>
+			<bounds x="685" y="430" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="699" y="430" width="3" height="14">
-			</bounds>
+			<bounds x="699" y="430" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="699" y="442" width="3" height="14">
-			</bounds>
+			<bounds x="699" y="442" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="685" y="454" width="17" height="2">
-			</bounds>
+			<bounds x="685" y="454" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="685" y="442" width="3" height="14">
-			</bounds>
+			<bounds x="685" y="442" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="685" y="430" width="3" height="14">
-			</bounds>
+			<bounds x="685" y="430" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="685" y="442" width="17" height="2">
-			</bounds>
+			<bounds x="685" y="442" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="702" y="454" width="3" height="2">
-			</bounds>
+			<bounds x="702" y="454" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label76" element="label_76">
-			<bounds x="658" y="460" width="42" height="16">
-			</bounds>
+			<bounds x="658" y="460" width="42" height="16"/>
 		</backdrop>
 		<backdrop name="label79" element="label_79">
-			<bounds x="16" y="24" width="70" height="22">
-			</bounds>
+			<bounds x="16" y="24" width="70" height="22"/>
 		</backdrop>
 		<backdrop name="label82" element="label_82">
-			<bounds x="30" y="321" width="138" height="32">
-			</bounds>
+			<bounds x="30" y="321" width="138" height="32"/>
 		</backdrop>
 		<backdrop name="label83" element="label_83">
-			<bounds x="48" y="351" width="94" height="28">
-			</bounds>
+			<bounds x="48" y="351" width="94" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_button" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1bartk.lay
+++ b/src/mame/layout/sc1bartk.lay
@@ -6,6430 +6,4846 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png">
-		</image>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="colour_button_86_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_86">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="SingleBar,TripleBar(1),Bell,DoubleBar(3),Cherry,SingleBar,DoubleBar,BlueBell,Cherry(1),DoubleBar,Bell,TripleBar(2),Cherry,DoubleBar,BlueBell(1),Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="SingleBar,TripleBar(1),BlueBell,DoubleBar,Cherry(1),SingleBar,DoubleBar,BlueBell(2),Cherry,DoubleBar,BlueBell,TripleBar,Cherry,SingleBar,Bell(3),Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="SingleBar(1),TripleBar,Bell,DoubleBar,Cherry(3),SingleBar,DoubleBar,BlueBell,Cherry,DoubleBar(2),Bell,TripleBar,Cherry(1),SingleBar,BlueBell,Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="1" symbollist="12,11,10,9,8,7,6,5,4,3,2,1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
-			<bounds x="0" y="0" width="677" height="665">
-			</bounds>
+		<backdrop element="backdrop_colour">
+			<bounds x="0" y="0" width="677" height="665"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="74" y="439" width="78" height="98">
-			</bounds>
+			<bounds x="74" y="439" width="78" height="98"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="74.0000" y="439.0000" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="74.0000" y="439.0000" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="77.2500" y="440.3611" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="77.2500" y="440.3611" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="80.5000" y="441.7222" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="80.5000" y="441.7222" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="83.7500" y="443.0833" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="83.7500" y="443.0833" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="87.0000" y="444.4445" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="87.0000" y="444.4445" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="90.2500" y="445.8055" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="90.2500" y="445.8055" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="74.0000" y="471.6667" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="74.0000" y="471.6667" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="77.2500" y="473.0278" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="77.2500" y="473.0278" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="80.5000" y="474.3889" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="80.5000" y="474.3889" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="83.7500" y="475.7500" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="83.7500" y="475.7500" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="87.0000" y="477.1111" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="87.0000" y="477.1111" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="90.2500" y="478.4722" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="90.2500" y="478.4722" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="74.0000" y="504.3333" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="74.0000" y="504.3333" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="77.2500" y="505.6945" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="77.2500" y="505.6945" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="80.5000" y="507.0556" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="80.5000" y="507.0556" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="83.7500" y="508.4167" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="83.7500" y="508.4167" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="87.0000" y="509.7778" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="87.0000" y="509.7778" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="90.2500" y="511.1389" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="90.2500" y="511.1389" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="74" y="439" width="78" height="98">
-			</bounds>
+			<bounds x="74" y="439" width="78" height="98"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="194" y="439" width="78" height="98">
-			</bounds>
+			<bounds x="194" y="439" width="78" height="98"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="194.0000" y="439.0000" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="194.0000" y="439.0000" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.2500" y="440.3611" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="197.2500" y="440.3611" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.5000" y="441.7222" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="200.5000" y="441.7222" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="443.0833" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="203.7500" y="443.0833" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="207.0000" y="444.4445" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="207.0000" y="444.4445" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="210.2500" y="445.8055" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="210.2500" y="445.8055" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="194.0000" y="471.6667" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="194.0000" y="471.6667" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.2500" y="473.0278" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="197.2500" y="473.0278" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.5000" y="474.3889" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="200.5000" y="474.3889" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="475.7500" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="203.7500" y="475.7500" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="207.0000" y="477.1111" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="207.0000" y="477.1111" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="210.2500" y="478.4722" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="210.2500" y="478.4722" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="194.0000" y="504.3333" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="194.0000" y="504.3333" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.2500" y="505.6945" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="197.2500" y="505.6945" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.5000" y="507.0556" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="200.5000" y="507.0556" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="508.4167" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="203.7500" y="508.4167" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="207.0000" y="509.7778" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="207.0000" y="509.7778" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="210.2500" y="511.1389" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="210.2500" y="511.1389" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="194" y="439" width="78" height="98">
-			</bounds>
+			<bounds x="194" y="439" width="78" height="98"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="314" y="439" width="78" height="98">
-			</bounds>
+			<bounds x="314" y="439" width="78" height="98"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="314.0000" y="439.0000" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="314.0000" y="439.0000" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="317.2500" y="440.3611" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="317.2500" y="440.3611" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="320.5000" y="441.7222" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="320.5000" y="441.7222" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.7500" y="443.0833" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="323.7500" y="443.0833" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="327.0000" y="444.4445" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="327.0000" y="444.4445" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="330.2500" y="445.8055" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="330.2500" y="445.8055" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="314.0000" y="471.6667" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="314.0000" y="471.6667" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="317.2500" y="473.0278" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="317.2500" y="473.0278" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="320.5000" y="474.3889" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="320.5000" y="474.3889" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.7500" y="475.7500" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="323.7500" y="475.7500" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="327.0000" y="477.1111" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="327.0000" y="477.1111" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="330.2500" y="478.4722" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="330.2500" y="478.4722" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="314.0000" y="504.3333" width="78.0000" height="32.6667">
-			</bounds>
+			<bounds x="314.0000" y="504.3333" width="78.0000" height="32.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="317.2500" y="505.6945" width="71.5000" height="29.9444">
-			</bounds>
+			<bounds x="317.2500" y="505.6945" width="71.5000" height="29.9444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="320.5000" y="507.0556" width="65.0000" height="27.2222">
-			</bounds>
+			<bounds x="320.5000" y="507.0556" width="65.0000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.7500" y="508.4167" width="58.5000" height="24.5000">
-			</bounds>
+			<bounds x="323.7500" y="508.4167" width="58.5000" height="24.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="327.0000" y="509.7778" width="52.0000" height="21.7778">
-			</bounds>
+			<bounds x="327.0000" y="509.7778" width="52.0000" height="21.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="330.2500" y="511.1389" width="45.5000" height="19.0556">
-			</bounds>
+			<bounds x="330.2500" y="511.1389" width="45.5000" height="19.0556"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="314" y="439" width="78" height="98">
-			</bounds>
+			<bounds x="314" y="439" width="78" height="98"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="35" y="265" width="58" height="48">
-			</bounds>
+			<bounds x="35" y="265" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="35" y="265" width="58" height="48">
-			</bounds>
+			<bounds x="35" y="265" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_86_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="558" y="19" width="42" height="58">
-			</bounds>
+			<bounds x="558" y="19" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_86" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="560" y="21" width="38" height="54">
-			</bounds>
+			<bounds x="560" y="21" width="38" height="54"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="592" y="559" width="23" height="30">
-			</bounds>
+			<bounds x="592" y="559" width="23" height="30"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="595" y="561" width="16" height="2">
-			</bounds>
+			<bounds x="595" y="561" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="608" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="608" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="608" y="572" width="3" height="13">
-			</bounds>
+			<bounds x="608" y="572" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="595" y="583" width="16" height="2">
-			</bounds>
+			<bounds x="595" y="583" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="595" y="572" width="3" height="13">
-			</bounds>
+			<bounds x="595" y="572" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="595" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="595" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="595" y="572" width="16" height="2">
-			</bounds>
+			<bounds x="595" y="572" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="611" y="583" width="3" height="2">
-			</bounds>
+			<bounds x="611" y="583" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="595" y="561" width="16" height="2">
-			</bounds>
+			<bounds x="595" y="561" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="608" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="608" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="608" y="572" width="3" height="13">
-			</bounds>
+			<bounds x="608" y="572" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="595" y="583" width="16" height="2">
-			</bounds>
+			<bounds x="595" y="583" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="595" y="572" width="3" height="13">
-			</bounds>
+			<bounds x="595" y="572" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="595" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="595" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="595" y="572" width="16" height="2">
-			</bounds>
+			<bounds x="595" y="572" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="611" y="583" width="3" height="2">
-			</bounds>
+			<bounds x="611" y="583" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="615" y="559" width="23" height="30">
-			</bounds>
+			<bounds x="615" y="559" width="23" height="30"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="618" y="561" width="16" height="2">
-			</bounds>
+			<bounds x="618" y="561" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="631" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="631" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="631" y="572" width="3" height="13">
-			</bounds>
+			<bounds x="631" y="572" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="618" y="583" width="16" height="2">
-			</bounds>
+			<bounds x="618" y="583" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="618" y="572" width="3" height="13">
-			</bounds>
+			<bounds x="618" y="572" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="618" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="618" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="618" y="572" width="16" height="2">
-			</bounds>
+			<bounds x="618" y="572" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="634" y="583" width="3" height="2">
-			</bounds>
+			<bounds x="634" y="583" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="618" y="561" width="16" height="2">
-			</bounds>
+			<bounds x="618" y="561" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="631" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="631" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="631" y="572" width="3" height="13">
-			</bounds>
+			<bounds x="631" y="572" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="618" y="583" width="16" height="2">
-			</bounds>
+			<bounds x="618" y="583" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="618" y="572" width="3" height="13">
-			</bounds>
+			<bounds x="618" y="572" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="618" y="561" width="3" height="13">
-			</bounds>
+			<bounds x="618" y="561" width="3" height="13"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="618" y="572" width="16" height="2">
-			</bounds>
+			<bounds x="618" y="572" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="634" y="583" width="3" height="2">
-			</bounds>
+			<bounds x="634" y="583" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="106" y="18" width="49" height="58">
-			</bounds>
+			<bounds x="106" y="18" width="49" height="58"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="113" y="23" width="35" height="5">
-			</bounds>
+			<bounds x="113" y="23" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="141" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="141" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="141" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="141" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="113" y="65" width="35" height="5">
-			</bounds>
+			<bounds x="113" y="65" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="113" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="113" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="113" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="113" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="113" y="44" width="35" height="5">
-			</bounds>
+			<bounds x="113" y="44" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="148" y="65" width="7" height="5">
-			</bounds>
+			<bounds x="148" y="65" width="7" height="5"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="113" y="23" width="35" height="5">
-			</bounds>
+			<bounds x="113" y="23" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="141" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="141" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="141" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="141" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="113" y="65" width="35" height="5">
-			</bounds>
+			<bounds x="113" y="65" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="113" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="113" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="113" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="113" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="113" y="44" width="35" height="5">
-			</bounds>
+			<bounds x="113" y="44" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="148" y="65" width="7" height="5">
-			</bounds>
+			<bounds x="148" y="65" width="7" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="155" y="18" width="49" height="58">
-			</bounds>
+			<bounds x="155" y="18" width="49" height="58"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="162" y="23" width="35" height="5">
-			</bounds>
+			<bounds x="162" y="23" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="190" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="190" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="190" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="190" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="162" y="65" width="35" height="5">
-			</bounds>
+			<bounds x="162" y="65" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="162" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="162" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="162" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="162" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="162" y="44" width="35" height="5">
-			</bounds>
+			<bounds x="162" y="44" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="197" y="65" width="7" height="5">
-			</bounds>
+			<bounds x="197" y="65" width="7" height="5"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="162" y="23" width="35" height="5">
-			</bounds>
+			<bounds x="162" y="23" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="190" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="190" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="190" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="190" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="162" y="65" width="35" height="5">
-			</bounds>
+			<bounds x="162" y="65" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="162" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="162" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="162" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="162" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="162" y="44" width="35" height="5">
-			</bounds>
+			<bounds x="162" y="44" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="197" y="65" width="7" height="5">
-			</bounds>
+			<bounds x="197" y="65" width="7" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="204" y="18" width="49" height="58">
-			</bounds>
+			<bounds x="204" y="18" width="49" height="58"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="211" y="23" width="35" height="5">
-			</bounds>
+			<bounds x="211" y="23" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="239" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="239" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="239" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="239" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="211" y="65" width="35" height="5">
-			</bounds>
+			<bounds x="211" y="65" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="211" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="211" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="211" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="211" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="211" y="44" width="35" height="5">
-			</bounds>
+			<bounds x="211" y="44" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="246" y="65" width="7" height="5">
-			</bounds>
+			<bounds x="246" y="65" width="7" height="5"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="211" y="23" width="35" height="5">
-			</bounds>
+			<bounds x="211" y="23" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="239" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="239" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="239" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="239" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="211" y="65" width="35" height="5">
-			</bounds>
+			<bounds x="211" y="65" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="211" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="211" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="211" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="211" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="211" y="44" width="35" height="5">
-			</bounds>
+			<bounds x="211" y="44" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="246" y="65" width="7" height="5">
-			</bounds>
+			<bounds x="246" y="65" width="7" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="253" y="18" width="49" height="58">
-			</bounds>
+			<bounds x="253" y="18" width="49" height="58"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="260" y="23" width="35" height="5">
-			</bounds>
+			<bounds x="260" y="23" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="288" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="288" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="288" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="288" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="260" y="65" width="35" height="5">
-			</bounds>
+			<bounds x="260" y="65" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="260" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="260" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="260" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="260" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="260" y="44" width="35" height="5">
-			</bounds>
+			<bounds x="260" y="44" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="295" y="65" width="7" height="5">
-			</bounds>
+			<bounds x="295" y="65" width="7" height="5"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="260" y="23" width="35" height="5">
-			</bounds>
+			<bounds x="260" y="23" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="288" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="288" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="288" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="288" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="260" y="65" width="35" height="5">
-			</bounds>
+			<bounds x="260" y="65" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="260" y="44" width="7" height="26">
-			</bounds>
+			<bounds x="260" y="44" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="260" y="23" width="7" height="26">
-			</bounds>
+			<bounds x="260" y="23" width="7" height="26"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="260" y="44" width="35" height="5">
-			</bounds>
+			<bounds x="260" y="44" width="35" height="5"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="295" y="65" width="7" height="5">
-			</bounds>
+			<bounds x="295" y="65" width="7" height="5"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1cl65.lay
+++ b/src/mame/layout/sc1cl65.lay
@@ -8,10476 +8,6889 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Club 65 Special ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.18"/>
 		</text>
 		<text string=" ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.23" width="0.90" height="0.18"/>
 		</text>
 		<text string="20p Play ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.41" width="0.90" height="0.18"/>
 		</text>
 		<text string="&#xA3;150 Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Club 65 Special ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string=" ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="20p Play ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="&#xA3;150 Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.77" width="0.90" height="0.18"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="PINEAPPLES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="PINEAPPLES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="PLUMS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="PLUMS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STRAWBERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STRAWBERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="APPLES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="APPLES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ORANGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ORANGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STAKE 40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAKE 40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="STAKE 60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="STAKE 60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STAKE &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAKE &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_78_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_78">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_84_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_84">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_85_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_85">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_86_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_86">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_87_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_87">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_88_border">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_88">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STAKE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_89_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_89">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="STAKE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_90_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_90">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STAKE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_91_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_91">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel5" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_44">
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_45">
 		<text string="METER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_46">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_47">
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_48">
 		<text string="GAMES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_49">
 		<text string="5 LINES PAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_50">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_66">
 		<text string="27 WAYS TO WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_70">
 		<text string="Club 65 Special">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_5">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="679" height="668">
-			</bounds>
+			<bounds x="0" y="0" width="679" height="668"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="116" y="393" width="70" height="140">
-			</bounds>
+			<bounds x="116" y="393" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="393.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="393.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="118.9167" y="394.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="118.9167" y="394.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="121.8333" y="396.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="121.8333" y="396.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="124.7500" y="398.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="124.7500" y="398.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="127.6667" y="400.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="127.6667" y="400.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="130.5833" y="402.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="130.5833" y="402.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="439.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="439.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="118.9167" y="441.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="118.9167" y="441.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="121.8333" y="443.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="121.8333" y="443.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="124.7500" y="445.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="124.7500" y="445.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="127.6667" y="447.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="127.6667" y="447.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="130.5833" y="449.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="130.5833" y="449.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="486.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="486.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="118.9167" y="488.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="118.9167" y="488.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="121.8333" y="490.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="121.8333" y="490.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="124.7500" y="492.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="124.7500" y="492.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="127.6667" y="494.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="127.6667" y="494.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="130.5833" y="496.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="130.5833" y="496.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="116" y="393" width="70" height="140">
-			</bounds>
+			<bounds x="116" y="393" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="195" y="393" width="70" height="140">
-			</bounds>
+			<bounds x="195" y="393" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="393.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="195.0000" y="393.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.9167" y="394.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="197.9167" y="394.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.8333" y="396.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="200.8333" y="396.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="398.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="203.7500" y="398.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="206.6667" y="400.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="206.6667" y="400.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="209.5833" y="402.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="209.5833" y="402.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="439.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="195.0000" y="439.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.9167" y="441.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="197.9167" y="441.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.8333" y="443.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="200.8333" y="443.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="445.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="203.7500" y="445.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="206.6667" y="447.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="206.6667" y="447.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="209.5833" y="449.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="209.5833" y="449.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="486.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="195.0000" y="486.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.9167" y="488.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="197.9167" y="488.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.8333" y="490.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="200.8333" y="490.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="492.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="203.7500" y="492.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="206.6667" y="494.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="206.6667" y="494.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="209.5833" y="496.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="209.5833" y="496.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="195" y="393" width="70" height="140">
-			</bounds>
+			<bounds x="195" y="393" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="274" y="393" width="70" height="140">
-			</bounds>
+			<bounds x="274" y="393" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="393.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="274.0000" y="393.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.9167" y="394.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="276.9167" y="394.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.8333" y="396.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="279.8333" y="396.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.7500" y="398.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="282.7500" y="398.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.6667" y="400.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="285.6667" y="400.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.5833" y="402.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="288.5833" y="402.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="439.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="274.0000" y="439.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.9167" y="441.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="276.9167" y="441.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.8333" y="443.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="279.8333" y="443.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.7500" y="445.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="282.7500" y="445.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.6667" y="447.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="285.6667" y="447.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.5833" y="449.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="288.5833" y="449.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="486.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="274.0000" y="486.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.9167" y="488.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="276.9167" y="488.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.8333" y="490.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="279.8333" y="490.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.7500" y="492.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="282.7500" y="492.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.6667" y="494.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="285.6667" y="494.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.5833" y="496.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="288.5833" y="496.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="274" y="393" width="70" height="140">
-			</bounds>
+			<bounds x="274" y="393" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="116" y="113" width="70" height="140">
-			</bounds>
+			<bounds x="116" y="113" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="113.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="113.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="118.9167" y="114.9444" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="118.9167" y="114.9444" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="121.8333" y="116.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="121.8333" y="116.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="124.7500" y="118.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="124.7500" y="118.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="127.6667" y="120.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="127.6667" y="120.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="130.5833" y="122.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="130.5833" y="122.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="159.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="159.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="118.9167" y="161.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="118.9167" y="161.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="121.8333" y="163.5556" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="121.8333" y="163.5556" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="124.7500" y="165.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="124.7500" y="165.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="127.6667" y="167.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="127.6667" y="167.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="130.5833" y="169.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="130.5833" y="169.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="116.0000" y="206.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="116.0000" y="206.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="118.9167" y="208.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="118.9167" y="208.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="121.8333" y="210.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="121.8333" y="210.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="124.7500" y="212.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="124.7500" y="212.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="127.6667" y="214.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="127.6667" y="214.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="130.5833" y="216.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="130.5833" y="216.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="116" y="113" width="70" height="140">
-			</bounds>
+			<bounds x="116" y="113" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="195" y="114" width="70" height="140">
-			</bounds>
+			<bounds x="195" y="114" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="114.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="195.0000" y="114.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.9167" y="115.9444" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="197.9167" y="115.9444" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.8333" y="117.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="200.8333" y="117.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="119.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="203.7500" y="119.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="206.6667" y="121.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="206.6667" y="121.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="209.5833" y="123.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="209.5833" y="123.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="160.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="195.0000" y="160.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.9167" y="162.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="197.9167" y="162.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.8333" y="164.5556" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="200.8333" y="164.5556" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="166.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="203.7500" y="166.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="206.6667" y="168.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="206.6667" y="168.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="209.5833" y="170.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="209.5833" y="170.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="207.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="195.0000" y="207.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="197.9167" y="209.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="197.9167" y="209.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="200.8333" y="211.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="200.8333" y="211.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="203.7500" y="213.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="203.7500" y="213.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="206.6667" y="215.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="206.6667" y="215.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="209.5833" y="217.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="209.5833" y="217.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="195" y="114" width="70" height="140">
-			</bounds>
+			<bounds x="195" y="114" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="274" y="114" width="70" height="140">
-			</bounds>
+			<bounds x="274" y="114" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="114.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="274.0000" y="114.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.9167" y="115.9444" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="276.9167" y="115.9444" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.8333" y="117.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="279.8333" y="117.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.7500" y="119.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="282.7500" y="119.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.6667" y="121.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="285.6667" y="121.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.5833" y="123.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="288.5833" y="123.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="160.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="274.0000" y="160.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.9167" y="162.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="276.9167" y="162.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.8333" y="164.5556" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="279.8333" y="164.5556" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.7500" y="166.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="282.7500" y="166.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.6667" y="168.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="285.6667" y="168.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.5833" y="170.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="288.5833" y="170.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="274.0000" y="207.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="274.0000" y="207.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="276.9167" y="209.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="276.9167" y="209.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.8333" y="211.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="279.8333" y="211.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.7500" y="213.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="282.7500" y="213.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.6667" y="215.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="285.6667" y="215.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.5833" y="217.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="288.5833" y="217.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<bounds x="274" y="114" width="70" height="140">
-			</bounds>
+			<bounds x="274" y="114" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="15" y="12" width="102" height="82">
-			</bounds>
+			<bounds x="15" y="12" width="102" height="82"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="17" y="14" width="98" height="78">
-			</bounds>
+			<bounds x="17" y="14" width="98" height="78"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="550" y="403" width="62" height="32">
-			</bounds>
+			<bounds x="550" y="403" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="552" y="405" width="58" height="28">
-			</bounds>
+			<bounds x="552" y="405" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="402" y="67" width="107" height="32">
-			</bounds>
+			<bounds x="402" y="67" width="107" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="404" y="69" width="103" height="28">
-			</bounds>
+			<bounds x="404" y="69" width="103" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="402" y="99" width="107" height="32">
-			</bounds>
+			<bounds x="402" y="99" width="107" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="404" y="101" width="103" height="28">
-			</bounds>
+			<bounds x="404" y="101" width="103" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="402" y="131" width="107" height="32">
-			</bounds>
+			<bounds x="402" y="131" width="107" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="404" y="133" width="103" height="28">
-			</bounds>
+			<bounds x="404" y="133" width="103" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="402" y="163" width="107" height="32">
-			</bounds>
+			<bounds x="402" y="163" width="107" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="404" y="165" width="103" height="28">
-			</bounds>
+			<bounds x="404" y="165" width="103" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="402" y="195" width="107" height="32">
-			</bounds>
+			<bounds x="402" y="195" width="107" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="404" y="197" width="103" height="28">
-			</bounds>
+			<bounds x="404" y="197" width="103" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="402" y="227" width="107" height="32">
-			</bounds>
+			<bounds x="402" y="227" width="107" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="404" y="229" width="103" height="28">
-			</bounds>
+			<bounds x="404" y="229" width="103" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="402" y="259" width="107" height="32">
-			</bounds>
+			<bounds x="402" y="259" width="107" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="404" y="261" width="103" height="28">
-			</bounds>
+			<bounds x="404" y="261" width="103" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="513" y="67" width="47" height="32">
-			</bounds>
+			<bounds x="513" y="67" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="515" y="69" width="43" height="28">
-			</bounds>
+			<bounds x="515" y="69" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="566" y="67" width="47" height="32">
-			</bounds>
+			<bounds x="566" y="67" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="568" y="69" width="43" height="28">
-			</bounds>
+			<bounds x="568" y="69" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="619" y="67" width="47" height="32">
-			</bounds>
+			<bounds x="619" y="67" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="621" y="69" width="43" height="28">
-			</bounds>
+			<bounds x="621" y="69" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="513" y="99" width="47" height="32">
-			</bounds>
+			<bounds x="513" y="99" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="515" y="101" width="43" height="28">
-			</bounds>
+			<bounds x="515" y="101" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="513" y="131" width="47" height="32">
-			</bounds>
+			<bounds x="513" y="131" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="515" y="133" width="43" height="28">
-			</bounds>
+			<bounds x="515" y="133" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="566" y="131" width="47" height="32">
-			</bounds>
+			<bounds x="566" y="131" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="568" y="133" width="43" height="28">
-			</bounds>
+			<bounds x="568" y="133" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="619" y="131" width="47" height="32">
-			</bounds>
+			<bounds x="619" y="131" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="621" y="133" width="43" height="28">
-			</bounds>
+			<bounds x="621" y="133" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="513" y="163" width="47" height="32">
-			</bounds>
+			<bounds x="513" y="163" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="515" y="165" width="43" height="28">
-			</bounds>
+			<bounds x="515" y="165" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="566" y="163" width="47" height="32">
-			</bounds>
+			<bounds x="566" y="163" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="568" y="165" width="43" height="28">
-			</bounds>
+			<bounds x="568" y="165" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="566" y="99" width="47" height="32">
-			</bounds>
+			<bounds x="566" y="99" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="568" y="101" width="43" height="28">
-			</bounds>
+			<bounds x="568" y="101" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="619" y="99" width="47" height="32">
-			</bounds>
+			<bounds x="619" y="99" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="621" y="101" width="43" height="28">
-			</bounds>
+			<bounds x="621" y="101" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="619" y="195" width="47" height="32">
-			</bounds>
+			<bounds x="619" y="195" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="621" y="197" width="43" height="28">
-			</bounds>
+			<bounds x="621" y="197" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="619" y="227" width="47" height="32">
-			</bounds>
+			<bounds x="619" y="227" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="621" y="229" width="43" height="28">
-			</bounds>
+			<bounds x="621" y="229" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="566" y="259" width="47" height="32">
-			</bounds>
+			<bounds x="566" y="259" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="568" y="261" width="43" height="28">
-			</bounds>
+			<bounds x="568" y="261" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="619" y="259" width="47" height="32">
-			</bounds>
+			<bounds x="619" y="259" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="621" y="261" width="43" height="28">
-			</bounds>
+			<bounds x="621" y="261" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="619" y="163" width="47" height="32">
-			</bounds>
+			<bounds x="619" y="163" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="621" y="165" width="43" height="28">
-			</bounds>
+			<bounds x="621" y="165" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="513" y="259" width="47" height="32">
-			</bounds>
+			<bounds x="513" y="259" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="515" y="261" width="43" height="28">
-			</bounds>
+			<bounds x="515" y="261" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="513" y="227" width="47" height="32">
-			</bounds>
+			<bounds x="513" y="227" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="515" y="229" width="43" height="28">
-			</bounds>
+			<bounds x="515" y="229" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="513" y="195" width="47" height="32">
-			</bounds>
+			<bounds x="513" y="195" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="515" y="197" width="43" height="28">
-			</bounds>
+			<bounds x="515" y="197" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="566" y="196" width="47" height="32">
-			</bounds>
+			<bounds x="566" y="196" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="568" y="198" width="43" height="28">
-			</bounds>
+			<bounds x="568" y="198" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="566" y="228" width="47" height="32">
-			</bounds>
+			<bounds x="566" y="228" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="568" y="230" width="43" height="28">
-			</bounds>
+			<bounds x="568" y="230" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="596" y="474" width="32" height="32">
-			</bounds>
+			<bounds x="596" y="474" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="598" y="476" width="28" height="28">
-			</bounds>
+			<bounds x="598" y="476" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="550" y="515" width="62" height="32">
-			</bounds>
+			<bounds x="550" y="515" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="552" y="517" width="58" height="28">
-			</bounds>
+			<bounds x="552" y="517" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="565" y="443" width="32" height="32">
-			</bounds>
+			<bounds x="565" y="443" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="567" y="445" width="28" height="28">
-			</bounds>
+			<bounds x="567" y="445" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="349" y="81" width="32" height="32">
-			</bounds>
+			<bounds x="349" y="81" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="351" y="83" width="28" height="28">
-			</bounds>
+			<bounds x="351" y="83" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="349" y="122" width="32" height="32">
-			</bounds>
+			<bounds x="349" y="122" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="351" y="124" width="28" height="28">
-			</bounds>
+			<bounds x="351" y="124" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="349" y="168" width="32" height="32">
-			</bounds>
+			<bounds x="349" y="168" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="351" y="170" width="28" height="28">
-			</bounds>
+			<bounds x="351" y="170" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="349" y="214" width="32" height="32">
-			</bounds>
+			<bounds x="349" y="214" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="351" y="216" width="28" height="28">
-			</bounds>
+			<bounds x="351" y="216" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="349" y="255" width="32" height="32">
-			</bounds>
+			<bounds x="349" y="255" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="351" y="257" width="28" height="28">
-			</bounds>
+			<bounds x="351" y="257" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="386" y="451" width="32" height="32">
-			</bounds>
+			<bounds x="386" y="451" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="388" y="453" width="28" height="28">
-			</bounds>
+			<bounds x="388" y="453" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="456" y="451" width="32" height="32">
-			</bounds>
+			<bounds x="456" y="451" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="458" y="453" width="28" height="28">
-			</bounds>
+			<bounds x="458" y="453" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="421" y="451" width="32" height="32">
-			</bounds>
+			<bounds x="421" y="451" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="423" y="453" width="28" height="28">
-			</bounds>
+			<bounds x="423" y="453" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="535" y="474" width="32" height="32">
-			</bounds>
+			<bounds x="535" y="474" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="537" y="476" width="28" height="28">
-			</bounds>
+			<bounds x="537" y="476" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="386" y="489" width="32" height="32">
-			</bounds>
+			<bounds x="386" y="489" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="388" y="491" width="28" height="28">
-			</bounds>
+			<bounds x="388" y="491" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="456" y="526" width="32" height="32">
-			</bounds>
+			<bounds x="456" y="526" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="458" y="528" width="28" height="28">
-			</bounds>
+			<bounds x="458" y="528" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="456" y="489" width="32" height="32">
-			</bounds>
+			<bounds x="456" y="489" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="458" y="491" width="28" height="28">
-			</bounds>
+			<bounds x="458" y="491" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="386" y="526" width="32" height="32">
-			</bounds>
+			<bounds x="386" y="526" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="388" y="528" width="28" height="28">
-			</bounds>
+			<bounds x="388" y="528" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="421" y="489" width="32" height="32">
-			</bounds>
+			<bounds x="421" y="489" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="423" y="491" width="28" height="28">
-			</bounds>
+			<bounds x="423" y="491" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="421" y="526" width="32" height="32">
-			</bounds>
+			<bounds x="421" y="526" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="423" y="528" width="28" height="28">
-			</bounds>
+			<bounds x="423" y="528" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="513" y="30" width="47" height="32">
-			</bounds>
+			<bounds x="513" y="30" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="515" y="32" width="43" height="28">
-			</bounds>
+			<bounds x="515" y="32" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="566" y="30" width="47" height="32">
-			</bounds>
+			<bounds x="566" y="30" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="568" y="32" width="43" height="28">
-			</bounds>
+			<bounds x="568" y="32" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="619" y="30" width="47" height="32">
-			</bounds>
+			<bounds x="619" y="30" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="621" y="32" width="43" height="28">
-			</bounds>
+			<bounds x="621" y="32" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp23" element="colour_button_78_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="446" y="15" width="39" height="39">
-			</bounds>
+			<bounds x="446" y="15" width="39" height="39"/>
 		</backdrop>
 		<backdrop name="lamp23" element="colour_button_78" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="448" y="17" width="35" height="35">
-			</bounds>
+			<bounds x="448" y="17" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_84_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="36" y="599" width="72" height="42">
-			</bounds>
+			<bounds x="36" y="599" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_84" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="38" y="601" width="68" height="38">
-			</bounds>
+			<bounds x="38" y="601" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_85_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="115" y="599" width="72" height="42">
-			</bounds>
+			<bounds x="115" y="599" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_85" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="117" y="601" width="68" height="38">
-			</bounds>
+			<bounds x="117" y="601" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_86_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="194" y="599" width="72" height="42">
-			</bounds>
+			<bounds x="194" y="599" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_86" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="196" y="601" width="68" height="38">
-			</bounds>
+			<bounds x="196" y="601" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_87_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="274" y="599" width="72" height="42">
-			</bounds>
+			<bounds x="274" y="599" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_87" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="276" y="601" width="68" height="38">
-			</bounds>
+			<bounds x="276" y="601" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_88_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="365" y="599" width="72" height="42">
-			</bounds>
+			<bounds x="365" y="599" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_88" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="367" y="601" width="68" height="38">
-			</bounds>
+			<bounds x="367" y="601" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_89_border" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="443" y="599" width="72" height="42">
-			</bounds>
+			<bounds x="443" y="599" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_89" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="445" y="601" width="68" height="38">
-			</bounds>
+			<bounds x="445" y="601" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_90_border" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="520" y="599" width="72" height="42">
-			</bounds>
+			<bounds x="520" y="599" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_90" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="522" y="601" width="68" height="38">
-			</bounds>
+			<bounds x="522" y="601" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_91_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="597" y="599" width="72" height="42">
-			</bounds>
+			<bounds x="597" y="599" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_91" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="599" y="601" width="68" height="38">
-			</bounds>
+			<bounds x="599" y="601" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="136" y="302" width="45" height="70">
-			</bounds>
+			<bounds x="136" y="302" width="45" height="70"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="142" y="308" width="32" height="6">
-			</bounds>
+			<bounds x="142" y="308" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="168" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="168" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="168" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="168" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="142" y="359" width="32" height="6">
-			</bounds>
+			<bounds x="142" y="359" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="142" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="142" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="142" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="142" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="142" y="333" width="32" height="6">
-			</bounds>
+			<bounds x="142" y="333" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="174" y="359" width="6" height="6">
-			</bounds>
+			<bounds x="174" y="359" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="142" y="308" width="32" height="6">
-			</bounds>
+			<bounds x="142" y="308" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="168" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="168" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="168" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="168" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="142" y="359" width="32" height="6">
-			</bounds>
+			<bounds x="142" y="359" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="142" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="142" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="142" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="142" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="142" y="333" width="32" height="6">
-			</bounds>
+			<bounds x="142" y="333" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="174" y="359" width="6" height="6">
-			</bounds>
+			<bounds x="174" y="359" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="181" y="302" width="45" height="70">
-			</bounds>
+			<bounds x="181" y="302" width="45" height="70"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="187" y="308" width="32" height="6">
-			</bounds>
+			<bounds x="187" y="308" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="213" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="213" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="213" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="213" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="187" y="359" width="32" height="6">
-			</bounds>
+			<bounds x="187" y="359" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="187" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="187" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="187" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="187" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="187" y="333" width="32" height="6">
-			</bounds>
+			<bounds x="187" y="333" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="219" y="359" width="6" height="6">
-			</bounds>
+			<bounds x="219" y="359" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="187" y="308" width="32" height="6">
-			</bounds>
+			<bounds x="187" y="308" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="213" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="213" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="213" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="213" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="187" y="359" width="32" height="6">
-			</bounds>
+			<bounds x="187" y="359" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="187" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="187" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="187" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="187" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="187" y="333" width="32" height="6">
-			</bounds>
+			<bounds x="187" y="333" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="219" y="359" width="6" height="6">
-			</bounds>
+			<bounds x="219" y="359" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="226" y="302" width="45" height="70">
-			</bounds>
+			<bounds x="226" y="302" width="45" height="70"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="232" y="308" width="32" height="6">
-			</bounds>
+			<bounds x="232" y="308" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="258" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="258" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="258" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="258" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="232" y="359" width="32" height="6">
-			</bounds>
+			<bounds x="232" y="359" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="232" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="232" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="232" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="232" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="232" y="333" width="32" height="6">
-			</bounds>
+			<bounds x="232" y="333" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="264" y="359" width="6" height="6">
-			</bounds>
+			<bounds x="264" y="359" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="232" y="308" width="32" height="6">
-			</bounds>
+			<bounds x="232" y="308" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="258" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="258" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="258" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="258" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="232" y="359" width="32" height="6">
-			</bounds>
+			<bounds x="232" y="359" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="232" y="333" width="6" height="31">
-			</bounds>
+			<bounds x="232" y="333" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="232" y="308" width="6" height="31">
-			</bounds>
+			<bounds x="232" y="308" width="6" height="31"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="232" y="333" width="32" height="6">
-			</bounds>
+			<bounds x="232" y="333" width="32" height="6"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="264" y="359" width="6" height="6">
-			</bounds>
+			<bounds x="264" y="359" width="6" height="6"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="270" y="332" width="30" height="40">
-			</bounds>
+			<bounds x="270" y="332" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="274" y="335" width="21" height="3">
-			</bounds>
+			<bounds x="274" y="335" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="291" y="335" width="4" height="18">
-			</bounds>
+			<bounds x="291" y="335" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="291" y="350" width="4" height="18">
-			</bounds>
+			<bounds x="291" y="350" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="274" y="364" width="21" height="3">
-			</bounds>
+			<bounds x="274" y="364" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="274" y="350" width="4" height="18">
-			</bounds>
+			<bounds x="274" y="350" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="274" y="335" width="4" height="18">
-			</bounds>
+			<bounds x="274" y="335" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="274" y="350" width="21" height="3">
-			</bounds>
+			<bounds x="274" y="350" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="295" y="364" width="4" height="3">
-			</bounds>
+			<bounds x="295" y="364" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="274" y="335" width="21" height="3">
-			</bounds>
+			<bounds x="274" y="335" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="291" y="335" width="4" height="18">
-			</bounds>
+			<bounds x="291" y="335" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="291" y="350" width="4" height="18">
-			</bounds>
+			<bounds x="291" y="350" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="274" y="364" width="21" height="3">
-			</bounds>
+			<bounds x="274" y="364" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="274" y="350" width="4" height="18">
-			</bounds>
+			<bounds x="274" y="350" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="274" y="335" width="4" height="18">
-			</bounds>
+			<bounds x="274" y="335" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="274" y="350" width="21" height="3">
-			</bounds>
+			<bounds x="274" y="350" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="295" y="364" width="4" height="3">
-			</bounds>
+			<bounds x="295" y="364" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="300" y="332" width="30" height="40">
-			</bounds>
+			<bounds x="300" y="332" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="304" y="335" width="21" height="3">
-			</bounds>
+			<bounds x="304" y="335" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="321" y="335" width="4" height="18">
-			</bounds>
+			<bounds x="321" y="335" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="321" y="350" width="4" height="18">
-			</bounds>
+			<bounds x="321" y="350" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="304" y="364" width="21" height="3">
-			</bounds>
+			<bounds x="304" y="364" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="304" y="350" width="4" height="18">
-			</bounds>
+			<bounds x="304" y="350" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="304" y="335" width="4" height="18">
-			</bounds>
+			<bounds x="304" y="335" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="304" y="350" width="21" height="3">
-			</bounds>
+			<bounds x="304" y="350" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="325" y="364" width="4" height="3">
-			</bounds>
+			<bounds x="325" y="364" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="304" y="335" width="21" height="3">
-			</bounds>
+			<bounds x="304" y="335" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="321" y="335" width="4" height="18">
-			</bounds>
+			<bounds x="321" y="335" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="321" y="350" width="4" height="18">
-			</bounds>
+			<bounds x="321" y="350" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="304" y="364" width="21" height="3">
-			</bounds>
+			<bounds x="304" y="364" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="304" y="350" width="4" height="18">
-			</bounds>
+			<bounds x="304" y="350" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="304" y="335" width="4" height="18">
-			</bounds>
+			<bounds x="304" y="335" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="304" y="350" width="21" height="3">
-			</bounds>
+			<bounds x="304" y="350" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="325" y="364" width="4" height="3">
-			</bounds>
+			<bounds x="325" y="364" width="4" height="3"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="132" y="567" width="200" height="30">
-			</bounds>
+			<bounds x="132" y="567" width="200" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="132" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="132" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="145" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="145" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="158" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="158" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="171" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="171" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="184" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="184" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="197" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="197" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="210" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="210" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="223" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="223" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="236" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="236" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="249" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="249" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="262" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="262" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="275" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="275" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="288" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="288" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="301" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="301" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="314" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="314" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="327" y="567" width="13" height="30">
-			</bounds>
+			<bounds x="327" y="567" width="13" height="30"/>
 		</backdrop>
 		<backdrop name="label44" element="label_44">
-			<bounds x="161" y="273" width="69" height="24">
-			</bounds>
+			<bounds x="161" y="273" width="69" height="24"/>
 		</backdrop>
 		<backdrop name="label45" element="label_45">
-			<bounds x="230" y="273" width="73" height="24">
-			</bounds>
+			<bounds x="230" y="273" width="73" height="24"/>
 		</backdrop>
 		<backdrop name="label46" element="label_46">
-			<bounds x="115" y="342" width="20" height="37">
-			</bounds>
+			<bounds x="115" y="342" width="20" height="37"/>
 		</backdrop>
 		<backdrop name="label47" element="label_47">
-			<bounds x="160" y="59" width="69" height="24">
-			</bounds>
+			<bounds x="160" y="59" width="69" height="24"/>
 		</backdrop>
 		<backdrop name="label48" element="label_48">
-			<bounds x="228" y="59" width="74" height="24">
-			</bounds>
+			<bounds x="228" y="59" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="label49" element="label_49">
-			<bounds x="172" y="80" width="122" height="24">
-			</bounds>
+			<bounds x="172" y="80" width="122" height="24"/>
 		</backdrop>
 		<backdrop name="label50" element="label_50">
-			<bounds x="127" y="552" width="65" height="13">
-			</bounds>
+			<bounds x="127" y="552" width="65" height="13"/>
 		</backdrop>
 		<backdrop name="label66" element="label_66">
-			<bounds x="382" y="429" width="105" height="13">
-			</bounds>
+			<bounds x="382" y="429" width="105" height="13"/>
 		</backdrop>
 		<backdrop name="label70" element="label_70">
-			<bounds x="137" y="6" width="240" height="37">
-			</bounds>
+			<bounds x="137" y="6" width="240" height="37"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_button" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="312.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="312.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="315.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="315.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="318.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="318.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="322.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="322.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="325.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="325.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp0" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="328.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="328.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="392.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="392.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="395.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="395.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="398.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="398.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="402.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="402.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="405.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="405.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp8" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="408.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="408.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="472.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="472.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="475.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="475.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="478.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="478.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="482.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="482.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="485.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="485.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp16" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="488.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="488.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel6" element="debug_stepper_value">
-			<bounds x="1100" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="552" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_5">
-			<bounds x="1180" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="552" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1clbtma.lay
+++ b/src/mame/layout/sc1clbtma.lay
@@ -8,14178 +8,8434 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="  4 OF A KIND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="  4 OF A KIND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGEPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGEPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI LO CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI LO CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RICOCHET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RICOCHET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE A NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE A NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REEL MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGEPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGEPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="  3 OF A KIND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="  3 OF A KIND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STEP TO NEAREST WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STEP TO NEAREST WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.13">
-			</bounds>
-		</text>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.18" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.18" width="0.90" height="0.13"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.31" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.31" width="0.90" height="0.13"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.44" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.44" width="0.90" height="0.13"/>
 		</text>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.56" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.56" width="0.90" height="0.13"/>
 		</text>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.69" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.82" width="0.90" height="0.13">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.18" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.31" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.44" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.56" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.69" width="0.90" height="0.13">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.82" width="0.90" height="0.13">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.69" width="0.90" height="0.13"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE A TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE A TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="20p PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE FOR FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE FOR FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="   CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="   CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STRIKES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STRIKES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="AVAILABLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="AVAILABLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_146_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_146">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_149_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_149">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_80">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_113">
 		<text string="RESERVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_114">
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="TEMPTATION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="Club">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="750" height="658">
-			</bounds>
+			<bounds x="0" y="0" width="750" height="658"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="24" y="484" width="70" height="100">
-			</bounds>
+			<bounds x="24" y="484" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="24.0000" y="484.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="24.0000" y="484.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="26.9167" y="485.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="26.9167" y="485.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="29.8333" y="486.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="29.8333" y="486.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="32.7500" y="488.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="32.7500" y="488.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="35.6667" y="489.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="35.6667" y="489.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="38.5833" y="490.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="38.5833" y="490.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="24.0000" y="517.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="24.0000" y="517.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="26.9167" y="518.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="26.9167" y="518.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="29.8333" y="520.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="29.8333" y="520.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="32.7500" y="521.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="32.7500" y="521.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="35.6667" y="522.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="35.6667" y="522.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="38.5833" y="524.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="38.5833" y="524.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="24.0000" y="550.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="24.0000" y="550.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="26.9167" y="552.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="26.9167" y="552.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="29.8333" y="553.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="29.8333" y="553.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="32.7500" y="554.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="32.7500" y="554.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="35.6667" y="556.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="35.6667" y="556.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="38.5833" y="557.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="38.5833" y="557.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="24" y="484" width="70" height="100">
-			</bounds>
+			<bounds x="24" y="484" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="108" y="484" width="70" height="100">
-			</bounds>
+			<bounds x="108" y="484" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="108.0000" y="484.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="108.0000" y="484.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="110.9167" y="485.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="110.9167" y="485.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="113.8333" y="486.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="113.8333" y="486.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="116.7500" y="488.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="116.7500" y="488.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="119.6667" y="489.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="119.6667" y="489.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="122.5833" y="490.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="122.5833" y="490.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="108.0000" y="517.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="108.0000" y="517.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="110.9167" y="518.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="110.9167" y="518.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="113.8333" y="520.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="113.8333" y="520.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="116.7500" y="521.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="116.7500" y="521.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="119.6667" y="522.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="119.6667" y="522.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="122.5833" y="524.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="122.5833" y="524.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="108.0000" y="550.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="108.0000" y="550.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="110.9167" y="552.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="110.9167" y="552.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="113.8333" y="553.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="113.8333" y="553.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="116.7500" y="554.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="116.7500" y="554.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="119.6667" y="556.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="119.6667" y="556.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="122.5833" y="557.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="122.5833" y="557.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="108" y="484" width="70" height="100">
-			</bounds>
+			<bounds x="108" y="484" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="192" y="484" width="70" height="100">
-			</bounds>
+			<bounds x="192" y="484" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="192.0000" y="484.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="192.0000" y="484.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="194.9167" y="485.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="194.9167" y="485.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="197.8333" y="486.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="197.8333" y="486.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="200.7500" y="488.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="200.7500" y="488.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="203.6667" y="489.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="203.6667" y="489.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="206.5833" y="490.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="206.5833" y="490.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="192.0000" y="517.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="192.0000" y="517.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="194.9167" y="518.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="194.9167" y="518.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="197.8333" y="520.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="197.8333" y="520.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="200.7500" y="521.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="200.7500" y="521.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="203.6667" y="522.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="203.6667" y="522.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="206.5833" y="524.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="206.5833" y="524.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="192.0000" y="550.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="192.0000" y="550.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="194.9167" y="552.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="194.9167" y="552.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="197.8333" y="553.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="197.8333" y="553.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="200.7500" y="554.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="200.7500" y="554.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="203.6667" y="556.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="203.6667" y="556.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="206.5833" y="557.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="206.5833" y="557.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="192" y="484" width="70" height="100">
-			</bounds>
+			<bounds x="192" y="484" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="277" y="484" width="70" height="100">
-			</bounds>
+			<bounds x="277" y="484" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="277.0000" y="484.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="277.0000" y="484.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="279.9167" y="485.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="279.9167" y="485.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.8333" y="486.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="282.8333" y="486.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="285.7500" y="488.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="285.7500" y="488.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="288.6667" y="489.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="288.6667" y="489.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="291.5833" y="490.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="291.5833" y="490.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="277.0000" y="517.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="277.0000" y="517.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="279.9167" y="518.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="279.9167" y="518.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.8333" y="520.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="282.8333" y="520.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="285.7500" y="521.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="285.7500" y="521.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="288.6667" y="522.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="288.6667" y="522.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="291.5833" y="524.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="291.5833" y="524.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="277.0000" y="550.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="277.0000" y="550.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="279.9167" y="552.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="279.9167" y="552.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.8333" y="553.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="282.8333" y="553.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="285.7500" y="554.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="285.7500" y="554.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="288.6667" y="556.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="288.6667" y="556.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="291.5833" y="557.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="291.5833" y="557.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="277" y="484" width="70" height="100">
-			</bounds>
+			<bounds x="277" y="484" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="34" y="168" width="50" height="60">
-			</bounds>
+			<bounds x="34" y="168" width="50" height="60"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="34.0000" y="168.0000" width="50.0000" height="60.0000">
-			</bounds>
+			<bounds x="34.0000" y="168.0000" width="50.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="36.0833" y="170.5000" width="45.8333" height="55.0000">
-			</bounds>
+			<bounds x="36.0833" y="170.5000" width="45.8333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="38.1667" y="173.0000" width="41.6667" height="50.0000">
-			</bounds>
+			<bounds x="38.1667" y="173.0000" width="41.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="40.2500" y="175.5000" width="37.5000" height="45.0000">
-			</bounds>
+			<bounds x="40.2500" y="175.5000" width="37.5000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="42.3333" y="178.0000" width="33.3333" height="40.0000">
-			</bounds>
+			<bounds x="42.3333" y="178.0000" width="33.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="44.4167" y="180.5000" width="29.1667" height="35.0000">
-			</bounds>
+			<bounds x="44.4167" y="180.5000" width="29.1667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="34" y="168" width="50" height="60">
-			</bounds>
+			<bounds x="34" y="168" width="50" height="60"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="380" y="61" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="61" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="382" y="63" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="63" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="380" y="125" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="125" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="382" y="127" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="127" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="380" y="93" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="93" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="382" y="95" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="95" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="380" y="157" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="157" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="382" y="159" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="159" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="380" y="189" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="189" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="382" y="191" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="191" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="380" y="221" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="221" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="382" y="223" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="223" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="380" y="253" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="253" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="382" y="255" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="255" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="380" y="285" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="285" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="382" y="287" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="287" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="380" y="317" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="317" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="382" y="319" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="319" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="380" y="349" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="349" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="382" y="351" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="351" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="380" y="381" width="102" height="32">
-			</bounds>
+			<bounds x="380" y="381" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="382" y="383" width="98" height="28">
-			</bounds>
+			<bounds x="382" y="383" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="362" y="394" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="394" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="364" y="396" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="396" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="362" y="362" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="362" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="364" y="364" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="364" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="362" y="330" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="330" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="364" y="332" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="332" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="362" y="298" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="298" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="364" y="300" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="300" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="362" y="266" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="266" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="364" y="268" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="268" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="362" y="233" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="233" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="364" y="235" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="235" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="362" y="202" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="202" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="364" y="204" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="204" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="362" y="170" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="170" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="364" y="172" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="172" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="362" y="138" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="138" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="364" y="140" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="140" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="362" y="105" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="105" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="364" y="107" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="107" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="362" y="74" width="19" height="19">
-			</bounds>
+			<bounds x="362" y="74" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="364" y="76" width="15" height="15">
-			</bounds>
+			<bounds x="364" y="76" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="363" y="444" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="444" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="365" y="446" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="446" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="363" y="424" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="424" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="365" y="426" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="426" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="363" y="484" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="484" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="365" y="486" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="486" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="363" y="564" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="564" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="365" y="566" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="566" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="363" y="464" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="464" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="365" y="466" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="466" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="363" y="504" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="504" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="365" y="506" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="506" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="363" y="524" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="524" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="365" y="526" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="526" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="363" y="544" width="19" height="19">
-			</bounds>
+			<bounds x="363" y="544" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="365" y="546" width="15" height="15">
-			</bounds>
+			<bounds x="365" y="546" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="392" y="467" width="19" height="57">
-			</bounds>
+			<bounds x="392" y="467" width="19" height="57"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="394" y="469" width="15" height="53">
-			</bounds>
+			<bounds x="394" y="469" width="15" height="53"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="392" y="526" width="19" height="57">
-			</bounds>
+			<bounds x="392" y="526" width="19" height="57"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="394" y="528" width="15" height="53">
-			</bounds>
+			<bounds x="394" y="528" width="15" height="53"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="395" y="419" width="42" height="19">
-			</bounds>
+			<bounds x="395" y="419" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="397" y="421" width="38" height="15">
-			</bounds>
+			<bounds x="397" y="421" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="395" y="435" width="42" height="19">
-			</bounds>
+			<bounds x="395" y="435" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="397" y="437" width="38" height="15">
-			</bounds>
+			<bounds x="397" y="437" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="279" y="105" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="105" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="281" y="107" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="107" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="279" y="138" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="138" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="281" y="140" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="140" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="279" y="170" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="170" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="281" y="172" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="172" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="279" y="202" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="202" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="281" y="204" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="204" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="279" y="233" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="233" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="281" y="235" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="235" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="279" y="266" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="266" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="281" y="268" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="268" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="279" y="298" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="298" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="281" y="300" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="300" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="279" y="330" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="330" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="281" y="332" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="332" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="279" y="362" width="82" height="19">
-			</bounds>
+			<bounds x="279" y="362" width="82" height="19"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="281" y="364" width="78" height="15">
-			</bounds>
+			<bounds x="281" y="364" width="78" height="15"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="19" y="315" width="19" height="126">
-			</bounds>
+			<bounds x="19" y="315" width="19" height="126"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="21" y="317" width="15" height="122">
-			</bounds>
+			<bounds x="21" y="317" width="15" height="122"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="39" y="315" width="82" height="32">
-			</bounds>
+			<bounds x="39" y="315" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="41" y="317" width="78" height="28">
-			</bounds>
+			<bounds x="41" y="317" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="39" y="346" width="82" height="32">
-			</bounds>
+			<bounds x="39" y="346" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="41" y="348" width="78" height="28">
-			</bounds>
+			<bounds x="41" y="348" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="39" y="377" width="82" height="32">
-			</bounds>
+			<bounds x="39" y="377" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="41" y="379" width="78" height="28">
-			</bounds>
+			<bounds x="41" y="379" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="39" y="409" width="82" height="32">
-			</bounds>
+			<bounds x="39" y="409" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="41" y="411" width="78" height="28">
-			</bounds>
+			<bounds x="41" y="411" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="17" y="5" width="132" height="72">
-			</bounds>
+			<bounds x="17" y="5" width="132" height="72"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="19" y="7" width="128" height="68">
-			</bounds>
+			<bounds x="19" y="7" width="128" height="68"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="493" y="558" width="42" height="27">
-			</bounds>
+			<bounds x="493" y="558" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="495" y="560" width="38" height="23">
-			</bounds>
+			<bounds x="495" y="560" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="545" y="558" width="42" height="27">
-			</bounds>
+			<bounds x="545" y="558" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="547" y="560" width="38" height="23">
-			</bounds>
+			<bounds x="547" y="560" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="649" y="531" width="42" height="27">
-			</bounds>
+			<bounds x="649" y="531" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="651" y="533" width="38" height="23">
-			</bounds>
+			<bounds x="651" y="533" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="597" y="558" width="42" height="27">
-			</bounds>
+			<bounds x="597" y="558" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="599" y="560" width="38" height="23">
-			</bounds>
+			<bounds x="599" y="560" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="649" y="558" width="42" height="27">
-			</bounds>
+			<bounds x="649" y="558" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="651" y="560" width="38" height="23">
-			</bounds>
+			<bounds x="651" y="560" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="597" y="531" width="42" height="27">
-			</bounds>
+			<bounds x="597" y="531" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="599" y="533" width="38" height="23">
-			</bounds>
+			<bounds x="599" y="533" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="545" y="531" width="42" height="27">
-			</bounds>
+			<bounds x="545" y="531" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="547" y="533" width="38" height="23">
-			</bounds>
+			<bounds x="547" y="533" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="545" y="504" width="42" height="27">
-			</bounds>
+			<bounds x="545" y="504" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="547" y="506" width="38" height="23">
-			</bounds>
+			<bounds x="547" y="506" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="597" y="504" width="42" height="27">
-			</bounds>
+			<bounds x="597" y="504" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="599" y="506" width="38" height="23">
-			</bounds>
+			<bounds x="599" y="506" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="649" y="504" width="42" height="27">
-			</bounds>
+			<bounds x="649" y="504" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="651" y="506" width="38" height="23">
-			</bounds>
+			<bounds x="651" y="506" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="649" y="477" width="42" height="27">
-			</bounds>
+			<bounds x="649" y="477" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="651" y="479" width="38" height="23">
-			</bounds>
+			<bounds x="651" y="479" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="597" y="477" width="42" height="27">
-			</bounds>
+			<bounds x="597" y="477" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="599" y="479" width="38" height="23">
-			</bounds>
+			<bounds x="599" y="479" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="545" y="477" width="42" height="27">
-			</bounds>
+			<bounds x="545" y="477" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="547" y="479" width="38" height="23">
-			</bounds>
+			<bounds x="547" y="479" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="545" y="450" width="42" height="27">
-			</bounds>
+			<bounds x="545" y="450" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="547" y="452" width="38" height="23">
-			</bounds>
+			<bounds x="547" y="452" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="597" y="450" width="42" height="27">
-			</bounds>
+			<bounds x="597" y="450" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="599" y="452" width="38" height="23">
-			</bounds>
+			<bounds x="599" y="452" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="649" y="435" width="72" height="42">
-			</bounds>
+			<bounds x="649" y="435" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="651" y="437" width="68" height="38">
-			</bounds>
+			<bounds x="651" y="437" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="38" y="126" width="42" height="32">
-			</bounds>
+			<bounds x="38" y="126" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="40" y="128" width="38" height="28">
-			</bounds>
+			<bounds x="40" y="128" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="38" y="237" width="42" height="32">
-			</bounds>
+			<bounds x="38" y="237" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="40" y="239" width="38" height="28">
-			</bounds>
+			<bounds x="40" y="239" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="104" y="254" width="82" height="32">
-			</bounds>
+			<bounds x="104" y="254" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="106" y="256" width="78" height="28">
-			</bounds>
+			<bounds x="106" y="256" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="183" y="254" width="92" height="32">
-			</bounds>
+			<bounds x="183" y="254" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="185" y="256" width="88" height="28">
-			</bounds>
+			<bounds x="185" y="256" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="139" y="287" width="32" height="32">
-			</bounds>
+			<bounds x="139" y="287" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="141" y="289" width="28" height="28">
-			</bounds>
+			<bounds x="141" y="289" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="176" y="287" width="32" height="32">
-			</bounds>
+			<bounds x="176" y="287" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="178" y="289" width="28" height="28">
-			</bounds>
+			<bounds x="178" y="289" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="213" y="287" width="32" height="32">
-			</bounds>
+			<bounds x="213" y="287" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="215" y="289" width="28" height="28">
-			</bounds>
+			<bounds x="215" y="289" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="213" y="319" width="32" height="32">
-			</bounds>
+			<bounds x="213" y="319" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="215" y="321" width="28" height="28">
-			</bounds>
+			<bounds x="215" y="321" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="176" y="319" width="32" height="32">
-			</bounds>
+			<bounds x="176" y="319" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="178" y="321" width="28" height="28">
-			</bounds>
+			<bounds x="178" y="321" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="139" y="319" width="32" height="32">
-			</bounds>
+			<bounds x="139" y="319" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="141" y="321" width="28" height="28">
-			</bounds>
+			<bounds x="141" y="321" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="139" y="351" width="32" height="32">
-			</bounds>
+			<bounds x="139" y="351" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="141" y="353" width="28" height="28">
-			</bounds>
+			<bounds x="141" y="353" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="176" y="351" width="32" height="32">
-			</bounds>
+			<bounds x="176" y="351" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="178" y="353" width="28" height="28">
-			</bounds>
+			<bounds x="178" y="353" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="213" y="351" width="32" height="32">
-			</bounds>
+			<bounds x="213" y="351" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="215" y="353" width="28" height="28">
-			</bounds>
+			<bounds x="215" y="353" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="213" y="383" width="32" height="32">
-			</bounds>
+			<bounds x="213" y="383" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="215" y="385" width="28" height="28">
-			</bounds>
+			<bounds x="215" y="385" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="176" y="383" width="32" height="32">
-			</bounds>
+			<bounds x="176" y="383" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="178" y="385" width="28" height="28">
-			</bounds>
+			<bounds x="178" y="385" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="139" y="383" width="32" height="32">
-			</bounds>
+			<bounds x="139" y="383" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="141" y="385" width="28" height="28">
-			</bounds>
+			<bounds x="141" y="385" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="139" y="415" width="32" height="32">
-			</bounds>
+			<bounds x="139" y="415" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="141" y="417" width="28" height="28">
-			</bounds>
+			<bounds x="141" y="417" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="176" y="415" width="32" height="32">
-			</bounds>
+			<bounds x="176" y="415" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="178" y="417" width="28" height="28">
-			</bounds>
+			<bounds x="178" y="417" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="213" y="415" width="32" height="32">
-			</bounds>
+			<bounds x="213" y="415" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="215" y="417" width="28" height="28">
-			</bounds>
+			<bounds x="215" y="417" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="216" y="93" width="42" height="32">
-			</bounds>
+			<bounds x="216" y="93" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="218" y="95" width="38" height="28">
-			</bounds>
+			<bounds x="218" y="95" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="216" y="125" width="42" height="32">
-			</bounds>
+			<bounds x="216" y="125" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="218" y="127" width="38" height="28">
-			</bounds>
+			<bounds x="218" y="127" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="174" y="93" width="42" height="32">
-			</bounds>
+			<bounds x="174" y="93" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="176" y="95" width="38" height="28">
-			</bounds>
+			<bounds x="176" y="95" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="132" y="93" width="42" height="32">
-			</bounds>
+			<bounds x="132" y="93" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="134" y="95" width="38" height="28">
-			</bounds>
+			<bounds x="134" y="95" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="132" y="125" width="42" height="32">
-			</bounds>
+			<bounds x="132" y="125" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="134" y="127" width="38" height="28">
-			</bounds>
+			<bounds x="134" y="127" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="174" y="125" width="42" height="32">
-			</bounds>
+			<bounds x="174" y="125" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="176" y="127" width="38" height="28">
-			</bounds>
+			<bounds x="176" y="127" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="216" y="157" width="42" height="32">
-			</bounds>
+			<bounds x="216" y="157" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="218" y="159" width="38" height="28">
-			</bounds>
+			<bounds x="218" y="159" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="174" y="157" width="42" height="32">
-			</bounds>
+			<bounds x="174" y="157" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="176" y="159" width="38" height="28">
-			</bounds>
+			<bounds x="176" y="159" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="132" y="157" width="42" height="32">
-			</bounds>
+			<bounds x="132" y="157" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="134" y="159" width="38" height="28">
-			</bounds>
+			<bounds x="134" y="159" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="132" y="189" width="42" height="32">
-			</bounds>
+			<bounds x="132" y="189" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="134" y="191" width="38" height="28">
-			</bounds>
+			<bounds x="134" y="191" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="174" y="189" width="42" height="32">
-			</bounds>
+			<bounds x="174" y="189" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="176" y="191" width="38" height="28">
-			</bounds>
+			<bounds x="176" y="191" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="216" y="189" width="42" height="32">
-			</bounds>
+			<bounds x="216" y="189" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="218" y="191" width="38" height="28">
-			</bounds>
+			<bounds x="218" y="191" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="132" y="221" width="42" height="32">
-			</bounds>
+			<bounds x="132" y="221" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="134" y="223" width="38" height="28">
-			</bounds>
+			<bounds x="134" y="223" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="174" y="221" width="42" height="32">
-			</bounds>
+			<bounds x="174" y="221" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="176" y="223" width="38" height="28">
-			</bounds>
+			<bounds x="176" y="223" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="216" y="221" width="42" height="32">
-			</bounds>
+			<bounds x="216" y="221" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="218" y="223" width="38" height="28">
-			</bounds>
+			<bounds x="218" y="223" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="560" y="345" width="42" height="32">
-			</bounds>
+			<bounds x="560" y="345" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="562" y="347" width="38" height="28">
-			</bounds>
+			<bounds x="562" y="347" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="610" y="345" width="42" height="32">
-			</bounds>
+			<bounds x="610" y="345" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="612" y="347" width="38" height="28">
-			</bounds>
+			<bounds x="612" y="347" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="659" y="345" width="42" height="32">
-			</bounds>
+			<bounds x="659" y="345" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="661" y="347" width="38" height="28">
-			</bounds>
+			<bounds x="661" y="347" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="659" y="312" width="42" height="32">
-			</bounds>
+			<bounds x="659" y="312" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="661" y="314" width="38" height="28">
-			</bounds>
+			<bounds x="661" y="314" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="610" y="312" width="42" height="32">
-			</bounds>
+			<bounds x="610" y="312" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="612" y="314" width="38" height="28">
-			</bounds>
+			<bounds x="612" y="314" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="560" y="312" width="42" height="32">
-			</bounds>
+			<bounds x="560" y="312" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="562" y="314" width="38" height="28">
-			</bounds>
+			<bounds x="562" y="314" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="560" y="279" width="42" height="32">
-			</bounds>
+			<bounds x="560" y="279" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="562" y="281" width="38" height="28">
-			</bounds>
+			<bounds x="562" y="281" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="610" y="279" width="42" height="32">
-			</bounds>
+			<bounds x="610" y="279" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="612" y="281" width="38" height="28">
-			</bounds>
+			<bounds x="612" y="281" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="659" y="279" width="42" height="32">
-			</bounds>
+			<bounds x="659" y="279" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="661" y="281" width="38" height="28">
-			</bounds>
+			<bounds x="661" y="281" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="632" y="246" width="42" height="32">
-			</bounds>
+			<bounds x="632" y="246" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="634" y="248" width="38" height="28">
-			</bounds>
+			<bounds x="634" y="248" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="587" y="246" width="42" height="32">
-			</bounds>
+			<bounds x="587" y="246" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="589" y="248" width="38" height="28">
-			</bounds>
+			<bounds x="589" y="248" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="527" y="213" width="82" height="32">
-			</bounds>
+			<bounds x="527" y="213" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="529" y="215" width="78" height="28">
-			</bounds>
+			<bounds x="529" y="215" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="610" y="213" width="42" height="32">
-			</bounds>
+			<bounds x="610" y="213" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="612" y="215" width="38" height="28">
-			</bounds>
+			<bounds x="612" y="215" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="653" y="213" width="82" height="32">
-			</bounds>
+			<bounds x="653" y="213" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="655" y="215" width="78" height="28">
-			</bounds>
+			<bounds x="655" y="215" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp23" element="colour_button_137_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="636" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="636" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp23" element="colour_button_137" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="638" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="638" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_143_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="23" y="605" width="72" height="42">
-			</bounds>
+			<bounds x="23" y="605" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_143" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="25" y="607" width="68" height="38">
-			</bounds>
+			<bounds x="25" y="607" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_144_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="106" y="605" width="72" height="42">
-			</bounds>
+			<bounds x="106" y="605" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_144" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="108" y="607" width="68" height="38">
-			</bounds>
+			<bounds x="108" y="607" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_145_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="191" y="605" width="72" height="42">
-			</bounds>
+			<bounds x="191" y="605" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_145" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="193" y="607" width="68" height="38">
-			</bounds>
+			<bounds x="193" y="607" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_146_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="276" y="605" width="72" height="42">
-			</bounds>
+			<bounds x="276" y="605" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_146" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="278" y="607" width="68" height="38">
-			</bounds>
+			<bounds x="278" y="607" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_147_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="379" y="605" width="75" height="42">
-			</bounds>
+			<bounds x="379" y="605" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_147" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="381" y="607" width="71" height="38">
-			</bounds>
+			<bounds x="381" y="607" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_148_border" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="466" y="605" width="75" height="42">
-			</bounds>
+			<bounds x="466" y="605" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_148" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="468" y="607" width="71" height="38">
-			</bounds>
+			<bounds x="468" y="607" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_149_border" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="553" y="605" width="79" height="42">
-			</bounds>
+			<bounds x="553" y="605" width="79" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_149" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="555" y="607" width="75" height="38">
-			</bounds>
+			<bounds x="555" y="607" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_150_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="644" y="605" width="72" height="42">
-			</bounds>
+			<bounds x="644" y="605" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_150" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="646" y="607" width="68" height="38">
-			</bounds>
+			<bounds x="646" y="607" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="514" y="122" width="23" height="31">
-			</bounds>
+			<bounds x="514" y="122" width="23" height="31"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="517" y="124" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="124" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="530" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="530" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="530" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="530" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="517" y="147" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="147" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="517" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="517" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="517" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="517" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="517" y="136" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="136" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="533" y="147" width="3" height="2">
-			</bounds>
+			<bounds x="533" y="147" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="517" y="124" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="124" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="530" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="530" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="530" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="530" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="517" y="147" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="147" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="517" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="517" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="517" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="517" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="517" y="136" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="136" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="533" y="147" width="3" height="2">
-			</bounds>
+			<bounds x="533" y="147" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="537" y="122" width="23" height="31">
-			</bounds>
+			<bounds x="537" y="122" width="23" height="31"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="540" y="124" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="124" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="553" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="553" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="540" y="147" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="147" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="540" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="540" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="540" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="540" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="540" y="136" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="136" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="556" y="147" width="3" height="2">
-			</bounds>
+			<bounds x="556" y="147" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="540" y="124" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="124" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="553" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="553" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="540" y="147" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="147" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="540" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="540" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="540" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="540" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="540" y="136" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="136" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="556" y="147" width="3" height="2">
-			</bounds>
+			<bounds x="556" y="147" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="560" y="122" width="23" height="31">
-			</bounds>
+			<bounds x="560" y="122" width="23" height="31"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="563" y="124" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="124" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="576" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="576" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="576" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="576" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="563" y="147" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="147" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="563" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="563" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="563" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="563" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_off">
-			<bounds x="563" y="136" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="136" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_dot_off">
-			<bounds x="579" y="147" width="3" height="2">
-			</bounds>
+			<bounds x="579" y="147" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="563" y="124" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="124" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="576" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="576" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="576" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="576" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="563" y="147" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="147" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="563" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="563" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="563" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="563" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_on">
-			<bounds x="563" y="136" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="136" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_dot_on">
-			<bounds x="579" y="147" width="3" height="2">
-			</bounds>
+			<bounds x="579" y="147" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="583" y="122" width="23" height="31">
-			</bounds>
+			<bounds x="583" y="122" width="23" height="31"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="586" y="124" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="124" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="599" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="599" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="599" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="599" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="586" y="147" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="147" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="586" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="586" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="586" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="586" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off127" element="led_off">
-			<bounds x="586" y="136" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="136" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off120" element="led_dot_off">
-			<bounds x="602" y="147" width="3" height="2">
-			</bounds>
+			<bounds x="602" y="147" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="586" y="124" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="124" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="599" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="599" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="599" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="599" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="586" y="147" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="147" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="586" y="136" width="3" height="14">
-			</bounds>
+			<bounds x="586" y="136" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="586" y="124" width="3" height="14">
-			</bounds>
+			<bounds x="586" y="124" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp127" element="led_on">
-			<bounds x="586" y="136" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="136" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp120" element="led_dot_on">
-			<bounds x="602" y="147" width="3" height="2">
-			</bounds>
+			<bounds x="602" y="147" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="514" y="82" width="23" height="31">
-			</bounds>
+			<bounds x="514" y="82" width="23" height="31"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="517" y="84" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="84" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="530" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="530" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="530" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="530" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="517" y="107" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="107" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="517" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="517" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="517" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="517" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="517" y="96" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="96" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="533" y="107" width="3" height="2">
-			</bounds>
+			<bounds x="533" y="107" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="517" y="84" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="84" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="530" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="530" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="530" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="530" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="517" y="107" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="107" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="517" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="517" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="517" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="517" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="517" y="96" width="16" height="2">
-			</bounds>
+			<bounds x="517" y="96" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="533" y="107" width="3" height="2">
-			</bounds>
+			<bounds x="533" y="107" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="537" y="82" width="23" height="31">
-			</bounds>
+			<bounds x="537" y="82" width="23" height="31"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="540" y="84" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="84" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="553" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="553" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="540" y="107" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="107" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="540" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="540" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="540" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="540" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="540" y="96" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="96" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="556" y="107" width="3" height="2">
-			</bounds>
+			<bounds x="556" y="107" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="540" y="84" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="84" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="553" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="553" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="553" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="540" y="107" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="107" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="540" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="540" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="540" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="540" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="540" y="96" width="16" height="2">
-			</bounds>
+			<bounds x="540" y="96" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="556" y="107" width="3" height="2">
-			</bounds>
+			<bounds x="556" y="107" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="560" y="82" width="23" height="31">
-			</bounds>
+			<bounds x="560" y="82" width="23" height="31"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="563" y="84" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="84" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="576" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="576" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="576" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="576" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="563" y="107" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="107" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="563" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="563" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="563" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="563" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="563" y="96" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="96" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="579" y="107" width="3" height="2">
-			</bounds>
+			<bounds x="579" y="107" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="563" y="84" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="84" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="576" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="576" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="576" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="576" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="563" y="107" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="107" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="563" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="563" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="563" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="563" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="563" y="96" width="16" height="2">
-			</bounds>
+			<bounds x="563" y="96" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="579" y="107" width="3" height="2">
-			</bounds>
+			<bounds x="579" y="107" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="583" y="82" width="23" height="31">
-			</bounds>
+			<bounds x="583" y="82" width="23" height="31"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="586" y="84" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="84" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="599" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="599" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="599" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="599" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="586" y="107" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="107" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="586" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="586" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="586" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="586" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="586" y="96" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="96" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="602" y="107" width="3" height="2">
-			</bounds>
+			<bounds x="602" y="107" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="586" y="84" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="84" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="599" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="599" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="599" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="599" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="586" y="107" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="107" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="586" y="96" width="3" height="14">
-			</bounds>
+			<bounds x="586" y="96" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="586" y="84" width="3" height="14">
-			</bounds>
+			<bounds x="586" y="84" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="586" y="96" width="16" height="2">
-			</bounds>
+			<bounds x="586" y="96" width="16" height="2"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="602" y="107" width="3" height="2">
-			</bounds>
+			<bounds x="602" y="107" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="484" y="407" width="240" height="25">
-			</bounds>
+			<bounds x="484" y="407" width="240" height="25"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="484" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="484" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="499" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="499" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="514" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="514" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="529" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="529" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="544" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="544" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="559" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="559" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="574" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="574" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="589" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="589" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="604" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="604" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="619" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="619" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="634" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="634" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="649" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="649" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="664" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="664" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="679" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="679" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="694" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="694" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="709" y="407" width="15" height="25">
-			</bounds>
+			<bounds x="709" y="407" width="15" height="25"/>
 		</backdrop>
 		<backdrop name="label80" element="label_80">
-			<bounds x="486" y="392" width="65" height="13">
-			</bounds>
+			<bounds x="486" y="392" width="65" height="13"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="511" y="59" width="98" height="24">
-			</bounds>
+			<bounds x="511" y="59" width="98" height="24"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="511" y="153" width="99" height="24">
-			</bounds>
+			<bounds x="511" y="153" width="99" height="24"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="167" y="26" width="218" height="37">
-			</bounds>
+			<bounds x="167" y="26" width="218" height="37"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="167" y="11" width="32" height="16">
-			</bounds>
+			<bounds x="167" y="11" width="32" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_button" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_button" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1cwcl.lay
+++ b/src/mame/layout/sc1cwcl.lay
@@ -8,9228 +8,6244 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CLOCKWISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLOCKWISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.29">
-			</color>
+			<color red="0.50" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
+			<color red="0.12" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.58">
-			</color>
+			<color red="1.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.15">
-			</color>
+			<color red="0.25" green="0.15" blue="0.15"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="WARNING !">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="REFILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="REQUIRED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="WARNING !">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="REFILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="REQUIRED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.19" blue="0.19">
-			</color>
+			<color red="0.50" green="0.19" blue="0.19"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.38" blue="0.38">
-			</color>
+			<color red="1.00" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.09">
-			</color>
+			<color red="0.25" green="0.09" blue="0.09"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.09" blue="0.09">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
+			<color red="0.50" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
+			<color red="1.00" green="0.46" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
+			<color red="0.25" green="0.11" blue="0.11"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
+			<color red="0.50" green="0.10" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
+			<color red="1.00" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
+			<color red="0.50" green="0.06" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
+			<color red="1.00" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
+			<color red="0.25" green="0.03" blue="0.03"/>
 		</rect>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.03" blue="0.03">
-			</color>
-		</rect>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
+			<color red="0.50" green="0.02" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
+			<color red="1.00" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
+			<color red="0.25" green="0.01" blue="0.01"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
+			<color red="0.50" green="0.15" blue="0.15"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
+			<color red="1.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
+			<color red="0.25" green="0.07" blue="0.07"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.07" blue="0.07">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.31">
-			</color>
+			<color red="0.50" green="0.31" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
+			<color red="0.12" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.62">
-			</color>
+			<color red="1.00" green="0.62" blue="0.62"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.15">
-			</color>
+			<color red="0.25" green="0.15" blue="0.15"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.62">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.29">
-			</color>
+			<color red="0.50" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
+			<color red="0.12" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.58">
-			</color>
+			<color red="1.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.15">
-			</color>
+			<color red="0.25" green="0.15" blue="0.15"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.27">
-			</color>
+			<color red="0.50" green="0.27" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
+			<color red="0.12" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.54">
-			</color>
+			<color red="1.00" green="0.54" blue="0.54"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.27" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.54" blue="0.54">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REFILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REFILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REFILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REFILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="REFILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="REFILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.40" blue="0.03">
-			</color>
+			<color red="0.47" green="0.40" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.81" blue="0.06">
-			</color>
+			<color red="0.94" green="0.81" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
+			<color red="0.24" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.40" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.81" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.47" green="0.40" blue="0.03">
-			</color>
+			<color red="0.47" green="0.40" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.94" green="0.81" blue="0.06">
-			</color>
+			<color red="0.94" green="0.81" blue="0.06"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
+			<color red="0.24" green="0.20" blue="0.01"/>
 		</rect>
 		<text string="SHUFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.47" green="0.40" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.94" green="0.81" blue="0.06">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.01">
-			</color>
-		</rect>
-		<text string="SHUFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
+			<color red="0.50" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
+			<color red="1.00" green="0.46" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
+			<color red="0.25" green="0.11" blue="0.11"/>
 		</rect>
 		<text string="4 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="1 KING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="ALL OR NOTHING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<text string="4 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="1 KING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="ALL OR NOTHING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
+			<color red="0.50" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
+			<color red="1.00" green="0.46" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
+			<color red="0.25" green="0.11" blue="0.11"/>
 		</rect>
 		<text string="5 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="1 KING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<text string="5 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="1 KING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
+			<color red="0.50" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
+			<color red="1.00" green="0.46" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
+			<color red="0.25" green="0.11" blue="0.11"/>
 		</rect>
 		<text string="6 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="2 KINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<text string="6 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="2 KINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
+			<color red="0.50" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
+			<color red="1.00" green="0.46" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
+			<color red="0.25" green="0.11" blue="0.11"/>
 		</rect>
 		<text string="9 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<text string="9 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
+			<color red="0.50" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
+			<color red="1.00" green="0.46" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
+			<color red="0.25" green="0.11" blue="0.11"/>
 		</rect>
 		<text string="8 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="4 KINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<text string="8 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="4 KINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
+			<color red="0.50" green="0.23" blue="0.23"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
+			<color red="1.00" green="0.46" blue="0.46"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
+			<color red="0.25" green="0.11" blue="0.11"/>
 		</rect>
 		<text string="7 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="3 KINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.23" blue="0.23">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.46" blue="0.46">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.11">
-			</color>
-		</rect>
-		<text string="7 FRUITS LINKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="3 KINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_99_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_99">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_100_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_100">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_101_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_101">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_102_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_102">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_103_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_103">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_104_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_104">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_106_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_106">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_107_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_107">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DEALER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_108_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_108">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHUFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_114_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_114">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_69">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_70">
 		<text string="&#xA3;150 / &#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_71">
 		<text string="&#xA3;100 / &#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_72">
 		<text string="&#xA3;50 / &#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_73">
 		<text string="&#xA3;50 / &#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_74">
 		<text string="&#xA3;30 / &#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_75">
 		<text string="&#xA3;20 / &#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_76">
 		<text string="&#xA3;10 / &#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="&#xA3;8 / &#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="&#xA3;6 / &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_79">
 		<text string="&#xA3;4 / &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_80">
 		<text string="&#xA3;2 / 80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_81">
 		<text string="&#xA3;2 / 80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_82">
 		<text string="&#xA3;2 / &#xA3;1 / 40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_97">
 		<text string="Bugs and Trouty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="v1.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="Totem">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="958" height="690">
-			</bounds>
+			<bounds x="0" y="0" width="958" height="690"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="83" y="492" width="80" height="132">
-			</bounds>
+			<bounds x="83" y="492" width="80" height="132"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="83.0000" y="492.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="83.0000" y="492.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="86.3333" y="493.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="86.3333" y="493.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="89.6667" y="495.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="89.6667" y="495.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="93.0000" y="497.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="93.0000" y="497.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="96.3333" y="499.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="96.3333" y="499.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="99.6667" y="501.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="99.6667" y="501.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="83.0000" y="536.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="83.0000" y="536.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="86.3333" y="537.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="86.3333" y="537.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="89.6667" y="539.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="89.6667" y="539.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="93.0000" y="541.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="93.0000" y="541.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="96.3333" y="543.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="96.3333" y="543.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="99.6667" y="545.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="99.6667" y="545.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="83.0000" y="580.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="83.0000" y="580.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="86.3333" y="581.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="86.3333" y="581.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="89.6667" y="583.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="89.6667" y="583.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="93.0000" y="585.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="93.0000" y="585.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="96.3333" y="587.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="96.3333" y="587.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="99.6667" y="589.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="99.6667" y="589.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="83" y="492" width="80" height="132">
-			</bounds>
+			<bounds x="83" y="492" width="80" height="132"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="188" y="492" width="80" height="132">
-			</bounds>
+			<bounds x="188" y="492" width="80" height="132"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="188.0000" y="492.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="188.0000" y="492.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="191.3333" y="493.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="191.3333" y="493.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="194.6667" y="495.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="194.6667" y="495.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="198.0000" y="497.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="198.0000" y="497.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="201.3333" y="499.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="201.3333" y="499.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="204.6667" y="501.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="204.6667" y="501.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="188.0000" y="536.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="188.0000" y="536.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="191.3333" y="537.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="191.3333" y="537.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="194.6667" y="539.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="194.6667" y="539.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="198.0000" y="541.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="198.0000" y="541.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="201.3333" y="543.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="201.3333" y="543.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="204.6667" y="545.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="204.6667" y="545.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="188.0000" y="580.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="188.0000" y="580.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="191.3333" y="581.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="191.3333" y="581.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="194.6667" y="583.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="194.6667" y="583.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="198.0000" y="585.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="198.0000" y="585.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="201.3333" y="587.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="201.3333" y="587.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="204.6667" y="589.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="204.6667" y="589.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="188" y="492" width="80" height="132">
-			</bounds>
+			<bounds x="188" y="492" width="80" height="132"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="293" y="492" width="80" height="132">
-			</bounds>
+			<bounds x="293" y="492" width="80" height="132"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="293.0000" y="492.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="293.0000" y="492.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="296.3333" y="493.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="296.3333" y="493.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="299.6667" y="495.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="299.6667" y="495.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="303.0000" y="497.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="303.0000" y="497.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="306.3333" y="499.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="306.3333" y="499.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="309.6667" y="501.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="309.6667" y="501.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="293.0000" y="536.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="293.0000" y="536.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="296.3333" y="537.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="296.3333" y="537.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="299.6667" y="539.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="299.6667" y="539.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="303.0000" y="541.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="303.0000" y="541.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="306.3333" y="543.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="306.3333" y="543.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="309.6667" y="545.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="309.6667" y="545.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="293.0000" y="580.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="293.0000" y="580.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="296.3333" y="581.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="296.3333" y="581.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="299.6667" y="583.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="299.6667" y="583.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="303.0000" y="585.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="303.0000" y="585.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="306.3333" y="587.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="306.3333" y="587.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="309.6667" y="589.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="309.6667" y="589.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="293" y="492" width="80" height="132">
-			</bounds>
+			<bounds x="293" y="492" width="80" height="132"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="398" y="492" width="80" height="132">
-			</bounds>
+			<bounds x="398" y="492" width="80" height="132"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="398.0000" y="492.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="398.0000" y="492.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="401.3333" y="493.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="401.3333" y="493.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="404.6667" y="495.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="404.6667" y="495.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="408.0000" y="497.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="408.0000" y="497.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="411.3333" y="499.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="411.3333" y="499.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="414.6667" y="501.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="414.6667" y="501.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="398.0000" y="536.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="398.0000" y="536.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="401.3333" y="537.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="401.3333" y="537.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="404.6667" y="539.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="404.6667" y="539.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="408.0000" y="541.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="408.0000" y="541.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="411.3333" y="543.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="411.3333" y="543.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="414.6667" y="545.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="414.6667" y="545.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="398.0000" y="580.0000" width="80.0000" height="44.0000">
-			</bounds>
+			<bounds x="398.0000" y="580.0000" width="80.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="401.3333" y="581.8333" width="73.3333" height="40.3333">
-			</bounds>
+			<bounds x="401.3333" y="581.8333" width="73.3333" height="40.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="404.6667" y="583.6667" width="66.6667" height="36.6667">
-			</bounds>
+			<bounds x="404.6667" y="583.6667" width="66.6667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="408.0000" y="585.5000" width="60.0000" height="33.0000">
-			</bounds>
+			<bounds x="408.0000" y="585.5000" width="60.0000" height="33.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="411.3333" y="587.3333" width="53.3333" height="29.3333">
-			</bounds>
+			<bounds x="411.3333" y="587.3333" width="53.3333" height="29.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="414.6667" y="589.1667" width="46.6667" height="25.6667">
-			</bounds>
+			<bounds x="414.6667" y="589.1667" width="46.6667" height="25.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="398" y="492" width="80" height="132">
-			</bounds>
+			<bounds x="398" y="492" width="80" height="132"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="73" y="170" width="80" height="60">
-			</bounds>
+			<bounds x="73" y="170" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="73.0000" y="170.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="73.0000" y="170.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="76.3333" y="172.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="76.3333" y="172.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="79.6667" y="175.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="79.6667" y="175.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="83.0000" y="177.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="83.0000" y="177.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="86.3333" y="180.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="86.3333" y="180.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="89.6667" y="182.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="89.6667" y="182.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="73" y="170" width="80" height="60">
-			</bounds>
+			<bounds x="73" y="170" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="43" y="11" width="302" height="52">
-			</bounds>
+			<bounds x="43" y="11" width="302" height="52"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="45" y="13" width="298" height="48">
-			</bounds>
+			<bounds x="45" y="13" width="298" height="48"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="530" y="16" width="102" height="42">
-			</bounds>
+			<bounds x="530" y="16" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="532" y="18" width="98" height="38">
-			</bounds>
+			<bounds x="532" y="18" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="82" y="365" width="72" height="38">
-			</bounds>
+			<bounds x="82" y="365" width="72" height="38"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="84" y="367" width="68" height="34">
-			</bounds>
+			<bounds x="84" y="367" width="68" height="34"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="585" y="557" width="62" height="35">
-			</bounds>
+			<bounds x="585" y="557" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="587" y="559" width="58" height="31">
-			</bounds>
+			<bounds x="587" y="559" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="645" y="557" width="62" height="35">
-			</bounds>
+			<bounds x="645" y="557" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="647" y="559" width="58" height="31">
-			</bounds>
+			<bounds x="647" y="559" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="705" y="557" width="62" height="35">
-			</bounds>
+			<bounds x="705" y="557" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="707" y="559" width="58" height="31">
-			</bounds>
+			<bounds x="707" y="559" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="585" y="524" width="62" height="35">
-			</bounds>
+			<bounds x="585" y="524" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="587" y="526" width="58" height="31">
-			</bounds>
+			<bounds x="587" y="526" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="645" y="524" width="62" height="35">
-			</bounds>
+			<bounds x="645" y="524" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="647" y="526" width="58" height="31">
-			</bounds>
+			<bounds x="647" y="526" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="705" y="524" width="62" height="35">
-			</bounds>
+			<bounds x="705" y="524" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="707" y="526" width="58" height="31">
-			</bounds>
+			<bounds x="707" y="526" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="705" y="491" width="62" height="35">
-			</bounds>
+			<bounds x="705" y="491" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="707" y="493" width="58" height="31">
-			</bounds>
+			<bounds x="707" y="493" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="645" y="491" width="62" height="35">
-			</bounds>
+			<bounds x="645" y="491" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="647" y="493" width="58" height="31">
-			</bounds>
+			<bounds x="647" y="493" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="585" y="491" width="62" height="35">
-			</bounds>
+			<bounds x="585" y="491" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="587" y="493" width="58" height="31">
-			</bounds>
+			<bounds x="587" y="493" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="525" y="491" width="62" height="35">
-			</bounds>
+			<bounds x="525" y="491" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="527" y="493" width="58" height="31">
-			</bounds>
+			<bounds x="527" y="493" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="525" y="524" width="62" height="35">
-			</bounds>
+			<bounds x="525" y="524" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="527" y="526" width="58" height="31">
-			</bounds>
+			<bounds x="527" y="526" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="525" y="590" width="62" height="35">
-			</bounds>
+			<bounds x="525" y="590" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="527" y="592" width="58" height="31">
-			</bounds>
+			<bounds x="527" y="592" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="525" y="557" width="62" height="35">
-			</bounds>
+			<bounds x="525" y="557" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="527" y="559" width="58" height="31">
-			</bounds>
+			<bounds x="527" y="559" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="585" y="590" width="62" height="35">
-			</bounds>
+			<bounds x="585" y="590" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="587" y="592" width="58" height="31">
-			</bounds>
+			<bounds x="587" y="592" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="645" y="590" width="62" height="35">
-			</bounds>
+			<bounds x="645" y="590" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="647" y="592" width="58" height="31">
-			</bounds>
+			<bounds x="647" y="592" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="705" y="590" width="62" height="35">
-			</bounds>
+			<bounds x="705" y="590" width="62" height="35"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="707" y="592" width="58" height="31">
-			</bounds>
+			<bounds x="707" y="592" width="58" height="31"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="118" y="125" width="46" height="28">
-			</bounds>
+			<bounds x="118" y="125" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="120" y="127" width="42" height="24">
-			</bounds>
+			<bounds x="120" y="127" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="62" y="125" width="46" height="28">
-			</bounds>
+			<bounds x="62" y="125" width="46" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="64" y="127" width="42" height="24">
-			</bounds>
+			<bounds x="64" y="127" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="691" y="19" width="42" height="27">
-			</bounds>
+			<bounds x="691" y="19" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="693" y="21" width="38" height="23">
-			</bounds>
+			<bounds x="693" y="21" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="713" y="45" width="42" height="27">
-			</bounds>
+			<bounds x="713" y="45" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="715" y="47" width="38" height="23">
-			</bounds>
+			<bounds x="715" y="47" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="669" y="45" width="42" height="27">
-			</bounds>
+			<bounds x="669" y="45" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="671" y="47" width="38" height="23">
-			</bounds>
+			<bounds x="671" y="47" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="120" y="451" width="42" height="32">
-			</bounds>
+			<bounds x="120" y="451" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="122" y="453" width="38" height="28">
-			</bounds>
+			<bounds x="122" y="453" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="55" y="453" width="52" height="28">
-			</bounds>
+			<bounds x="55" y="453" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="57" y="455" width="48" height="24">
-			</bounds>
+			<bounds x="57" y="455" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="715" y="453" width="52" height="28">
-			</bounds>
+			<bounds x="715" y="453" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="717" y="455" width="48" height="24">
-			</bounds>
+			<bounds x="717" y="455" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="120" y="418" width="97" height="32">
-			</bounds>
+			<bounds x="120" y="418" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="122" y="420" width="93" height="28">
-			</bounds>
+			<bounds x="122" y="420" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="217" y="418" width="97" height="32">
-			</bounds>
+			<bounds x="217" y="418" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="219" y="420" width="93" height="28">
-			</bounds>
+			<bounds x="219" y="420" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="314" y="418" width="97" height="32">
-			</bounds>
+			<bounds x="314" y="418" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="316" y="420" width="93" height="28">
-			</bounds>
+			<bounds x="316" y="420" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="605" y="418" width="97" height="32">
-			</bounds>
+			<bounds x="605" y="418" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="607" y="420" width="93" height="28">
-			</bounds>
+			<bounds x="607" y="420" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="508" y="418" width="97" height="32">
-			</bounds>
+			<bounds x="508" y="418" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="510" y="420" width="93" height="28">
-			</bounds>
+			<bounds x="510" y="420" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="411" y="418" width="97" height="32">
-			</bounds>
+			<bounds x="411" y="418" width="97" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="413" y="420" width="93" height="28">
-			</bounds>
+			<bounds x="413" y="420" width="93" height="28"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_99_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="7" y="630" width="68" height="42">
-			</bounds>
+			<bounds x="7" y="630" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_99" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="9" y="632" width="64" height="38">
-			</bounds>
+			<bounds x="9" y="632" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp15" element="colour_button_100_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="418" y="22" width="46" height="62">
-			</bounds>
+			<bounds x="418" y="22" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp15" element="colour_button_100" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="420" y="24" width="42" height="58">
-			</bounds>
+			<bounds x="420" y="24" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_101_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="404" y="629" width="68" height="42">
-			</bounds>
+			<bounds x="404" y="629" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_101" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="406" y="631" width="64" height="38">
-			</bounds>
+			<bounds x="406" y="631" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_102_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="299" y="629" width="68" height="42">
-			</bounds>
+			<bounds x="299" y="629" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_102" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="301" y="631" width="64" height="38">
-			</bounds>
+			<bounds x="301" y="631" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_103_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="194" y="629" width="68" height="42">
-			</bounds>
+			<bounds x="194" y="629" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_103" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="196" y="631" width="64" height="38">
-			</bounds>
+			<bounds x="196" y="631" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_104_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="89" y="629" width="68" height="42">
-			</bounds>
+			<bounds x="89" y="629" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_104" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="91" y="631" width="64" height="38">
-			</bounds>
+			<bounds x="91" y="631" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_106_border" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="492" y="629" width="68" height="42">
-			</bounds>
+			<bounds x="492" y="629" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_106" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="494" y="631" width="64" height="38">
-			</bounds>
+			<bounds x="494" y="631" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_107_border" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="630" y="629" width="68" height="42">
-			</bounds>
+			<bounds x="630" y="629" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_107" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="632" y="631" width="64" height="38">
-			</bounds>
+			<bounds x="632" y="631" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_108_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="561" y="629" width="68" height="42">
-			</bounds>
+			<bounds x="561" y="629" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_108" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="563" y="631" width="64" height="38">
-			</bounds>
+			<bounds x="563" y="631" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_114_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="699" y="629" width="68" height="42">
-			</bounds>
+			<bounds x="699" y="629" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_114" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="701" y="631" width="64" height="38">
-			</bounds>
+			<bounds x="701" y="631" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="679" y="103" width="27" height="36">
-			</bounds>
+			<bounds x="679" y="103" width="27" height="36"/>
 		</backdrop>
 		<backdrop name="led_off153" element="led_off">
-			<bounds x="682" y="106" width="19" height="3">
-			</bounds>
+			<bounds x="682" y="106" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off154" element="led_off">
-			<bounds x="698" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="698" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off155" element="led_off">
-			<bounds x="698" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="698" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off156" element="led_off">
-			<bounds x="682" y="132" width="19" height="3">
-			</bounds>
+			<bounds x="682" y="132" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off157" element="led_off">
-			<bounds x="682" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="682" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off158" element="led_off">
-			<bounds x="682" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="682" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off159" element="led_off">
-			<bounds x="682" y="119" width="19" height="3">
-			</bounds>
+			<bounds x="682" y="119" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off160" element="led_dot_off">
-			<bounds x="702" y="132" width="3" height="3">
-			</bounds>
+			<bounds x="702" y="132" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="lamp153" element="led_on">
-			<bounds x="682" y="106" width="19" height="3">
-			</bounds>
+			<bounds x="682" y="106" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp154" element="led_on">
-			<bounds x="698" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="698" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp155" element="led_on">
-			<bounds x="698" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="698" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp156" element="led_on">
-			<bounds x="682" y="132" width="19" height="3">
-			</bounds>
+			<bounds x="682" y="132" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp157" element="led_on">
-			<bounds x="682" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="682" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp158" element="led_on">
-			<bounds x="682" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="682" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp159" element="led_on">
-			<bounds x="682" y="119" width="19" height="3">
-			</bounds>
+			<bounds x="682" y="119" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp160" element="led_dot_on">
-			<bounds x="702" y="132" width="3" height="3">
-			</bounds>
+			<bounds x="702" y="132" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="652" y="103" width="27" height="36">
-			</bounds>
+			<bounds x="652" y="103" width="27" height="36"/>
 		</backdrop>
 		<backdrop name="led_off169" element="led_off">
-			<bounds x="655" y="106" width="19" height="3">
-			</bounds>
+			<bounds x="655" y="106" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off170" element="led_off">
-			<bounds x="671" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="671" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off171" element="led_off">
-			<bounds x="671" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="671" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off172" element="led_off">
-			<bounds x="655" y="132" width="19" height="3">
-			</bounds>
+			<bounds x="655" y="132" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off173" element="led_off">
-			<bounds x="655" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="655" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off174" element="led_off">
-			<bounds x="655" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="655" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off175" element="led_off">
-			<bounds x="655" y="119" width="19" height="3">
-			</bounds>
+			<bounds x="655" y="119" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off176" element="led_dot_off">
-			<bounds x="675" y="132" width="3" height="3">
-			</bounds>
+			<bounds x="675" y="132" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="lamp169" element="led_on">
-			<bounds x="655" y="106" width="19" height="3">
-			</bounds>
+			<bounds x="655" y="106" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp170" element="led_on">
-			<bounds x="671" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="671" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp171" element="led_on">
-			<bounds x="671" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="671" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp172" element="led_on">
-			<bounds x="655" y="132" width="19" height="3">
-			</bounds>
+			<bounds x="655" y="132" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp173" element="led_on">
-			<bounds x="655" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="655" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp174" element="led_on">
-			<bounds x="655" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="655" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp175" element="led_on">
-			<bounds x="655" y="119" width="19" height="3">
-			</bounds>
+			<bounds x="655" y="119" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp176" element="led_dot_on">
-			<bounds x="675" y="132" width="3" height="3">
-			</bounds>
+			<bounds x="675" y="132" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="706" y="103" width="27" height="36">
-			</bounds>
+			<bounds x="706" y="103" width="27" height="36"/>
 		</backdrop>
 		<backdrop name="led_off137" element="led_off">
-			<bounds x="709" y="106" width="19" height="3">
-			</bounds>
+			<bounds x="709" y="106" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off138" element="led_off">
-			<bounds x="725" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="725" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off139" element="led_off">
-			<bounds x="725" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="725" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off140" element="led_off">
-			<bounds x="709" y="132" width="19" height="3">
-			</bounds>
+			<bounds x="709" y="132" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off141" element="led_off">
-			<bounds x="709" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="709" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off142" element="led_off">
-			<bounds x="709" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="709" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="led_off143" element="led_off">
-			<bounds x="709" y="119" width="19" height="3">
-			</bounds>
+			<bounds x="709" y="119" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="led_off144" element="led_dot_off">
-			<bounds x="729" y="132" width="3" height="3">
-			</bounds>
+			<bounds x="729" y="132" width="3" height="3"/>
 		</backdrop>
 		<backdrop name="lamp137" element="led_on">
-			<bounds x="709" y="106" width="19" height="3">
-			</bounds>
+			<bounds x="709" y="106" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp138" element="led_on">
-			<bounds x="725" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="725" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp139" element="led_on">
-			<bounds x="725" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="725" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp140" element="led_on">
-			<bounds x="709" y="132" width="19" height="3">
-			</bounds>
+			<bounds x="709" y="132" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp141" element="led_on">
-			<bounds x="709" y="119" width="3" height="16">
-			</bounds>
+			<bounds x="709" y="119" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp142" element="led_on">
-			<bounds x="709" y="106" width="3" height="16">
-			</bounds>
+			<bounds x="709" y="106" width="3" height="16"/>
 		</backdrop>
 		<backdrop name="lamp143" element="led_on">
-			<bounds x="709" y="119" width="19" height="3">
-			</bounds>
+			<bounds x="709" y="119" width="19" height="3"/>
 		</backdrop>
 		<backdrop name="lamp144" element="led_dot_on">
-			<bounds x="729" y="132" width="3" height="3">
-			</bounds>
+			<bounds x="729" y="132" width="3" height="3"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="90" y="81" width="272" height="30">
-			</bounds>
+			<bounds x="90" y="81" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="90" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="90" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="107" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="107" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="124" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="124" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="141" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="141" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="158" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="158" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="175" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="175" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="192" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="192" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="209" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="209" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="226" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="226" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="243" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="243" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="260" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="260" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="277" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="277" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="294" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="294" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="311" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="311" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="328" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="328" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="345" y="81" width="17" height="30">
-			</bounds>
+			<bounds x="345" y="81" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label69" element="label_69">
-			<bounds x="616" y="84" width="36" height="75">
-			</bounds>
+			<bounds x="616" y="84" width="36" height="75"/>
 		</backdrop>
 		<backdrop name="label70" element="label_70">
-			<bounds x="842" y="125" width="75" height="19">
-			</bounds>
+			<bounds x="842" y="125" width="75" height="19"/>
 		</backdrop>
 		<backdrop name="label71" element="label_71">
-			<bounds x="842" y="158" width="75" height="19">
-			</bounds>
+			<bounds x="842" y="158" width="75" height="19"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="842" y="193" width="66" height="19">
-			</bounds>
+			<bounds x="842" y="193" width="66" height="19"/>
 		</backdrop>
 		<backdrop name="label73" element="label_73">
-			<bounds x="844" y="225" width="57" height="19">
-			</bounds>
+			<bounds x="844" y="225" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="label74" element="label_74">
-			<bounds x="844" y="259" width="57" height="19">
-			</bounds>
+			<bounds x="844" y="259" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="label75" element="label_75">
-			<bounds x="842" y="294" width="57" height="19">
-			</bounds>
+			<bounds x="842" y="294" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="label76" element="label_76">
-			<bounds x="844" y="327" width="57" height="19">
-			</bounds>
+			<bounds x="844" y="327" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="844" y="361" width="70" height="19">
-			</bounds>
+			<bounds x="844" y="361" width="70" height="19"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="844" y="395" width="48" height="19">
-			</bounds>
+			<bounds x="844" y="395" width="48" height="19"/>
 		</backdrop>
 		<backdrop name="label79" element="label_79">
-			<bounds x="844" y="430" width="48" height="19">
-			</bounds>
+			<bounds x="844" y="430" width="48" height="19"/>
 		</backdrop>
 		<backdrop name="label80" element="label_80">
-			<bounds x="844" y="463" width="58" height="19">
-			</bounds>
+			<bounds x="844" y="463" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="label81" element="label_81">
-			<bounds x="844" y="497" width="58" height="19">
-			</bounds>
+			<bounds x="844" y="497" width="58" height="19"/>
 		</backdrop>
 		<backdrop name="label82" element="label_82">
-			<bounds x="844" y="522" width="88" height="19">
-			</bounds>
+			<bounds x="844" y="522" width="88" height="19"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="828" y="554" width="95" height="32">
-			</bounds>
+			<bounds x="828" y="554" width="95" height="32"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="10" y="672" width="36" height="16">
-			</bounds>
+			<bounds x="10" y="672" width="36" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_button" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_button" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1dblch.lay
+++ b/src/mame/layout/sc1dblch.lay
@@ -8,12734 +8,7605 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NO PRIZE GREATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="THAN &#xA3;4.80 CAN BE WON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="FROM ANY ONE GAME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="NO PRIZE GREATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="THAN &#xA3;4.80 CAN BE WON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="FROM ANY ONE GAME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="REEL MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STEP TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NEAREST WI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STEP TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NEAREST WI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE WINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FOR SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="EXCHANGE WINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FOR SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3 SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2 SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1 SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5 SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4 SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="IN VIEW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="IN VIEW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="SKILLSTOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="SKILLSTOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.18"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.23" width="0.90" height="0.18"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.41" width="0.90" height="0.18"/>
 		</text>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.59" width="0.90" height="0.18"/>
 		</text>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.18">
-			</bounds>
-		</text>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.18">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.77" width="0.90" height="0.18"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="CASHTRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="CASHTRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
+			<color red="0.48" green="0.29" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
+			<color red="0.12" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
+			<color red="0.96" green="0.59" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
+			<color red="0.24" green="0.15" blue="0.01"/>
 		</rect>
 		<text string="NUDGEPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.48" green="0.29" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.96" green="0.59" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.15" blue="0.01">
-			</color>
-		</rect>
-		<text string="NUDGEPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="BEST WIN FROM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="NUDGES SHOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="IN GAMBLE PANEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="BEST WIN FROM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="NUDGES SHOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="IN GAMBLE PANEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_144_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="NING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="NING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="STR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="STR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
+			<color red="0.50" green="0.39" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
+			<color red="1.00" green="0.78" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
+			<color red="0.25" green="0.19" blue="0.00"/>
 		</rect>
 		<text string="EAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.39" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.78" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.19" blue="0.00">
-			</color>
-		</rect>
-		<text string="EAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI-LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI-LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.11"/>
 		</text>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.16" width="0.90" height="0.11"/>
 		</text>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.11"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.39" width="0.90" height="0.11"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.11"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.61" width="0.90" height="0.11"/>
 		</text>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.11"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.84" width="0.90" height="0.11"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.11"/>
 		</text>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.16" width="0.90" height="0.11"/>
 		</text>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.11"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.39" width="0.90" height="0.11"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.11"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.61" width="0.90" height="0.11"/>
 		</text>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.11"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.84" width="0.90" height="0.11"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.11"/>
 		</text>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.16" width="0.90" height="0.11"/>
 		</text>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.11"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.39" width="0.90" height="0.11"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.11"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.61" width="0.90" height="0.11"/>
 		</text>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.11"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.84" width="0.90" height="0.11"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="STOP N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="STOP N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.11"/>
 		</text>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.16" width="0.90" height="0.11"/>
 		</text>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.11"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.39" width="0.90" height="0.11"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.11"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.61" width="0.90" height="0.11"/>
 		</text>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.11"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.84" width="0.90" height="0.11"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.11"/>
 		</text>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.16" width="0.90" height="0.11"/>
 		</text>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.11"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.39" width="0.90" height="0.11"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.11"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.61" width="0.90" height="0.11"/>
 		</text>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.11"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.84" width="0.90" height="0.11"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.11"/>
 		</text>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.16" width="0.90" height="0.11"/>
 		</text>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.11"/>
 		</text>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.39" width="0.90" height="0.11"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.11"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.61" width="0.90" height="0.11"/>
 		</text>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.11"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.16" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.39" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.61" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.11">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.84" width="0.90" height="0.11">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.84" width="0.90" height="0.11"/>
 		</text>
 	</element>
 	<element name="colour_button_124_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_124">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_125_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_125">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_126_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_126">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_127_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_127">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_128_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_128">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_129_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_129">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_130_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_130">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_131_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_131">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Bar,Cherry,Jackpot,Plum,WinningStreak,Lemon,Melon(1),Cherry,Grape(3),Orange,Bell(2),Plum,Orange(2),Pound,Pear,Lemon(1)">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Bar,Cherry,Jackpot,Plum,WinningStreak,Lemon(1),Melon,Cherry(2),Grape,Orange(B),Bell,Plum(2),Orange,Pound,Pear(3),Lemon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Bar,WinningStreak,Jackpot,Bell,Plum,Cherry(1),Grape,Orange(3),Cherry,Grape(B),Pound,Pear(2),Plum,Lemon,Orange(2),Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="1" symbollist="12(Blue),11(Blue),10(Blue),9(Blue),8(Blue),7(Blue),6(Red),5(Red),4(Red),3(Red),2(Red),1(Red)">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_14">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_118">
 		<text string="Bugs and Trouty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="v1.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="20p PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_120">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_123">
 		<text string="Xanadu">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="756" height="662">
-			</bounds>
+			<bounds x="0" y="0" width="756" height="662"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="100" y="412" width="80" height="100">
-			</bounds>
+			<bounds x="100" y="412" width="80" height="100"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="100.0000" y="412.0000" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="100.0000" y="412.0000" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="103.3333" y="413.3889" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="103.3333" y="413.3889" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="106.6667" y="414.7778" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="106.6667" y="414.7778" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="110.0000" y="416.1667" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="110.0000" y="416.1667" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="113.3333" y="417.5555" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="113.3333" y="417.5555" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="116.6667" y="418.9445" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="116.6667" y="418.9445" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="100.0000" y="445.3333" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="100.0000" y="445.3333" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="103.3333" y="446.7222" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="103.3333" y="446.7222" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="106.6667" y="448.1111" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="106.6667" y="448.1111" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="110.0000" y="449.5000" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="110.0000" y="449.5000" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="113.3333" y="450.8889" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="113.3333" y="450.8889" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="116.6667" y="452.2778" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="116.6667" y="452.2778" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="100.0000" y="478.6667" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="100.0000" y="478.6667" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="103.3333" y="480.0555" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="103.3333" y="480.0555" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="106.6667" y="481.4444" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="106.6667" y="481.4444" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="110.0000" y="482.8333" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="110.0000" y="482.8333" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="113.3333" y="484.2222" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="113.3333" y="484.2222" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="116.6667" y="485.6111" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="116.6667" y="485.6111" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="100" y="412" width="80" height="100">
-			</bounds>
+			<bounds x="100" y="412" width="80" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="230" y="412" width="80" height="100">
-			</bounds>
+			<bounds x="230" y="412" width="80" height="100"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="412.0000" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="230.0000" y="412.0000" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="413.3889" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="233.3333" y="413.3889" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="414.7778" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="236.6667" y="414.7778" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="416.1667" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="240.0000" y="416.1667" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="417.5555" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="243.3333" y="417.5555" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="418.9445" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="246.6667" y="418.9445" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="445.3333" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="230.0000" y="445.3333" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="446.7222" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="233.3333" y="446.7222" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="448.1111" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="236.6667" y="448.1111" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="449.5000" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="240.0000" y="449.5000" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="450.8889" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="243.3333" y="450.8889" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="452.2778" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="246.6667" y="452.2778" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="478.6667" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="230.0000" y="478.6667" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="480.0555" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="233.3333" y="480.0555" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="481.4444" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="236.6667" y="481.4444" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="482.8333" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="240.0000" y="482.8333" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="484.2222" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="243.3333" y="484.2222" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="485.6111" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="246.6667" y="485.6111" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="230" y="412" width="80" height="100">
-			</bounds>
+			<bounds x="230" y="412" width="80" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="360" y="412" width="80" height="100">
-			</bounds>
+			<bounds x="360" y="412" width="80" height="100"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="360.0000" y="412.0000" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="360.0000" y="412.0000" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="363.3333" y="413.3889" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="363.3333" y="413.3889" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="366.6667" y="414.7778" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="366.6667" y="414.7778" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="370.0000" y="416.1667" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="370.0000" y="416.1667" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="373.3333" y="417.5555" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="373.3333" y="417.5555" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="376.6667" y="418.9445" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="376.6667" y="418.9445" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="360.0000" y="445.3333" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="360.0000" y="445.3333" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="363.3333" y="446.7222" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="363.3333" y="446.7222" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="366.6667" y="448.1111" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="366.6667" y="448.1111" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="370.0000" y="449.5000" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="370.0000" y="449.5000" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="373.3333" y="450.8889" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="373.3333" y="450.8889" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="376.6667" y="452.2778" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="376.6667" y="452.2778" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="360.0000" y="478.6667" width="80.0000" height="33.3333">
-			</bounds>
+			<bounds x="360.0000" y="478.6667" width="80.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="363.3333" y="480.0555" width="73.3333" height="30.5556">
-			</bounds>
+			<bounds x="363.3333" y="480.0555" width="73.3333" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="366.6667" y="481.4444" width="66.6667" height="27.7778">
-			</bounds>
+			<bounds x="366.6667" y="481.4444" width="66.6667" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="370.0000" y="482.8333" width="60.0000" height="25.0000">
-			</bounds>
+			<bounds x="370.0000" y="482.8333" width="60.0000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="373.3333" y="484.2222" width="53.3333" height="22.2222">
-			</bounds>
+			<bounds x="373.3333" y="484.2222" width="53.3333" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="376.6667" y="485.6111" width="46.6667" height="19.4444">
-			</bounds>
+			<bounds x="376.6667" y="485.6111" width="46.6667" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="360" y="412" width="80" height="100">
-			</bounds>
+			<bounds x="360" y="412" width="80" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="44" y="132" width="80" height="60">
-			</bounds>
+			<bounds x="44" y="132" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="44.0000" y="132.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="44.0000" y="132.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="47.3333" y="134.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="47.3333" y="134.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="50.6667" y="137.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="50.6667" y="137.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="54.0000" y="139.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="54.0000" y="139.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="57.3333" y="142.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="57.3333" y="142.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="60.6667" y="144.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="60.6667" y="144.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="44" y="132" width="80" height="60">
-			</bounds>
+			<bounds x="44" y="132" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="455" y="35" width="112" height="30">
-			</bounds>
+			<bounds x="455" y="35" width="112" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="457" y="37" width="108" height="26">
-			</bounds>
+			<bounds x="457" y="37" width="108" height="26"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="455" y="17" width="112" height="19">
-			</bounds>
+			<bounds x="455" y="17" width="112" height="19"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="457" y="19" width="108" height="15">
-			</bounds>
+			<bounds x="457" y="19" width="108" height="15"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="316" y="178" width="133" height="57">
-			</bounds>
+			<bounds x="316" y="178" width="133" height="57"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="318" y="180" width="129" height="53">
-			</bounds>
+			<bounds x="318" y="180" width="129" height="53"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="318" y="243" width="131" height="53">
-			</bounds>
+			<bounds x="318" y="243" width="131" height="53"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="320" y="245" width="127" height="49">
-			</bounds>
+			<bounds x="320" y="245" width="127" height="49"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="320" y="304" width="129" height="48">
-			</bounds>
+			<bounds x="320" y="304" width="129" height="48"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="322" y="306" width="125" height="44">
-			</bounds>
+			<bounds x="322" y="306" width="125" height="44"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="376" y="353" width="18" height="18">
-			</bounds>
+			<bounds x="376" y="353" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="378" y="355" width="14" height="14">
-			</bounds>
+			<bounds x="378" y="355" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="376" y="375" width="18" height="18">
-			</bounds>
+			<bounds x="376" y="375" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="378" y="377" width="14" height="14">
-			</bounds>
+			<bounds x="378" y="377" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="406" y="353" width="18" height="18">
-			</bounds>
+			<bounds x="406" y="353" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="408" y="355" width="14" height="14">
-			</bounds>
+			<bounds x="408" y="355" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="406" y="375" width="18" height="18">
-			</bounds>
+			<bounds x="406" y="375" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="408" y="377" width="14" height="14">
-			</bounds>
+			<bounds x="408" y="377" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="346" y="353" width="18" height="18">
-			</bounds>
+			<bounds x="346" y="353" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="348" y="355" width="14" height="14">
-			</bounds>
+			<bounds x="348" y="355" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="346" y="375" width="18" height="18">
-			</bounds>
+			<bounds x="346" y="375" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="348" y="377" width="14" height="14">
-			</bounds>
+			<bounds x="348" y="377" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="627" y="249" width="46" height="26">
-			</bounds>
+			<bounds x="627" y="249" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="629" y="251" width="42" height="22">
-			</bounds>
+			<bounds x="629" y="251" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="625" y="287" width="46" height="26">
-			</bounds>
+			<bounds x="625" y="287" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="627" y="289" width="42" height="22">
-			</bounds>
+			<bounds x="627" y="289" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="623" y="325" width="42" height="26">
-			</bounds>
+			<bounds x="623" y="325" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="625" y="327" width="38" height="22">
-			</bounds>
+			<bounds x="625" y="327" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="629" y="211" width="46" height="26">
-			</bounds>
+			<bounds x="629" y="211" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="631" y="213" width="42" height="22">
-			</bounds>
+			<bounds x="631" y="213" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="631" y="173" width="46" height="26">
-			</bounds>
+			<bounds x="631" y="173" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="633" y="175" width="42" height="22">
-			</bounds>
+			<bounds x="633" y="175" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="633" y="135" width="46" height="26">
-			</bounds>
+			<bounds x="633" y="135" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="635" y="137" width="42" height="22">
-			</bounds>
+			<bounds x="635" y="137" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="687" y="123" width="46" height="26">
-			</bounds>
+			<bounds x="687" y="123" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="689" y="125" width="42" height="22">
-			</bounds>
+			<bounds x="689" y="125" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="685" y="161" width="46" height="26">
-			</bounds>
+			<bounds x="685" y="161" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="687" y="163" width="42" height="22">
-			</bounds>
+			<bounds x="687" y="163" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="684" y="199" width="46" height="26">
-			</bounds>
+			<bounds x="684" y="199" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="686" y="201" width="42" height="22">
-			</bounds>
+			<bounds x="686" y="201" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="677" y="313" width="46" height="26">
-			</bounds>
+			<bounds x="677" y="313" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="679" y="315" width="42" height="22">
-			</bounds>
+			<bounds x="679" y="315" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="679" y="275" width="46" height="26">
-			</bounds>
+			<bounds x="679" y="275" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="681" y="277" width="42" height="22">
-			</bounds>
+			<bounds x="681" y="277" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="681" y="237" width="46" height="26">
-			</bounds>
+			<bounds x="681" y="237" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="683" y="239" width="42" height="22">
-			</bounds>
+			<bounds x="683" y="239" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="302" y="128" width="81" height="42">
-			</bounds>
+			<bounds x="302" y="128" width="81" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="304" y="130" width="77" height="38">
-			</bounds>
+			<bounds x="304" y="130" width="77" height="38"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="536" y="128" width="79" height="42">
-			</bounds>
+			<bounds x="536" y="128" width="79" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="538" y="130" width="75" height="38">
-			</bounds>
+			<bounds x="538" y="130" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="548" y="89" width="67" height="42">
-			</bounds>
+			<bounds x="548" y="89" width="67" height="42"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="550" y="91" width="63" height="38">
-			</bounds>
+			<bounds x="550" y="91" width="63" height="38"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="302" y="89" width="85" height="42">
-			</bounds>
+			<bounds x="302" y="89" width="85" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="304" y="91" width="81" height="38">
-			</bounds>
+			<bounds x="304" y="91" width="81" height="38"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="5" y="575" width="52" height="22">
-			</bounds>
+			<bounds x="5" y="575" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="7" y="577" width="48" height="18">
-			</bounds>
+			<bounds x="7" y="577" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="5" y="517" width="52" height="22">
-			</bounds>
+			<bounds x="5" y="517" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="7" y="519" width="48" height="18">
-			</bounds>
+			<bounds x="7" y="519" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="19" y="481" width="52" height="22">
-			</bounds>
+			<bounds x="19" y="481" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="21" y="483" width="48" height="18">
-			</bounds>
+			<bounds x="21" y="483" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="19" y="421" width="52" height="22">
-			</bounds>
+			<bounds x="19" y="421" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="21" y="423" width="48" height="18">
-			</bounds>
+			<bounds x="21" y="423" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="527" y="557" width="42" height="24">
-			</bounds>
+			<bounds x="527" y="557" width="42" height="24"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="529" y="559" width="38" height="20">
-			</bounds>
+			<bounds x="529" y="559" width="38" height="20"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="527" y="529" width="88" height="24">
-			</bounds>
+			<bounds x="527" y="529" width="88" height="24"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="529" y="531" width="84" height="20">
-			</bounds>
+			<bounds x="529" y="531" width="84" height="20"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="609" y="501" width="42" height="14">
-			</bounds>
+			<bounds x="609" y="501" width="42" height="14"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="611" y="503" width="38" height="10">
-			</bounds>
+			<bounds x="611" y="503" width="38" height="10"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="568" y="501" width="42" height="14">
-			</bounds>
+			<bounds x="568" y="501" width="42" height="14"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="570" y="503" width="38" height="10">
-			</bounds>
+			<bounds x="570" y="503" width="38" height="10"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="527" y="501" width="42" height="14">
-			</bounds>
+			<bounds x="527" y="501" width="42" height="14"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="529" y="503" width="38" height="10">
-			</bounds>
+			<bounds x="529" y="503" width="38" height="10"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="691" y="501" width="42" height="14">
-			</bounds>
+			<bounds x="691" y="501" width="42" height="14"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="693" y="503" width="38" height="10">
-			</bounds>
+			<bounds x="693" y="503" width="38" height="10"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="650" y="501" width="42" height="14">
-			</bounds>
+			<bounds x="650" y="501" width="42" height="14"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="652" y="503" width="38" height="10">
-			</bounds>
+			<bounds x="652" y="503" width="38" height="10"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="527" y="515" width="32" height="14">
-			</bounds>
+			<bounds x="527" y="515" width="32" height="14"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="529" y="517" width="28" height="10">
-			</bounds>
+			<bounds x="529" y="517" width="28" height="10"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="691" y="473" width="42" height="28">
-			</bounds>
+			<bounds x="691" y="473" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="693" y="475" width="38" height="24">
-			</bounds>
+			<bounds x="693" y="475" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="650" y="473" width="42" height="28">
-			</bounds>
+			<bounds x="650" y="473" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="652" y="475" width="38" height="24">
-			</bounds>
+			<bounds x="652" y="475" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="609" y="473" width="42" height="28">
-			</bounds>
+			<bounds x="609" y="473" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="611" y="475" width="38" height="24">
-			</bounds>
+			<bounds x="611" y="475" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="568" y="473" width="42" height="28">
-			</bounds>
+			<bounds x="568" y="473" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="570" y="475" width="38" height="24">
-			</bounds>
+			<bounds x="570" y="475" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="527" y="473" width="42" height="28">
-			</bounds>
+			<bounds x="527" y="473" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="529" y="475" width="38" height="24">
-			</bounds>
+			<bounds x="529" y="475" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="658" y="443" width="58" height="30">
-			</bounds>
+			<bounds x="658" y="443" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="660" y="445" width="54" height="26">
-			</bounds>
+			<bounds x="660" y="445" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="601" y="443" width="58" height="30">
-			</bounds>
+			<bounds x="601" y="443" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="603" y="445" width="54" height="26">
-			</bounds>
+			<bounds x="603" y="445" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="544" y="443" width="58" height="30">
-			</bounds>
+			<bounds x="544" y="443" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="546" y="445" width="54" height="26">
-			</bounds>
+			<bounds x="546" y="445" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="656" y="411" width="52" height="32">
-			</bounds>
+			<bounds x="656" y="411" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="658" y="413" width="48" height="28">
-			</bounds>
+			<bounds x="658" y="413" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="554" y="411" width="52" height="32">
-			</bounds>
+			<bounds x="554" y="411" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="556" y="413" width="48" height="28">
-			</bounds>
+			<bounds x="556" y="413" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="476" y="411" width="40" height="26">
-			</bounds>
+			<bounds x="476" y="411" width="40" height="26"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="478" y="413" width="36" height="22">
-			</bounds>
+			<bounds x="478" y="413" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="480" y="533" width="32" height="22">
-			</bounds>
+			<bounds x="480" y="533" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="482" y="535" width="28" height="18">
-			</bounds>
+			<bounds x="482" y="535" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="479" y="504" width="34" height="23">
-			</bounds>
+			<bounds x="479" y="504" width="34" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="481" y="506" width="30" height="19">
-			</bounds>
+			<bounds x="481" y="506" width="30" height="19"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="478" y="473" width="36" height="24">
-			</bounds>
+			<bounds x="478" y="473" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="480" y="475" width="32" height="20">
-			</bounds>
+			<bounds x="480" y="475" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="477" y="443" width="38" height="25">
-			</bounds>
+			<bounds x="477" y="443" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="479" y="445" width="34" height="21">
-			</bounds>
+			<bounds x="479" y="445" width="34" height="21"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="481" y="561" width="30" height="21">
-			</bounds>
+			<bounds x="481" y="561" width="30" height="21"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="483" y="563" width="26" height="17">
-			</bounds>
+			<bounds x="483" y="563" width="26" height="17"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="90" y="214" width="35" height="23">
-			</bounds>
+			<bounds x="90" y="214" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="92" y="216" width="31" height="19">
-			</bounds>
+			<bounds x="92" y="216" width="31" height="19"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="43" y="214" width="35" height="23">
-			</bounds>
+			<bounds x="43" y="214" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="45" y="216" width="31" height="19">
-			</bounds>
+			<bounds x="45" y="216" width="31" height="19"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="58" y="355" width="82" height="24">
-			</bounds>
+			<bounds x="58" y="355" width="82" height="24"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="60" y="357" width="78" height="20">
-			</bounds>
+			<bounds x="60" y="357" width="78" height="20"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="58" y="331" width="82" height="14">
-			</bounds>
+			<bounds x="58" y="331" width="82" height="14"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="60" y="333" width="78" height="10">
-			</bounds>
+			<bounds x="60" y="333" width="78" height="10"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="58" y="343" width="82" height="14">
-			</bounds>
+			<bounds x="58" y="343" width="82" height="14"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="60" y="345" width="78" height="10">
-			</bounds>
+			<bounds x="60" y="345" width="78" height="10"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="58" y="319" width="82" height="14">
-			</bounds>
+			<bounds x="58" y="319" width="82" height="14"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="60" y="321" width="78" height="10">
-			</bounds>
+			<bounds x="60" y="321" width="78" height="10"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="19" y="319" width="19" height="60">
-			</bounds>
+			<bounds x="19" y="319" width="19" height="60"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="21" y="321" width="15" height="56">
-			</bounds>
+			<bounds x="21" y="321" width="15" height="56"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="112" y="276" width="28" height="28">
-			</bounds>
+			<bounds x="112" y="276" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="114" y="278" width="24" height="24">
-			</bounds>
+			<bounds x="114" y="278" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="184" y="369" width="110" height="24">
-			</bounds>
+			<bounds x="184" y="369" width="110" height="24"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="186" y="371" width="106" height="20">
-			</bounds>
+			<bounds x="186" y="371" width="106" height="20"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="494" y="353" width="18" height="18">
-			</bounds>
+			<bounds x="494" y="353" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="496" y="355" width="14" height="14">
-			</bounds>
+			<bounds x="496" y="355" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="494" y="375" width="18" height="18">
-			</bounds>
+			<bounds x="494" y="375" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="496" y="377" width="14" height="14">
-			</bounds>
+			<bounds x="496" y="377" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="524" y="375" width="18" height="18">
-			</bounds>
+			<bounds x="524" y="375" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="526" y="377" width="14" height="14">
-			</bounds>
+			<bounds x="526" y="377" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="524" y="353" width="18" height="18">
-			</bounds>
+			<bounds x="524" y="353" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="526" y="355" width="14" height="14">
-			</bounds>
+			<bounds x="526" y="355" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="554" y="375" width="18" height="18">
-			</bounds>
+			<bounds x="554" y="375" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="556" y="377" width="14" height="14">
-			</bounds>
+			<bounds x="556" y="377" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="554" y="353" width="18" height="18">
-			</bounds>
+			<bounds x="554" y="353" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="556" y="355" width="14" height="14">
-			</bounds>
+			<bounds x="556" y="355" width="14" height="14"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="623" y="93" width="110" height="24">
-			</bounds>
+			<bounds x="623" y="93" width="110" height="24"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="625" y="95" width="106" height="20">
-			</bounds>
+			<bounds x="625" y="95" width="106" height="20"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="254" y="93" width="32" height="36">
-			</bounds>
+			<bounds x="254" y="93" width="32" height="36"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="256" y="95" width="28" height="32">
-			</bounds>
+			<bounds x="256" y="95" width="28" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="20" y="266" width="62" height="36">
-			</bounds>
+			<bounds x="20" y="266" width="62" height="36"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="22" y="268" width="58" height="32">
-			</bounds>
+			<bounds x="22" y="268" width="58" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="623" y="357" width="110" height="36">
-			</bounds>
+			<bounds x="623" y="357" width="110" height="36"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="625" y="359" width="106" height="32">
-			</bounds>
+			<bounds x="625" y="359" width="106" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_2_border" state="0">
-			<bounds x="384" y="89" width="76" height="42">
-			</bounds>
+			<bounds x="384" y="89" width="76" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_2" state="0">
-			<bounds x="386" y="91" width="72" height="38">
-			</bounds>
+			<bounds x="386" y="91" width="72" height="38"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_2_border" state="0">
-			<bounds x="457" y="89" width="94" height="42">
-			</bounds>
+			<bounds x="457" y="89" width="94" height="42"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_2" state="0">
-			<bounds x="459" y="91" width="90" height="38">
-			</bounds>
+			<bounds x="459" y="91" width="90" height="38"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2_border" state="0">
-			<bounds x="380" y="128" width="80" height="42">
-			</bounds>
+			<bounds x="380" y="128" width="80" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_2" state="0">
-			<bounds x="382" y="130" width="76" height="38">
-			</bounds>
+			<bounds x="382" y="130" width="76" height="38"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_2_border" state="0">
-			<bounds x="457" y="128" width="82" height="42">
-			</bounds>
+			<bounds x="457" y="128" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_2" state="0">
-			<bounds x="459" y="130" width="78" height="38">
-			</bounds>
+			<bounds x="459" y="130" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="468" y="178" width="133" height="57">
-			</bounds>
+			<bounds x="468" y="178" width="133" height="57"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="470" y="180" width="129" height="53">
-			</bounds>
+			<bounds x="470" y="180" width="129" height="53"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="603" y="181" width="12" height="52">
-			</bounds>
+			<bounds x="603" y="181" width="12" height="52"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="605" y="183" width="8" height="48">
-			</bounds>
+			<bounds x="605" y="183" width="8" height="48"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="602" y="242" width="12" height="52">
-			</bounds>
+			<bounds x="602" y="242" width="12" height="52"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="604" y="244" width="8" height="48">
-			</bounds>
+			<bounds x="604" y="244" width="8" height="48"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="601" y="302" width="12" height="52">
-			</bounds>
+			<bounds x="601" y="302" width="12" height="52"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="603" y="304" width="8" height="48">
-			</bounds>
+			<bounds x="603" y="304" width="8" height="48"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="468" y="243" width="131" height="53">
-			</bounds>
+			<bounds x="468" y="243" width="131" height="53"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="470" y="245" width="127" height="49">
-			</bounds>
+			<bounds x="470" y="245" width="127" height="49"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="468" y="304" width="129" height="48">
-			</bounds>
+			<bounds x="468" y="304" width="129" height="48"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="470" y="306" width="125" height="44">
-			</bounds>
+			<bounds x="470" y="306" width="125" height="44"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="304" y="302" width="12" height="52">
-			</bounds>
+			<bounds x="304" y="302" width="12" height="52"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="306" y="304" width="8" height="48">
-			</bounds>
+			<bounds x="306" y="304" width="8" height="48"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="303" y="243" width="12" height="52">
-			</bounds>
+			<bounds x="303" y="243" width="12" height="52"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="305" y="245" width="8" height="48">
-			</bounds>
+			<bounds x="305" y="245" width="8" height="48"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="302" y="181" width="12" height="52">
-			</bounds>
+			<bounds x="302" y="181" width="12" height="52"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="304" y="183" width="8" height="48">
-			</bounds>
+			<bounds x="304" y="183" width="8" height="48"/>
 		</backdrop>
 		<backdrop name="lamp23" element="colour_button_124_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="655" y="15" width="46" height="62">
-			</bounds>
+			<bounds x="655" y="15" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp23" element="colour_button_124" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="657" y="17" width="42" height="58">
-			</bounds>
+			<bounds x="657" y="17" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_125_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="5" y="603" width="68" height="42">
-			</bounds>
+			<bounds x="5" y="603" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_125" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="7" y="605" width="64" height="38">
-			</bounds>
+			<bounds x="7" y="605" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_126_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="106" y="603" width="68" height="42">
-			</bounds>
+			<bounds x="106" y="603" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_126" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="108" y="605" width="64" height="38">
-			</bounds>
+			<bounds x="108" y="605" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_127_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="236" y="603" width="68" height="42">
-			</bounds>
+			<bounds x="236" y="603" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_127" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="238" y="605" width="64" height="38">
-			</bounds>
+			<bounds x="238" y="605" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_128_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="366" y="603" width="68" height="42">
-			</bounds>
+			<bounds x="366" y="603" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_128" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="368" y="605" width="64" height="38">
-			</bounds>
+			<bounds x="368" y="605" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_129_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="493" y="603" width="68" height="42">
-			</bounds>
+			<bounds x="493" y="603" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_129" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="495" y="605" width="64" height="38">
-			</bounds>
+			<bounds x="495" y="605" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_130_border" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="576" y="603" width="68" height="42">
-			</bounds>
+			<bounds x="576" y="603" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_130" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="578" y="605" width="64" height="38">
-			</bounds>
+			<bounds x="578" y="605" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_131_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="660" y="603" width="68" height="42">
-			</bounds>
+			<bounds x="660" y="603" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_131" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="662" y="605" width="64" height="38">
-			</bounds>
+			<bounds x="662" y="605" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="177" y="16" width="51" height="49">
-			</bounds>
+			<bounds x="177" y="16" width="51" height="49"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="184" y="20" width="36" height="4">
-			</bounds>
+			<bounds x="184" y="20" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="213" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="213" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="213" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="213" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="184" y="56" width="36" height="4">
-			</bounds>
+			<bounds x="184" y="56" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="184" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="184" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="184" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="184" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="184" y="38" width="36" height="4">
-			</bounds>
+			<bounds x="184" y="38" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="220" y="56" width="7" height="4">
-			</bounds>
+			<bounds x="220" y="56" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="184" y="20" width="36" height="4">
-			</bounds>
+			<bounds x="184" y="20" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="213" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="213" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="213" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="213" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="184" y="56" width="36" height="4">
-			</bounds>
+			<bounds x="184" y="56" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="184" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="184" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="184" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="184" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="184" y="38" width="36" height="4">
-			</bounds>
+			<bounds x="184" y="38" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="220" y="56" width="7" height="4">
-			</bounds>
+			<bounds x="220" y="56" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="228" y="16" width="51" height="49">
-			</bounds>
+			<bounds x="228" y="16" width="51" height="49"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="235" y="20" width="36" height="4">
-			</bounds>
+			<bounds x="235" y="20" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="264" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="264" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="264" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="264" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="235" y="56" width="36" height="4">
-			</bounds>
+			<bounds x="235" y="56" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="235" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="235" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="235" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="235" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="235" y="38" width="36" height="4">
-			</bounds>
+			<bounds x="235" y="38" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="271" y="56" width="7" height="4">
-			</bounds>
+			<bounds x="271" y="56" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="235" y="20" width="36" height="4">
-			</bounds>
+			<bounds x="235" y="20" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="264" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="264" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="264" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="264" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="235" y="56" width="36" height="4">
-			</bounds>
+			<bounds x="235" y="56" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="235" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="235" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="235" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="235" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="235" y="38" width="36" height="4">
-			</bounds>
+			<bounds x="235" y="38" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="271" y="56" width="7" height="4">
-			</bounds>
+			<bounds x="271" y="56" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="278" y="16" width="51" height="49">
-			</bounds>
+			<bounds x="278" y="16" width="51" height="49"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="285" y="20" width="36" height="4">
-			</bounds>
+			<bounds x="285" y="20" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="314" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="314" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="314" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="314" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="285" y="56" width="36" height="4">
-			</bounds>
+			<bounds x="285" y="56" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="285" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="285" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="285" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="285" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="285" y="38" width="36" height="4">
-			</bounds>
+			<bounds x="285" y="38" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="321" y="56" width="7" height="4">
-			</bounds>
+			<bounds x="321" y="56" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="285" y="20" width="36" height="4">
-			</bounds>
+			<bounds x="285" y="20" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="314" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="314" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="314" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="314" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="285" y="56" width="36" height="4">
-			</bounds>
+			<bounds x="285" y="56" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="285" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="285" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="285" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="285" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="285" y="38" width="36" height="4">
-			</bounds>
+			<bounds x="285" y="38" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="321" y="56" width="7" height="4">
-			</bounds>
+			<bounds x="321" y="56" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="328" y="16" width="51" height="49">
-			</bounds>
+			<bounds x="328" y="16" width="51" height="49"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="335" y="20" width="36" height="4">
-			</bounds>
+			<bounds x="335" y="20" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="364" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="364" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="364" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="364" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="335" y="56" width="36" height="4">
-			</bounds>
+			<bounds x="335" y="56" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="335" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="335" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="335" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="335" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="335" y="38" width="36" height="4">
-			</bounds>
+			<bounds x="335" y="38" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="371" y="56" width="7" height="4">
-			</bounds>
+			<bounds x="371" y="56" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="335" y="20" width="36" height="4">
-			</bounds>
+			<bounds x="335" y="20" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="364" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="364" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="364" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="364" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="335" y="56" width="36" height="4">
-			</bounds>
+			<bounds x="335" y="56" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="335" y="38" width="7" height="22">
-			</bounds>
+			<bounds x="335" y="38" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="335" y="20" width="7" height="22">
-			</bounds>
+			<bounds x="335" y="20" width="7" height="22"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="335" y="38" width="36" height="4">
-			</bounds>
+			<bounds x="335" y="38" width="36" height="4"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="371" y="56" width="7" height="4">
-			</bounds>
+			<bounds x="371" y="56" width="7" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="670" y="529" width="24" height="32">
-			</bounds>
+			<bounds x="670" y="529" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="673" y="531" width="17" height="2">
-			</bounds>
+			<bounds x="673" y="531" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="687" y="531" width="3" height="14">
-			</bounds>
+			<bounds x="687" y="531" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="687" y="543" width="3" height="14">
-			</bounds>
+			<bounds x="687" y="543" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="673" y="555" width="17" height="2">
-			</bounds>
+			<bounds x="673" y="555" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="673" y="543" width="3" height="14">
-			</bounds>
+			<bounds x="673" y="543" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="673" y="531" width="3" height="14">
-			</bounds>
+			<bounds x="673" y="531" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="673" y="543" width="17" height="2">
-			</bounds>
+			<bounds x="673" y="543" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="690" y="555" width="3" height="2">
-			</bounds>
+			<bounds x="690" y="555" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="673" y="531" width="17" height="2">
-			</bounds>
+			<bounds x="673" y="531" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="687" y="531" width="3" height="14">
-			</bounds>
+			<bounds x="687" y="531" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="687" y="543" width="3" height="14">
-			</bounds>
+			<bounds x="687" y="543" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="673" y="555" width="17" height="2">
-			</bounds>
+			<bounds x="673" y="555" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="673" y="543" width="3" height="14">
-			</bounds>
+			<bounds x="673" y="543" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="673" y="531" width="3" height="14">
-			</bounds>
+			<bounds x="673" y="531" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="673" y="543" width="17" height="2">
-			</bounds>
+			<bounds x="673" y="543" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="690" y="555" width="3" height="2">
-			</bounds>
+			<bounds x="690" y="555" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="693" y="529" width="24" height="32">
-			</bounds>
+			<bounds x="693" y="529" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="696" y="531" width="17" height="2">
-			</bounds>
+			<bounds x="696" y="531" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="710" y="531" width="3" height="14">
-			</bounds>
+			<bounds x="710" y="531" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="710" y="543" width="3" height="14">
-			</bounds>
+			<bounds x="710" y="543" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="696" y="555" width="17" height="2">
-			</bounds>
+			<bounds x="696" y="555" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="696" y="543" width="3" height="14">
-			</bounds>
+			<bounds x="696" y="543" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="696" y="531" width="3" height="14">
-			</bounds>
+			<bounds x="696" y="531" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="696" y="543" width="17" height="2">
-			</bounds>
+			<bounds x="696" y="543" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="713" y="555" width="3" height="2">
-			</bounds>
+			<bounds x="713" y="555" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="696" y="531" width="17" height="2">
-			</bounds>
+			<bounds x="696" y="531" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="710" y="531" width="3" height="14">
-			</bounds>
+			<bounds x="710" y="531" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="710" y="543" width="3" height="14">
-			</bounds>
+			<bounds x="710" y="543" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="696" y="555" width="17" height="2">
-			</bounds>
+			<bounds x="696" y="555" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="696" y="543" width="3" height="14">
-			</bounds>
+			<bounds x="696" y="543" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="696" y="531" width="3" height="14">
-			</bounds>
+			<bounds x="696" y="531" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="696" y="543" width="17" height="2">
-			</bounds>
+			<bounds x="696" y="543" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="713" y="555" width="3" height="2">
-			</bounds>
+			<bounds x="713" y="555" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label14" element="label_14">
-			<bounds x="140" y="2" width="36" height="75">
-			</bounds>
+			<bounds x="140" y="2" width="36" height="75"/>
 		</backdrop>
 		<backdrop name="label118" element="label_118">
-			<bounds x="8" y="37" width="95" height="32">
-			</bounds>
+			<bounds x="8" y="37" width="95" height="32"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="664" y="571" width="50" height="14">
-			</bounds>
+			<bounds x="664" y="571" width="50" height="14"/>
 		</backdrop>
 		<backdrop name="label120" element="label_120">
-			<bounds x="665" y="559" width="56" height="16">
-			</bounds>
+			<bounds x="665" y="559" width="56" height="16"/>
 		</backdrop>
 		<backdrop name="label123" element="label_123">
-			<bounds x="6" y="643" width="42" height="16">
-			</bounds>
+			<bounds x="6" y="643" width="42" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_button" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_button" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1pwrl.lay
+++ b/src/mame/layout/sc1pwrl.lay
@@ -8,10058 +8,6577 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bonus ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Selecta ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Selecta ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="surprize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="surprize">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_231_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_231">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_239_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_239">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_240_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_240">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_241_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_241">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_242_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_242">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_243_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_243">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_244_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_244">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_245_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_245">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="powergam">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Melon,BigMoney,Grape,Grape,Plum,Plum,Plum,Orange,Orange,Orange,Bell,Jackpot,Cherry,Cherry,Cherry,Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Melon,Plum,Cherry,Grape,Grape,Grape,Orange,Plum,BigMoney,Orange,Orange,Bell,Cherry,Cherry,Cherry,Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Melon,Grape,Grape,Plum,Plum,Plum,Jackpot,Orange,Orange,Orange,Bell,BigMoney,Cherry,Cherry,Cherry,Grape">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_66">
 		<text string="Reserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_67">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_155">
 		<text string="Plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_156">
 		<text string="MFME 2.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_167">
 		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_182">
 		<text string="&#xA3;4.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_183">
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_184">
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_185">
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_186">
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_187">
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_188">
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_189">
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_194">
 		<text string="Power">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_195">
 		<text string="Lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_206">
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="806" height="676">
-			</bounds>
+			<bounds x="0" y="0" width="806" height="676"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="272" y="476" width="80" height="140">
-			</bounds>
+			<bounds x="272" y="476" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="272.0000" y="476.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="272.0000" y="476.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="275.3333" y="477.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="275.3333" y="477.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="278.6667" y="479.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="278.6667" y="479.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.0000" y="481.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="282.0000" y="481.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.3333" y="483.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="285.3333" y="483.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.6667" y="485.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="288.6667" y="485.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="272.0000" y="522.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="272.0000" y="522.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="275.3333" y="524.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="275.3333" y="524.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="278.6667" y="526.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="278.6667" y="526.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.0000" y="528.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="282.0000" y="528.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.3333" y="530.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="285.3333" y="530.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.6667" y="532.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="288.6667" y="532.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="272.0000" y="569.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="272.0000" y="569.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="275.3333" y="571.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="275.3333" y="571.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="278.6667" y="573.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="278.6667" y="573.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.0000" y="575.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="282.0000" y="575.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="285.3333" y="577.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="285.3333" y="577.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="288.6667" y="579.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="288.6667" y="579.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="272" y="476" width="80" height="140">
-			</bounds>
+			<bounds x="272" y="476" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="355" y="476" width="80" height="140">
-			</bounds>
+			<bounds x="355" y="476" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="355.0000" y="476.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="355.0000" y="476.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="358.3333" y="477.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="358.3333" y="477.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="361.6667" y="479.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="361.6667" y="479.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.0000" y="481.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="365.0000" y="481.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.3333" y="483.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="368.3333" y="483.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.6667" y="485.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="371.6667" y="485.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="355.0000" y="522.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="355.0000" y="522.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="358.3333" y="524.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="358.3333" y="524.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="361.6667" y="526.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="361.6667" y="526.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.0000" y="528.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="365.0000" y="528.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.3333" y="530.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="368.3333" y="530.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.6667" y="532.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="371.6667" y="532.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="355.0000" y="569.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="355.0000" y="569.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="358.3333" y="571.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="358.3333" y="571.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="361.6667" y="573.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="361.6667" y="573.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.0000" y="575.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="365.0000" y="575.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.3333" y="577.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="368.3333" y="577.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.6667" y="579.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="371.6667" y="579.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="355" y="476" width="80" height="140">
-			</bounds>
+			<bounds x="355" y="476" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="438" y="476" width="80" height="140">
-			</bounds>
+			<bounds x="438" y="476" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="438.0000" y="476.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="438.0000" y="476.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="441.3333" y="477.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="441.3333" y="477.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="444.6667" y="479.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="444.6667" y="479.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="448.0000" y="481.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="448.0000" y="481.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="451.3333" y="483.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="451.3333" y="483.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="454.6667" y="485.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="454.6667" y="485.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="438.0000" y="522.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="438.0000" y="522.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="441.3333" y="524.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="441.3333" y="524.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="444.6667" y="526.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="444.6667" y="526.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="448.0000" y="528.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="448.0000" y="528.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="451.3333" y="530.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="451.3333" y="530.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="454.6667" y="532.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="454.6667" y="532.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="438.0000" y="569.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="438.0000" y="569.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="441.3333" y="571.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="441.3333" y="571.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="444.6667" y="573.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="444.6667" y="573.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="448.0000" y="575.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="448.0000" y="575.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="451.3333" y="577.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="451.3333" y="577.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="454.6667" y="579.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="454.6667" y="579.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="438" y="476" width="80" height="140">
-			</bounds>
+			<bounds x="438" y="476" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="72" y="594" width="87" height="32">
-			</bounds>
+			<bounds x="72" y="594" width="87" height="32"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="74" y="596" width="83" height="28">
-			</bounds>
+			<bounds x="74" y="596" width="83" height="28"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="103" y="495" width="22" height="27">
-			</bounds>
+			<bounds x="103" y="495" width="22" height="27"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="105" y="497" width="18" height="23">
-			</bounds>
+			<bounds x="105" y="497" width="18" height="23"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="103" y="527" width="22" height="27">
-			</bounds>
+			<bounds x="103" y="527" width="22" height="27"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="105" y="529" width="18" height="23">
-			</bounds>
+			<bounds x="105" y="529" width="18" height="23"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="102" y="560" width="22" height="27">
-			</bounds>
+			<bounds x="102" y="560" width="22" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="104" y="562" width="18" height="23">
-			</bounds>
+			<bounds x="104" y="562" width="18" height="23"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="229" y="245" width="62" height="32">
-			</bounds>
+			<bounds x="229" y="245" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="231" y="247" width="58" height="28">
-			</bounds>
+			<bounds x="231" y="247" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="481" y="82" width="62" height="22">
-			</bounds>
+			<bounds x="481" y="82" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="483" y="84" width="58" height="18">
-			</bounds>
+			<bounds x="483" y="84" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="310" y="188" width="32" height="19">
-			</bounds>
+			<bounds x="310" y="188" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="312" y="190" width="28" height="15">
-			</bounds>
+			<bounds x="312" y="190" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="311" y="164" width="32" height="19">
-			</bounds>
+			<bounds x="311" y="164" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="313" y="166" width="28" height="15">
-			</bounds>
+			<bounds x="313" y="166" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="311" y="148" width="32" height="19">
-			</bounds>
+			<bounds x="311" y="148" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="313" y="150" width="28" height="15">
-			</bounds>
+			<bounds x="313" y="150" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="308" y="293" width="32" height="19">
-			</bounds>
+			<bounds x="308" y="293" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="310" y="295" width="28" height="15">
-			</bounds>
+			<bounds x="310" y="295" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="308" y="277" width="32" height="19">
-			</bounds>
+			<bounds x="308" y="277" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="310" y="279" width="28" height="15">
-			</bounds>
+			<bounds x="310" y="279" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="308" y="261" width="32" height="19">
-			</bounds>
+			<bounds x="308" y="261" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="310" y="263" width="28" height="15">
-			</bounds>
+			<bounds x="310" y="263" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="310" y="236" width="32" height="19">
-			</bounds>
+			<bounds x="310" y="236" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="312" y="238" width="28" height="15">
-			</bounds>
+			<bounds x="312" y="238" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="310" y="220" width="32" height="19">
-			</bounds>
+			<bounds x="310" y="220" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="312" y="222" width="28" height="15">
-			</bounds>
+			<bounds x="312" y="222" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="310" y="204" width="32" height="19">
-			</bounds>
+			<bounds x="310" y="204" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="312" y="206" width="28" height="15">
-			</bounds>
+			<bounds x="312" y="206" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="307" y="400" width="32" height="19">
-			</bounds>
+			<bounds x="307" y="400" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="309" y="402" width="28" height="15">
-			</bounds>
+			<bounds x="309" y="402" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="307" y="384" width="32" height="19">
-			</bounds>
+			<bounds x="307" y="384" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="309" y="386" width="28" height="15">
-			</bounds>
+			<bounds x="309" y="386" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="307" y="368" width="32" height="19">
-			</bounds>
+			<bounds x="307" y="368" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="309" y="370" width="28" height="15">
-			</bounds>
+			<bounds x="309" y="370" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="308" y="347" width="32" height="19">
-			</bounds>
+			<bounds x="308" y="347" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="310" y="349" width="28" height="15">
-			</bounds>
+			<bounds x="310" y="349" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="308" y="331" width="32" height="19">
-			</bounds>
+			<bounds x="308" y="331" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="310" y="333" width="28" height="15">
-			</bounds>
+			<bounds x="310" y="333" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="308" y="316" width="32" height="19">
-			</bounds>
+			<bounds x="308" y="316" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="310" y="318" width="28" height="15">
-			</bounds>
+			<bounds x="310" y="318" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="312" y="82" width="32" height="19">
-			</bounds>
+			<bounds x="312" y="82" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="314" y="84" width="28" height="15">
-			</bounds>
+			<bounds x="314" y="84" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="311" y="117" width="32" height="19">
-			</bounds>
+			<bounds x="311" y="117" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="313" y="119" width="28" height="15">
-			</bounds>
+			<bounds x="313" y="119" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="311" y="132" width="32" height="19">
-			</bounds>
+			<bounds x="311" y="132" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="313" y="134" width="28" height="15">
-			</bounds>
+			<bounds x="313" y="134" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="344" y="259" width="122" height="56">
-			</bounds>
+			<bounds x="344" y="259" width="122" height="56"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="346" y="261" width="118" height="52">
-			</bounds>
+			<bounds x="346" y="261" width="118" height="52"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="344" y="186" width="122" height="76">
-			</bounds>
+			<bounds x="344" y="186" width="122" height="76"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="346" y="188" width="118" height="72">
-			</bounds>
+			<bounds x="346" y="188" width="118" height="72"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="344" y="113" width="122" height="76">
-			</bounds>
+			<bounds x="344" y="113" width="122" height="76"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="346" y="115" width="118" height="72">
-			</bounds>
+			<bounds x="346" y="115" width="118" height="72"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="342" y="365" width="122" height="56">
-			</bounds>
+			<bounds x="342" y="365" width="122" height="56"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="344" y="367" width="118" height="52">
-			</bounds>
+			<bounds x="344" y="367" width="118" height="52"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="343" y="312" width="122" height="56">
-			</bounds>
+			<bounds x="343" y="312" width="122" height="56"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="345" y="314" width="118" height="52">
-			</bounds>
+			<bounds x="345" y="314" width="118" height="52"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="229" y="602" width="27" height="27">
-			</bounds>
+			<bounds x="229" y="602" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="231" y="604" width="23" height="23">
-			</bounds>
+			<bounds x="231" y="604" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="228" y="462" width="27" height="27">
-			</bounds>
+			<bounds x="228" y="462" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="230" y="464" width="23" height="23">
-			</bounds>
+			<bounds x="230" y="464" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="228" y="494" width="27" height="27">
-			</bounds>
+			<bounds x="228" y="494" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="230" y="496" width="23" height="23">
-			</bounds>
+			<bounds x="230" y="496" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="229" y="570" width="27" height="27">
-			</bounds>
+			<bounds x="229" y="570" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="231" y="572" width="23" height="23">
-			</bounds>
+			<bounds x="231" y="572" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="216" y="539" width="50" height="19">
-			</bounds>
+			<bounds x="216" y="539" width="50" height="19"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="218" y="541" width="46" height="15">
-			</bounds>
+			<bounds x="218" y="541" width="46" height="15"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="528" y="599" width="27" height="27">
-			</bounds>
+			<bounds x="528" y="599" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="530" y="601" width="23" height="23">
-			</bounds>
+			<bounds x="530" y="601" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="528" y="569" width="27" height="27">
-			</bounds>
+			<bounds x="528" y="569" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="530" y="571" width="23" height="23">
-			</bounds>
+			<bounds x="530" y="571" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="527" y="490" width="27" height="27">
-			</bounds>
+			<bounds x="527" y="490" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="529" y="492" width="23" height="23">
-			</bounds>
+			<bounds x="529" y="492" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="526" y="459" width="27" height="27">
-			</bounds>
+			<bounds x="526" y="459" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="528" y="461" width="23" height="23">
-			</bounds>
+			<bounds x="528" y="461" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="519" y="537" width="50" height="19">
-			</bounds>
+			<bounds x="519" y="537" width="50" height="19"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="521" y="539" width="46" height="15">
-			</bounds>
+			<bounds x="521" y="539" width="46" height="15"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="551" y="262" width="42" height="42">
-			</bounds>
+			<bounds x="551" y="262" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="553" y="264" width="38" height="38">
-			</bounds>
+			<bounds x="553" y="264" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="551" y="220" width="42" height="42">
-			</bounds>
+			<bounds x="551" y="220" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="553" y="222" width="38" height="38">
-			</bounds>
+			<bounds x="553" y="222" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="551" y="346" width="42" height="42">
-			</bounds>
+			<bounds x="551" y="346" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="553" y="348" width="38" height="38">
-			</bounds>
+			<bounds x="553" y="348" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="551" y="304" width="42" height="42">
-			</bounds>
+			<bounds x="551" y="304" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="553" y="306" width="38" height="38">
-			</bounds>
+			<bounds x="553" y="306" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="551" y="178" width="42" height="42">
-			</bounds>
+			<bounds x="551" y="178" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="553" y="180" width="38" height="38">
-			</bounds>
+			<bounds x="553" y="180" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="508" y="178" width="42" height="42">
-			</bounds>
+			<bounds x="508" y="178" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="510" y="180" width="38" height="38">
-			</bounds>
+			<bounds x="510" y="180" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="508" y="220" width="42" height="42">
-			</bounds>
+			<bounds x="508" y="220" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="510" y="222" width="38" height="38">
-			</bounds>
+			<bounds x="510" y="222" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="508" y="262" width="42" height="42">
-			</bounds>
+			<bounds x="508" y="262" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="510" y="264" width="38" height="38">
-			</bounds>
+			<bounds x="510" y="264" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="508" y="304" width="42" height="42">
-			</bounds>
+			<bounds x="508" y="304" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="510" y="306" width="38" height="38">
-			</bounds>
+			<bounds x="510" y="306" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="508" y="346" width="42" height="42">
-			</bounds>
+			<bounds x="508" y="346" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="510" y="348" width="38" height="38">
-			</bounds>
+			<bounds x="510" y="348" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_231_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="654" y="6" width="52" height="52">
-			</bounds>
+			<bounds x="654" y="6" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_231" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="656" y="8" width="48" height="48">
-			</bounds>
+			<bounds x="656" y="8" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_239_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="560" y="627" width="75" height="42">
-			</bounds>
+			<bounds x="560" y="627" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_239" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="562" y="629" width="71" height="38">
-			</bounds>
+			<bounds x="562" y="629" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_240_border" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="439" y="627" width="75" height="42">
-			</bounds>
+			<bounds x="439" y="627" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_240" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="441" y="629" width="71" height="38">
-			</bounds>
+			<bounds x="441" y="629" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_241_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="357" y="627" width="75" height="42">
-			</bounds>
+			<bounds x="357" y="627" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_241" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="359" y="629" width="71" height="38">
-			</bounds>
+			<bounds x="359" y="629" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_242_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="276" y="627" width="75" height="42">
-			</bounds>
+			<bounds x="276" y="627" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_242" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="278" y="629" width="71" height="38">
-			</bounds>
+			<bounds x="278" y="629" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_243_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="49" y="627" width="75" height="42">
-			</bounds>
+			<bounds x="49" y="627" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_243" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="51" y="629" width="71" height="38">
-			</bounds>
+			<bounds x="51" y="629" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_244_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="161" y="627" width="75" height="42">
-			</bounds>
+			<bounds x="161" y="627" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_244" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="163" y="629" width="71" height="38">
-			</bounds>
+			<bounds x="163" y="629" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_245_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="668" y="627" width="90" height="42">
-			</bounds>
+			<bounds x="668" y="627" width="90" height="42"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_245" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="670" y="629" width="86" height="38">
-			</bounds>
+			<bounds x="670" y="629" width="86" height="38"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="347" y="422" width="36" height="48">
-			</bounds>
+			<bounds x="347" y="422" width="36" height="48"/>
 		</backdrop>
 		<backdrop name="led_off137" element="led_off">
-			<bounds x="352" y="426" width="25" height="4">
-			</bounds>
+			<bounds x="352" y="426" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off138" element="led_off">
-			<bounds x="372" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="372" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off139" element="led_off">
-			<bounds x="372" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="372" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off140" element="led_off">
-			<bounds x="352" y="461" width="25" height="4">
-			</bounds>
+			<bounds x="352" y="461" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off141" element="led_off">
-			<bounds x="352" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="352" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off142" element="led_off">
-			<bounds x="352" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="352" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off143" element="led_off">
-			<bounds x="352" y="443" width="25" height="4">
-			</bounds>
+			<bounds x="352" y="443" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="377" y="461" width="5" height="4">
-			</bounds>
+			<bounds x="377" y="461" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="lamp137" element="led_on">
-			<bounds x="352" y="426" width="25" height="4">
-			</bounds>
+			<bounds x="352" y="426" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp138" element="led_on">
-			<bounds x="372" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="372" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp139" element="led_on">
-			<bounds x="372" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="372" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp140" element="led_on">
-			<bounds x="352" y="461" width="25" height="4">
-			</bounds>
+			<bounds x="352" y="461" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp141" element="led_on">
-			<bounds x="352" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="352" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp142" element="led_on">
-			<bounds x="352" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="352" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp143" element="led_on">
-			<bounds x="352" y="443" width="25" height="4">
-			</bounds>
+			<bounds x="352" y="443" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="377" y="461" width="5" height="4">
-			</bounds>
+			<bounds x="377" y="461" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="382" y="422" width="36" height="48">
-			</bounds>
+			<bounds x="382" y="422" width="36" height="48"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="387" y="426" width="25" height="4">
-			</bounds>
+			<bounds x="387" y="426" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="407" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="407" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="407" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="407" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="387" y="461" width="25" height="4">
-			</bounds>
+			<bounds x="387" y="461" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="387" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="387" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="387" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="387" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off127" element="led_off">
-			<bounds x="387" y="443" width="25" height="4">
-			</bounds>
+			<bounds x="387" y="443" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="412" y="461" width="5" height="4">
-			</bounds>
+			<bounds x="412" y="461" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="387" y="426" width="25" height="4">
-			</bounds>
+			<bounds x="387" y="426" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="407" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="407" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="407" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="407" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="387" y="461" width="25" height="4">
-			</bounds>
+			<bounds x="387" y="461" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="387" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="387" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="387" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="387" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp127" element="led_on">
-			<bounds x="387" y="443" width="25" height="4">
-			</bounds>
+			<bounds x="387" y="443" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="412" y="461" width="5" height="4">
-			</bounds>
+			<bounds x="412" y="461" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="418" y="422" width="36" height="48">
-			</bounds>
+			<bounds x="418" y="422" width="36" height="48"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="423" y="426" width="25" height="4">
-			</bounds>
+			<bounds x="423" y="426" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="443" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="443" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="443" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="443" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="423" y="461" width="25" height="4">
-			</bounds>
+			<bounds x="423" y="461" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="423" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="423" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="423" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="423" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_off">
-			<bounds x="423" y="443" width="25" height="4">
-			</bounds>
+			<bounds x="423" y="443" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="448" y="461" width="5" height="4">
-			</bounds>
+			<bounds x="448" y="461" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="423" y="426" width="25" height="4">
-			</bounds>
+			<bounds x="423" y="426" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="443" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="443" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="443" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="443" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="423" y="461" width="25" height="4">
-			</bounds>
+			<bounds x="423" y="461" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="423" y="443" width="5" height="21">
-			</bounds>
+			<bounds x="423" y="443" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="423" y="426" width="5" height="21">
-			</bounds>
+			<bounds x="423" y="426" width="5" height="21"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_on">
-			<bounds x="423" y="443" width="25" height="4">
-			</bounds>
+			<bounds x="423" y="443" width="25" height="4"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="448" y="461" width="5" height="4">
-			</bounds>
+			<bounds x="448" y="461" width="5" height="4"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="453" y="4" width="48" height="64">
-			</bounds>
+			<bounds x="453" y="4" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="459" y="9" width="34" height="5">
-			</bounds>
+			<bounds x="459" y="9" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="487" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="487" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="487" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="487" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="459" y="56" width="34" height="5">
-			</bounds>
+			<bounds x="459" y="56" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="459" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="459" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="459" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="459" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="459" y="33" width="34" height="5">
-			</bounds>
+			<bounds x="459" y="33" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="494" y="56" width="6" height="5">
-			</bounds>
+			<bounds x="494" y="56" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="459" y="9" width="34" height="5">
-			</bounds>
+			<bounds x="459" y="9" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="487" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="487" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="487" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="487" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="459" y="56" width="34" height="5">
-			</bounds>
+			<bounds x="459" y="56" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="459" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="459" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="459" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="459" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="459" y="33" width="34" height="5">
-			</bounds>
+			<bounds x="459" y="33" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="494" y="56" width="6" height="5">
-			</bounds>
+			<bounds x="494" y="56" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="406" y="4" width="48" height="64">
-			</bounds>
+			<bounds x="406" y="4" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="412" y="9" width="34" height="5">
-			</bounds>
+			<bounds x="412" y="9" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="440" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="440" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="440" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="440" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="412" y="56" width="34" height="5">
-			</bounds>
+			<bounds x="412" y="56" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="412" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="412" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="412" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="412" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="412" y="33" width="34" height="5">
-			</bounds>
+			<bounds x="412" y="33" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="447" y="56" width="6" height="5">
-			</bounds>
+			<bounds x="447" y="56" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="412" y="9" width="34" height="5">
-			</bounds>
+			<bounds x="412" y="9" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="440" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="440" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="440" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="440" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="412" y="56" width="34" height="5">
-			</bounds>
+			<bounds x="412" y="56" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="412" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="412" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="412" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="412" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="412" y="33" width="34" height="5">
-			</bounds>
+			<bounds x="412" y="33" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="447" y="56" width="6" height="5">
-			</bounds>
+			<bounds x="447" y="56" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="358" y="4" width="48" height="64">
-			</bounds>
+			<bounds x="358" y="4" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="364" y="9" width="34" height="5">
-			</bounds>
+			<bounds x="364" y="9" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="392" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="392" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="392" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="392" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="364" y="56" width="34" height="5">
-			</bounds>
+			<bounds x="364" y="56" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="364" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="364" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="364" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="364" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="364" y="33" width="34" height="5">
-			</bounds>
+			<bounds x="364" y="33" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="399" y="56" width="6" height="5">
-			</bounds>
+			<bounds x="399" y="56" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="364" y="9" width="34" height="5">
-			</bounds>
+			<bounds x="364" y="9" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="392" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="392" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="392" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="392" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="364" y="56" width="34" height="5">
-			</bounds>
+			<bounds x="364" y="56" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="364" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="364" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="364" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="364" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="364" y="33" width="34" height="5">
-			</bounds>
+			<bounds x="364" y="33" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="399" y="56" width="6" height="5">
-			</bounds>
+			<bounds x="399" y="56" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="310" y="4" width="48" height="64">
-			</bounds>
+			<bounds x="310" y="4" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="316" y="9" width="34" height="5">
-			</bounds>
+			<bounds x="316" y="9" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="344" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="344" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="344" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="344" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="316" y="56" width="34" height="5">
-			</bounds>
+			<bounds x="316" y="56" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="316" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="316" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="316" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="316" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="316" y="33" width="34" height="5">
-			</bounds>
+			<bounds x="316" y="33" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="351" y="56" width="6" height="5">
-			</bounds>
+			<bounds x="351" y="56" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="316" y="9" width="34" height="5">
-			</bounds>
+			<bounds x="316" y="9" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="344" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="344" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="344" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="344" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="316" y="56" width="34" height="5">
-			</bounds>
+			<bounds x="316" y="56" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="316" y="33" width="6" height="29">
-			</bounds>
+			<bounds x="316" y="33" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="316" y="9" width="6" height="29">
-			</bounds>
+			<bounds x="316" y="9" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="316" y="33" width="34" height="5">
-			</bounds>
+			<bounds x="316" y="33" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="351" y="56" width="6" height="5">
-			</bounds>
+			<bounds x="351" y="56" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="661" y="532" width="24" height="32">
-			</bounds>
+			<bounds x="661" y="532" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="664" y="534" width="17" height="2">
-			</bounds>
+			<bounds x="664" y="534" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="678" y="534" width="3" height="14">
-			</bounds>
+			<bounds x="678" y="534" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="678" y="546" width="3" height="14">
-			</bounds>
+			<bounds x="678" y="546" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="664" y="558" width="17" height="2">
-			</bounds>
+			<bounds x="664" y="558" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="664" y="546" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="546" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="664" y="534" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="534" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="664" y="546" width="17" height="2">
-			</bounds>
+			<bounds x="664" y="546" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="681" y="558" width="3" height="2">
-			</bounds>
+			<bounds x="681" y="558" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="664" y="534" width="17" height="2">
-			</bounds>
+			<bounds x="664" y="534" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="678" y="534" width="3" height="14">
-			</bounds>
+			<bounds x="678" y="534" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="678" y="546" width="3" height="14">
-			</bounds>
+			<bounds x="678" y="546" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="664" y="558" width="17" height="2">
-			</bounds>
+			<bounds x="664" y="558" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="664" y="546" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="546" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="664" y="534" width="3" height="14">
-			</bounds>
+			<bounds x="664" y="534" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="664" y="546" width="17" height="2">
-			</bounds>
+			<bounds x="664" y="546" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="681" y="558" width="3" height="2">
-			</bounds>
+			<bounds x="681" y="558" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="685" y="532" width="24" height="32">
-			</bounds>
+			<bounds x="685" y="532" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="688" y="534" width="17" height="2">
-			</bounds>
+			<bounds x="688" y="534" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="702" y="534" width="3" height="14">
-			</bounds>
+			<bounds x="702" y="534" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="702" y="546" width="3" height="14">
-			</bounds>
+			<bounds x="702" y="546" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="688" y="558" width="17" height="2">
-			</bounds>
+			<bounds x="688" y="558" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="688" y="546" width="3" height="14">
-			</bounds>
+			<bounds x="688" y="546" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="688" y="534" width="3" height="14">
-			</bounds>
+			<bounds x="688" y="534" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="688" y="546" width="17" height="2">
-			</bounds>
+			<bounds x="688" y="546" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="705" y="558" width="3" height="2">
-			</bounds>
+			<bounds x="705" y="558" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="688" y="534" width="17" height="2">
-			</bounds>
+			<bounds x="688" y="534" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="702" y="534" width="3" height="14">
-			</bounds>
+			<bounds x="702" y="534" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="702" y="546" width="3" height="14">
-			</bounds>
+			<bounds x="702" y="546" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="688" y="558" width="17" height="2">
-			</bounds>
+			<bounds x="688" y="558" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="688" y="546" width="3" height="14">
-			</bounds>
+			<bounds x="688" y="546" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="688" y="534" width="3" height="14">
-			</bounds>
+			<bounds x="688" y="534" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="688" y="546" width="17" height="2">
-			</bounds>
+			<bounds x="688" y="546" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="705" y="558" width="3" height="2">
-			</bounds>
+			<bounds x="705" y="558" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label66" element="label_66">
-			<bounds x="88" y="2" width="93" height="30">
-			</bounds>
+			<bounds x="88" y="2" width="93" height="30"/>
 		</backdrop>
 		<backdrop name="label67" element="label_67">
-			<bounds x="263" y="2" width="32" height="68">
-			</bounds>
+			<bounds x="263" y="2" width="32" height="68"/>
 		</backdrop>
 		<backdrop name="label155" element="label_155">
-			<bounds x="662" y="568" width="48" height="23">
-			</bounds>
+			<bounds x="662" y="568" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="label156" element="label_156">
-			<bounds x="758" y="14" width="35" height="30">
-			</bounds>
+			<bounds x="758" y="14" width="35" height="30"/>
 		</backdrop>
 		<backdrop name="label167" element="label_167">
-			<bounds x="82" y="202" width="94" height="30">
-			</bounds>
+			<bounds x="82" y="202" width="94" height="30"/>
 		</backdrop>
 		<backdrop name="label182" element="label_182">
-			<bounds x="733" y="82" width="58" height="27">
-			</bounds>
+			<bounds x="733" y="82" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="label183" element="label_183">
-			<bounds x="733" y="116" width="58" height="27">
-			</bounds>
+			<bounds x="733" y="116" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="label184" element="label_184">
-			<bounds x="731" y="155" width="58" height="27">
-			</bounds>
+			<bounds x="731" y="155" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="label185" element="label_185">
-			<bounds x="731" y="197" width="58" height="27">
-			</bounds>
+			<bounds x="731" y="197" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="label186" element="label_186">
-			<bounds x="737" y="315" width="39" height="27">
-			</bounds>
+			<bounds x="737" y="315" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label187" element="label_187">
-			<bounds x="737" y="237" width="39" height="27">
-			</bounds>
+			<bounds x="737" y="237" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label188" element="label_188">
-			<bounds x="739" y="353" width="39" height="27">
-			</bounds>
+			<bounds x="739" y="353" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label189" element="label_189">
-			<bounds x="738" y="276" width="39" height="27">
-			</bounds>
+			<bounds x="738" y="276" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="label194" element="label_194">
-			<bounds x="138" y="402" width="165" height="68">
-			</bounds>
+			<bounds x="138" y="402" width="165" height="68"/>
 		</backdrop>
 		<backdrop name="label195" element="label_195">
-			<bounds x="505" y="404" width="141" height="68">
-			</bounds>
+			<bounds x="505" y="404" width="141" height="68"/>
 		</backdrop>
 		<backdrop name="label206" element="label_206">
-			<bounds x="507" y="135" width="87" height="60">
-			</bounds>
+			<bounds x="507" y="135" width="87" height="60"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_button" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1sirb.lay
+++ b/src/mame/layout/sc1sirb.lay
@@ -8,10338 +8,6652 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STRIKE IT RICH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STRIKE IT RICH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="NUMBERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="6p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="6p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="8p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="8p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="4p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="4p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="2p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="2p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="24p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="24p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="22p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="22p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="18p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="18p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="16p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="16p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="12p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="12p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="14p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="14p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="26p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="26p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="28p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="28p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="SKILL CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="SKILL CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PLUS REPEAT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PLUS REPEAT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="STOP N MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="STOP N MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2P PLUS CLIMB CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2P PLUS CLIMB CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLAY HI-LO FOR CHANCE OF GREATER FEATURE OR TAKE FEATURE OR COLLECT CASH LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLAY HI-LO FOR CHANCE OF GREATER FEATURE OR TAKE FEATURE OR COLLECT CASH LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="YES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_212_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_212">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_213_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_213">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_272_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_272">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_273_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_273">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_274_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_274">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_275_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_275">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_276_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_276">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_277_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_277">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_278_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_278">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_279_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_279">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string=" HI ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_280_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_280">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_57">
 		<text string="NUMBER RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_117">
 		<text string="ALL PAIRS PAY 4P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_118">
 		<text string="10P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_119">
 		<text string="8P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_120">
 		<text string="6P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_121">
 		<text string="6P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_123">
 		<text string="12P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_124">
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="40P REPEAT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="30P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="WIN LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="WIN LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="CASH BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_144">
 		<text string="GAMES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="788" height="788">
-			</bounds>
+			<bounds x="0" y="0" width="788" height="788"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="105" y="504" width="80" height="140">
-			</bounds>
+			<bounds x="105" y="504" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="105.0000" y="504.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="105.0000" y="504.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="108.3333" y="505.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="108.3333" y="505.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="111.6667" y="507.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="111.6667" y="507.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="115.0000" y="509.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="115.0000" y="509.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="118.3333" y="511.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="118.3333" y="511.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="121.6667" y="513.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="121.6667" y="513.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="105.0000" y="550.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="105.0000" y="550.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="108.3333" y="552.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="108.3333" y="552.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="111.6667" y="554.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="111.6667" y="554.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="115.0000" y="556.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="115.0000" y="556.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="118.3333" y="558.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="118.3333" y="558.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="121.6667" y="560.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="121.6667" y="560.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="105.0000" y="597.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="105.0000" y="597.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="108.3333" y="599.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="108.3333" y="599.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="111.6667" y="601.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="111.6667" y="601.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="115.0000" y="603.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="115.0000" y="603.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="118.3333" y="605.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="118.3333" y="605.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="121.6667" y="607.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="121.6667" y="607.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="105" y="504" width="80" height="140">
-			</bounds>
+			<bounds x="105" y="504" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="221" y="504" width="80" height="140">
-			</bounds>
+			<bounds x="221" y="504" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="221.0000" y="504.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="221.0000" y="504.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="224.3333" y="505.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="224.3333" y="505.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="227.6667" y="507.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="227.6667" y="507.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="231.0000" y="509.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="231.0000" y="509.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="234.3333" y="511.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="234.3333" y="511.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.6667" y="513.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="237.6667" y="513.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="221.0000" y="550.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="221.0000" y="550.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="224.3333" y="552.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="224.3333" y="552.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="227.6667" y="554.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="227.6667" y="554.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="231.0000" y="556.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="231.0000" y="556.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="234.3333" y="558.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="234.3333" y="558.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.6667" y="560.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="237.6667" y="560.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="221.0000" y="597.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="221.0000" y="597.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="224.3333" y="599.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="224.3333" y="599.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="227.6667" y="601.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="227.6667" y="601.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="231.0000" y="603.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="231.0000" y="603.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="234.3333" y="605.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="234.3333" y="605.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.6667" y="607.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="237.6667" y="607.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="221" y="504" width="80" height="140">
-			</bounds>
+			<bounds x="221" y="504" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="336" y="504" width="80" height="140">
-			</bounds>
+			<bounds x="336" y="504" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="336.0000" y="504.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="336.0000" y="504.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="339.3333" y="505.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="339.3333" y="505.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="342.6667" y="507.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="342.6667" y="507.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="346.0000" y="509.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="346.0000" y="509.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="349.3333" y="511.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="349.3333" y="511.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="352.6667" y="513.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="352.6667" y="513.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="336.0000" y="550.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="336.0000" y="550.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="339.3333" y="552.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="339.3333" y="552.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="342.6667" y="554.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="342.6667" y="554.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="346.0000" y="556.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="346.0000" y="556.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="349.3333" y="558.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="349.3333" y="558.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="352.6667" y="560.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="352.6667" y="560.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="336.0000" y="597.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="336.0000" y="597.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="339.3333" y="599.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="339.3333" y="599.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="342.6667" y="601.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="342.6667" y="601.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="346.0000" y="603.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="346.0000" y="603.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="349.3333" y="605.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="349.3333" y="605.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="352.6667" y="607.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="352.6667" y="607.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="336" y="504" width="80" height="140">
-			</bounds>
+			<bounds x="336" y="504" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="160" y="213" width="80" height="80">
-			</bounds>
+			<bounds x="160" y="213" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="160.0000" y="213.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="160.0000" y="213.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="163.3333" y="216.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="163.3333" y="216.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="166.6667" y="219.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="166.6667" y="219.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="170.0000" y="223.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="170.0000" y="223.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="173.3333" y="226.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="173.3333" y="226.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="176.6667" y="229.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="176.6667" y="229.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="160" y="213" width="80" height="80">
-			</bounds>
+			<bounds x="160" y="213" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="307" y="416" width="78" height="25">
-			</bounds>
+			<bounds x="307" y="416" width="78" height="25"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="309" y="418" width="74" height="21">
-			</bounds>
+			<bounds x="309" y="418" width="74" height="21"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="21" y="588" width="76" height="46">
-			</bounds>
+			<bounds x="21" y="588" width="76" height="46"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="23" y="590" width="72" height="42">
-			</bounds>
+			<bounds x="23" y="590" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="324" y="350" width="46" height="24">
-			</bounds>
+			<bounds x="324" y="350" width="46" height="24"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="326" y="352" width="42" height="20">
-			</bounds>
+			<bounds x="326" y="352" width="42" height="20"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="477" y="348" width="56" height="26">
-			</bounds>
+			<bounds x="477" y="348" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="479" y="350" width="52" height="22">
-			</bounds>
+			<bounds x="479" y="350" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="544" y="627" width="56" height="24">
-			</bounds>
+			<bounds x="544" y="627" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="546" y="629" width="52" height="20">
-			</bounds>
+			<bounds x="546" y="629" width="52" height="20"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="493" y="628" width="48" height="24">
-			</bounds>
+			<bounds x="493" y="628" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="495" y="630" width="44" height="20">
-			</bounds>
+			<bounds x="495" y="630" width="44" height="20"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="225" y="18" width="222" height="58">
-			</bounds>
+			<bounds x="225" y="18" width="222" height="58"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="227" y="20" width="218" height="54">
-			</bounds>
+			<bounds x="227" y="20" width="218" height="54"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="548" y="406" width="68" height="26">
-			</bounds>
+			<bounds x="548" y="406" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="550" y="408" width="64" height="22">
-			</bounds>
+			<bounds x="550" y="408" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="466" y="423" width="80" height="24">
-			</bounds>
+			<bounds x="466" y="423" width="80" height="24"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="468" y="425" width="76" height="20">
-			</bounds>
+			<bounds x="468" y="425" width="76" height="20"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="474" y="373" width="66" height="19">
-			</bounds>
+			<bounds x="474" y="373" width="66" height="19"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="476" y="375" width="62" height="15">
-			</bounds>
+			<bounds x="476" y="375" width="62" height="15"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="307" y="391" width="78" height="25">
-			</bounds>
+			<bounds x="307" y="391" width="78" height="25"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="309" y="393" width="74" height="21">
-			</bounds>
+			<bounds x="309" y="393" width="74" height="21"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="21" y="495" width="76" height="46">
-			</bounds>
+			<bounds x="21" y="495" width="76" height="46"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="23" y="497" width="72" height="42">
-			</bounds>
+			<bounds x="23" y="497" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="571" y="567" width="35" height="35">
-			</bounds>
+			<bounds x="571" y="567" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="573" y="569" width="31" height="31">
-			</bounds>
+			<bounds x="573" y="569" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="607" y="530" width="35" height="35">
-			</bounds>
+			<bounds x="607" y="530" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="609" y="532" width="31" height="31">
-			</bounds>
+			<bounds x="609" y="532" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="607" y="567" width="35" height="35">
-			</bounds>
+			<bounds x="607" y="567" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="609" y="569" width="31" height="31">
-			</bounds>
+			<bounds x="609" y="569" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="535" y="567" width="35" height="35">
-			</bounds>
+			<bounds x="535" y="567" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="537" y="569" width="31" height="31">
-			</bounds>
+			<bounds x="537" y="569" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="499" y="567" width="35" height="35">
-			</bounds>
+			<bounds x="499" y="567" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="501" y="569" width="31" height="31">
-			</bounds>
+			<bounds x="501" y="569" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="607" y="493" width="35" height="35">
-			</bounds>
+			<bounds x="607" y="493" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="609" y="495" width="31" height="31">
-			</bounds>
+			<bounds x="609" y="495" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="571" y="493" width="35" height="35">
-			</bounds>
+			<bounds x="571" y="493" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="573" y="495" width="31" height="31">
-			</bounds>
+			<bounds x="573" y="495" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="535" y="493" width="35" height="35">
-			</bounds>
+			<bounds x="535" y="493" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="537" y="495" width="31" height="31">
-			</bounds>
+			<bounds x="537" y="495" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="499" y="493" width="35" height="35">
-			</bounds>
+			<bounds x="499" y="493" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="501" y="495" width="31" height="31">
-			</bounds>
+			<bounds x="501" y="495" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="499" y="530" width="35" height="35">
-			</bounds>
+			<bounds x="499" y="530" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="501" y="532" width="31" height="31">
-			</bounds>
+			<bounds x="501" y="532" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="571" y="530" width="35" height="35">
-			</bounds>
+			<bounds x="571" y="530" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="573" y="532" width="31" height="31">
-			</bounds>
+			<bounds x="573" y="532" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="535" y="530" width="35" height="35">
-			</bounds>
+			<bounds x="535" y="530" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="537" y="532" width="31" height="31">
-			</bounds>
+			<bounds x="537" y="532" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="499" y="456" width="35" height="35">
-			</bounds>
+			<bounds x="499" y="456" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="501" y="458" width="31" height="31">
-			</bounds>
+			<bounds x="501" y="458" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="607" y="456" width="35" height="35">
-			</bounds>
+			<bounds x="607" y="456" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="609" y="458" width="31" height="31">
-			</bounds>
+			<bounds x="609" y="458" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="571" y="456" width="35" height="35">
-			</bounds>
+			<bounds x="571" y="456" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="573" y="458" width="31" height="31">
-			</bounds>
+			<bounds x="573" y="458" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="535" y="456" width="35" height="35">
-			</bounds>
+			<bounds x="535" y="456" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="537" y="458" width="31" height="31">
-			</bounds>
+			<bounds x="537" y="458" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="427" y="456" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="456" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="429" y="458" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="458" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="427" y="493" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="493" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="429" y="495" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="495" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="427" y="530" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="530" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="429" y="532" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="532" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="427" y="567" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="567" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="429" y="569" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="569" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="427" y="604" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="604" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="429" y="606" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="606" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="427" y="347" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="347" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="429" y="349" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="349" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="427" y="310" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="310" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="429" y="312" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="312" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="427" y="273" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="273" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="429" y="275" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="275" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="427" y="236" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="236" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="429" y="238" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="238" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="427" y="199" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="199" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="429" y="201" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="201" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="427" y="162" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="162" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="429" y="164" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="164" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="427" y="125" width="35" height="35">
-			</bounds>
+			<bounds x="427" y="125" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="429" y="127" width="31" height="31">
-			</bounds>
+			<bounds x="429" y="127" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="298" y="162" width="100" height="35">
-			</bounds>
+			<bounds x="298" y="162" width="100" height="35"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="300" y="164" width="96" height="31">
-			</bounds>
+			<bounds x="300" y="164" width="96" height="31"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="298" y="199" width="100" height="35">
-			</bounds>
+			<bounds x="298" y="199" width="100" height="35"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="300" y="201" width="96" height="31">
-			</bounds>
+			<bounds x="300" y="201" width="96" height="31"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="298" y="236" width="100" height="35">
-			</bounds>
+			<bounds x="298" y="236" width="100" height="35"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="300" y="238" width="96" height="31">
-			</bounds>
+			<bounds x="300" y="238" width="96" height="31"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="298" y="111" width="100" height="48">
-			</bounds>
+			<bounds x="298" y="111" width="100" height="48"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="300" y="113" width="96" height="44">
-			</bounds>
+			<bounds x="300" y="113" width="96" height="44"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="298" y="273" width="100" height="35">
-			</bounds>
+			<bounds x="298" y="273" width="100" height="35"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="300" y="275" width="96" height="31">
-			</bounds>
+			<bounds x="300" y="275" width="96" height="31"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="298" y="310" width="100" height="35">
-			</bounds>
+			<bounds x="298" y="310" width="100" height="35"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="300" y="312" width="96" height="31">
-			</bounds>
+			<bounds x="300" y="312" width="96" height="31"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="505" y="219" width="56" height="14">
-			</bounds>
+			<bounds x="505" y="219" width="56" height="14"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="507" y="221" width="52" height="10">
-			</bounds>
+			<bounds x="507" y="221" width="52" height="10"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="544" y="143" width="48" height="24">
-			</bounds>
+			<bounds x="544" y="143" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="546" y="145" width="44" height="20">
-			</bounds>
+			<bounds x="546" y="145" width="44" height="20"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="493" y="143" width="48" height="24">
-			</bounds>
+			<bounds x="493" y="143" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="495" y="145" width="44" height="20">
-			</bounds>
+			<bounds x="495" y="145" width="44" height="20"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="505" y="302" width="56" height="14">
-			</bounds>
+			<bounds x="505" y="302" width="56" height="14"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="507" y="304" width="52" height="10">
-			</bounds>
+			<bounds x="507" y="304" width="52" height="10"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_2_border" state="0">
-			<bounds x="467" y="88" width="302" height="46">
-			</bounds>
+			<bounds x="467" y="88" width="302" height="46"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_2" state="0">
-			<bounds x="469" y="90" width="298" height="42">
-			</bounds>
+			<bounds x="469" y="90" width="298" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="505" y="261" width="56" height="14">
-			</bounds>
+			<bounds x="505" y="261" width="56" height="14"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="507" y="263" width="52" height="10">
-			</bounds>
+			<bounds x="507" y="263" width="52" height="10"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="505" y="174" width="56" height="14">
-			</bounds>
+			<bounds x="505" y="174" width="56" height="14"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="507" y="176" width="52" height="10">
-			</bounds>
+			<bounds x="507" y="176" width="52" height="10"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="187" y="295" width="35" height="35">
-			</bounds>
+			<bounds x="187" y="295" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="189" y="297" width="31" height="31">
-			</bounds>
+			<bounds x="189" y="297" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="187" y="169" width="35" height="35">
-			</bounds>
+			<bounds x="187" y="169" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="189" y="171" width="31" height="31">
-			</bounds>
+			<bounds x="189" y="171" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="624" y="405" width="58" height="26">
-			</bounds>
+			<bounds x="624" y="405" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="626" y="407" width="54" height="22">
-			</bounds>
+			<bounds x="626" y="407" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="550" y="355" width="58" height="24">
-			</bounds>
+			<bounds x="550" y="355" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="552" y="357" width="54" height="20">
-			</bounds>
+			<bounds x="552" y="357" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="623" y="366" width="34" height="26">
-			</bounds>
+			<bounds x="623" y="366" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="625" y="368" width="30" height="22">
-			</bounds>
+			<bounds x="625" y="368" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="623" y="337" width="34" height="26">
-			</bounds>
+			<bounds x="623" y="337" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="625" y="339" width="30" height="22">
-			</bounds>
+			<bounds x="625" y="339" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_212_border" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="668" y="1" width="55" height="27">
-			</bounds>
+			<bounds x="668" y="1" width="55" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_212" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="670" y="3" width="51" height="23">
-			</bounds>
+			<bounds x="670" y="3" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_213_border" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="725" y="1" width="55" height="27">
-			</bounds>
+			<bounds x="725" y="1" width="55" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_213" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="727" y="3" width="51" height="23">
-			</bounds>
+			<bounds x="727" y="3" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_272_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="611" y="1" width="55" height="27">
-			</bounds>
+			<bounds x="611" y="1" width="55" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_272" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="613" y="3" width="51" height="23">
-			</bounds>
+			<bounds x="613" y="3" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_273_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="22" y="744" width="75" height="37">
-			</bounds>
+			<bounds x="22" y="744" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_273" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="24" y="746" width="71" height="33">
-			</bounds>
+			<bounds x="24" y="746" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_274_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="109" y="744" width="75" height="37">
-			</bounds>
+			<bounds x="109" y="744" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_274" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="111" y="746" width="71" height="33">
-			</bounds>
+			<bounds x="111" y="746" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_275_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="225" y="744" width="75" height="37">
-			</bounds>
+			<bounds x="225" y="744" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_275" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="227" y="746" width="71" height="33">
-			</bounds>
+			<bounds x="227" y="746" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_276_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="347" y="744" width="75" height="37">
-			</bounds>
+			<bounds x="347" y="744" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_276" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="349" y="746" width="71" height="33">
-			</bounds>
+			<bounds x="349" y="746" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_277_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="606" y="744" width="75" height="37">
-			</bounds>
+			<bounds x="606" y="744" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_277" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="608" y="746" width="71" height="33">
-			</bounds>
+			<bounds x="608" y="746" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_278_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="687" y="744" width="75" height="37">
-			</bounds>
+			<bounds x="687" y="744" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_278" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="689" y="746" width="71" height="33">
-			</bounds>
+			<bounds x="689" y="746" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_279_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="447" y="744" width="75" height="37">
-			</bounds>
+			<bounds x="447" y="744" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_279" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="449" y="746" width="71" height="33">
-			</bounds>
+			<bounds x="449" y="746" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_280_border" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="526" y="744" width="75" height="37">
-			</bounds>
+			<bounds x="526" y="744" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_280" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="528" y="746" width="71" height="33">
-			</bounds>
+			<bounds x="528" y="746" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="721" y="670" width="24" height="32">
-			</bounds>
+			<bounds x="721" y="670" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off225" element="led_off">
-			<bounds x="724" y="672" width="17" height="2">
-			</bounds>
+			<bounds x="724" y="672" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off226" element="led_off">
-			<bounds x="738" y="672" width="3" height="14">
-			</bounds>
+			<bounds x="738" y="672" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off227" element="led_off">
-			<bounds x="738" y="684" width="3" height="14">
-			</bounds>
+			<bounds x="738" y="684" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off228" element="led_off">
-			<bounds x="724" y="696" width="17" height="2">
-			</bounds>
+			<bounds x="724" y="696" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off229" element="led_off">
-			<bounds x="724" y="684" width="3" height="14">
-			</bounds>
+			<bounds x="724" y="684" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off230" element="led_off">
-			<bounds x="724" y="672" width="3" height="14">
-			</bounds>
+			<bounds x="724" y="672" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off231" element="led_off">
-			<bounds x="724" y="684" width="17" height="2">
-			</bounds>
+			<bounds x="724" y="684" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="741" y="696" width="3" height="2">
-			</bounds>
+			<bounds x="741" y="696" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp225" element="led_on">
-			<bounds x="724" y="672" width="17" height="2">
-			</bounds>
+			<bounds x="724" y="672" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp226" element="led_on">
-			<bounds x="738" y="672" width="3" height="14">
-			</bounds>
+			<bounds x="738" y="672" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp227" element="led_on">
-			<bounds x="738" y="684" width="3" height="14">
-			</bounds>
+			<bounds x="738" y="684" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp228" element="led_on">
-			<bounds x="724" y="696" width="17" height="2">
-			</bounds>
+			<bounds x="724" y="696" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp229" element="led_on">
-			<bounds x="724" y="684" width="3" height="14">
-			</bounds>
+			<bounds x="724" y="684" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp230" element="led_on">
-			<bounds x="724" y="672" width="3" height="14">
-			</bounds>
+			<bounds x="724" y="672" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp231" element="led_on">
-			<bounds x="724" y="684" width="17" height="2">
-			</bounds>
+			<bounds x="724" y="684" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="741" y="696" width="3" height="2">
-			</bounds>
+			<bounds x="741" y="696" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="697" y="670" width="24" height="32">
-			</bounds>
+			<bounds x="697" y="670" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off241" element="led_off">
-			<bounds x="700" y="672" width="17" height="2">
-			</bounds>
+			<bounds x="700" y="672" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off242" element="led_off">
-			<bounds x="714" y="672" width="3" height="14">
-			</bounds>
+			<bounds x="714" y="672" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off243" element="led_off">
-			<bounds x="714" y="684" width="3" height="14">
-			</bounds>
+			<bounds x="714" y="684" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off244" element="led_off">
-			<bounds x="700" y="696" width="17" height="2">
-			</bounds>
+			<bounds x="700" y="696" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off245" element="led_off">
-			<bounds x="700" y="684" width="3" height="14">
-			</bounds>
+			<bounds x="700" y="684" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off246" element="led_off">
-			<bounds x="700" y="672" width="3" height="14">
-			</bounds>
+			<bounds x="700" y="672" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off247" element="led_off">
-			<bounds x="700" y="684" width="17" height="2">
-			</bounds>
+			<bounds x="700" y="684" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="717" y="696" width="3" height="2">
-			</bounds>
+			<bounds x="717" y="696" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp241" element="led_on">
-			<bounds x="700" y="672" width="17" height="2">
-			</bounds>
+			<bounds x="700" y="672" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp242" element="led_on">
-			<bounds x="714" y="672" width="3" height="14">
-			</bounds>
+			<bounds x="714" y="672" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp243" element="led_on">
-			<bounds x="714" y="684" width="3" height="14">
-			</bounds>
+			<bounds x="714" y="684" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp244" element="led_on">
-			<bounds x="700" y="696" width="17" height="2">
-			</bounds>
+			<bounds x="700" y="696" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp245" element="led_on">
-			<bounds x="700" y="684" width="3" height="14">
-			</bounds>
+			<bounds x="700" y="684" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp246" element="led_on">
-			<bounds x="700" y="672" width="3" height="14">
-			</bounds>
+			<bounds x="700" y="672" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp247" element="led_on">
-			<bounds x="700" y="684" width="17" height="2">
-			</bounds>
+			<bounds x="700" y="684" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="717" y="696" width="3" height="2">
-			</bounds>
+			<bounds x="717" y="696" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label57" element="label_57">
-			<bounds x="33" y="548" width="47" height="28">
-			</bounds>
+			<bounds x="33" y="548" width="47" height="28"/>
 		</backdrop>
 		<backdrop name="label117" element="label_117">
-			<bounds x="415" y="658" width="43" height="64">
-			</bounds>
+			<bounds x="415" y="658" width="43" height="64"/>
 		</backdrop>
 		<backdrop name="label118" element="label_118">
-			<bounds x="376" y="661" width="23" height="16">
-			</bounds>
+			<bounds x="376" y="661" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label119" element="label_119">
-			<bounds x="376" y="674" width="16" height="16">
-			</bounds>
+			<bounds x="376" y="674" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="label120" element="label_120">
-			<bounds x="376" y="690" width="16" height="16">
-			</bounds>
+			<bounds x="376" y="690" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="label121" element="label_121">
-			<bounds x="376" y="706" width="16" height="16">
-			</bounds>
+			<bounds x="376" y="706" width="16" height="16"/>
 		</backdrop>
 		<backdrop name="label123" element="label_123">
-			<bounds x="263" y="706" width="23" height="16">
-			</bounds>
+			<bounds x="263" y="706" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="263" y="690" width="23" height="16">
-			</bounds>
+			<bounds x="263" y="690" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="263" y="674" width="23" height="16">
-			</bounds>
+			<bounds x="263" y="674" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="263" y="661" width="23" height="16">
-			</bounds>
+			<bounds x="263" y="661" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="126" y="657" width="32" height="16">
-			</bounds>
+			<bounds x="126" y="657" width="32" height="16"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="100" y="674" width="65" height="14">
-			</bounds>
+			<bounds x="100" y="674" width="65" height="14"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="126" y="690" width="23" height="16">
-			</bounds>
+			<bounds x="126" y="690" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="126" y="706" width="23" height="16">
-			</bounds>
+			<bounds x="126" y="706" width="23" height="16"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="188" y="559" width="23" height="28">
-			</bounds>
+			<bounds x="188" y="559" width="23" height="28"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="303" y="559" width="23" height="28">
-			</bounds>
+			<bounds x="303" y="559" width="23" height="28"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="2" y="106" width="97" height="19">
-			</bounds>
+			<bounds x="2" y="106" width="97" height="19"/>
 		</backdrop>
 		<backdrop name="label144" element="label_144">
-			<bounds x="692" y="704" width="58" height="19">
-			</bounds>
+			<bounds x="692" y="704" width="58" height="19"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_segment" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_segment" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_segment" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_segment" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_segment" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_segment" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_segment" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1spct.lay
+++ b/src/mame/layout/sc1spct.lay
@@ -8,9560 +8,6338 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BARCODE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BARCODE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Stop a Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop a Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Number">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Number">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bounce">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bounce">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Spin &#x26;&#x26;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Spin &#x26;&#x26;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Graphic Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Graphic Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Fruit ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Stop &#x26;&#x26; Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stop &#x26;&#x26; Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="UNLIMITED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="UNLIMITED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_79_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_79">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_80_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_80">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_81_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_81">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_82_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_82">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_89_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_89">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_90_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_90">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_91_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_91">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_92_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_92">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_93_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_93">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_94_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_94">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_95_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_95">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="SingleBar(1),TripleBar,Bell,DoubleBar,Cherry(3),SingleBar,DoubleBar,BlueBell,Cherry,DoubleBar(2),Bell,TripleBar,Cherry(1),SingleBar,BlueBell,Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="SingleBar,TripleBar(1),BlueBell,DoubleBar,Cherry(1),SingleBar,DoubleBar,BlueBell(2),Cherry,DoubleBar,BlueBell,TripleBar,Cherry,SingleBar,Bell(3),Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="SingleBar,TripleBar(1),Bell,DoubleBar(3),Cherry,SingleBar,DoubleBar,BlueBell,Cherry(1),DoubleBar,Bell,TripleBar(2),Cherry,SingleBar,BlueBell(1),Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="1365" numsymbolsvisible="1" symbollist="12,11,10,9,8,7,6,5,4,3,2,1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_15">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_61">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_76">
 		<text string="SPECTRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="With thanks to Retrofruit &#x26;&#x26; leeham">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="793" height="620">
-			</bounds>
+			<bounds x="0" y="0" width="793" height="620"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="284" y="420" width="80" height="140">
-			</bounds>
+			<bounds x="284" y="420" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="284.0000" y="420.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="284.0000" y="420.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="287.3333" y="421.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="287.3333" y="421.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="290.6667" y="423.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="290.6667" y="423.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="294.0000" y="425.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="294.0000" y="425.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="297.3333" y="427.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="297.3333" y="427.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="300.6667" y="429.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="300.6667" y="429.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="284.0000" y="466.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="284.0000" y="466.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="287.3333" y="468.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="287.3333" y="468.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="290.6667" y="470.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="290.6667" y="470.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="294.0000" y="472.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="294.0000" y="472.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="297.3333" y="474.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="297.3333" y="474.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="300.6667" y="476.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="300.6667" y="476.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="284.0000" y="513.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="284.0000" y="513.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="287.3333" y="515.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="287.3333" y="515.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="290.6667" y="517.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="290.6667" y="517.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="294.0000" y="519.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="294.0000" y="519.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="297.3333" y="521.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="297.3333" y="521.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="300.6667" y="523.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="300.6667" y="523.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="284" y="420" width="80" height="140">
-			</bounds>
+			<bounds x="284" y="420" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="368" y="420" width="80" height="140">
-			</bounds>
+			<bounds x="368" y="420" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="368.0000" y="420.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="368.0000" y="420.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="371.3333" y="421.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="371.3333" y="421.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="374.6667" y="423.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="374.6667" y="423.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="378.0000" y="425.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="378.0000" y="425.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="381.3333" y="427.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="381.3333" y="427.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="384.6667" y="429.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="384.6667" y="429.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="368.0000" y="466.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="368.0000" y="466.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="371.3333" y="468.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="371.3333" y="468.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="374.6667" y="470.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="374.6667" y="470.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="378.0000" y="472.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="378.0000" y="472.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="381.3333" y="474.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="381.3333" y="474.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="384.6667" y="476.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="384.6667" y="476.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="368.0000" y="513.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="368.0000" y="513.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="371.3333" y="515.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="371.3333" y="515.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="374.6667" y="517.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="374.6667" y="517.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="378.0000" y="519.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="378.0000" y="519.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="381.3333" y="521.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="381.3333" y="521.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="384.6667" y="523.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="384.6667" y="523.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="368" y="420" width="80" height="140">
-			</bounds>
+			<bounds x="368" y="420" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="453" y="420" width="80" height="140">
-			</bounds>
+			<bounds x="453" y="420" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="453.0000" y="420.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="453.0000" y="420.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="456.3333" y="421.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="456.3333" y="421.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="459.6667" y="423.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="459.6667" y="423.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="463.0000" y="425.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="463.0000" y="425.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="466.3333" y="427.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="466.3333" y="427.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="469.6667" y="429.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="469.6667" y="429.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="453.0000" y="466.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="453.0000" y="466.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="456.3333" y="468.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="456.3333" y="468.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="459.6667" y="470.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="459.6667" y="470.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="463.0000" y="472.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="463.0000" y="472.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="466.3333" y="474.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="466.3333" y="474.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="469.6667" y="476.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="469.6667" y="476.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="453.0000" y="513.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="453.0000" y="513.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="456.3333" y="515.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="456.3333" y="515.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="459.6667" y="517.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="459.6667" y="517.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="463.0000" y="519.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="463.0000" y="519.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="466.3333" y="521.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="466.3333" y="521.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="469.6667" y="523.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="469.6667" y="523.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="453" y="420" width="80" height="140">
-			</bounds>
+			<bounds x="453" y="420" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="68" y="128" width="80" height="60">
-			</bounds>
+			<bounds x="68" y="128" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="68.0000" y="128.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="68.0000" y="128.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="71.3333" y="130.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="71.3333" y="130.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="74.6667" y="133.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="74.6667" y="133.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="78.0000" y="135.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="78.0000" y="135.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="81.3333" y="138.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="81.3333" y="138.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="84.6667" y="140.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="84.6667" y="140.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="68" y="128" width="80" height="60">
-			</bounds>
+			<bounds x="68" y="128" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="681" y="129" width="62" height="27">
-			</bounds>
+			<bounds x="681" y="129" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="683" y="131" width="58" height="23">
-			</bounds>
+			<bounds x="683" y="131" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="547" y="489" width="52" height="27">
-			</bounds>
+			<bounds x="547" y="489" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="549" y="491" width="48" height="23">
-			</bounds>
+			<bounds x="549" y="491" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="547" y="461" width="52" height="27">
-			</bounds>
+			<bounds x="547" y="461" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="549" y="463" width="48" height="23">
-			</bounds>
+			<bounds x="549" y="463" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="43" y="45" width="142" height="37">
-			</bounds>
+			<bounds x="43" y="45" width="142" height="37"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="45" y="47" width="138" height="33">
-			</bounds>
+			<bounds x="45" y="47" width="138" height="33"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="473" y="99" width="62" height="19">
-			</bounds>
+			<bounds x="473" y="99" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="475" y="101" width="58" height="15">
-			</bounds>
+			<bounds x="475" y="101" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="473" y="229" width="62" height="37">
-			</bounds>
+			<bounds x="473" y="229" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="475" y="231" width="58" height="33">
-			</bounds>
+			<bounds x="475" y="231" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="473" y="157" width="62" height="37">
-			</bounds>
+			<bounds x="473" y="157" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="475" y="159" width="58" height="33">
-			</bounds>
+			<bounds x="475" y="159" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="473" y="193" width="62" height="37">
-			</bounds>
+			<bounds x="473" y="193" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="475" y="195" width="58" height="33">
-			</bounds>
+			<bounds x="475" y="195" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="473" y="265" width="62" height="37">
-			</bounds>
+			<bounds x="473" y="265" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="475" y="267" width="58" height="33">
-			</bounds>
+			<bounds x="475" y="267" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="473" y="121" width="62" height="37">
-			</bounds>
+			<bounds x="473" y="121" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="475" y="123" width="58" height="33">
-			</bounds>
+			<bounds x="475" y="123" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="473" y="301" width="62" height="37">
-			</bounds>
+			<bounds x="473" y="301" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="475" y="303" width="58" height="33">
-			</bounds>
+			<bounds x="475" y="303" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="287" y="99" width="62" height="19">
-			</bounds>
+			<bounds x="287" y="99" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="289" y="101" width="58" height="15">
-			</bounds>
+			<bounds x="289" y="101" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="87" y="103" width="42" height="22">
-			</bounds>
+			<bounds x="87" y="103" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="89" y="105" width="38" height="18">
-			</bounds>
+			<bounds x="89" y="105" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="87" y="191" width="42" height="22">
-			</bounds>
+			<bounds x="87" y="191" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="89" y="193" width="38" height="18">
-			</bounds>
+			<bounds x="89" y="193" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="373" y="99" width="72" height="19">
-			</bounds>
+			<bounds x="373" y="99" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="375" y="101" width="68" height="15">
-			</bounds>
+			<bounds x="375" y="101" width="68" height="15"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="243" y="347" width="62" height="32">
-			</bounds>
+			<bounds x="243" y="347" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="245" y="349" width="58" height="28">
-			</bounds>
+			<bounds x="245" y="349" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="365" y="347" width="62" height="32">
-			</bounds>
+			<bounds x="365" y="347" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="367" y="349" width="58" height="28">
-			</bounds>
+			<bounds x="367" y="349" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="304" y="379" width="62" height="32">
-			</bounds>
+			<bounds x="304" y="379" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="306" y="381" width="58" height="28">
-			</bounds>
+			<bounds x="306" y="381" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="365" y="379" width="62" height="32">
-			</bounds>
+			<bounds x="365" y="379" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="367" y="381" width="58" height="28">
-			</bounds>
+			<bounds x="367" y="381" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="487" y="379" width="62" height="32">
-			</bounds>
+			<bounds x="487" y="379" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="489" y="381" width="58" height="28">
-			</bounds>
+			<bounds x="489" y="381" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="426" y="379" width="62" height="32">
-			</bounds>
+			<bounds x="426" y="379" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="428" y="381" width="58" height="28">
-			</bounds>
+			<bounds x="428" y="381" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="426" y="347" width="62" height="32">
-			</bounds>
+			<bounds x="426" y="347" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="428" y="349" width="58" height="28">
-			</bounds>
+			<bounds x="428" y="349" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="304" y="347" width="62" height="32">
-			</bounds>
+			<bounds x="304" y="347" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="306" y="349" width="58" height="28">
-			</bounds>
+			<bounds x="306" y="349" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="487" y="347" width="62" height="32">
-			</bounds>
+			<bounds x="487" y="347" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="489" y="349" width="58" height="28">
-			</bounds>
+			<bounds x="489" y="349" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="249" y="383" width="52" height="22">
-			</bounds>
+			<bounds x="249" y="383" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="251" y="385" width="48" height="18">
-			</bounds>
+			<bounds x="251" y="385" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="165" y="527" width="32" height="32">
-			</bounds>
+			<bounds x="165" y="527" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="167" y="529" width="28" height="28">
-			</bounds>
+			<bounds x="167" y="529" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="165" y="419" width="32" height="32">
-			</bounds>
+			<bounds x="165" y="419" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="167" y="421" width="28" height="28">
-			</bounds>
+			<bounds x="167" y="421" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="165" y="455" width="32" height="32">
-			</bounds>
+			<bounds x="165" y="455" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="167" y="457" width="28" height="28">
-			</bounds>
+			<bounds x="167" y="457" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="165" y="491" width="32" height="32">
-			</bounds>
+			<bounds x="165" y="491" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="167" y="493" width="28" height="28">
-			</bounds>
+			<bounds x="167" y="493" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="145" y="369" width="77" height="19">
-			</bounds>
+			<bounds x="145" y="369" width="77" height="19"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="147" y="371" width="73" height="15">
-			</bounds>
+			<bounds x="147" y="371" width="73" height="15"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="147" y="387" width="72" height="27">
-			</bounds>
+			<bounds x="147" y="387" width="72" height="27"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="149" y="389" width="68" height="23">
-			</bounds>
+			<bounds x="149" y="389" width="68" height="23"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="633" y="445" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="445" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="635" y="447" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="447" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="633" y="481" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="481" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="635" y="483" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="483" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="633" y="517" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="517" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="635" y="519" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="519" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="633" y="409" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="409" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="635" y="411" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="411" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="633" y="157" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="157" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="635" y="159" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="159" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="633" y="193" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="193" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="635" y="195" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="195" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="633" y="229" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="229" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="635" y="231" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="231" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="633" y="265" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="265" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="635" y="267" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="267" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="633" y="301" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="301" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="635" y="303" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="303" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="633" y="121" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="121" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="635" y="123" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="123" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="633" y="373" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="373" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="635" y="375" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="375" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="633" y="337" width="37" height="37">
-			</bounds>
+			<bounds x="633" y="337" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="635" y="339" width="33" height="33">
-			</bounds>
+			<bounds x="635" y="339" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_79_border" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="725" y="27" width="34" height="27">
-			</bounds>
+			<bounds x="725" y="27" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_79" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="727" y="29" width="30" height="23">
-			</bounds>
+			<bounds x="727" y="29" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_80_border" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="724" y="1" width="34" height="27">
-			</bounds>
+			<bounds x="724" y="1" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_80" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="726" y="3" width="30" height="23">
-			</bounds>
+			<bounds x="726" y="3" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_81_border" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="758" y="27" width="34" height="27">
-			</bounds>
+			<bounds x="758" y="27" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_81" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="760" y="29" width="30" height="23">
-			</bounds>
+			<bounds x="760" y="29" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_82_border" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="758" y="1" width="34" height="27">
-			</bounds>
+			<bounds x="758" y="1" width="34" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_82" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="760" y="3" width="30" height="23">
-			</bounds>
+			<bounds x="760" y="3" width="30" height="23"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_89_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="693" y="569" width="75" height="37">
-			</bounds>
+			<bounds x="693" y="569" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_89" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="695" y="571" width="71" height="33">
-			</bounds>
+			<bounds x="695" y="571" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_90_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="535" y="569" width="75" height="37">
-			</bounds>
+			<bounds x="535" y="569" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_90" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="537" y="571" width="71" height="33">
-			</bounds>
+			<bounds x="537" y="571" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_91_border" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="615" y="569" width="75" height="37">
-			</bounds>
+			<bounds x="615" y="569" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_91" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="617" y="571" width="71" height="33">
-			</bounds>
+			<bounds x="617" y="571" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_92_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="290" y="569" width="75" height="37">
-			</bounds>
+			<bounds x="290" y="569" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_92" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="292" y="571" width="71" height="33">
-			</bounds>
+			<bounds x="292" y="571" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_93_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="373" y="569" width="75" height="37">
-			</bounds>
+			<bounds x="373" y="569" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_93" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="375" y="571" width="71" height="33">
-			</bounds>
+			<bounds x="375" y="571" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_94_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="455" y="569" width="75" height="37">
-			</bounds>
+			<bounds x="455" y="569" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_94" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="457" y="571" width="71" height="33">
-			</bounds>
+			<bounds x="457" y="571" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_95_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="145" y="567" width="75" height="37">
-			</bounds>
+			<bounds x="145" y="567" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_95" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="147" y="569" width="71" height="33">
-			</bounds>
+			<bounds x="147" y="569" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="382" y="21" width="48" height="64">
-			</bounds>
+			<bounds x="382" y="21" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="388" y="26" width="34" height="5">
-			</bounds>
+			<bounds x="388" y="26" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="416" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="416" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="416" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="416" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="388" y="73" width="34" height="5">
-			</bounds>
+			<bounds x="388" y="73" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="388" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="388" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="388" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="388" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="388" y="50" width="34" height="5">
-			</bounds>
+			<bounds x="388" y="50" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="423" y="73" width="6" height="5">
-			</bounds>
+			<bounds x="423" y="73" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="388" y="26" width="34" height="5">
-			</bounds>
+			<bounds x="388" y="26" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="416" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="416" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="416" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="416" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="388" y="73" width="34" height="5">
-			</bounds>
+			<bounds x="388" y="73" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="388" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="388" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="388" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="388" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="388" y="50" width="34" height="5">
-			</bounds>
+			<bounds x="388" y="50" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="423" y="73" width="6" height="5">
-			</bounds>
+			<bounds x="423" y="73" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="334" y="21" width="48" height="64">
-			</bounds>
+			<bounds x="334" y="21" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="340" y="26" width="34" height="5">
-			</bounds>
+			<bounds x="340" y="26" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="368" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="368" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="368" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="368" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="340" y="73" width="34" height="5">
-			</bounds>
+			<bounds x="340" y="73" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="340" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="340" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="340" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="340" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="340" y="50" width="34" height="5">
-			</bounds>
+			<bounds x="340" y="50" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="375" y="73" width="6" height="5">
-			</bounds>
+			<bounds x="375" y="73" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="340" y="26" width="34" height="5">
-			</bounds>
+			<bounds x="340" y="26" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="368" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="368" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="368" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="368" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="340" y="73" width="34" height="5">
-			</bounds>
+			<bounds x="340" y="73" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="340" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="340" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="340" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="340" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="340" y="50" width="34" height="5">
-			</bounds>
+			<bounds x="340" y="50" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="375" y="73" width="6" height="5">
-			</bounds>
+			<bounds x="375" y="73" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="430" y="21" width="48" height="64">
-			</bounds>
+			<bounds x="430" y="21" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="436" y="26" width="34" height="5">
-			</bounds>
+			<bounds x="436" y="26" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="464" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="464" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="464" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="464" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="436" y="73" width="34" height="5">
-			</bounds>
+			<bounds x="436" y="73" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="436" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="436" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="436" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="436" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="436" y="50" width="34" height="5">
-			</bounds>
+			<bounds x="436" y="50" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="471" y="73" width="6" height="5">
-			</bounds>
+			<bounds x="471" y="73" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="436" y="26" width="34" height="5">
-			</bounds>
+			<bounds x="436" y="26" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="464" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="464" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="464" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="464" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="436" y="73" width="34" height="5">
-			</bounds>
+			<bounds x="436" y="73" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="436" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="436" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="436" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="436" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="436" y="50" width="34" height="5">
-			</bounds>
+			<bounds x="436" y="50" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="471" y="73" width="6" height="5">
-			</bounds>
+			<bounds x="471" y="73" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="478" y="21" width="48" height="64">
-			</bounds>
+			<bounds x="478" y="21" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="484" y="26" width="34" height="5">
-			</bounds>
+			<bounds x="484" y="26" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="512" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="512" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="512" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="512" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="484" y="73" width="34" height="5">
-			</bounds>
+			<bounds x="484" y="73" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="484" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="484" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="484" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="484" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="484" y="50" width="34" height="5">
-			</bounds>
+			<bounds x="484" y="50" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="519" y="73" width="6" height="5">
-			</bounds>
+			<bounds x="519" y="73" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="484" y="26" width="34" height="5">
-			</bounds>
+			<bounds x="484" y="26" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="512" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="512" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="512" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="512" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="484" y="73" width="34" height="5">
-			</bounds>
+			<bounds x="484" y="73" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="484" y="50" width="6" height="29">
-			</bounds>
+			<bounds x="484" y="50" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="484" y="26" width="6" height="29">
-			</bounds>
+			<bounds x="484" y="26" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="484" y="50" width="34" height="5">
-			</bounds>
+			<bounds x="484" y="50" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="519" y="73" width="6" height="5">
-			</bounds>
+			<bounds x="519" y="73" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="728" y="502" width="24" height="32">
-			</bounds>
+			<bounds x="728" y="502" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="731" y="504" width="17" height="2">
-			</bounds>
+			<bounds x="731" y="504" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="745" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="745" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="745" y="516" width="3" height="14">
-			</bounds>
+			<bounds x="745" y="516" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="731" y="528" width="17" height="2">
-			</bounds>
+			<bounds x="731" y="528" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="731" y="516" width="3" height="14">
-			</bounds>
+			<bounds x="731" y="516" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="731" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="731" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="731" y="516" width="17" height="2">
-			</bounds>
+			<bounds x="731" y="516" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="748" y="528" width="3" height="2">
-			</bounds>
+			<bounds x="748" y="528" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="731" y="504" width="17" height="2">
-			</bounds>
+			<bounds x="731" y="504" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="745" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="745" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="745" y="516" width="3" height="14">
-			</bounds>
+			<bounds x="745" y="516" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="731" y="528" width="17" height="2">
-			</bounds>
+			<bounds x="731" y="528" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="731" y="516" width="3" height="14">
-			</bounds>
+			<bounds x="731" y="516" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="731" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="731" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="731" y="516" width="17" height="2">
-			</bounds>
+			<bounds x="731" y="516" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="748" y="528" width="3" height="2">
-			</bounds>
+			<bounds x="748" y="528" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="704" y="502" width="24" height="32">
-			</bounds>
+			<bounds x="704" y="502" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="707" y="504" width="17" height="2">
-			</bounds>
+			<bounds x="707" y="504" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="721" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="721" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="721" y="516" width="3" height="14">
-			</bounds>
+			<bounds x="721" y="516" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="707" y="528" width="17" height="2">
-			</bounds>
+			<bounds x="707" y="528" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="707" y="516" width="3" height="14">
-			</bounds>
+			<bounds x="707" y="516" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="707" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="707" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="707" y="516" width="17" height="2">
-			</bounds>
+			<bounds x="707" y="516" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="724" y="528" width="3" height="2">
-			</bounds>
+			<bounds x="724" y="528" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="707" y="504" width="17" height="2">
-			</bounds>
+			<bounds x="707" y="504" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="721" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="721" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="721" y="516" width="3" height="14">
-			</bounds>
+			<bounds x="721" y="516" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="707" y="528" width="17" height="2">
-			</bounds>
+			<bounds x="707" y="528" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="707" y="516" width="3" height="14">
-			</bounds>
+			<bounds x="707" y="516" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="707" y="504" width="3" height="14">
-			</bounds>
+			<bounds x="707" y="504" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="707" y="516" width="17" height="2">
-			</bounds>
+			<bounds x="707" y="516" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="724" y="528" width="3" height="2">
-			</bounds>
+			<bounds x="724" y="528" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="label15" element="label_15">
-			<bounds x="288" y="14" width="36" height="75">
-			</bounds>
+			<bounds x="288" y="14" width="36" height="75"/>
 		</backdrop>
 		<backdrop name="label61" element="label_61">
-			<bounds x="692" y="535" width="72" height="19">
-			</bounds>
+			<bounds x="692" y="535" width="72" height="19"/>
 		</backdrop>
 		<backdrop name="label76" element="label_76">
-			<bounds x="50" y="242" width="130" height="32">
-			</bounds>
+			<bounds x="50" y="242" width="130" height="32"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="54" y="272" width="108" height="28">
-			</bounds>
+			<bounds x="54" y="272" width="108" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_button" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_standard" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc1str4.lay
+++ b/src/mame/layout/sc1str4.lay
@@ -6,6032 +6,4547 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png">
-		</image>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
-			<bounds x="0" y="0" width="1276" height="920">
-			</bounds>
+		<backdrop element="backdrop_colour">
+			<bounds x="0" y="0" width="1276" height="920"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="141" y="639" width="70" height="100">
-			</bounds>
+			<bounds x="141" y="639" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="141.0000" y="639.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="141.0000" y="639.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="143.9167" y="640.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="143.9167" y="640.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="146.8333" y="641.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="146.8333" y="641.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="149.7500" y="643.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="149.7500" y="643.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="152.6667" y="644.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="152.6667" y="644.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="155.5833" y="645.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="155.5833" y="645.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="141.0000" y="672.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="141.0000" y="672.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="143.9167" y="673.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="143.9167" y="673.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="146.8333" y="675.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="146.8333" y="675.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="149.7500" y="676.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="149.7500" y="676.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="152.6667" y="677.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="152.6667" y="677.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="155.5833" y="679.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="155.5833" y="679.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="141.0000" y="705.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="141.0000" y="705.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="143.9167" y="707.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="143.9167" y="707.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="146.8333" y="708.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="146.8333" y="708.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="149.7500" y="709.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="149.7500" y="709.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="152.6667" y="711.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="152.6667" y="711.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="155.5833" y="712.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="155.5833" y="712.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="141" y="639" width="70" height="100">
-			</bounds>
+			<bounds x="141" y="639" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="259" y="639" width="70" height="100">
-			</bounds>
+			<bounds x="259" y="639" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="259.0000" y="639.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="259.0000" y="639.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.9167" y="640.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="261.9167" y="640.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="264.8333" y="641.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="264.8333" y="641.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="267.7500" y="643.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="267.7500" y="643.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.6667" y="644.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="270.6667" y="644.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="273.5833" y="645.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="273.5833" y="645.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="259.0000" y="672.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="259.0000" y="672.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.9167" y="673.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="261.9167" y="673.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="264.8333" y="675.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="264.8333" y="675.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="267.7500" y="676.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="267.7500" y="676.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.6667" y="677.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="270.6667" y="677.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="273.5833" y="679.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="273.5833" y="679.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="259.0000" y="705.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="259.0000" y="705.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.9167" y="707.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="261.9167" y="707.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="264.8333" y="708.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="264.8333" y="708.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="267.7500" y="709.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="267.7500" y="709.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.6667" y="711.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="270.6667" y="711.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="273.5833" y="712.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="273.5833" y="712.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="259" y="639" width="70" height="100">
-			</bounds>
+			<bounds x="259" y="639" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="380" y="639" width="70" height="100">
-			</bounds>
+			<bounds x="380" y="639" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="380.0000" y="639.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="380.0000" y="639.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="382.9167" y="640.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="382.9167" y="640.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="385.8333" y="641.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="385.8333" y="641.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="388.7500" y="643.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="388.7500" y="643.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="391.6667" y="644.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="391.6667" y="644.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="394.5833" y="645.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="394.5833" y="645.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="380.0000" y="672.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="380.0000" y="672.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="382.9167" y="673.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="382.9167" y="673.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="385.8333" y="675.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="385.8333" y="675.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="388.7500" y="676.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="388.7500" y="676.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="391.6667" y="677.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="391.6667" y="677.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="394.5833" y="679.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="394.5833" y="679.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="380.0000" y="705.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="380.0000" y="705.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="382.9167" y="707.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="382.9167" y="707.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="385.8333" y="708.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="385.8333" y="708.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="388.7500" y="709.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="388.7500" y="709.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="391.6667" y="711.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="391.6667" y="711.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="394.5833" y="712.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="394.5833" y="712.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="380" y="639" width="70" height="100">
-			</bounds>
+			<bounds x="380" y="639" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="143" y="534" width="280" height="30">
-			</bounds>
+			<bounds x="143" y="534" width="280" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="143" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="143" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="161" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="161" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="179" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="179" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="197" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="197" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="215" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="215" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="233" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="233" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="251" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="251" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="269" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="269" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="287" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="287" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="305" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="305" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="323" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="323" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="341" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="341" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="359" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="359" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="377" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="377" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="395" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="395" y="534" width="18" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="413" y="534" width="18" height="30">
-			</bounds>
+			<bounds x="413" y="534" width="18" height="30"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_8" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_10" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_11" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2casr2.lay
+++ b/src/mame/layout/sc2casr2.lay
@@ -8,11104 +8,6971 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="GRID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="GRID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="STOP A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SNAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="STOP A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SNAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="FALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="FALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CLIMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="CLIMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="FRUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="FRUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="STOP N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="STOP N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="GRID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="GRID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="CHOOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="CHOOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="FRUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="FRUIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="BOUNCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="BOUNCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="CHOOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="A GRID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="CHOOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="A GRID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="WIN SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="WIN SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_6_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_6_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ANY MIXED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ANY MIXED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_288_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_288">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_352_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_352">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_353_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_353">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_354_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_354">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_355_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_355">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_356_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_356">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_357_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_357">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_358_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_358">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel5" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_203">
 		<text string="ON WINLINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GIVES HIDDEN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_287">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_5">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="724" height="852">
-			</bounds>
+			<bounds x="0" y="0" width="724" height="852"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="169" y="617" width="80" height="140">
-			</bounds>
+			<bounds x="169" y="617" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="169.0000" y="617.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="169.0000" y="617.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="172.3333" y="618.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="172.3333" y="618.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="175.6667" y="620.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="175.6667" y="620.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="179.0000" y="622.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="179.0000" y="622.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="182.3333" y="624.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="182.3333" y="624.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="185.6667" y="626.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="185.6667" y="626.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="169.0000" y="663.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="169.0000" y="663.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="172.3333" y="665.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="172.3333" y="665.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="175.6667" y="667.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="175.6667" y="667.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="179.0000" y="669.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="179.0000" y="669.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="182.3333" y="671.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="182.3333" y="671.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="185.6667" y="673.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="185.6667" y="673.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="169.0000" y="710.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="169.0000" y="710.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="172.3333" y="712.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="172.3333" y="712.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="175.6667" y="714.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="175.6667" y="714.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="179.0000" y="716.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="179.0000" y="716.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="182.3333" y="718.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="182.3333" y="718.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="185.6667" y="720.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="185.6667" y="720.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="169" y="617" width="80" height="140">
-			</bounds>
+			<bounds x="169" y="617" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="251" y="617" width="80" height="140">
-			</bounds>
+			<bounds x="251" y="617" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="251.0000" y="617.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="251.0000" y="617.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="254.3333" y="618.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="254.3333" y="618.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="257.6667" y="620.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="257.6667" y="620.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="261.0000" y="622.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="261.0000" y="622.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="264.3333" y="624.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="264.3333" y="624.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="267.6667" y="626.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="267.6667" y="626.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="251.0000" y="663.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="251.0000" y="663.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="254.3333" y="665.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="254.3333" y="665.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="257.6667" y="667.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="257.6667" y="667.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="261.0000" y="669.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="261.0000" y="669.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="264.3333" y="671.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="264.3333" y="671.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="267.6667" y="673.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="267.6667" y="673.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="251.0000" y="710.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="251.0000" y="710.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="254.3333" y="712.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="254.3333" y="712.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="257.6667" y="714.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="257.6667" y="714.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="261.0000" y="716.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="261.0000" y="716.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="264.3333" y="718.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="264.3333" y="718.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="267.6667" y="720.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="267.6667" y="720.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="251" y="617" width="80" height="140">
-			</bounds>
+			<bounds x="251" y="617" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="333" y="617" width="80" height="140">
-			</bounds>
+			<bounds x="333" y="617" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="617.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="333.0000" y="617.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="618.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="336.3333" y="618.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="620.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="339.6667" y="620.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="622.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="343.0000" y="622.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="624.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="346.3333" y="624.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="626.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="349.6667" y="626.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="663.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="333.0000" y="663.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="665.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="336.3333" y="665.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="667.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="339.6667" y="667.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="669.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="343.0000" y="669.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="671.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="346.3333" y="671.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="673.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="349.6667" y="673.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="710.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="333.0000" y="710.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="712.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="336.3333" y="712.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="714.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="339.6667" y="714.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="716.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="343.0000" y="716.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="718.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="346.3333" y="718.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="720.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="349.6667" y="720.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="333" y="617" width="80" height="140">
-			</bounds>
+			<bounds x="333" y="617" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="459" y="356" width="80" height="80">
-			</bounds>
+			<bounds x="459" y="356" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="459.0000" y="356.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="459.0000" y="356.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="462.3333" y="359.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="462.3333" y="359.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="465.6667" y="362.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="465.6667" y="362.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="469.0000" y="366.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="469.0000" y="366.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="472.3333" y="369.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="472.3333" y="369.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="475.6667" y="372.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="475.6667" y="372.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="459" y="356" width="80" height="80">
-			</bounds>
+			<bounds x="459" y="356" width="80" height="80"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="974" y="99" width="80" height="140">
-			</bounds>
+			<bounds x="974" y="99" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="974.0000" y="99.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="974.0000" y="99.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="977.3333" y="100.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="977.3333" y="100.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="980.6667" y="102.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="980.6667" y="102.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="984.0000" y="104.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="984.0000" y="104.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="987.3333" y="106.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="987.3333" y="106.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="990.6667" y="108.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="990.6667" y="108.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="974.0000" y="145.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="974.0000" y="145.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="977.3333" y="147.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="977.3333" y="147.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="980.6667" y="149.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="980.6667" y="149.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="984.0000" y="151.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="984.0000" y="151.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="987.3333" y="153.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="987.3333" y="153.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="990.6667" y="155.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="990.6667" y="155.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="974.0000" y="192.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="974.0000" y="192.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="977.3333" y="194.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="977.3333" y="194.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="980.6667" y="196.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="980.6667" y="196.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="984.0000" y="198.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="984.0000" y="198.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="987.3333" y="200.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="987.3333" y="200.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="990.6667" y="202.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="990.6667" y="202.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="974" y="99" width="80" height="140">
-			</bounds>
+			<bounds x="974" y="99" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1010" y="174" width="80" height="140">
-			</bounds>
+			<bounds x="1010" y="174" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1010.0000" y="174.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="1010.0000" y="174.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1013.3333" y="175.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="1013.3333" y="175.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1016.6667" y="177.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="1016.6667" y="177.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1020.0000" y="179.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="1020.0000" y="179.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1023.3333" y="181.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="1023.3333" y="181.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1026.6666" y="183.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="1026.6666" y="183.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1010.0000" y="220.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="1010.0000" y="220.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1013.3333" y="222.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="1013.3333" y="222.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1016.6667" y="224.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="1016.6667" y="224.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1020.0000" y="226.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="1020.0000" y="226.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1023.3333" y="228.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="1023.3333" y="228.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1026.6666" y="230.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="1026.6666" y="230.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1010.0000" y="267.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="1010.0000" y="267.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1013.3333" y="269.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="1013.3333" y="269.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1016.6667" y="271.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="1016.6667" y="271.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1020.0000" y="273.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="1020.0000" y="273.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1023.3333" y="275.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="1023.3333" y="275.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1026.6666" y="277.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="1026.6666" y="277.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<bounds x="1010" y="174" width="80" height="140">
-			</bounds>
+			<bounds x="1010" y="174" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="540" y="387" width="36" height="26">
-			</bounds>
+			<bounds x="540" y="387" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="542" y="389" width="32" height="22">
-			</bounds>
+			<bounds x="542" y="389" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="422" y="387" width="36" height="26">
-			</bounds>
+			<bounds x="422" y="387" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="424" y="389" width="32" height="22">
-			</bounds>
+			<bounds x="424" y="389" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="426" y="787" width="58" height="24">
-			</bounds>
+			<bounds x="426" y="787" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="428" y="789" width="54" height="20">
-			</bounds>
+			<bounds x="428" y="789" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="515" y="255" width="36" height="26">
-			</bounds>
+			<bounds x="515" y="255" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="517" y="257" width="32" height="22">
-			</bounds>
+			<bounds x="517" y="257" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="551" y="255" width="26" height="26">
-			</bounds>
+			<bounds x="551" y="255" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="553" y="257" width="22" height="22">
-			</bounds>
+			<bounds x="553" y="257" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="577" y="255" width="26" height="26">
-			</bounds>
+			<bounds x="577" y="255" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="579" y="257" width="22" height="22">
-			</bounds>
+			<bounds x="579" y="257" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="603" y="255" width="26" height="26">
-			</bounds>
+			<bounds x="603" y="255" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="605" y="257" width="22" height="22">
-			</bounds>
+			<bounds x="605" y="257" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="629" y="255" width="26" height="26">
-			</bounds>
+			<bounds x="629" y="255" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="631" y="257" width="22" height="22">
-			</bounds>
+			<bounds x="631" y="257" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="655" y="255" width="26" height="26">
-			</bounds>
+			<bounds x="655" y="255" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="657" y="257" width="22" height="22">
-			</bounds>
+			<bounds x="657" y="257" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="515" y="287" width="36" height="26">
-			</bounds>
+			<bounds x="515" y="287" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="517" y="289" width="32" height="22">
-			</bounds>
+			<bounds x="517" y="289" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="551" y="287" width="26" height="26">
-			</bounds>
+			<bounds x="551" y="287" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="553" y="289" width="22" height="22">
-			</bounds>
+			<bounds x="553" y="289" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="577" y="287" width="26" height="26">
-			</bounds>
+			<bounds x="577" y="287" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="579" y="289" width="22" height="22">
-			</bounds>
+			<bounds x="579" y="289" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="603" y="287" width="26" height="26">
-			</bounds>
+			<bounds x="603" y="287" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="605" y="289" width="22" height="22">
-			</bounds>
+			<bounds x="605" y="289" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="629" y="287" width="26" height="26">
-			</bounds>
+			<bounds x="629" y="287" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="631" y="289" width="22" height="22">
-			</bounds>
+			<bounds x="631" y="289" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="655" y="287" width="26" height="26">
-			</bounds>
+			<bounds x="655" y="287" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="657" y="289" width="22" height="22">
-			</bounds>
+			<bounds x="657" y="289" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="424" y="757" width="26" height="26">
-			</bounds>
+			<bounds x="424" y="757" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="426" y="759" width="22" height="22">
-			</bounds>
+			<bounds x="426" y="759" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="424" y="731" width="26" height="26">
-			</bounds>
+			<bounds x="424" y="731" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="426" y="733" width="22" height="22">
-			</bounds>
+			<bounds x="426" y="733" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="424" y="705" width="26" height="26">
-			</bounds>
+			<bounds x="424" y="705" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="426" y="707" width="22" height="22">
-			</bounds>
+			<bounds x="426" y="707" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="424" y="679" width="26" height="26">
-			</bounds>
+			<bounds x="424" y="679" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="426" y="681" width="22" height="22">
-			</bounds>
+			<bounds x="426" y="681" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="424" y="653" width="26" height="26">
-			</bounds>
+			<bounds x="424" y="653" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="426" y="655" width="22" height="22">
-			</bounds>
+			<bounds x="426" y="655" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="424" y="627" width="26" height="26">
-			</bounds>
+			<bounds x="424" y="627" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="426" y="629" width="22" height="22">
-			</bounds>
+			<bounds x="426" y="629" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="601" y="533" width="50" height="26">
-			</bounds>
+			<bounds x="601" y="533" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="603" y="535" width="46" height="22">
-			</bounds>
+			<bounds x="603" y="535" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="552" y="533" width="50" height="26">
-			</bounds>
+			<bounds x="552" y="533" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="554" y="535" width="46" height="22">
-			</bounds>
+			<bounds x="554" y="535" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="202" y="795" width="26" height="26">
-			</bounds>
+			<bounds x="202" y="795" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="204" y="797" width="22" height="22">
-			</bounds>
+			<bounds x="204" y="797" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="230" y="795" width="26" height="26">
-			</bounds>
+			<bounds x="230" y="795" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="232" y="797" width="22" height="22">
-			</bounds>
+			<bounds x="232" y="797" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="258" y="795" width="26" height="26">
-			</bounds>
+			<bounds x="258" y="795" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="260" y="797" width="22" height="22">
-			</bounds>
+			<bounds x="260" y="797" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="286" y="795" width="26" height="26">
-			</bounds>
+			<bounds x="286" y="795" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="288" y="797" width="22" height="22">
-			</bounds>
+			<bounds x="288" y="797" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="314" y="795" width="46" height="26">
-			</bounds>
+			<bounds x="314" y="795" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="316" y="797" width="42" height="22">
-			</bounds>
+			<bounds x="316" y="797" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="275" y="323" width="36" height="36">
-			</bounds>
+			<bounds x="275" y="323" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="277" y="325" width="32" height="32">
-			</bounds>
+			<bounds x="277" y="325" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="193" y="301" width="36" height="36">
-			</bounds>
+			<bounds x="193" y="301" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="195" y="303" width="32" height="32">
-			</bounds>
+			<bounds x="195" y="303" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="267" y="260" width="56" height="56">
-			</bounds>
+			<bounds x="267" y="260" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="269" y="262" width="52" height="52">
-			</bounds>
+			<bounds x="269" y="262" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="212" y="57" width="56" height="56">
-			</bounds>
+			<bounds x="212" y="57" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="214" y="59" width="52" height="52">
-			</bounds>
+			<bounds x="214" y="59" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="172" y="205" width="56" height="56">
-			</bounds>
+			<bounds x="172" y="205" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="174" y="207" width="52" height="52">
-			</bounds>
+			<bounds x="174" y="207" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="213" y="246" width="56" height="56">
-			</bounds>
+			<bounds x="213" y="246" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="215" y="248" width="52" height="52">
-			</bounds>
+			<bounds x="215" y="248" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="158" y="151" width="56" height="56">
-			</bounds>
+			<bounds x="158" y="151" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="160" y="153" width="52" height="52">
-			</bounds>
+			<bounds x="160" y="153" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="173" y="97" width="56" height="56">
-			</bounds>
+			<bounds x="173" y="97" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="175" y="99" width="52" height="52">
-			</bounds>
+			<bounds x="175" y="99" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="376" y="151" width="56" height="56">
-			</bounds>
+			<bounds x="376" y="151" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="378" y="153" width="52" height="52">
-			</bounds>
+			<bounds x="378" y="153" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="267" y="44" width="56" height="56">
-			</bounds>
+			<bounds x="267" y="44" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="269" y="46" width="52" height="52">
-			</bounds>
+			<bounds x="269" y="46" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="322" y="246" width="56" height="56">
-			</bounds>
+			<bounds x="322" y="246" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="324" y="248" width="52" height="52">
-			</bounds>
+			<bounds x="324" y="248" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="362" y="97" width="56" height="56">
-			</bounds>
+			<bounds x="362" y="97" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="364" y="99" width="52" height="52">
-			</bounds>
+			<bounds x="364" y="99" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="362" y="205" width="56" height="56">
-			</bounds>
+			<bounds x="362" y="205" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="364" y="207" width="52" height="52">
-			</bounds>
+			<bounds x="364" y="207" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="322" y="57" width="56" height="56">
-			</bounds>
+			<bounds x="322" y="57" width="56" height="56"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="324" y="59" width="52" height="52">
-			</bounds>
+			<bounds x="324" y="59" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="359" y="301" width="36" height="36">
-			</bounds>
+			<bounds x="359" y="301" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="361" y="303" width="32" height="32">
-			</bounds>
+			<bounds x="361" y="303" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="420" y="238" width="36" height="36">
-			</bounds>
+			<bounds x="420" y="238" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="422" y="240" width="32" height="32">
-			</bounds>
+			<bounds x="422" y="240" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="438" y="162" width="36" height="36">
-			</bounds>
+			<bounds x="438" y="162" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="440" y="164" width="32" height="32">
-			</bounds>
+			<bounds x="440" y="164" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="419" y="87" width="36" height="36">
-			</bounds>
+			<bounds x="419" y="87" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="421" y="89" width="32" height="32">
-			</bounds>
+			<bounds x="421" y="89" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="355" y="25" width="36" height="36">
-			</bounds>
+			<bounds x="355" y="25" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="357" y="27" width="32" height="32">
-			</bounds>
+			<bounds x="357" y="27" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="137" y="238" width="36" height="36">
-			</bounds>
+			<bounds x="137" y="238" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="139" y="240" width="32" height="32">
-			</bounds>
+			<bounds x="139" y="240" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="118" y="162" width="36" height="36">
-			</bounds>
+			<bounds x="118" y="162" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="120" y="164" width="32" height="32">
-			</bounds>
+			<bounds x="120" y="164" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="135" y="87" width="36" height="36">
-			</bounds>
+			<bounds x="135" y="87" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="137" y="89" width="32" height="32">
-			</bounds>
+			<bounds x="137" y="89" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="196" y="25" width="36" height="36">
-			</bounds>
+			<bounds x="196" y="25" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="198" y="27" width="32" height="32">
-			</bounds>
+			<bounds x="198" y="27" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="275" y="3" width="36" height="36">
-			</bounds>
+			<bounds x="275" y="3" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="277" y="5" width="32" height="32">
-			</bounds>
+			<bounds x="277" y="5" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1_border" state="0">
-			<bounds x="214" y="99" width="162" height="162">
-			</bounds>
+			<bounds x="214" y="99" width="162" height="162"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1" state="0">
-			<bounds x="216" y="101" width="158" height="158">
-			</bounds>
+			<bounds x="216" y="101" width="158" height="158"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="290" y="544" width="46" height="26">
-			</bounds>
+			<bounds x="290" y="544" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="292" y="546" width="42" height="22">
-			</bounds>
+			<bounds x="292" y="546" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="336" y="362" width="46" height="26">
-			</bounds>
+			<bounds x="336" y="362" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="338" y="364" width="42" height="22">
-			</bounds>
+			<bounds x="338" y="364" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="336" y="544" width="46" height="26">
-			</bounds>
+			<bounds x="336" y="544" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="338" y="546" width="42" height="22">
-			</bounds>
+			<bounds x="338" y="546" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="336" y="518" width="46" height="26">
-			</bounds>
+			<bounds x="336" y="518" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="338" y="520" width="42" height="22">
-			</bounds>
+			<bounds x="338" y="520" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="336" y="492" width="46" height="26">
-			</bounds>
+			<bounds x="336" y="492" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="338" y="494" width="42" height="22">
-			</bounds>
+			<bounds x="338" y="494" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="336" y="466" width="46" height="26">
-			</bounds>
+			<bounds x="336" y="466" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="338" y="468" width="42" height="22">
-			</bounds>
+			<bounds x="338" y="468" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="336" y="440" width="46" height="26">
-			</bounds>
+			<bounds x="336" y="440" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="338" y="442" width="42" height="22">
-			</bounds>
+			<bounds x="338" y="442" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="336" y="414" width="46" height="26">
-			</bounds>
+			<bounds x="336" y="414" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="338" y="416" width="42" height="22">
-			</bounds>
+			<bounds x="338" y="416" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="336" y="388" width="46" height="26">
-			</bounds>
+			<bounds x="336" y="388" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="338" y="390" width="42" height="22">
-			</bounds>
+			<bounds x="338" y="390" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_2_border" state="0">
-			<bounds x="381" y="362" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="362" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_2" state="0">
-			<bounds x="383" y="364" width="22" height="22">
-			</bounds>
+			<bounds x="383" y="364" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_2_border" state="0">
-			<bounds x="381" y="388" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="388" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_2" state="0">
-			<bounds x="383" y="390" width="22" height="22">
-			</bounds>
+			<bounds x="383" y="390" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_2_border" state="0">
-			<bounds x="381" y="414" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="414" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_2" state="0">
-			<bounds x="383" y="416" width="22" height="22">
-			</bounds>
+			<bounds x="383" y="416" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_2_border" state="0">
-			<bounds x="381" y="440" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="440" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_2" state="0">
-			<bounds x="383" y="442" width="22" height="22">
-			</bounds>
+			<bounds x="383" y="442" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2_border" state="0">
-			<bounds x="381" y="466" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="466" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_2" state="0">
-			<bounds x="383" y="468" width="22" height="22">
-			</bounds>
+			<bounds x="383" y="468" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2_border" state="0">
-			<bounds x="381" y="492" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="492" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_2" state="0">
-			<bounds x="383" y="494" width="22" height="22">
-			</bounds>
+			<bounds x="383" y="494" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2_border" state="0">
-			<bounds x="381" y="518" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="518" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_2" state="0">
-			<bounds x="383" y="520" width="22" height="22">
-			</bounds>
+			<bounds x="383" y="520" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_2_border" state="0">
-			<bounds x="381" y="544" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="544" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_2" state="0">
-			<bounds x="383" y="546" width="22" height="22">
-			</bounds>
+			<bounds x="383" y="546" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_288_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="675" y="1" width="46" height="36">
-			</bounds>
+			<bounds x="675" y="1" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_288" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="677" y="3" width="42" height="32">
-			</bounds>
+			<bounds x="677" y="3" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_352_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="419" y="825" width="75" height="27">
-			</bounds>
+			<bounds x="419" y="825" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_352" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="421" y="827" width="71" height="23">
-			</bounds>
+			<bounds x="421" y="827" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_353_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="498" y="825" width="75" height="27">
-			</bounds>
+			<bounds x="498" y="825" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_353" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="500" y="827" width="71" height="23">
-			</bounds>
+			<bounds x="500" y="827" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_354_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="578" y="825" width="75" height="27">
-			</bounds>
+			<bounds x="578" y="825" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_354" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="580" y="827" width="71" height="23">
-			</bounds>
+			<bounds x="580" y="827" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_355_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="335" y="825" width="75" height="27">
-			</bounds>
+			<bounds x="335" y="825" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_355" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="337" y="827" width="71" height="23">
-			</bounds>
+			<bounds x="337" y="827" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_356_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="248" y="825" width="75" height="27">
-			</bounds>
+			<bounds x="248" y="825" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_356" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="250" y="827" width="71" height="23">
-			</bounds>
+			<bounds x="250" y="827" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_357_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="166" y="825" width="75" height="27">
-			</bounds>
+			<bounds x="166" y="825" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_357" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="168" y="827" width="71" height="23">
-			</bounds>
+			<bounds x="168" y="827" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_358_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="59" y="825" width="75" height="27">
-			</bounds>
+			<bounds x="59" y="825" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_358" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="61" y="827" width="71" height="23">
-			</bounds>
+			<bounds x="61" y="827" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="438" y="490" width="272" height="30">
-			</bounds>
+			<bounds x="438" y="490" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="438" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="438" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="455" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="455" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="472" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="472" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="489" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="489" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="506" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="506" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="523" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="523" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="540" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="540" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="557" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="557" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="574" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="574" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="591" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="591" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="608" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="608" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="625" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="625" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="642" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="642" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="659" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="659" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="676" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="676" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="693" y="490" width="17" height="30">
-			</bounds>
+			<bounds x="693" y="490" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label203" element="label_203">
-			<bounds x="221" y="758" width="193" height="32">
-			</bounds>
+			<bounds x="221" y="758" width="193" height="32"/>
 		</backdrop>
 		<backdrop name="label287" element="label_287">
-			<bounds x="138" y="676" width="29" height="26">
-			</bounds>
+			<bounds x="138" y="676" width="29" height="26"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="312.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="312.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="315.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="315.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="318.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="318.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="322.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="322.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="325.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="325.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="328.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="328.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="392.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="392.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="395.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="395.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="398.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="398.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="402.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="402.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="405.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="405.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="408.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="408.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="472.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="472.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="475.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="475.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="478.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="478.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="482.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="482.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="485.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="485.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="488.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="488.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel6" element="debug_stepper_value">
-			<bounds x="1100" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="552" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_5">
-			<bounds x="1180" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="552" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2copcl7.lay
+++ b/src/mame/layout/sc2copcl7.lay
@@ -8,11898 +8,7502 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Press Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="For Winning Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Press Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="For Winning Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="VIC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="VIC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BERT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BERT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Wrongful">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Arrest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Wrongful">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Arrest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fine - End">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Of Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fine - End">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Of Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Case">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dismiss">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Case">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dismiss">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Chain">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gang">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Chain">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Gang">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Packed To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Parkhurst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Packed To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Parkhurst">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Sent To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="The Scrubs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Sent To">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="The Scrubs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Key">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Key">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Key">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Key">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Key">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Key">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hidden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hidden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="POLICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="DOOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="DOOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Handed">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Handed">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="I.D.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Parade">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="I.D.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Parade">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hidden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hidden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3 Swags">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 Swags">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4 Swags">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Millionaires">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Row">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 Swags">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Millionaires">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Row">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now !">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now !">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string=" START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_170_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_170">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD    HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_171_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_171">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD    LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_172_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_172">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_173_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_173">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_174_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_174">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_175_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_175">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
+	</element>
+	<element name="dmd_background">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_5">
 		<text string="Reserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_10">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_11">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_21">
 		<text string="I.D.PARADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_28">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_29">
 		<text string="1 - 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_70">
 		<text string="Police">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_89">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_97">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_99">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_100">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_101">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_102">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_113">
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_122">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_134">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_135">
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="646">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="646"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="231" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="231" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="231.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="231.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="234.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="234.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="237.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="237.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="241.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="241.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="244.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="244.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="247.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="247.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="231.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="231.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="234.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="234.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="237.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="237.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="241.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="241.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="244.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="244.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="247.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="247.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="231.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="231.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="234.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="234.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="237.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="237.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="241.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="241.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="244.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="244.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="247.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="247.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="231" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="231" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="313" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="313" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="313.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="316.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="319.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="323.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="326.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="329.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="313.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="316.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="319.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="323.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="326.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="329.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="313.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="313.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="316.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="316.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="319.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="319.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="323.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="323.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="326.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="326.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="329.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="329.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="313" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="313" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="395" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="395" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="395.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="395.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="398.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="398.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="401.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="401.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="405.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="405.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="408.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="408.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="411.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="411.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="395.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="395.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="398.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="398.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="401.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="401.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="405.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="405.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="408.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="408.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="411.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="411.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="395.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="395.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="398.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="398.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="401.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="401.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="405.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="405.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="408.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="408.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="411.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="411.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="395" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="395" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="477" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="477" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="477.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="477.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="480.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="480.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="483.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="483.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="487.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="487.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="490.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="490.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="493.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="493.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="477.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="477.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="480.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="480.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="483.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="483.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="487.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="487.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="490.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="490.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="493.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="493.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="477.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="477.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="480.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="480.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="483.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="483.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="487.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="487.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="490.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="490.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="493.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="493.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="477" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="477" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="262" y="195" width="70" height="70">
-			</bounds>
+			<bounds x="262" y="195" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_0" state="0">
-			<bounds x="262.0000" y="195.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="262.0000" y="195.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_1" state="0">
-			<bounds x="264.9167" y="197.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="264.9167" y="197.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_2" state="0">
-			<bounds x="267.8333" y="200.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="267.8333" y="200.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_3" state="0">
-			<bounds x="270.7500" y="203.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="270.7500" y="203.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_4" state="0">
-			<bounds x="273.6667" y="206.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="273.6667" y="206.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_5" state="0">
-			<bounds x="276.5833" y="209.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="276.5833" y="209.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="262" y="195" width="70" height="70">
-			</bounds>
+			<bounds x="262" y="195" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="327" y="356" width="132" height="47">
-			</bounds>
+			<bounds x="327" y="356" width="132" height="47"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="329" y="358" width="128" height="43">
-			</bounds>
+			<bounds x="329" y="358" width="128" height="43"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="599" y="200" width="62" height="32">
-			</bounds>
+			<bounds x="599" y="200" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="601" y="202" width="58" height="28">
-			</bounds>
+			<bounds x="601" y="202" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="661" y="200" width="62" height="32">
-			</bounds>
+			<bounds x="661" y="200" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="663" y="202" width="58" height="28">
-			</bounds>
+			<bounds x="663" y="202" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="723" y="200" width="62" height="32">
-			</bounds>
+			<bounds x="723" y="200" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="725" y="202" width="58" height="28">
-			</bounds>
+			<bounds x="725" y="202" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="693" y="282" width="76" height="32">
-			</bounds>
+			<bounds x="693" y="282" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="695" y="284" width="72" height="28">
-			</bounds>
+			<bounds x="695" y="284" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="693" y="314" width="76" height="32">
-			</bounds>
+			<bounds x="693" y="314" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="695" y="316" width="72" height="28">
-			</bounds>
+			<bounds x="695" y="316" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="693" y="346" width="76" height="32">
-			</bounds>
+			<bounds x="693" y="346" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="695" y="348" width="72" height="28">
-			</bounds>
+			<bounds x="695" y="348" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="617" y="282" width="76" height="32">
-			</bounds>
+			<bounds x="617" y="282" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="619" y="284" width="72" height="28">
-			</bounds>
+			<bounds x="619" y="284" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="617" y="314" width="76" height="32">
-			</bounds>
+			<bounds x="617" y="314" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="619" y="316" width="72" height="28">
-			</bounds>
+			<bounds x="619" y="316" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="617" y="346" width="76" height="32">
-			</bounds>
+			<bounds x="617" y="346" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="619" y="348" width="72" height="28">
-			</bounds>
+			<bounds x="619" y="348" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="407" y="195" width="34" height="22">
-			</bounds>
+			<bounds x="407" y="195" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="409" y="197" width="30" height="18">
-			</bounds>
+			<bounds x="409" y="197" width="30" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="407" y="218" width="34" height="22">
-			</bounds>
+			<bounds x="407" y="218" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="409" y="220" width="30" height="18">
-			</bounds>
+			<bounds x="409" y="220" width="30" height="18"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="407" y="241" width="34" height="22">
-			</bounds>
+			<bounds x="407" y="241" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="409" y="243" width="30" height="18">
-			</bounds>
+			<bounds x="409" y="243" width="30" height="18"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="396" y="271" width="56" height="28">
-			</bounds>
+			<bounds x="396" y="271" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="398" y="273" width="52" height="24">
-			</bounds>
+			<bounds x="398" y="273" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="452" y="159" width="56" height="28">
-			</bounds>
+			<bounds x="452" y="159" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="454" y="161" width="52" height="24">
-			</bounds>
+			<bounds x="454" y="161" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="452" y="187" width="56" height="28">
-			</bounds>
+			<bounds x="452" y="187" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="454" y="189" width="52" height="24">
-			</bounds>
+			<bounds x="454" y="189" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="452" y="215" width="56" height="28">
-			</bounds>
+			<bounds x="452" y="215" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="454" y="217" width="52" height="24">
-			</bounds>
+			<bounds x="454" y="217" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="452" y="243" width="56" height="28">
-			</bounds>
+			<bounds x="452" y="243" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="454" y="245" width="52" height="24">
-			</bounds>
+			<bounds x="454" y="245" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="452" y="271" width="56" height="28">
-			</bounds>
+			<bounds x="452" y="271" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="454" y="273" width="52" height="24">
-			</bounds>
+			<bounds x="454" y="273" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="396" y="159" width="56" height="28">
-			</bounds>
+			<bounds x="396" y="159" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="398" y="161" width="52" height="24">
-			</bounds>
+			<bounds x="398" y="161" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="340" y="187" width="56" height="28">
-			</bounds>
+			<bounds x="340" y="187" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="342" y="189" width="52" height="24">
-			</bounds>
+			<bounds x="342" y="189" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="340" y="159" width="56" height="28">
-			</bounds>
+			<bounds x="340" y="159" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="342" y="161" width="52" height="24">
-			</bounds>
+			<bounds x="342" y="161" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="340" y="215" width="56" height="28">
-			</bounds>
+			<bounds x="340" y="215" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="342" y="217" width="52" height="24">
-			</bounds>
+			<bounds x="342" y="217" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="340" y="243" width="56" height="28">
-			</bounds>
+			<bounds x="340" y="243" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="342" y="245" width="52" height="24">
-			</bounds>
+			<bounds x="342" y="245" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="340" y="271" width="56" height="28">
-			</bounds>
+			<bounds x="340" y="271" width="56" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="342" y="273" width="52" height="24">
-			</bounds>
+			<bounds x="342" y="273" width="52" height="24"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="509" y="199" width="22" height="62">
-			</bounds>
+			<bounds x="509" y="199" width="22" height="62"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="511" y="201" width="18" height="58">
-			</bounds>
+			<bounds x="511" y="201" width="18" height="58"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="532" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="534" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="476" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="476" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="478" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="478" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="420" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="420" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="422" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="422" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="364" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="364" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="366" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="366" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="308" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="308" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="310" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="310" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="252" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="252" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="254" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="254" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="308" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="308" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="310" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="310" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="252" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="252" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="254" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="254" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="532" y="150" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="150" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="534" y="152" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="152" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="532" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="534" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="476" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="476" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="478" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="478" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="420" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="420" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="422" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="422" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="532" y="182" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="182" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="534" y="184" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="184" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="532" y="214" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="214" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="534" y="216" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="216" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="532" y="246" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="246" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="534" y="248" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="248" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="532" y="278" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="278" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="534" y="280" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="280" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="364" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="364" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="366" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="366" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="196" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="198" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="196" y="150" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="150" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="198" y="152" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="152" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="196" y="182" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="182" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="198" y="184" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="184" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="196" y="214" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="214" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="198" y="216" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="216" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="196" y="246" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="246" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="198" y="248" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="248" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="196" y="278" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="278" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="198" y="280" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="280" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="196" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="198" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="712" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="714" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="658" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="660" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="604" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="606" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="604" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="606" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="658" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="660" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="712" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="714" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="604" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="606" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="658" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="660" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="712" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="714" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="604" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="606" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="658" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="660" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="712" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="714" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="604" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="606" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="658" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="660" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="712" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="714" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="604" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="606" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="658" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="660" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="712" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="714" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="186" y="33" width="72" height="32">
-			</bounds>
+			<bounds x="186" y="33" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="188" y="35" width="68" height="28">
-			</bounds>
+			<bounds x="188" y="35" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="186" y="65" width="72" height="47">
-			</bounds>
+			<bounds x="186" y="65" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="188" y="67" width="68" height="43">
-			</bounds>
+			<bounds x="188" y="67" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="80" y="449" width="52" height="32">
-			</bounds>
+			<bounds x="80" y="449" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="82" y="451" width="48" height="28">
-			</bounds>
+			<bounds x="82" y="451" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_168_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="564" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="564" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_168" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="566" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="566" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_169_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="646" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="646" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_169" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="648" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="648" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_170_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="394" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="394" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_170" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="396" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="396" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_171_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="476" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="476" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_171" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="478" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="478" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_172_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="230" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="230" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_172" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="232" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="232" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_173_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="312" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="312" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_173" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="314" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="314" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_174_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="149" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="149" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_174" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="151" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="151" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_175_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="739" y="585" width="42" height="27">
-			</bounds>
+			<bounds x="739" y="585" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_175" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="741" y="587" width="38" height="23">
-			</bounds>
+			<bounds x="741" y="587" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="717" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="717" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="721" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="738" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="738" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="738" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="738" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="721" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="721" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="721" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="721" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="721" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="721" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="742" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="742" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="721" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="738" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="738" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="738" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="738" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="721" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="721" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="721" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="721" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="721" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="721" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="742" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="742" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="687" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="687" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="691" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="708" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="708" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="691" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="691" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="691" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="691" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="712" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="712" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="691" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="708" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="708" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="691" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="691" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="691" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="691" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="712" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="712" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="747" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="747" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="751" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="768" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="768" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="768" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="768" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="751" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="751" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="751" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="751" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="751" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="751" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="772" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="772" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="751" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="768" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="768" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="768" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="768" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="751" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="751" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="751" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="751" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="751" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="751" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="772" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="772" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="657" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="657" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="661" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="678" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="678" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="661" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="661" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="661" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="661" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="682" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="661" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="678" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="678" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="661" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="661" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="661" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="661" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="682" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="717" y="101" width="30" height="40">
-			</bounds>
+			<bounds x="717" y="101" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="721" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="738" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="738" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="738" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="738" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="721" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="721" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="721" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="721" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="721" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_off">
-			<bounds x="721" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_dot_off">
-			<bounds x="742" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="742" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="721" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="738" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="738" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="738" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="738" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="721" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="721" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="721" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="721" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="721" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_on">
-			<bounds x="721" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="721" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_dot_on">
-			<bounds x="742" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="742" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="687" y="101" width="30" height="40">
-			</bounds>
+			<bounds x="687" y="101" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="691" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="708" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="708" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="691" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="691" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="691" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="691" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="712" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="712" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="691" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="708" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="708" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="691" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="691" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="691" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="691" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="712" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="712" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="747" y="101" width="30" height="40">
-			</bounds>
+			<bounds x="747" y="101" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="751" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="768" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="768" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="768" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="768" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="751" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="751" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="751" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="751" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="751" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off127" element="led_off">
-			<bounds x="751" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off120" element="led_dot_off">
-			<bounds x="772" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="772" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="751" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="768" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="768" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="768" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="768" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="751" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="751" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="751" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="751" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="751" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp127" element="led_on">
-			<bounds x="751" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="751" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp120" element="led_dot_on">
-			<bounds x="772" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="772" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="657" y="101" width="30" height="40">
-			</bounds>
+			<bounds x="657" y="101" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="661" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="678" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="678" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="661" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="661" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="661" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="661" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="682" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="661" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="678" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="678" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="661" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="661" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="661" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="661" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="682" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="133" width="4" height="3"/>
 		</backdrop>
-
-	<!-- The DMD -->
-	<screen index="0">
-	  <bounds left="261" top="29" right="523" bottom="115" />
-	</screen>
-
+		<backdrop element="dmd_background">
+			<bounds x="261" y="29" width="262" height="86"/>
+		</backdrop>
+		<screen index="0">
+			<bounds left="261" top="29" right="523" bottom="115"/>
+		</screen>
+		<screen index="0">
+			<bounds left="261" top="29" right="523" bottom="115"/>
+		</screen>
+		<screen index="0">
+			<bounds left="261" top="29" right="523" bottom="115"/>
+		</screen>
 		<backdrop name="label5" element="label_5">
-			<bounds x="668" y="5" width="84" height="24">
-			</bounds>
+			<bounds x="668" y="5" width="84" height="24"/>
 		</backdrop>
 		<backdrop name="label10" element="label_10">
-			<bounds x="619" y="11" width="38" height="67">
-			</bounds>
+			<bounds x="619" y="11" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="619" y="85" width="38" height="67">
-			</bounds>
+			<bounds x="619" y="85" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="662" y="79" width="101" height="24">
-			</bounds>
+			<bounds x="662" y="79" width="101" height="24"/>
 		</backdrop>
 		<backdrop name="label21" element="label_21">
-			<bounds x="635" y="177" width="107" height="22">
-			</bounds>
+			<bounds x="635" y="177" width="107" height="22"/>
 		</backdrop>
 		<backdrop name="label28" element="label_28">
-			<bounds x="559" y="495" width="25" height="26">
-			</bounds>
+			<bounds x="559" y="495" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label29" element="label_29">
-			<bounds x="278" y="173" width="38" height="22">
-			</bounds>
+			<bounds x="278" y="173" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="label70" element="label_70">
-			<bounds x="655" y="258" width="57" height="22">
-			</bounds>
+			<bounds x="655" y="258" width="57" height="22"/>
 		</backdrop>
 		<backdrop name="label89" element="label_89">
-			<bounds x="204" y="495" width="25" height="26">
-			</bounds>
+			<bounds x="204" y="495" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="109" y="197" width="33" height="22">
-			</bounds>
+			<bounds x="109" y="197" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="109" y="385" width="22" height="22">
-			</bounds>
+			<bounds x="109" y="385" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label99" element="label_99">
-			<bounds x="109" y="360" width="40" height="19">
-			</bounds>
+			<bounds x="109" y="360" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label100" element="label_100">
-			<bounds x="109" y="331" width="22" height="22">
-			</bounds>
+			<bounds x="109" y="331" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label101" element="label_101">
-			<bounds x="109" y="304" width="22" height="22">
-			</bounds>
+			<bounds x="109" y="304" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label102" element="label_102">
-			<bounds x="109" y="277" width="22" height="22">
-			</bounds>
+			<bounds x="109" y="277" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="109" y="251" width="22" height="22">
-			</bounds>
+			<bounds x="109" y="251" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label122" element="label_122">
-			<bounds x="109" y="224" width="33" height="22">
-			</bounds>
+			<bounds x="109" y="224" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="122" y="88" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="88" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="122" y="9" width="44" height="22">
-			</bounds>
+			<bounds x="122" y="9" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="122" y="35" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="35" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="122" y="62" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="62" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="122" y="114" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="114" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label134" element="label_134">
-			<bounds x="122" y="143" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="143" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label135" element="label_135">
-			<bounds x="122" y="169" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="169" width="33" height="22"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
+		<screen index="0">
+			<bounds left="1400" top="400" right="1790" bottom="526"/>
+		</screen>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2cpe.lay
+++ b/src/mame/layout/sc2cpe.lay
@@ -8,11922 +8,7495 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VIOLIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VIOLIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hidden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hidden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="STATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINEUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="STATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINEUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VIOLIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VIOLIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Press Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="For Winning Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Press Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="For Winning Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VIOLIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VIOLIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hidden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hidden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="STATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINEUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="STATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINEUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VIOLIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VIOLIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Violin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Violin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Violin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Violin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Violin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Violin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Violin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Violin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Alcatraz">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Alcatraz">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Chain">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gang">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Chain">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Gang">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="State">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="State">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Pen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Getaway">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Car">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Getaway">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Car">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Scarper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="And Exit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Scarper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="And Exit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Wrongful">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Arrest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Wrongful">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Arrest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Gappy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Malone">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Gappy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Malone">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Public Enemy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Number 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Public Enemy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Number 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="John">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cornett">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="John">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cornett">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4 Stars For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Protection">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Racket">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 Stars For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Protection">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Racket">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3 Stars For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 Stars For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now !">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now !">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_132_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_132">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_133_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_133">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string=" START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD    HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD    LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
+	</element>
+	<element name="dmd_background">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_51">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_69">
 		<text string="Reserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_70">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_71">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="1 - 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_79">
 		<text string="STATE LINE-UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_83">
 		<text string="Shoot Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_91">
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_92">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_93">
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_94">
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_95">
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_96">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_97">
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_98">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_99">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_100">
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_101">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_102">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_103">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_104">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_105">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="Protection racket">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="646">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="646"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="236" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="236" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="236.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="239.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="242.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="246.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="249.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="252.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="236.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="239.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="242.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="246.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="249.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="252.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="236.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="239.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="242.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="246.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="249.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="252.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="236" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="236" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="318" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="318" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="318.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="321.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="324.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="328.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="331.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="334.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="318.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="321.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="324.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="328.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="331.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="334.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="318.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="321.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="324.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="328.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="331.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="334.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="318" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="318" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="400" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="400" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="400.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="400.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="403.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="406.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="406.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="410.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="410.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="413.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="413.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="416.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="416.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="400.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="400.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="403.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="406.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="406.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="410.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="410.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="413.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="413.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="416.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="416.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="400.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="400.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="403.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="406.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="406.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="410.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="410.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="413.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="413.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="416.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="416.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="400" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="400" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="482" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="482" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="482.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="482.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="485.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="485.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="488.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="488.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="492.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="492.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="495.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="495.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="498.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="498.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="482.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="482.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="485.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="485.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="488.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="488.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="492.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="492.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="495.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="495.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="498.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="498.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="482.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="482.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="485.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="485.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="488.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="488.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="492.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="492.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="495.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="495.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="498.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="498.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="482" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="482" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="269" y="198" width="70" height="70">
-			</bounds>
+			<bounds x="269" y="198" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="269" y="198" width="70" height="70">
-			</bounds>
+			<bounds x="269" y="198" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="252" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="252" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="254" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="254" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="308" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="308" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="310" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="310" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="364" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="364" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="366" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="366" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="420" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="420" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="422" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="422" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="196" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="198" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="196" y="278" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="278" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="198" y="280" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="280" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="196" y="246" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="246" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="198" y="248" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="248" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="196" y="214" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="214" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="198" y="216" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="216" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="476" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="476" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="478" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="478" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="532" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="534" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="196" y="182" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="182" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="198" y="184" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="184" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="620" y="354" width="132" height="47">
-			</bounds>
+			<bounds x="620" y="354" width="132" height="47"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="622" y="356" width="128" height="43">
-			</bounds>
+			<bounds x="622" y="356" width="128" height="43"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="476" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="476" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="478" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="478" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="420" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="420" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="422" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="422" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="364" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="364" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="366" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="366" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="308" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="308" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="310" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="310" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="252" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="252" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="254" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="254" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="196" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="198" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="196" y="150" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="150" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="198" y="152" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="152" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="532" y="118" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="118" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="534" y="120" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="120" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="532" y="150" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="150" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="534" y="152" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="152" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="532" y="182" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="182" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="534" y="184" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="184" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="532" y="214" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="214" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="534" y="216" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="216" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="532" y="246" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="246" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="534" y="248" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="248" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="532" y="278" width="56" height="32">
-			</bounds>
+			<bounds x="532" y="278" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="534" y="280" width="52" height="28">
-			</bounds>
+			<bounds x="534" y="280" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="604" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="606" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="655" y="310" width="62" height="32">
-			</bounds>
+			<bounds x="655" y="310" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="657" y="312" width="58" height="28">
-			</bounds>
+			<bounds x="657" y="312" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="717" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="719" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="717" y="278" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="278" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="719" y="280" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="280" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="717" y="246" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="246" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="719" y="248" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="248" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="717" y="214" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="214" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="719" y="216" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="216" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="717" y="182" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="182" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="719" y="184" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="184" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="655" y="182" width="62" height="32">
-			</bounds>
+			<bounds x="655" y="182" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="657" y="184" width="58" height="28">
-			</bounds>
+			<bounds x="657" y="184" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="599" y="182" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="182" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="601" y="184" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="184" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="599" y="214" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="214" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="601" y="216" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="216" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="599" y="246" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="246" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="601" y="248" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="248" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="599" y="278" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="278" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="601" y="280" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="280" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="599" y="310" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="310" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="601" y="312" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="312" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="660" y="284" width="52" height="22">
-			</bounds>
+			<bounds x="660" y="284" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="662" y="286" width="48" height="18">
-			</bounds>
+			<bounds x="662" y="286" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="660" y="262" width="52" height="22">
-			</bounds>
+			<bounds x="660" y="262" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="662" y="264" width="48" height="18">
-			</bounds>
+			<bounds x="662" y="264" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="660" y="240" width="52" height="22">
-			</bounds>
+			<bounds x="660" y="240" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="662" y="242" width="48" height="18">
-			</bounds>
+			<bounds x="662" y="242" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="660" y="218" width="52" height="22">
-			</bounds>
+			<bounds x="660" y="218" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="662" y="220" width="48" height="18">
-			</bounds>
+			<bounds x="662" y="220" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="658" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="660" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="712" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="714" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="604" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="606" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="658" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="660" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="712" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="714" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="604" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="606" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="604" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="606" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="604" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="606" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="604" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="606" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="658" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="660" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="658" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="660" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="658" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="660" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="658" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="660" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="712" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="714" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="712" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="714" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="712" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="714" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="712" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="714" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="437" y="182" width="76" height="32">
-			</bounds>
+			<bounds x="437" y="182" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="439" y="184" width="72" height="28">
-			</bounds>
+			<bounds x="439" y="184" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="437" y="214" width="76" height="32">
-			</bounds>
+			<bounds x="437" y="214" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="439" y="216" width="72" height="28">
-			</bounds>
+			<bounds x="439" y="216" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="437" y="246" width="76" height="32">
-			</bounds>
+			<bounds x="437" y="246" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="439" y="248" width="72" height="28">
-			</bounds>
+			<bounds x="439" y="248" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="361" y="246" width="76" height="32">
-			</bounds>
+			<bounds x="361" y="246" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="363" y="248" width="72" height="28">
-			</bounds>
+			<bounds x="363" y="248" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="361" y="214" width="76" height="32">
-			</bounds>
+			<bounds x="361" y="214" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="363" y="216" width="72" height="28">
-			</bounds>
+			<bounds x="363" y="216" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="361" y="182" width="76" height="32">
-			</bounds>
+			<bounds x="361" y="182" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="363" y="184" width="72" height="28">
-			</bounds>
+			<bounds x="363" y="184" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="443" y="369" width="88" height="32">
-			</bounds>
+			<bounds x="443" y="369" width="88" height="32"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="445" y="371" width="84" height="28">
-			</bounds>
+			<bounds x="445" y="371" width="84" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="355" y="369" width="88" height="32">
-			</bounds>
+			<bounds x="355" y="369" width="88" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="357" y="371" width="84" height="28">
-			</bounds>
+			<bounds x="357" y="371" width="84" height="28"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="267" y="369" width="88" height="32">
-			</bounds>
+			<bounds x="267" y="369" width="88" height="32"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="269" y="371" width="84" height="28">
-			</bounds>
+			<bounds x="269" y="371" width="84" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="186" y="64" width="72" height="47">
-			</bounds>
+			<bounds x="186" y="64" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="188" y="66" width="68" height="43">
-			</bounds>
+			<bounds x="188" y="66" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="186" y="32" width="72" height="32">
-			</bounds>
+			<bounds x="186" y="32" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="188" y="34" width="68" height="28">
-			</bounds>
+			<bounds x="188" y="34" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="141" y="370" width="52" height="32">
-			</bounds>
+			<bounds x="141" y="370" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="143" y="372" width="48" height="28">
-			</bounds>
+			<bounds x="143" y="372" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_132_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="744" y="595" width="42" height="27">
-			</bounds>
+			<bounds x="744" y="595" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_132" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="746" y="597" width="38" height="23">
-			</bounds>
+			<bounds x="746" y="597" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_133_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="654" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="654" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_133" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="656" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="656" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_134_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="571" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="571" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_134" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="573" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="573" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_136_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="152" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="152" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_136" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="154" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="154" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_137_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="235" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="235" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_137" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="237" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="237" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_138_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="317" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="317" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_138" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="319" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="319" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_139_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="399" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="399" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_139" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="401" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="401" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_140_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="481" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="481" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_140" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="483" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="483" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="657" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="657" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="661" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="678" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="678" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="661" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="661" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="661" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="661" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="682" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="661" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="678" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="678" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="661" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="661" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="661" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="661" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="682" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="687" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="687" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="691" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="708" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="708" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="691" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="691" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="691" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="691" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="712" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="712" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="691" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="708" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="708" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="691" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="691" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="691" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="691" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="712" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="712" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="716" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="716" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="720" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="737" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="737" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="720" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="720" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="720" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="720" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="741" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="741" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="720" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="737" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="737" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="720" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="720" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="720" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="720" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="741" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="741" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="746" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="746" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="750" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="767" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="767" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="750" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="750" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="750" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="750" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="771" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="771" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="750" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="767" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="767" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="750" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="750" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="750" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="750" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="771" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="771" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="746" y="98" width="30" height="40">
-			</bounds>
+			<bounds x="746" y="98" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="750" y="101" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="101" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="767" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="767" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="750" y="130" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="130" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="750" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="750" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off127" element="led_off">
-			<bounds x="750" y="116" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="116" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off120" element="led_dot_off">
-			<bounds x="771" y="130" width="4" height="3">
-			</bounds>
+			<bounds x="771" y="130" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="750" y="101" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="101" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="767" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="767" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="750" y="130" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="130" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="750" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="750" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp127" element="led_on">
-			<bounds x="750" y="116" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="116" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp120" element="led_dot_on">
-			<bounds x="771" y="130" width="4" height="3">
-			</bounds>
+			<bounds x="771" y="130" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="716" y="98" width="30" height="40">
-			</bounds>
+			<bounds x="716" y="98" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="720" y="101" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="101" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="737" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="737" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="720" y="130" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="130" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="720" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="720" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_off">
-			<bounds x="720" y="116" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="116" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_dot_off">
-			<bounds x="741" y="130" width="4" height="3">
-			</bounds>
+			<bounds x="741" y="130" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="720" y="101" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="101" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="737" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="737" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="720" y="130" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="130" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="720" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="720" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_on">
-			<bounds x="720" y="116" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="116" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_dot_on">
-			<bounds x="741" y="130" width="4" height="3">
-			</bounds>
+			<bounds x="741" y="130" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="686" y="98" width="30" height="40">
-			</bounds>
+			<bounds x="686" y="98" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="690" y="101" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="101" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="707" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="707" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="707" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="707" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="690" y="130" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="130" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="690" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="690" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="690" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="690" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="690" y="116" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="116" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="711" y="130" width="4" height="3">
-			</bounds>
+			<bounds x="711" y="130" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="690" y="101" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="101" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="707" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="707" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="707" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="707" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="690" y="130" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="130" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="690" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="690" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="690" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="690" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="690" y="116" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="116" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="711" y="130" width="4" height="3">
-			</bounds>
+			<bounds x="711" y="130" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="657" y="98" width="30" height="40">
-			</bounds>
+			<bounds x="657" y="98" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="661" y="101" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="101" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="678" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="678" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="661" y="130" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="130" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="661" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="661" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="661" y="116" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="116" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="682" y="130" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="130" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="661" y="101" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="101" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="678" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="678" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="661" y="130" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="130" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="661" y="116" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="116" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="661" y="101" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="101" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="661" y="116" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="116" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="682" y="130" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="130" width="4" height="3"/>
 		</backdrop>
-
-	<!-- The DMD -->
-	<screen index="0">
-	  <bounds left="261" top="29" right="523" bottom="115" />
-	</screen>
-
+		<backdrop element="dmd_background">
+			<bounds x="261" y="29" width="262" height="86"/>
+		</backdrop>
+		<screen index="0">
+			<bounds left="261" top="29" right="523" bottom="115"/>
+		</screen>
+		<screen index="0">
+			<bounds left="261" top="29" right="523" bottom="115"/>
+		</screen>
+		<screen index="0">
+			<bounds left="261" top="29" right="523" bottom="115"/>
+		</screen>
 		<backdrop name="label51" element="label_51">
-			<bounds x="619" y="11" width="38" height="67">
-			</bounds>
+			<bounds x="619" y="11" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label69" element="label_69">
-			<bounds x="667" y="3" width="84" height="24">
-			</bounds>
+			<bounds x="667" y="3" width="84" height="24"/>
 		</backdrop>
 		<backdrop name="label70" element="label_70">
-			<bounds x="209" y="495" width="25" height="26">
-			</bounds>
+			<bounds x="209" y="495" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label71" element="label_71">
-			<bounds x="564" y="495" width="25" height="26">
-			</bounds>
+			<bounds x="564" y="495" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="284" y="176" width="38" height="22">
-			</bounds>
+			<bounds x="284" y="176" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="label79" element="label_79">
-			<bounds x="322" y="348" width="143" height="22">
-			</bounds>
+			<bounds x="322" y="348" width="143" height="22"/>
 		</backdrop>
 		<backdrop name="label83" element="label_83">
-			<bounds x="381" y="161" width="77" height="19">
-			</bounds>
+			<bounds x="381" y="161" width="77" height="19"/>
 		</backdrop>
 		<backdrop name="label91" element="label_91">
-			<bounds x="61" y="9" width="44" height="22">
-			</bounds>
+			<bounds x="61" y="9" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="label92" element="label_92">
-			<bounds x="61" y="36" width="33" height="22">
-			</bounds>
+			<bounds x="61" y="36" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label93" element="label_93">
-			<bounds x="61" y="63" width="33" height="22">
-			</bounds>
+			<bounds x="61" y="63" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label94" element="label_94">
-			<bounds x="61" y="90" width="33" height="22">
-			</bounds>
+			<bounds x="61" y="90" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label95" element="label_95">
-			<bounds x="61" y="116" width="33" height="22">
-			</bounds>
+			<bounds x="61" y="116" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label96" element="label_96">
-			<bounds x="61" y="144" width="33" height="22">
-			</bounds>
+			<bounds x="61" y="144" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="61" y="171" width="33" height="22">
-			</bounds>
+			<bounds x="61" y="171" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label98" element="label_98">
-			<bounds x="61" y="198" width="33" height="22">
-			</bounds>
+			<bounds x="61" y="198" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label99" element="label_99">
-			<bounds x="61" y="225" width="33" height="22">
-			</bounds>
+			<bounds x="61" y="225" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label100" element="label_100">
-			<bounds x="61" y="251" width="22" height="22">
-			</bounds>
+			<bounds x="61" y="251" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label101" element="label_101">
-			<bounds x="61" y="279" width="22" height="22">
-			</bounds>
+			<bounds x="61" y="279" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label102" element="label_102">
-			<bounds x="61" y="306" width="22" height="22">
-			</bounds>
+			<bounds x="61" y="306" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label103" element="label_103">
-			<bounds x="61" y="333" width="22" height="22">
-			</bounds>
+			<bounds x="61" y="333" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label104" element="label_104">
-			<bounds x="61" y="361" width="40" height="19">
-			</bounds>
+			<bounds x="61" y="361" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label105" element="label_105">
-			<bounds x="61" y="387" width="22" height="22">
-			</bounds>
+			<bounds x="61" y="387" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="660" y="74" width="85" height="24">
-			</bounds>
+			<bounds x="660" y="74" width="85" height="24"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="619" y="82" width="38" height="67">
-			</bounds>
+			<bounds x="619" y="82" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="617" y="167" width="95" height="14">
-			</bounds>
+			<bounds x="617" y="167" width="95" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
+		<screen index="0">
+			<bounds left="1400" top="400" right="1790" bottom="526"/>
+		</screen>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2cpg.lay
+++ b/src/mame/layout/sc2cpg.lay
@@ -8,13222 +8,7837 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Press 'Stop' For Winning Spin After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Press 'Stop' For Winning Spin After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Winning Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Winning Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Graphic">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Graphic">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Choose A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Choose A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Stop A Snake">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Stop A Snake">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bounce">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bounce">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Explosi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Explosi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Spin A Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Spin A Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Break The Barcode For A Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Break The Barcode For A Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_269_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_269">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_298_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_298">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_299_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_299">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_300_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_300">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_301_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_301">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_302_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_302">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_303_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_303">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_304_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_304">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_66">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_67">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_174">
 		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_175">
 		<text string="Credits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="727" height="656">
-			</bounds>
+			<bounds x="0" y="0" width="727" height="656"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="40" y="410" width="80" height="140">
-			</bounds>
+			<bounds x="40" y="410" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="40.0000" y="410.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="40.0000" y="410.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="43.3333" y="411.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="43.3333" y="411.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="46.6667" y="413.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="46.6667" y="413.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="50.0000" y="415.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="50.0000" y="415.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="53.3333" y="417.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="53.3333" y="417.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="56.6667" y="419.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="56.6667" y="419.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="40.0000" y="456.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="40.0000" y="456.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="43.3333" y="458.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="43.3333" y="458.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="46.6667" y="460.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="46.6667" y="460.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="50.0000" y="462.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="50.0000" y="462.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="53.3333" y="464.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="53.3333" y="464.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="56.6667" y="466.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="56.6667" y="466.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="40.0000" y="503.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="40.0000" y="503.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="43.3333" y="505.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="43.3333" y="505.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="46.6667" y="507.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="46.6667" y="507.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="50.0000" y="509.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="50.0000" y="509.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="53.3333" y="511.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="53.3333" y="511.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="56.6667" y="513.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="56.6667" y="513.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="40" y="410" width="80" height="140">
-			</bounds>
+			<bounds x="40" y="410" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="125" y="410" width="80" height="140">
-			</bounds>
+			<bounds x="125" y="410" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="125.0000" y="410.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="125.0000" y="410.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="128.3333" y="411.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="128.3333" y="411.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="131.6667" y="413.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="131.6667" y="413.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="135.0000" y="415.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="135.0000" y="415.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="138.3333" y="417.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="138.3333" y="417.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="141.6667" y="419.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="141.6667" y="419.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="125.0000" y="456.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="125.0000" y="456.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="128.3333" y="458.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="128.3333" y="458.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="131.6667" y="460.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="131.6667" y="460.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="135.0000" y="462.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="135.0000" y="462.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="138.3333" y="464.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="138.3333" y="464.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="141.6667" y="466.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="141.6667" y="466.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="125.0000" y="503.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="125.0000" y="503.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="128.3333" y="505.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="128.3333" y="505.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="131.6667" y="507.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="131.6667" y="507.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="135.0000" y="509.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="135.0000" y="509.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="138.3333" y="511.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="138.3333" y="511.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="141.6667" y="513.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="141.6667" y="513.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="125" y="410" width="80" height="140">
-			</bounds>
+			<bounds x="125" y="410" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="208" y="410" width="80" height="140">
-			</bounds>
+			<bounds x="208" y="410" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="208.0000" y="410.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="208.0000" y="410.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="211.3333" y="411.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="211.3333" y="411.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="214.6667" y="413.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="214.6667" y="413.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="218.0000" y="415.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="218.0000" y="415.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="221.3333" y="417.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="221.3333" y="417.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="224.6667" y="419.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="224.6667" y="419.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="208.0000" y="456.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="208.0000" y="456.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="211.3333" y="458.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="211.3333" y="458.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="214.6667" y="460.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="214.6667" y="460.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="218.0000" y="462.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="218.0000" y="462.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="221.3333" y="464.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="221.3333" y="464.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="224.6667" y="466.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="224.6667" y="466.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="208.0000" y="503.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="208.0000" y="503.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="211.3333" y="505.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="211.3333" y="505.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="214.6667" y="507.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="214.6667" y="507.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="218.0000" y="509.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="218.0000" y="509.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="221.3333" y="511.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="221.3333" y="511.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="224.6667" y="513.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="224.6667" y="513.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="208" y="410" width="80" height="140">
-			</bounds>
+			<bounds x="208" y="410" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="295" y="410" width="80" height="140">
-			</bounds>
+			<bounds x="295" y="410" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="295.0000" y="410.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="295.0000" y="410.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="298.3333" y="411.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="298.3333" y="411.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="301.6667" y="413.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="301.6667" y="413.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="305.0000" y="415.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="305.0000" y="415.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="308.3333" y="417.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="308.3333" y="417.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="311.6667" y="419.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="311.6667" y="419.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="295.0000" y="456.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="295.0000" y="456.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="298.3333" y="458.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="298.3333" y="458.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="301.6667" y="460.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="301.6667" y="460.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="305.0000" y="462.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="305.0000" y="462.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="308.3333" y="464.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="308.3333" y="464.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="311.6667" y="466.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="311.6667" y="466.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="295.0000" y="503.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="295.0000" y="503.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="298.3333" y="505.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="298.3333" y="505.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="301.6667" y="507.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="301.6667" y="507.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="305.0000" y="509.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="305.0000" y="509.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="308.3333" y="511.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="308.3333" y="511.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="311.6667" y="513.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="311.6667" y="513.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="295" y="410" width="80" height="140">
-			</bounds>
+			<bounds x="295" y="410" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="155" y="120" width="70" height="70">
-			</bounds>
+			<bounds x="155" y="120" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_0" state="0">
-			<bounds x="155.0000" y="120.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="155.0000" y="120.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_1" state="0">
-			<bounds x="157.9167" y="122.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="157.9167" y="122.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_2" state="0">
-			<bounds x="160.8333" y="125.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="160.8333" y="125.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_3" state="0">
-			<bounds x="163.7500" y="128.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="163.7500" y="128.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_4" state="0">
-			<bounds x="166.6667" y="131.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="166.6667" y="131.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_5" state="0">
-			<bounds x="169.5833" y="134.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="169.5833" y="134.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="155" y="120" width="70" height="70">
-			</bounds>
+			<bounds x="155" y="120" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="409" y="554" width="27" height="22">
-			</bounds>
+			<bounds x="409" y="554" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="411" y="556" width="23" height="18">
-			</bounds>
+			<bounds x="411" y="556" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="49" y="554" width="65" height="45">
-			</bounds>
+			<bounds x="49" y="554" width="65" height="45"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="51" y="556" width="61" height="41">
-			</bounds>
+			<bounds x="51" y="556" width="61" height="41"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="279" y="554" width="85" height="45">
-			</bounds>
+			<bounds x="279" y="554" width="85" height="45"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="281" y="556" width="81" height="41">
-			</bounds>
+			<bounds x="281" y="556" width="81" height="41"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="514" y="564" width="82" height="32">
-			</bounds>
+			<bounds x="514" y="564" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="516" y="566" width="78" height="28">
-			</bounds>
+			<bounds x="516" y="566" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="514" y="389" width="82" height="32">
-			</bounds>
+			<bounds x="514" y="389" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="516" y="391" width="78" height="28">
-			</bounds>
+			<bounds x="516" y="391" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="599" y="389" width="82" height="32">
-			</bounds>
+			<bounds x="599" y="389" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="601" y="391" width="78" height="28">
-			</bounds>
+			<bounds x="601" y="391" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="599" y="424" width="82" height="32">
-			</bounds>
+			<bounds x="599" y="424" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="601" y="426" width="78" height="28">
-			</bounds>
+			<bounds x="601" y="426" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="599" y="459" width="82" height="32">
-			</bounds>
+			<bounds x="599" y="459" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="601" y="461" width="78" height="28">
-			</bounds>
+			<bounds x="601" y="461" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="599" y="494" width="82" height="32">
-			</bounds>
+			<bounds x="599" y="494" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="601" y="496" width="78" height="28">
-			</bounds>
+			<bounds x="601" y="496" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="514" y="424" width="82" height="32">
-			</bounds>
+			<bounds x="514" y="424" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="516" y="426" width="78" height="28">
-			</bounds>
+			<bounds x="516" y="426" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="514" y="494" width="82" height="32">
-			</bounds>
+			<bounds x="514" y="494" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="516" y="496" width="78" height="28">
-			</bounds>
+			<bounds x="516" y="496" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="514" y="529" width="82" height="32">
-			</bounds>
+			<bounds x="514" y="529" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="516" y="531" width="78" height="28">
-			</bounds>
+			<bounds x="516" y="531" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="599" y="564" width="82" height="32">
-			</bounds>
+			<bounds x="599" y="564" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="601" y="566" width="78" height="28">
-			</bounds>
+			<bounds x="601" y="566" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="514" y="459" width="82" height="32">
-			</bounds>
+			<bounds x="514" y="459" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="516" y="461" width="78" height="28">
-			</bounds>
+			<bounds x="516" y="461" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="599" y="529" width="82" height="32">
-			</bounds>
+			<bounds x="599" y="529" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="601" y="531" width="78" height="28">
-			</bounds>
+			<bounds x="601" y="531" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="589" y="164" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="164" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="591" y="166" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="166" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="619" y="164" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="164" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="621" y="166" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="166" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="649" y="164" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="164" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="651" y="166" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="166" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="559" y="184" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="184" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="561" y="186" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="186" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="589" y="184" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="184" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="591" y="186" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="186" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="619" y="184" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="184" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="621" y="186" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="186" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="649" y="184" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="184" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="651" y="186" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="186" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="649" y="204" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="204" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="651" y="206" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="206" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="619" y="204" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="204" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="621" y="206" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="206" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="589" y="204" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="204" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="591" y="206" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="206" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="559" y="204" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="204" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="561" y="206" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="206" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="559" y="224" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="224" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="561" y="226" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="226" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="589" y="224" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="224" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="591" y="226" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="226" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="619" y="224" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="224" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="621" y="226" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="226" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="649" y="224" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="224" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="651" y="226" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="226" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="559" y="244" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="244" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="561" y="246" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="246" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="589" y="244" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="244" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="591" y="246" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="246" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="619" y="244" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="244" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="621" y="246" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="246" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="649" y="244" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="244" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="651" y="246" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="246" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="559" y="264" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="264" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="561" y="266" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="266" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="589" y="264" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="264" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="591" y="266" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="266" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="619" y="264" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="264" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="621" y="266" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="266" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="649" y="264" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="264" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="651" y="266" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="266" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="649" y="304" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="304" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="651" y="306" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="306" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="619" y="304" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="304" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="621" y="306" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="306" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="589" y="304" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="304" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="591" y="306" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="306" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="559" y="304" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="304" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="561" y="306" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="306" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="649" y="284" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="284" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="651" y="286" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="286" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="619" y="284" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="284" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="621" y="286" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="286" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="589" y="284" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="284" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="591" y="286" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="286" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="559" y="284" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="284" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="561" y="286" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="286" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="529" y="244" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="244" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="531" y="246" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="246" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="529" y="144" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="144" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="531" y="146" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="146" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="529" y="164" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="164" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="531" y="166" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="166" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="529" y="184" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="184" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="531" y="186" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="186" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="529" y="224" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="224" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="531" y="226" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="226" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="529" y="204" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="204" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="531" y="206" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="206" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="529" y="124" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="124" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="531" y="126" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="126" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="559" y="124" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="124" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="561" y="126" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="126" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="589" y="124" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="124" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="591" y="126" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="126" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="619" y="124" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="124" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="621" y="126" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="126" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="649" y="124" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="124" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="651" y="126" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="126" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="529" y="264" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="264" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="531" y="266" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="266" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="529" y="284" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="284" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="531" y="286" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="286" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="529" y="304" width="32" height="22">
-			</bounds>
+			<bounds x="529" y="304" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="531" y="306" width="28" height="18">
-			</bounds>
+			<bounds x="531" y="306" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="559" y="164" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="164" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="561" y="166" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="166" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="559" y="144" width="32" height="22">
-			</bounds>
+			<bounds x="559" y="144" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="561" y="146" width="28" height="18">
-			</bounds>
+			<bounds x="561" y="146" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="589" y="144" width="32" height="22">
-			</bounds>
+			<bounds x="589" y="144" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="591" y="146" width="28" height="18">
-			</bounds>
+			<bounds x="591" y="146" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="619" y="144" width="32" height="22">
-			</bounds>
+			<bounds x="619" y="144" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="621" y="146" width="28" height="18">
-			</bounds>
+			<bounds x="621" y="146" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="649" y="144" width="32" height="22">
-			</bounds>
+			<bounds x="649" y="144" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="651" y="146" width="28" height="18">
-			</bounds>
+			<bounds x="651" y="146" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="159" y="194" width="61" height="32">
-			</bounds>
+			<bounds x="159" y="194" width="61" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="161" y="196" width="57" height="28">
-			</bounds>
+			<bounds x="161" y="196" width="57" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="159" y="84" width="61" height="32">
-			</bounds>
+			<bounds x="159" y="84" width="61" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="161" y="86" width="57" height="28">
-			</bounds>
+			<bounds x="161" y="86" width="57" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="159" y="259" width="62" height="32">
-			</bounds>
+			<bounds x="159" y="259" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="161" y="261" width="58" height="28">
-			</bounds>
+			<bounds x="161" y="261" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="424" y="53" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="53" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="426" y="55" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="55" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="424" y="78" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="78" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="426" y="80" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="80" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="424" y="103" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="103" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="426" y="105" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="105" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="424" y="128" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="128" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="426" y="130" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="130" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="424" y="153" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="153" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="426" y="155" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="155" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="424" y="178" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="178" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="426" y="180" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="180" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="424" y="202" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="202" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="426" y="204" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="204" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="424" y="227" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="227" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="426" y="229" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="229" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="424" y="252" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="252" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="426" y="254" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="254" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="424" y="277" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="277" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="426" y="279" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="279" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="424" y="302" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="302" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="426" y="304" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="304" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="424" y="327" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="327" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="426" y="329" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="329" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="424" y="352" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="352" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="426" y="354" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="354" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="424" y="28" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="28" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="426" y="30" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="30" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="424" y="378" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="378" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="426" y="380" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="380" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="424" y="3" width="52" height="22">
-			</bounds>
+			<bounds x="424" y="3" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="426" y="5" width="48" height="18">
-			</bounds>
+			<bounds x="426" y="5" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="479" y="153" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="153" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="481" y="155" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="155" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="479" y="103" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="103" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="481" y="105" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="105" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="479" y="128" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="128" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="481" y="130" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="130" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="479" y="178" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="178" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="481" y="180" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="180" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="479" y="53" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="53" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="481" y="55" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="55" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="479" y="3" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="3" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="481" y="5" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="5" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="479" y="28" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="28" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="481" y="30" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="30" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="479" y="78" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="78" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="481" y="80" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="80" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="479" y="203" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="203" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="481" y="205" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="205" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="479" y="353" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="353" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="481" y="355" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="355" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="479" y="278" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="278" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="481" y="280" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="280" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="479" y="253" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="253" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="481" y="255" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="255" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="479" y="303" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="303" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="481" y="305" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="305" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="479" y="228" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="228" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="481" y="230" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="230" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="479" y="328" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="328" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="481" y="330" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="330" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="479" y="378" width="27" height="22">
-			</bounds>
+			<bounds x="479" y="378" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="481" y="380" width="23" height="18">
-			</bounds>
+			<bounds x="481" y="380" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="339" y="28" width="81" height="22">
-			</bounds>
+			<bounds x="339" y="28" width="81" height="22"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="341" y="30" width="77" height="18">
-			</bounds>
+			<bounds x="341" y="30" width="77" height="18"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="339" y="53" width="81" height="22">
-			</bounds>
+			<bounds x="339" y="53" width="81" height="22"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="341" y="55" width="77" height="18">
-			</bounds>
+			<bounds x="341" y="55" width="77" height="18"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="419" y="529" width="27" height="22">
-			</bounds>
+			<bounds x="419" y="529" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="421" y="531" width="23" height="18">
-			</bounds>
+			<bounds x="421" y="531" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="429" y="504" width="27" height="22">
-			</bounds>
+			<bounds x="429" y="504" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="431" y="506" width="23" height="18">
-			</bounds>
+			<bounds x="431" y="506" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="439" y="479" width="27" height="22">
-			</bounds>
+			<bounds x="439" y="479" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="441" y="481" width="23" height="18">
-			</bounds>
+			<bounds x="441" y="481" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="449" y="454" width="27" height="22">
-			</bounds>
+			<bounds x="449" y="454" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="451" y="456" width="23" height="18">
-			</bounds>
+			<bounds x="451" y="456" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="469" y="404" width="27" height="22">
-			</bounds>
+			<bounds x="469" y="404" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="471" y="406" width="23" height="18">
-			</bounds>
+			<bounds x="471" y="406" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="459" y="429" width="27" height="22">
-			</bounds>
+			<bounds x="459" y="429" width="27" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="461" y="431" width="23" height="18">
-			</bounds>
+			<bounds x="461" y="431" width="23" height="18"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_269_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="669" y="9" width="50" height="16">
-			</bounds>
+			<bounds x="669" y="9" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_269" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="671" y="11" width="46" height="12">
-			</bounds>
+			<bounds x="671" y="11" width="46" height="12"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_298_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="419" y="604" width="82" height="42">
-			</bounds>
+			<bounds x="419" y="604" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_298" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="421" y="606" width="78" height="38">
-			</bounds>
+			<bounds x="421" y="606" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_299_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="519" y="604" width="82" height="42">
-			</bounds>
+			<bounds x="519" y="604" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_299" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="521" y="606" width="78" height="38">
-			</bounds>
+			<bounds x="521" y="606" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_300_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="619" y="604" width="82" height="42">
-			</bounds>
+			<bounds x="619" y="604" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_300" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="621" y="606" width="78" height="38">
-			</bounds>
+			<bounds x="621" y="606" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_301_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="294" y="604" width="82" height="42">
-			</bounds>
+			<bounds x="294" y="604" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_301" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="296" y="606" width="78" height="38">
-			</bounds>
+			<bounds x="296" y="606" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_302_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="209" y="604" width="82" height="42">
-			</bounds>
+			<bounds x="209" y="604" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_302" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="211" y="606" width="78" height="38">
-			</bounds>
+			<bounds x="211" y="606" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_303_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="124" y="604" width="82" height="42">
-			</bounds>
+			<bounds x="124" y="604" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_303" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="126" y="606" width="78" height="38">
-			</bounds>
+			<bounds x="126" y="606" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_304_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="39" y="604" width="82" height="42">
-			</bounds>
+			<bounds x="39" y="604" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_304" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="41" y="606" width="78" height="38">
-			</bounds>
+			<bounds x="41" y="606" width="78" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="70" y="370" width="272" height="30">
-			</bounds>
+			<bounds x="70" y="370" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="70" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="70" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="87" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="87" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="104" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="104" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="121" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="121" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="138" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="138" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="155" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="155" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="172" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="172" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="189" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="189" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="206" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="206" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="223" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="223" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="240" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="240" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="257" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="257" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="274" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="274" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="291" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="291" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="308" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="308" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="325" y="370" width="17" height="30">
-			</bounds>
+			<bounds x="325" y="370" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label66" element="label_66">
-			<bounds x="5" y="465" width="24" height="28">
-			</bounds>
+			<bounds x="5" y="465" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label67" element="label_67">
-			<bounds x="380" y="465" width="24" height="28">
-			</bounds>
+			<bounds x="380" y="465" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label174" element="label_174">
-			<bounds x="75" y="355" width="27" height="14">
-			</bounds>
+			<bounds x="75" y="355" width="27" height="14"/>
 		</backdrop>
 		<backdrop name="label175" element="label_175">
-			<bounds x="285" y="355" width="41" height="14">
-			</bounds>
+			<bounds x="285" y="355" width="41" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2eggs1.lay
+++ b/src/mame/layout/sc2eggs1.lay
@@ -8,12590 +8,7488 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EGGS HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EGGS HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
+			<color red="0.13" green="0.31" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
+			<color red="0.03" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
+			<color red="0.25" green="0.62" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
+			<color red="0.06" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
+			<color red="0.08" green="0.29" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
+			<color red="0.17" green="0.58" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
+			<color red="0.04" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.27" blue="0.50">
-			</color>
+			<color red="0.04" green="0.27" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.07" blue="0.12">
-			</color>
+			<color red="0.01" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.54" blue="1.00">
-			</color>
+			<color red="0.08" green="0.54" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.13" blue="0.25">
-			</color>
+			<color red="0.02" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.27" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.54" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
+			<color red="0.50" green="0.42" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
+			<color red="0.12" green="0.10" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
+			<color red="1.00" green="0.84" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
+			<color red="0.25" green="0.21" blue="0.08"/>
 		</rect>
 		<text string="CELEBRITY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SNATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
-		</rect>
-		<text string="CELEBRITY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SNATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
+			<color red="0.50" green="0.42" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
+			<color red="0.12" green="0.10" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
+			<color red="1.00" green="0.84" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
+			<color red="0.25" green="0.21" blue="0.08"/>
 		</rect>
 		<text string="GET YOUR EGG OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
-		</rect>
-		<text string="GET YOUR EGG OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
+			<color red="0.50" green="0.42" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
+			<color red="0.12" green="0.10" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
+			<color red="1.00" green="0.84" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
+			<color red="0.25" green="0.21" blue="0.08"/>
 		</rect>
 		<text string="WINNING SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
-		</rect>
-		<text string="WINNING SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
+			<color red="0.50" green="0.42" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
+			<color red="0.12" green="0.10" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
+			<color red="1.00" green="0.84" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
+			<color red="0.25" green="0.21" blue="0.08"/>
 		</rect>
 		<text string="RISE AND SHINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
-		</rect>
-		<text string="RISE AND SHINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
+			<color red="0.50" green="0.42" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
+			<color red="0.12" green="0.10" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
+			<color red="1.00" green="0.84" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
+			<color red="0.25" green="0.21" blue="0.08"/>
 		</rect>
 		<text string="EGG ON YOUR FACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.42" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.84" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.21" blue="0.08">
-			</color>
-		</rect>
-		<text string="EGG ON YOUR FACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SOLDIER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SOLDIER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LAID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LAID">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="STAY OR GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAY OR GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
+			<color red="0.08" green="0.29" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
+			<color red="0.17" green="0.58" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
+			<color red="0.04" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
+			<color red="0.13" green="0.31" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
+			<color red="0.03" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
+			<color red="0.25" green="0.62" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
+			<color red="0.06" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
+			<color red="0.08" green="0.29" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
+			<color red="0.02" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
+			<color red="0.17" green="0.58" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
+			<color red="0.04" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.29" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="0.58" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
+			<color red="0.13" green="0.31" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
+			<color red="0.03" green="0.07" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
+			<color red="0.25" green="0.62" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
+			<color red="0.06" green="0.15" blue="0.25"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.31" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.07" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.62" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.15" blue="0.25">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Pants Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pants Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.01">
-			</color>
+			<color red="0.49" green="0.41" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.97" green="0.83" blue="0.03">
-			</color>
+			<color red="0.97" green="0.83" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.00">
-			</color>
+			<color red="0.24" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="PANTS DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.97" green="0.83" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="PANTS DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
+			<color red="0.13" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
+			<color red="0.25" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
+			<color red="0.08" green="0.50" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
+			<color red="0.02" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
+			<color red="0.17" green="1.00" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
+			<color red="0.04" green="0.25" blue="0.04"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
+			<color red="0.04" green="0.50" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
+			<color red="0.01" green="0.12" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
+			<color red="0.08" green="1.00" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
+			<color red="0.02" green="0.25" blue="0.02"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.01">
-			</color>
+			<color red="0.49" green="0.41" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.97" green="0.83" blue="0.03">
-			</color>
+			<color red="0.97" green="0.83" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.00">
-			</color>
+			<color red="0.24" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="COCK A DOODLE DO IT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.97" green="0.83" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="COCK A DOODLE DO IT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="HOUSEY HOUSEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="HOUSEY HOUSEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NEWS EGGSTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="NEWS EGGSTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="What's the Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="What's the Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="What's the Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="What's the Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pants">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pants">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="What's the Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="What's the Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="What's the Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="What's the Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cock A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Doodle Do">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cock A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Doodle Do">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Ready To Rhumba">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Ready To Rhumba">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Prize Is Right">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Prize Is Right">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="What's The Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="What's The Waffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra Eggs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Snap Cackle Pop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Snap Cackle Pop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="News Eggstra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.01">
-			</color>
+			<color red="0.49" green="0.41" blue="0.01"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
+			<color red="0.12" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.97" green="0.83" blue="0.03">
-			</color>
+			<color red="0.97" green="0.83" blue="0.03"/>
 		</rect>
 		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.00">
-			</color>
+			<color red="0.24" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="EGGS ON LEGS TOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.49" green="0.41" blue="0.01">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.97" green="0.83" blue="0.03">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.24" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="EGGS ON LEGS TOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.35" green="0.00" blue="0.00">
-			</color>
+			<color red="0.35" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
+			<color red="0.09" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<disk state="1">
-			<color red="0.69" green="0.00" blue="0.00">
-			</color>
+			<color red="0.69" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.00" blue="0.00">
-			</color>
+			<color red="0.17" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="CL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.35" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.09" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.69" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="CL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
+			<color red="0.08" green="0.50" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
+			<color red="0.02" green="0.12" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
+			<color red="0.17" green="1.00" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
+			<color red="0.04" green="0.25" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="0.50" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.12" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.17" green="1.00" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.25" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
+			<color red="0.04" green="0.50" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
+			<color red="0.01" green="0.12" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
+			<color red="0.08" green="1.00" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
+			<color red="0.02" green="0.25" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.04" green="0.50" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.01" green="0.12" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.08" green="1.00" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.02" green="0.25" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="WHAT'S THE WAFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="WHAT'S THE WAFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
+			<color red="0.16" green="0.50" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
+			<color red="0.04" green="0.12" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
+			<color red="0.33" green="1.00" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
+			<color red="0.08" green="0.25" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.16" green="0.50" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.12" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.33" green="1.00" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.25" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.21" green="0.50" blue="0.21">
-			</color>
+			<color red="0.21" green="0.50" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
+			<color red="0.05" green="0.12" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="1.00" blue="0.42">
-			</color>
+			<color red="0.42" green="1.00" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.10">
-			</color>
+			<color red="0.10" green="0.25" blue="0.10"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.21" green="0.50" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.05" green="0.12" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="1.00" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.25" blue="0.10">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
+			<color red="0.13" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
+			<color red="0.03" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
+			<color red="0.25" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
+			<color red="0.06" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.37" green="0.50" blue="0.37">
-			</color>
+			<color red="0.37" green="0.50" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.09">
-			</color>
+			<color red="0.09" green="0.12" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="1.00" blue="0.75">
-			</color>
+			<color red="0.75" green="1.00" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.25" blue="0.18">
-			</color>
+			<color red="0.18" green="0.25" blue="0.18"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.37" green="0.50" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.12" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="1.00" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.25" blue="0.18">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.50" green="0.37" blue="0.00">
-			</color>
+			<color red="0.50" green="0.37" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.00">
-			</color>
+			<color red="0.12" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="1.00" green="0.75" blue="0.00">
-			</color>
+			<color red="1.00" green="0.75" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.00">
-			</color>
+			<color red="0.25" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="HOUSEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOUSEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_149_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_149">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_152_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_152">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_43">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_44">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_112">
 		<text string="STARTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN STEPP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_117">
 		<text string="Bugs and Trouty v1.0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_118">
 		<text string="Scars">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="746" height="693">
-			</bounds>
+			<bounds x="0" y="0" width="746" height="693"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="102" y="415" width="80" height="140">
-			</bounds>
+			<bounds x="102" y="415" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="415.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="415.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="416.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="416.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="418.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="418.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="420.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="420.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="422.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="422.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="424.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="424.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="461.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="461.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="463.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="463.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="465.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="465.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="467.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="467.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="469.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="469.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="471.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="471.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="102.0000" y="508.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="102.0000" y="508.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="105.3333" y="510.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="105.3333" y="510.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.6667" y="512.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="108.6667" y="512.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.0000" y="514.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="112.0000" y="514.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.3333" y="516.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="115.3333" y="516.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="118.6667" y="518.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="118.6667" y="518.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="102" y="415" width="80" height="140">
-			</bounds>
+			<bounds x="102" y="415" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="232" y="415" width="80" height="140">
-			</bounds>
+			<bounds x="232" y="415" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="232.0000" y="415.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="232.0000" y="415.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="235.3333" y="416.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="235.3333" y="416.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="238.6667" y="418.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="238.6667" y="418.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="242.0000" y="420.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="242.0000" y="420.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="245.3333" y="422.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="245.3333" y="422.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="248.6667" y="424.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="248.6667" y="424.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="232.0000" y="461.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="232.0000" y="461.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="235.3333" y="463.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="235.3333" y="463.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="238.6667" y="465.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="238.6667" y="465.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="242.0000" y="467.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="242.0000" y="467.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="245.3333" y="469.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="245.3333" y="469.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="248.6667" y="471.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="248.6667" y="471.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="232.0000" y="508.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="232.0000" y="508.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="235.3333" y="510.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="235.3333" y="510.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="238.6667" y="512.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="238.6667" y="512.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="242.0000" y="514.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="242.0000" y="514.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="245.3333" y="516.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="245.3333" y="516.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="248.6667" y="518.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="248.6667" y="518.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="232" y="415" width="80" height="140">
-			</bounds>
+			<bounds x="232" y="415" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="362" y="415" width="80" height="140">
-			</bounds>
+			<bounds x="362" y="415" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="362.0000" y="415.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="362.0000" y="415.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="365.3333" y="416.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="365.3333" y="416.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="368.6667" y="418.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="368.6667" y="418.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="372.0000" y="420.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="372.0000" y="420.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="375.3333" y="422.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="375.3333" y="422.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="378.6667" y="424.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="378.6667" y="424.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="362.0000" y="461.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="362.0000" y="461.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="365.3333" y="463.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="365.3333" y="463.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="368.6667" y="465.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="368.6667" y="465.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="372.0000" y="467.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="372.0000" y="467.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="375.3333" y="469.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="375.3333" y="469.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="378.6667" y="471.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="378.6667" y="471.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="362.0000" y="508.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="362.0000" y="508.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="365.3333" y="510.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="365.3333" y="510.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="368.6667" y="512.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="368.6667" y="512.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="372.0000" y="514.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="372.0000" y="514.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="375.3333" y="516.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="375.3333" y="516.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="378.6667" y="518.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="378.6667" y="518.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="362" y="415" width="80" height="140">
-			</bounds>
+			<bounds x="362" y="415" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="348" y="117" width="60" height="50">
-			</bounds>
+			<bounds x="348" y="117" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="348.0000" y="117.0000" width="60.0000" height="50.0000">
-			</bounds>
+			<bounds x="348.0000" y="117.0000" width="60.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="350.5000" y="119.0833" width="55.0000" height="45.8333">
-			</bounds>
+			<bounds x="350.5000" y="119.0833" width="55.0000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="353.0000" y="121.1667" width="50.0000" height="41.6667">
-			</bounds>
+			<bounds x="353.0000" y="121.1667" width="50.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="355.5000" y="123.2500" width="45.0000" height="37.5000">
-			</bounds>
+			<bounds x="355.5000" y="123.2500" width="45.0000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="358.0000" y="125.3333" width="40.0000" height="33.3333">
-			</bounds>
+			<bounds x="358.0000" y="125.3333" width="40.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="360.5000" y="127.4167" width="35.0000" height="29.1667">
-			</bounds>
+			<bounds x="360.5000" y="127.4167" width="35.0000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="348" y="117" width="60" height="50">
-			</bounds>
+			<bounds x="348" y="117" width="60" height="50"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="495" y="520" width="32" height="27">
-			</bounds>
+			<bounds x="495" y="520" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="497" y="522" width="28" height="23">
-			</bounds>
+			<bounds x="497" y="522" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="495" y="494" width="32" height="27">
-			</bounds>
+			<bounds x="495" y="494" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="497" y="496" width="28" height="23">
-			</bounds>
+			<bounds x="497" y="496" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="495" y="468" width="32" height="27">
-			</bounds>
+			<bounds x="495" y="468" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="497" y="470" width="28" height="23">
-			</bounds>
+			<bounds x="497" y="470" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="495" y="442" width="32" height="27">
-			</bounds>
+			<bounds x="495" y="442" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="497" y="444" width="28" height="23">
-			</bounds>
+			<bounds x="497" y="444" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="464" y="442" width="32" height="27">
-			</bounds>
+			<bounds x="464" y="442" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="466" y="444" width="28" height="23">
-			</bounds>
+			<bounds x="466" y="444" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="464" y="468" width="32" height="27">
-			</bounds>
+			<bounds x="464" y="468" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="466" y="470" width="28" height="23">
-			</bounds>
+			<bounds x="466" y="470" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="464" y="520" width="32" height="27">
-			</bounds>
+			<bounds x="464" y="520" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="466" y="522" width="28" height="23">
-			</bounds>
+			<bounds x="466" y="522" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="464" y="494" width="32" height="27">
-			</bounds>
+			<bounds x="464" y="494" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="466" y="496" width="28" height="23">
-			</bounds>
+			<bounds x="466" y="496" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="526" y="442" width="32" height="27">
-			</bounds>
+			<bounds x="526" y="442" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="528" y="444" width="28" height="23">
-			</bounds>
+			<bounds x="528" y="444" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="526" y="468" width="32" height="27">
-			</bounds>
+			<bounds x="526" y="468" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="528" y="470" width="28" height="23">
-			</bounds>
+			<bounds x="528" y="470" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="526" y="494" width="32" height="27">
-			</bounds>
+			<bounds x="526" y="494" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="528" y="496" width="28" height="23">
-			</bounds>
+			<bounds x="528" y="496" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="526" y="520" width="32" height="27">
-			</bounds>
+			<bounds x="526" y="520" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="528" y="522" width="28" height="23">
-			</bounds>
+			<bounds x="528" y="522" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="464" y="423" width="94" height="19">
-			</bounds>
+			<bounds x="464" y="423" width="94" height="19"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="466" y="425" width="90" height="15">
-			</bounds>
+			<bounds x="466" y="425" width="90" height="15"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="34" y="506" width="52" height="32">
-			</bounds>
+			<bounds x="34" y="506" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="36" y="508" width="48" height="28">
-			</bounds>
+			<bounds x="36" y="508" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="34" y="476" width="52" height="32">
-			</bounds>
+			<bounds x="34" y="476" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="36" y="478" width="48" height="28">
-			</bounds>
+			<bounds x="36" y="478" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="34" y="446" width="52" height="32">
-			</bounds>
+			<bounds x="34" y="446" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="36" y="448" width="48" height="28">
-			</bounds>
+			<bounds x="36" y="448" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="34" y="416" width="52" height="32">
-			</bounds>
+			<bounds x="34" y="416" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="36" y="418" width="48" height="28">
-			</bounds>
+			<bounds x="36" y="418" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="34" y="536" width="52" height="16">
-			</bounds>
+			<bounds x="34" y="536" width="52" height="16"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="36" y="538" width="48" height="12">
-			</bounds>
+			<bounds x="36" y="538" width="48" height="12"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="606" y="583" width="122" height="26">
-			</bounds>
+			<bounds x="606" y="583" width="122" height="26"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="608" y="585" width="118" height="22">
-			</bounds>
+			<bounds x="608" y="585" width="118" height="22"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="486" y="583" width="122" height="26">
-			</bounds>
+			<bounds x="486" y="583" width="122" height="26"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="488" y="585" width="118" height="22">
-			</bounds>
+			<bounds x="488" y="585" width="118" height="22"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="366" y="583" width="122" height="26">
-			</bounds>
+			<bounds x="366" y="583" width="122" height="26"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="368" y="585" width="118" height="22">
-			</bounds>
+			<bounds x="368" y="585" width="118" height="22"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="246" y="583" width="122" height="26">
-			</bounds>
+			<bounds x="246" y="583" width="122" height="26"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="248" y="585" width="118" height="22">
-			</bounds>
+			<bounds x="248" y="585" width="118" height="22"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="126" y="583" width="122" height="26">
-			</bounds>
+			<bounds x="126" y="583" width="122" height="26"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="128" y="585" width="118" height="22">
-			</bounds>
+			<bounds x="128" y="585" width="118" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="6" y="583" width="122" height="26">
-			</bounds>
+			<bounds x="6" y="583" width="122" height="26"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="8" y="585" width="118" height="22">
-			</bounds>
+			<bounds x="8" y="585" width="118" height="22"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="646" y="346" width="70" height="32">
-			</bounds>
+			<bounds x="646" y="346" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="648" y="348" width="66" height="28">
-			</bounds>
+			<bounds x="648" y="348" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="646" y="315" width="70" height="32">
-			</bounds>
+			<bounds x="646" y="315" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="648" y="317" width="66" height="28">
-			</bounds>
+			<bounds x="648" y="317" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="577" y="315" width="70" height="32">
-			</bounds>
+			<bounds x="577" y="315" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="579" y="317" width="66" height="28">
-			</bounds>
+			<bounds x="579" y="317" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="508" y="315" width="70" height="32">
-			</bounds>
+			<bounds x="508" y="315" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="510" y="317" width="66" height="28">
-			</bounds>
+			<bounds x="510" y="317" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="508" y="346" width="70" height="32">
-			</bounds>
+			<bounds x="508" y="346" width="70" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="510" y="348" width="66" height="28">
-			</bounds>
+			<bounds x="510" y="348" width="66" height="28"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="651" y="246" width="62" height="32">
-			</bounds>
+			<bounds x="651" y="246" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="653" y="248" width="58" height="28">
-			</bounds>
+			<bounds x="653" y="248" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="590" y="246" width="62" height="32">
-			</bounds>
+			<bounds x="590" y="246" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="592" y="248" width="58" height="28">
-			</bounds>
+			<bounds x="592" y="248" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="651" y="214" width="62" height="32">
-			</bounds>
+			<bounds x="651" y="214" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="653" y="216" width="58" height="28">
-			</bounds>
+			<bounds x="653" y="216" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="590" y="214" width="62" height="32">
-			</bounds>
+			<bounds x="590" y="214" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="592" y="216" width="58" height="28">
-			</bounds>
+			<bounds x="592" y="216" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="650" y="136" width="27" height="27">
-			</bounds>
+			<bounds x="650" y="136" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="652" y="138" width="23" height="23">
-			</bounds>
+			<bounds x="652" y="138" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="634" y="161" width="27" height="27">
-			</bounds>
+			<bounds x="634" y="161" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="636" y="163" width="23" height="23">
-			</bounds>
+			<bounds x="636" y="163" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="681" y="136" width="27" height="27">
-			</bounds>
+			<bounds x="681" y="136" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="683" y="138" width="23" height="23">
-			</bounds>
+			<bounds x="683" y="138" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="697" y="161" width="27" height="27">
-			</bounds>
+			<bounds x="697" y="161" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="699" y="163" width="23" height="23">
-			</bounds>
+			<bounds x="699" y="163" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="660" y="106" width="38" height="32">
-			</bounds>
+			<bounds x="660" y="106" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="662" y="108" width="34" height="28">
-			</bounds>
+			<bounds x="662" y="108" width="34" height="28"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="649" y="69" width="62" height="38">
-			</bounds>
+			<bounds x="649" y="69" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="651" y="71" width="58" height="34">
-			</bounds>
+			<bounds x="651" y="71" width="58" height="34"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="35" y="373" width="32" height="22">
-			</bounds>
+			<bounds x="35" y="373" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="37" y="375" width="28" height="18">
-			</bounds>
+			<bounds x="37" y="375" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="35" y="352" width="32" height="22">
-			</bounds>
+			<bounds x="35" y="352" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="37" y="354" width="28" height="18">
-			</bounds>
+			<bounds x="37" y="354" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="35" y="331" width="32" height="22">
-			</bounds>
+			<bounds x="35" y="331" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="37" y="333" width="28" height="18">
-			</bounds>
+			<bounds x="37" y="333" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="35" y="310" width="32" height="22">
-			</bounds>
+			<bounds x="35" y="310" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="37" y="312" width="28" height="18">
-			</bounds>
+			<bounds x="37" y="312" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="20" y="259" width="62" height="52">
-			</bounds>
+			<bounds x="20" y="259" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="22" y="261" width="58" height="48">
-			</bounds>
+			<bounds x="22" y="261" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="536" y="293" width="152" height="22">
-			</bounds>
+			<bounds x="536" y="293" width="152" height="22"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="538" y="295" width="148" height="18">
-			</bounds>
+			<bounds x="538" y="295" width="148" height="18"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="33" y="609" width="68" height="19">
-			</bounds>
+			<bounds x="33" y="609" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="35" y="611" width="64" height="15">
-			</bounds>
+			<bounds x="35" y="611" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="153" y="609" width="68" height="19">
-			</bounds>
+			<bounds x="153" y="609" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="155" y="611" width="64" height="15">
-			</bounds>
+			<bounds x="155" y="611" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="273" y="609" width="68" height="19">
-			</bounds>
+			<bounds x="273" y="609" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="275" y="611" width="64" height="15">
-			</bounds>
+			<bounds x="275" y="611" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="393" y="609" width="68" height="19">
-			</bounds>
+			<bounds x="393" y="609" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="395" y="611" width="64" height="15">
-			</bounds>
+			<bounds x="395" y="611" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="513" y="609" width="68" height="19">
-			</bounds>
+			<bounds x="513" y="609" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="515" y="611" width="64" height="15">
-			</bounds>
+			<bounds x="515" y="611" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="410" y="126" width="42" height="32">
-			</bounds>
+			<bounds x="410" y="126" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="412" y="128" width="38" height="28">
-			</bounds>
+			<bounds x="412" y="128" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="304" y="126" width="42" height="32">
-			</bounds>
+			<bounds x="304" y="126" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="306" y="128" width="38" height="28">
-			</bounds>
+			<bounds x="306" y="128" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="508" y="225" width="82" height="38">
-			</bounds>
+			<bounds x="508" y="225" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="510" y="227" width="78" height="34">
-			</bounds>
+			<bounds x="510" y="227" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="414" y="344" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="344" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="416" y="346" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="346" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="414" y="374" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="374" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="416" y="376" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="376" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="494" y="68" width="62" height="32">
-			</bounds>
+			<bounds x="494" y="68" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="496" y="70" width="58" height="28">
-			</bounds>
+			<bounds x="496" y="70" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="554" y="68" width="66" height="32">
-			</bounds>
+			<bounds x="554" y="68" width="66" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="556" y="70" width="62" height="28">
-			</bounds>
+			<bounds x="556" y="70" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="414" y="68" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="68" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="416" y="70" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="70" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="334" y="68" width="82" height="32">
-			</bounds>
+			<bounds x="334" y="68" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="336" y="70" width="78" height="28">
-			</bounds>
+			<bounds x="336" y="70" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="14" y="68" width="82" height="32">
-			</bounds>
+			<bounds x="14" y="68" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="16" y="70" width="78" height="28">
-			</bounds>
+			<bounds x="16" y="70" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="94" y="68" width="82" height="32">
-			</bounds>
+			<bounds x="94" y="68" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="96" y="70" width="78" height="28">
-			</bounds>
+			<bounds x="96" y="70" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="174" y="68" width="82" height="32">
-			</bounds>
+			<bounds x="174" y="68" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="176" y="70" width="78" height="28">
-			</bounds>
+			<bounds x="176" y="70" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="254" y="68" width="82" height="32">
-			</bounds>
+			<bounds x="254" y="68" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="256" y="70" width="78" height="28">
-			</bounds>
+			<bounds x="256" y="70" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="554" y="138" width="66" height="42">
-			</bounds>
+			<bounds x="554" y="138" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="556" y="140" width="62" height="38">
-			</bounds>
+			<bounds x="556" y="140" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="554" y="98" width="66" height="42">
-			</bounds>
+			<bounds x="554" y="98" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="556" y="100" width="62" height="38">
-			</bounds>
+			<bounds x="556" y="100" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="334" y="216" width="82" height="32">
-			</bounds>
+			<bounds x="334" y="216" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="336" y="218" width="78" height="28">
-			</bounds>
+			<bounds x="336" y="218" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="254" y="216" width="82" height="32">
-			</bounds>
+			<bounds x="254" y="216" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="256" y="218" width="78" height="28">
-			</bounds>
+			<bounds x="256" y="218" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="174" y="216" width="82" height="32">
-			</bounds>
+			<bounds x="174" y="216" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="176" y="218" width="78" height="28">
-			</bounds>
+			<bounds x="176" y="218" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="94" y="216" width="82" height="32">
-			</bounds>
+			<bounds x="94" y="216" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="96" y="218" width="78" height="28">
-			</bounds>
+			<bounds x="96" y="218" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="14" y="213" width="82" height="32">
-			</bounds>
+			<bounds x="14" y="213" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="16" y="215" width="78" height="28">
-			</bounds>
+			<bounds x="16" y="215" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="414" y="216" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="216" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="416" y="218" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="218" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="414" y="314" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="314" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="416" y="316" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="316" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="334" y="314" width="82" height="32">
-			</bounds>
+			<bounds x="334" y="314" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="336" y="316" width="78" height="28">
-			</bounds>
+			<bounds x="336" y="316" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="254" y="314" width="82" height="32">
-			</bounds>
+			<bounds x="254" y="314" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="256" y="316" width="78" height="28">
-			</bounds>
+			<bounds x="256" y="316" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="174" y="314" width="82" height="32">
-			</bounds>
+			<bounds x="174" y="314" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="176" y="316" width="78" height="28">
-			</bounds>
+			<bounds x="176" y="316" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="94" y="310" width="82" height="32">
-			</bounds>
+			<bounds x="94" y="310" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="96" y="312" width="78" height="28">
-			</bounds>
+			<bounds x="96" y="312" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="94" y="280" width="82" height="32">
-			</bounds>
+			<bounds x="94" y="280" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="96" y="282" width="78" height="28">
-			</bounds>
+			<bounds x="96" y="282" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="174" y="276" width="82" height="32">
-			</bounds>
+			<bounds x="174" y="276" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="176" y="278" width="78" height="28">
-			</bounds>
+			<bounds x="176" y="278" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="254" y="276" width="82" height="32">
-			</bounds>
+			<bounds x="254" y="276" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="256" y="278" width="78" height="28">
-			</bounds>
+			<bounds x="256" y="278" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="334" y="276" width="82" height="32">
-			</bounds>
+			<bounds x="334" y="276" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="336" y="278" width="78" height="28">
-			</bounds>
+			<bounds x="336" y="278" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="414" y="276" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="276" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="416" y="278" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="278" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="414" y="246" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="246" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="416" y="248" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="248" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="494" y="178" width="126" height="32">
-			</bounds>
+			<bounds x="494" y="178" width="126" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="496" y="180" width="122" height="28">
-			</bounds>
+			<bounds x="496" y="180" width="122" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="414" y="178" width="82" height="32">
-			</bounds>
+			<bounds x="414" y="178" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="416" y="180" width="78" height="28">
-			</bounds>
+			<bounds x="416" y="180" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="334" y="178" width="82" height="32">
-			</bounds>
+			<bounds x="334" y="178" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="336" y="180" width="78" height="28">
-			</bounds>
+			<bounds x="336" y="180" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="254" y="178" width="82" height="32">
-			</bounds>
+			<bounds x="254" y="178" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="256" y="180" width="78" height="28">
-			</bounds>
+			<bounds x="256" y="180" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="174" y="178" width="82" height="32">
-			</bounds>
+			<bounds x="174" y="178" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="176" y="180" width="78" height="28">
-			</bounds>
+			<bounds x="176" y="180" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="94" y="178" width="82" height="32">
-			</bounds>
+			<bounds x="94" y="178" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="96" y="180" width="78" height="28">
-			</bounds>
+			<bounds x="96" y="180" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="14" y="182" width="82" height="32">
-			</bounds>
+			<bounds x="14" y="182" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="16" y="184" width="78" height="28">
-			</bounds>
+			<bounds x="16" y="184" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="109" y="7" width="402" height="54">
-			</bounds>
+			<bounds x="109" y="7" width="402" height="54"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="111" y="9" width="398" height="50">
-			</bounds>
+			<bounds x="111" y="9" width="398" height="50"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="587" y="22" width="27" height="27">
-			</bounds>
+			<bounds x="587" y="22" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="589" y="24" width="23" height="23">
-			</bounds>
+			<bounds x="589" y="24" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="96" y="149" width="42" height="27">
-			</bounds>
+			<bounds x="96" y="149" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="98" y="151" width="38" height="23">
-			</bounds>
+			<bounds x="98" y="151" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="96" y="124" width="42" height="27">
-			</bounds>
+			<bounds x="96" y="124" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="98" y="126" width="38" height="23">
-			</bounds>
+			<bounds x="98" y="126" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="56" y="124" width="42" height="27">
-			</bounds>
+			<bounds x="56" y="124" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="58" y="126" width="38" height="23">
-			</bounds>
+			<bounds x="58" y="126" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="16" y="102" width="162" height="22">
-			</bounds>
+			<bounds x="16" y="102" width="162" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="18" y="104" width="158" height="18">
-			</bounds>
+			<bounds x="18" y="104" width="158" height="18"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="16" y="124" width="42" height="27">
-			</bounds>
+			<bounds x="16" y="124" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="18" y="126" width="38" height="23">
-			</bounds>
+			<bounds x="18" y="126" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="16" y="149" width="42" height="27">
-			</bounds>
+			<bounds x="16" y="149" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="18" y="151" width="38" height="23">
-			</bounds>
+			<bounds x="18" y="151" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="56" y="149" width="42" height="27">
-			</bounds>
+			<bounds x="56" y="149" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="58" y="151" width="38" height="23">
-			</bounds>
+			<bounds x="58" y="151" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="136" y="124" width="42" height="27">
-			</bounds>
+			<bounds x="136" y="124" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="138" y="126" width="38" height="23">
-			</bounds>
+			<bounds x="138" y="126" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="136" y="149" width="42" height="27">
-			</bounds>
+			<bounds x="136" y="149" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="138" y="151" width="38" height="23">
-			</bounds>
+			<bounds x="138" y="151" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp87" element="colour_button_147_border" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="577" y="346" width="70" height="42">
-			</bounds>
+			<bounds x="577" y="346" width="70" height="42"/>
 		</backdrop>
 		<backdrop name="lamp87" element="colour_button_147" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="579" y="348" width="66" height="38">
-			</bounds>
+			<bounds x="579" y="348" width="66" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_149_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="649" y="631" width="72" height="42">
-			</bounds>
+			<bounds x="649" y="631" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_149" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="651" y="633" width="68" height="38">
-			</bounds>
+			<bounds x="651" y="633" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_150_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="371" y="631" width="62" height="42">
-			</bounds>
+			<bounds x="371" y="631" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_150" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="373" y="633" width="58" height="38">
-			</bounds>
+			<bounds x="373" y="633" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_151_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="241" y="631" width="62" height="42">
-			</bounds>
+			<bounds x="241" y="631" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_151" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="243" y="633" width="58" height="38">
-			</bounds>
+			<bounds x="243" y="633" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_152_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="111" y="631" width="62" height="42">
-			</bounds>
+			<bounds x="111" y="631" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_152" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="113" y="633" width="58" height="38">
-			</bounds>
+			<bounds x="113" y="633" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_153_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="6" y="631" width="72" height="42">
-			</bounds>
+			<bounds x="6" y="631" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_153" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="8" y="633" width="68" height="38">
-			</bounds>
+			<bounds x="8" y="633" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_154_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="559" y="631" width="72" height="42">
-			</bounds>
+			<bounds x="559" y="631" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_154" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="561" y="633" width="68" height="38">
-			</bounds>
+			<bounds x="561" y="633" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_155_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="469" y="631" width="72" height="42">
-			</bounds>
+			<bounds x="469" y="631" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_155" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="471" y="633" width="68" height="38">
-			</bounds>
+			<bounds x="471" y="633" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_156_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="640" y="2" width="46" height="62">
-			</bounds>
+			<bounds x="640" y="2" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_156" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="642" y="4" width="42" height="58">
-			</bounds>
+			<bounds x="642" y="4" width="42" height="58"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="119" y="367" width="272" height="31">
-			</bounds>
+			<bounds x="119" y="367" width="272" height="31"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="119" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="119" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="136" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="136" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="153" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="153" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="170" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="170" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="187" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="187" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="204" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="204" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="221" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="221" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="238" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="238" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="255" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="255" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="272" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="272" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="289" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="289" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="306" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="306" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="323" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="323" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="340" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="340" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="357" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="357" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="374" y="367" width="17" height="31">
-			</bounds>
+			<bounds x="374" y="367" width="17" height="31"/>
 		</backdrop>
 		<backdrop name="label43" element="label_43">
-			<bounds x="326" y="347" width="51" height="23">
-			</bounds>
+			<bounds x="326" y="347" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="label44" element="label_44">
-			<bounds x="140" y="348" width="45" height="23">
-			</bounds>
+			<bounds x="140" y="348" width="45" height="23"/>
 		</backdrop>
 		<backdrop name="label112" element="label_112">
-			<bounds x="609" y="487" width="74" height="32">
-			</bounds>
+			<bounds x="609" y="487" width="74" height="32"/>
 		</backdrop>
 		<backdrop name="label117" element="label_117">
-			<bounds x="599" y="525" width="100" height="32">
-			</bounds>
+			<bounds x="599" y="525" width="100" height="32"/>
 		</backdrop>
 		<backdrop name="label118" element="label_118">
-			<bounds x="7" y="674" width="33" height="16">
-			</bounds>
+			<bounds x="7" y="674" width="33" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_button" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2heypr.lay
+++ b/src/mame/layout/sc2heypr.lay
@@ -8,8832 +8,6003 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string=".00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string=".00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string=".60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string=".60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string=".40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string=".40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string=".20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string=".20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string=".00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string=".00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PRESTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PRESTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_66_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_66">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_82_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_82">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_84_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_84">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_85_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_85">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_86_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_86">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_87_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_87">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_88_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_88">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_89_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_89">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_41">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_65">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="678">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="678"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="303" y="473" width="80" height="140">
-			</bounds>
+			<bounds x="303" y="473" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="473.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="473.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="474.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="474.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="476.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="476.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="478.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="478.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="480.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="480.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="482.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="482.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="519.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="519.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="521.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="521.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="523.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="523.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="525.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="525.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="527.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="527.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="529.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="529.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="566.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="566.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="568.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="568.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="570.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="570.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="572.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="572.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="574.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="574.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="576.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="576.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="303" y="473" width="80" height="140">
-			</bounds>
+			<bounds x="303" y="473" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="385" y="473" width="80" height="140">
-			</bounds>
+			<bounds x="385" y="473" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="385.0000" y="473.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="385.0000" y="473.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="388.3333" y="474.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="388.3333" y="474.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="391.6667" y="476.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="391.6667" y="476.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="395.0000" y="478.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="395.0000" y="478.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="398.3333" y="480.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="398.3333" y="480.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="401.6667" y="482.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="401.6667" y="482.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="385.0000" y="519.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="385.0000" y="519.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="388.3333" y="521.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="388.3333" y="521.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="391.6667" y="523.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="391.6667" y="523.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="395.0000" y="525.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="395.0000" y="525.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="398.3333" y="527.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="398.3333" y="527.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="401.6667" y="529.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="401.6667" y="529.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="385.0000" y="566.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="385.0000" y="566.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="388.3333" y="568.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="388.3333" y="568.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="391.6667" y="570.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="391.6667" y="570.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="395.0000" y="572.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="395.0000" y="572.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="398.3333" y="574.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="398.3333" y="574.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="401.6667" y="576.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="401.6667" y="576.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="385" y="473" width="80" height="140">
-			</bounds>
+			<bounds x="385" y="473" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="467" y="473" width="80" height="140">
-			</bounds>
+			<bounds x="467" y="473" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="467.0000" y="473.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="467.0000" y="473.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="470.3333" y="474.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="470.3333" y="474.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="473.6667" y="476.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="473.6667" y="476.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="477.0000" y="478.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="477.0000" y="478.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="480.3333" y="480.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="480.3333" y="480.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="483.6667" y="482.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="483.6667" y="482.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="467.0000" y="519.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="467.0000" y="519.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="470.3333" y="521.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="470.3333" y="521.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="473.6667" y="523.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="473.6667" y="523.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="477.0000" y="525.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="477.0000" y="525.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="480.3333" y="527.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="480.3333" y="527.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="483.6667" y="529.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="483.6667" y="529.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="467.0000" y="566.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="467.0000" y="566.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="470.3333" y="568.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="470.3333" y="568.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="473.6667" y="570.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="473.6667" y="570.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="477.0000" y="572.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="477.0000" y="572.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="480.3333" y="574.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="480.3333" y="574.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="483.6667" y="576.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="483.6667" y="576.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="467" y="473" width="80" height="140">
-			</bounds>
+			<bounds x="467" y="473" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="68" y="429" width="80" height="80">
-			</bounds>
+			<bounds x="68" y="429" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="68.0000" y="429.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="68.0000" y="429.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="71.3333" y="432.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="71.3333" y="432.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="74.6667" y="435.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="74.6667" y="435.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="78.0000" y="439.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="78.0000" y="439.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="81.3333" y="442.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="81.3333" y="442.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="84.6667" y="445.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="84.6667" y="445.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="68" y="429" width="80" height="80">
-			</bounds>
+			<bounds x="68" y="429" width="80" height="80"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="73" y="205" width="80" height="80">
-			</bounds>
+			<bounds x="73" y="205" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_0" state="0">
-			<bounds x="73.0000" y="205.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="73.0000" y="205.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_1" state="0">
-			<bounds x="76.3333" y="208.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="76.3333" y="208.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_2" state="0">
-			<bounds x="79.6667" y="211.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="79.6667" y="211.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_3" state="0">
-			<bounds x="83.0000" y="215.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="83.0000" y="215.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_4" state="0">
-			<bounds x="86.3333" y="218.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="86.3333" y="218.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_5" state="0">
-			<bounds x="89.6667" y="221.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="89.6667" y="221.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="73" y="205" width="80" height="80">
-			</bounds>
+			<bounds x="73" y="205" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="43" y="235" width="26" height="26">
-			</bounds>
+			<bounds x="43" y="235" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="45" y="237" width="22" height="22">
-			</bounds>
+			<bounds x="45" y="237" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="156" y="235" width="26" height="26">
-			</bounds>
+			<bounds x="156" y="235" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="158" y="237" width="22" height="22">
-			</bounds>
+			<bounds x="158" y="237" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="575" y="307" width="30" height="38">
-			</bounds>
+			<bounds x="575" y="307" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="577" y="309" width="26" height="34">
-			</bounds>
+			<bounds x="577" y="309" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="546" y="307" width="30" height="38">
-			</bounds>
+			<bounds x="546" y="307" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="548" y="309" width="26" height="34">
-			</bounds>
+			<bounds x="548" y="309" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="546" y="157" width="30" height="38">
-			</bounds>
+			<bounds x="546" y="157" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="548" y="159" width="26" height="34">
-			</bounds>
+			<bounds x="548" y="159" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="575" y="157" width="30" height="38">
-			</bounds>
+			<bounds x="575" y="157" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="577" y="159" width="26" height="34">
-			</bounds>
+			<bounds x="577" y="159" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="546" y="207" width="30" height="38">
-			</bounds>
+			<bounds x="546" y="207" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="548" y="209" width="26" height="34">
-			</bounds>
+			<bounds x="548" y="209" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="575" y="207" width="30" height="38">
-			</bounds>
+			<bounds x="575" y="207" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="577" y="209" width="26" height="34">
-			</bounds>
+			<bounds x="577" y="209" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="546" y="257" width="30" height="38">
-			</bounds>
+			<bounds x="546" y="257" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="548" y="259" width="26" height="34">
-			</bounds>
+			<bounds x="548" y="259" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="575" y="257" width="30" height="38">
-			</bounds>
+			<bounds x="575" y="257" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="577" y="259" width="26" height="34">
-			</bounds>
+			<bounds x="577" y="259" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="546" y="107" width="30" height="38">
-			</bounds>
+			<bounds x="546" y="107" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="548" y="109" width="26" height="34">
-			</bounds>
+			<bounds x="548" y="109" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="575" y="107" width="30" height="38">
-			</bounds>
+			<bounds x="575" y="107" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="577" y="109" width="26" height="34">
-			</bounds>
+			<bounds x="577" y="109" width="26" height="34"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="604" y="57" width="78" height="38">
-			</bounds>
+			<bounds x="604" y="57" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="606" y="59" width="74" height="34">
-			</bounds>
+			<bounds x="606" y="59" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="546" y="57" width="58" height="38">
-			</bounds>
+			<bounds x="546" y="57" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="548" y="59" width="54" height="34">
-			</bounds>
+			<bounds x="548" y="59" width="54" height="34"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="546" y="7" width="66" height="38">
-			</bounds>
+			<bounds x="546" y="7" width="66" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="548" y="9" width="62" height="34">
-			</bounds>
+			<bounds x="548" y="9" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="612" y="7" width="98" height="38">
-			</bounds>
+			<bounds x="612" y="7" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="614" y="9" width="94" height="34">
-			</bounds>
+			<bounds x="614" y="9" width="94" height="34"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="292" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="292" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="294" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="294" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="322" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="322" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="324" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="324" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="232" y="380" width="58" height="26">
-			</bounds>
+			<bounds x="232" y="380" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="234" y="382" width="54" height="22">
-			</bounds>
+			<bounds x="234" y="382" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="238" y="405" width="48" height="26">
-			</bounds>
+			<bounds x="238" y="405" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="240" y="407" width="44" height="22">
-			</bounds>
+			<bounds x="240" y="407" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="442" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="442" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="444" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="444" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="472" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="472" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="474" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="474" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="502" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="502" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="504" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="504" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="412" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="412" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="414" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="414" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="382" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="382" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="384" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="384" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="352" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="352" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="354" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="354" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="532" y="401" width="30" height="30">
-			</bounds>
+			<bounds x="532" y="401" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="534" y="403" width="26" height="26">
-			</bounds>
+			<bounds x="534" y="403" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="564" y="405" width="30" height="26">
-			</bounds>
+			<bounds x="564" y="405" width="30" height="26"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="566" y="407" width="26" height="22">
-			</bounds>
+			<bounds x="566" y="407" width="26" height="22"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="252" y="488" width="26" height="26">
-			</bounds>
+			<bounds x="252" y="488" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="254" y="490" width="22" height="22">
-			</bounds>
+			<bounds x="254" y="490" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="252" y="516" width="26" height="26">
-			</bounds>
+			<bounds x="252" y="516" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="254" y="518" width="22" height="22">
-			</bounds>
+			<bounds x="254" y="518" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="252" y="544" width="26" height="26">
-			</bounds>
+			<bounds x="252" y="544" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="254" y="546" width="22" height="22">
-			</bounds>
+			<bounds x="254" y="546" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="241" y="571" width="50" height="30">
-			</bounds>
+			<bounds x="241" y="571" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="243" y="573" width="46" height="26">
-			</bounds>
+			<bounds x="243" y="573" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="812" y="75" width="88" height="54">
-			</bounds>
+			<bounds x="812" y="75" width="88" height="54"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="814" y="77" width="84" height="50">
-			</bounds>
+			<bounds x="814" y="77" width="84" height="50"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="778" y="128" width="150" height="54">
-			</bounds>
+			<bounds x="778" y="128" width="150" height="54"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="780" y="130" width="146" height="50">
-			</bounds>
+			<bounds x="780" y="130" width="146" height="50"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_66_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="912" y="13" width="38" height="38">
-			</bounds>
+			<bounds x="912" y="13" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_66" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="914" y="15" width="34" height="34">
-			</bounds>
+			<bounds x="914" y="15" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_82_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="70" y="511" width="75" height="27">
-			</bounds>
+			<bounds x="70" y="511" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_82" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="72" y="513" width="71" height="23">
-			</bounds>
+			<bounds x="72" y="513" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_84_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="469" y="617" width="75" height="38">
-			</bounds>
+			<bounds x="469" y="617" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_84" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="471" y="619" width="71" height="34">
-			</bounds>
+			<bounds x="471" y="619" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_85_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="387" y="617" width="75" height="38">
-			</bounds>
+			<bounds x="387" y="617" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_85" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="389" y="619" width="71" height="34">
-			</bounds>
+			<bounds x="389" y="619" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_86_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="302" y="617" width="75" height="38">
-			</bounds>
+			<bounds x="302" y="617" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_86" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="304" y="619" width="71" height="34">
-			</bounds>
+			<bounds x="304" y="619" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_87_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="222" y="617" width="75" height="38">
-			</bounds>
+			<bounds x="222" y="617" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_87" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="224" y="619" width="71" height="34">
-			</bounds>
+			<bounds x="224" y="619" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_88_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="549" y="617" width="75" height="38">
-			</bounds>
+			<bounds x="549" y="617" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_88" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="551" y="619" width="71" height="34">
-			</bounds>
+			<bounds x="551" y="619" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_89_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="625" y="617" width="75" height="38">
-			</bounds>
+			<bounds x="625" y="617" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_89" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="627" y="619" width="71" height="34">
-			</bounds>
+			<bounds x="627" y="619" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="358" y="363" width="24" height="32">
-			</bounds>
+			<bounds x="358" y="363" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="361" y="365" width="17" height="2">
-			</bounds>
+			<bounds x="361" y="365" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="375" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="375" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="375" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="375" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="361" y="389" width="17" height="2">
-			</bounds>
+			<bounds x="361" y="389" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="361" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="361" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="361" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="361" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="361" y="377" width="17" height="2">
-			</bounds>
+			<bounds x="361" y="377" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="378" y="389" width="3" height="2">
-			</bounds>
+			<bounds x="378" y="389" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="361" y="365" width="17" height="2">
-			</bounds>
+			<bounds x="361" y="365" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="375" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="375" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="375" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="375" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="361" y="389" width="17" height="2">
-			</bounds>
+			<bounds x="361" y="389" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="361" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="361" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="361" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="361" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="361" y="377" width="17" height="2">
-			</bounds>
+			<bounds x="361" y="377" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="378" y="389" width="3" height="2">
-			</bounds>
+			<bounds x="378" y="389" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="384" y="363" width="24" height="32">
-			</bounds>
+			<bounds x="384" y="363" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="387" y="365" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="365" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="401" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="401" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="401" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="401" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="387" y="389" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="389" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="387" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="387" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="387" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="387" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="387" y="377" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="377" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="404" y="389" width="3" height="2">
-			</bounds>
+			<bounds x="404" y="389" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="387" y="365" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="365" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="401" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="401" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="401" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="401" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="387" y="389" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="389" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="387" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="387" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="387" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="387" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="387" y="377" width="17" height="2">
-			</bounds>
+			<bounds x="387" y="377" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="404" y="389" width="3" height="2">
-			</bounds>
+			<bounds x="404" y="389" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="410" y="363" width="24" height="32">
-			</bounds>
+			<bounds x="410" y="363" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="413" y="365" width="17" height="2">
-			</bounds>
+			<bounds x="413" y="365" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="427" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="427" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="427" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="427" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="413" y="389" width="17" height="2">
-			</bounds>
+			<bounds x="413" y="389" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="413" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="413" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="413" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="413" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="413" y="377" width="17" height="2">
-			</bounds>
+			<bounds x="413" y="377" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="430" y="389" width="3" height="2">
-			</bounds>
+			<bounds x="430" y="389" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="413" y="365" width="17" height="2">
-			</bounds>
+			<bounds x="413" y="365" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="427" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="427" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="427" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="427" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="413" y="389" width="17" height="2">
-			</bounds>
+			<bounds x="413" y="389" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="413" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="413" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="413" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="413" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="413" y="377" width="17" height="2">
-			</bounds>
+			<bounds x="413" y="377" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="430" y="389" width="3" height="2">
-			</bounds>
+			<bounds x="430" y="389" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="436" y="363" width="24" height="32">
-			</bounds>
+			<bounds x="436" y="363" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="439" y="365" width="17" height="2">
-			</bounds>
+			<bounds x="439" y="365" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="453" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="453" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="453" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="453" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="439" y="389" width="17" height="2">
-			</bounds>
+			<bounds x="439" y="389" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="439" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="439" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="439" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="439" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="439" y="377" width="17" height="2">
-			</bounds>
+			<bounds x="439" y="377" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="456" y="389" width="3" height="2">
-			</bounds>
+			<bounds x="456" y="389" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="439" y="365" width="17" height="2">
-			</bounds>
+			<bounds x="439" y="365" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="453" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="453" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="453" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="453" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="439" y="389" width="17" height="2">
-			</bounds>
+			<bounds x="439" y="389" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="439" y="377" width="3" height="14">
-			</bounds>
+			<bounds x="439" y="377" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="439" y="365" width="3" height="14">
-			</bounds>
+			<bounds x="439" y="365" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="439" y="377" width="17" height="2">
-			</bounds>
+			<bounds x="439" y="377" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="456" y="389" width="3" height="2">
-			</bounds>
+			<bounds x="456" y="389" width="3" height="2"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="281" y="438" width="272" height="30">
-			</bounds>
+			<bounds x="281" y="438" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="281" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="281" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="298" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="298" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="315" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="315" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="332" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="332" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="349" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="349" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="366" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="366" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="383" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="383" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="400" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="400" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="417" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="417" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="434" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="434" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="451" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="451" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="468" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="468" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="485" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="485" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="502" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="502" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="519" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="519" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="536" y="438" width="17" height="30">
-			</bounds>
+			<bounds x="536" y="438" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label41" element="label_41">
-			<bounds x="336" y="362" width="20" height="37">
-			</bounds>
+			<bounds x="336" y="362" width="20" height="37"/>
 		</backdrop>
 		<backdrop name="label65" element="label_65">
-			<bounds x="556" y="527" width="29" height="26">
-			</bounds>
+			<bounds x="556" y="527" width="29" height="26"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2majes.lay
+++ b/src/mame/layout/sc2majes.lay
@@ -8,9506 +8,6320 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.11" blue="0.00">
-			</color>
+			<color red="0.50" green="0.11" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.22" blue="0.00">
-			</color>
+			<color red="1.00" green="0.22" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.00">
-			</color>
+			<color red="0.25" green="0.05" blue="0.00"/>
 		</rect>
 		<text string="SUPER BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.11" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.11" blue="0.00">
-			</color>
+			<color red="0.50" green="0.11" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
+			<color red="0.12" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.22" blue="0.00">
-			</color>
+			<color red="1.00" green="0.22" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.00">
-			</color>
+			<color red="0.25" green="0.05" blue="0.00"/>
 		</rect>
 		<text string="WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.11" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.20" width="0.90" height="0.15"/>
 		</text>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.15"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.15"/>
 		</text>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.15"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.20" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.15">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.80" width="0.90" height="0.15">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.80" width="0.90" height="0.15"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
+			<color red="0.50" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
+			<color red="1.00" green="0.17" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
+			<color red="0.25" green="0.04" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.17" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
+			<color red="0.50" green="0.16" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
+			<color red="0.12" green="0.04" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
+			<color red="1.00" green="0.33" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
+			<color red="0.25" green="0.08" blue="0.08"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.16" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.04" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.33" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
+			<color red="0.50" green="0.21" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
+			<color red="0.12" green="0.05" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
+			<color red="1.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
+			<color red="0.25" green="0.10" blue="0.10"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.21" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.42" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.29">
-			</color>
+			<color red="0.50" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
+			<color red="0.12" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.58">
-			</color>
+			<color red="1.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.15">
-			</color>
+			<color red="0.25" green="0.15" blue="0.15"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.15">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
+			<color red="0.50" green="0.04" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
+			<color red="0.12" green="0.01" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
+			<color red="1.00" green="0.08" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
+			<color red="0.25" green="0.02" blue="0.02"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.04" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.01" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.08" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.31" green="0.00" blue="0.37">
-			</color>
+			<color red="0.31" green="0.00" blue="0.37"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.00" blue="0.09">
-			</color>
+			<color red="0.07" green="0.00" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="0.62" green="0.00" blue="0.75">
-			</color>
+			<color red="0.62" green="0.00" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.00" blue="0.18">
-			</color>
+			<color red="0.15" green="0.00" blue="0.18"/>
 		</rect>
 		<text string="N U D G E S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.31" green="0.00" blue="0.37">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.00" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.62" green="0.00" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.00" blue="0.18">
-			</color>
-		</rect>
-		<text string="N U D G E S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.44" green="0.13" blue="0.50">
-			</color>
+			<color red="0.44" green="0.13" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.03" blue="0.12">
-			</color>
+			<color red="0.11" green="0.03" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="0.87" green="0.25" blue="1.00">
-			</color>
+			<color red="0.87" green="0.25" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.22" green="0.06" blue="0.25">
-			</color>
+			<color red="0.22" green="0.06" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.44" green="0.13" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.03" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.87" green="0.25" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.22" green="0.06" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.42" green="0.04" blue="0.50">
-			</color>
+			<color red="0.42" green="0.04" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.01" blue="0.12">
-			</color>
+			<color red="0.10" green="0.01" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.84" green="0.08" blue="1.00">
-			</color>
+			<color red="0.84" green="0.08" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.02" blue="0.25">
-			</color>
+			<color red="0.21" green="0.02" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.42" green="0.04" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.01" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.84" green="0.08" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.02" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.43" green="0.08" blue="0.50">
-			</color>
+			<color red="0.43" green="0.08" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.11" green="0.02" blue="0.12">
-			</color>
+			<color red="0.11" green="0.02" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="0.85" green="0.17" blue="1.00">
-			</color>
+			<color red="0.85" green="0.17" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.21" green="0.04" blue="0.25">
-			</color>
+			<color red="0.21" green="0.04" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.43" green="0.08" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.11" green="0.02" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.85" green="0.17" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.21" green="0.04" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.41" green="0.00" blue="0.50">
-			</color>
+			<color red="0.41" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.12">
-			</color>
+			<color red="0.10" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.82" green="0.00" blue="1.00">
-			</color>
+			<color red="0.82" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.25">
-			</color>
+			<color red="0.20" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MAJESTIC BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.41" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.82" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="MAJESTIC BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="TT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.45" blue="0.13">
-			</color>
+			<color red="0.50" green="0.45" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.03">
-			</color>
+			<color red="0.12" green="0.11" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.91" blue="0.25">
-			</color>
+			<color red="1.00" green="0.91" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.06">
-			</color>
+			<color red="0.25" green="0.23" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.45" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.91" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.45" blue="0.08">
-			</color>
+			<color red="0.50" green="0.45" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.02">
-			</color>
+			<color red="0.12" green="0.11" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.89" blue="0.17">
-			</color>
+			<color red="1.00" green="0.89" blue="0.17"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.04">
-			</color>
+			<color red="0.25" green="0.22" blue="0.04"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.45" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.89" blue="0.17">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.04">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.46" blue="0.16">
-			</color>
+			<color red="0.50" green="0.46" blue="0.16"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
+			<color red="0.12" green="0.11" blue="0.04"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.92" blue="0.33">
-			</color>
+			<color red="1.00" green="0.92" blue="0.33"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
+			<color red="0.25" green="0.23" blue="0.08"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.46" blue="0.16">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.04">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.92" blue="0.33">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.08">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.46" blue="0.21">
-			</color>
+			<color red="0.50" green="0.46" blue="0.21"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
+			<color red="0.12" green="0.11" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.93" blue="0.42">
-			</color>
+			<color red="1.00" green="0.93" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.10">
-			</color>
+			<color red="0.25" green="0.23" blue="0.10"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.46" blue="0.21">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.93" blue="0.42">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.23" blue="0.10">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.04">
-			</color>
+			<color red="0.50" green="0.44" blue="0.04"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.01">
-			</color>
+			<color red="0.12" green="0.11" blue="0.01"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.89" blue="0.08">
-			</color>
+			<color red="1.00" green="0.89" blue="0.08"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.02">
-			</color>
+			<color red="0.25" green="0.22" blue="0.02"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.04">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.01">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.89" blue="0.08">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.02">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
+			<color red="0.50" green="0.44" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
+			<color red="0.12" green="0.11" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
+			<color red="1.00" green="0.87" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
+			<color red="0.25" green="0.22" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.44" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.11" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.87" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.22" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_89_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_89">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_90_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_90">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_91_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_91">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_92_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_92">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_93_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_93">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_94_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_94">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_95_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_95">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_96_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_96">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_55">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_62">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_74">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_75">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_76">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_79">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_80">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_81">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_85">
 		<text string="REEL PLAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_87">
 		<text string="Bugs and Trouty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="v1.1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_88">
 		<text string="Presto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="937" height="662">
-			</bounds>
+			<bounds x="0" y="0" width="937" height="662"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="124" y="495" width="70" height="100">
-			</bounds>
+			<bounds x="124" y="495" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="124.0000" y="495.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="124.0000" y="495.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="126.9167" y="496.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="126.9167" y="496.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="129.8333" y="497.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="129.8333" y="497.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="132.7500" y="499.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="132.7500" y="499.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="135.6667" y="500.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="135.6667" y="500.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="138.5833" y="501.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="138.5833" y="501.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="124.0000" y="528.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="124.0000" y="528.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="126.9167" y="529.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="126.9167" y="529.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="129.8333" y="531.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="129.8333" y="531.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="132.7500" y="532.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="132.7500" y="532.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="135.6667" y="533.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="135.6667" y="533.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="138.5833" y="535.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="138.5833" y="535.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="124.0000" y="561.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="124.0000" y="561.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="126.9167" y="563.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="126.9167" y="563.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="129.8333" y="564.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="129.8333" y="564.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="132.7500" y="565.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="132.7500" y="565.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="135.6667" y="567.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="135.6667" y="567.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="138.5833" y="568.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="138.5833" y="568.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="124" y="495" width="70" height="100">
-			</bounds>
+			<bounds x="124" y="495" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="254" y="495" width="70" height="100">
-			</bounds>
+			<bounds x="254" y="495" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="495.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="254.0000" y="495.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="256.9167" y="496.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="256.9167" y="496.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="259.8333" y="497.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="259.8333" y="497.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="262.7500" y="499.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="262.7500" y="499.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="265.6667" y="500.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="265.6667" y="500.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="268.5833" y="501.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="268.5833" y="501.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="528.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="254.0000" y="528.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="256.9167" y="529.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="256.9167" y="529.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="259.8333" y="531.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="259.8333" y="531.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="262.7500" y="532.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="262.7500" y="532.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="265.6667" y="533.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="265.6667" y="533.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="268.5833" y="535.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="268.5833" y="535.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="561.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="254.0000" y="561.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="256.9167" y="563.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="256.9167" y="563.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="259.8333" y="564.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="259.8333" y="564.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="262.7500" y="565.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="262.7500" y="565.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="265.6667" y="567.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="265.6667" y="567.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="268.5833" y="568.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="268.5833" y="568.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="254" y="495" width="70" height="100">
-			</bounds>
+			<bounds x="254" y="495" width="70" height="100"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="384" y="495" width="70" height="100">
-			</bounds>
+			<bounds x="384" y="495" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="384.0000" y="495.0000" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="384.0000" y="495.0000" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="386.9167" y="496.3889" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="386.9167" y="496.3889" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="389.8333" y="497.7778" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="389.8333" y="497.7778" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.7500" y="499.1667" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="392.7500" y="499.1667" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.6667" y="500.5555" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="395.6667" y="500.5555" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.5833" y="501.9445" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="398.5833" y="501.9445" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="384.0000" y="528.3333" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="384.0000" y="528.3333" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="386.9167" y="529.7222" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="386.9167" y="529.7222" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="389.8333" y="531.1111" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="389.8333" y="531.1111" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.7500" y="532.5000" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="392.7500" y="532.5000" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.6667" y="533.8889" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="395.6667" y="533.8889" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.5833" y="535.2778" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="398.5833" y="535.2778" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="384.0000" y="561.6667" width="70.0000" height="33.3333">
-			</bounds>
+			<bounds x="384.0000" y="561.6667" width="70.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="386.9167" y="563.0556" width="64.1667" height="30.5556">
-			</bounds>
+			<bounds x="386.9167" y="563.0556" width="64.1667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="389.8333" y="564.4445" width="58.3333" height="27.7778">
-			</bounds>
+			<bounds x="389.8333" y="564.4445" width="58.3333" height="27.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="392.7500" y="565.8334" width="52.5000" height="25.0000">
-			</bounds>
+			<bounds x="392.7500" y="565.8334" width="52.5000" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="395.6667" y="567.2222" width="46.6667" height="22.2222">
-			</bounds>
+			<bounds x="395.6667" y="567.2222" width="46.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="398.5833" y="568.6111" width="40.8333" height="19.4444">
-			</bounds>
+			<bounds x="398.5833" y="568.6111" width="40.8333" height="19.4444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="384" y="495" width="70" height="100">
-			</bounds>
+			<bounds x="384" y="495" width="70" height="100"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="545" y="232" width="182" height="34">
-			</bounds>
+			<bounds x="545" y="232" width="182" height="34"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="547" y="234" width="178" height="30">
-			</bounds>
+			<bounds x="547" y="234" width="178" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="35" y="234" width="182" height="32">
-			</bounds>
+			<bounds x="35" y="234" width="182" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="37" y="236" width="178" height="28">
-			</bounds>
+			<bounds x="37" y="236" width="178" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="250" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="250" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="252" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="252" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="280" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="280" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="282" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="282" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="310" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="310" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="312" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="312" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="340" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="340" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="342" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="342" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="370" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="370" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="372" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="372" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="400" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="400" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="402" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="402" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="430" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="430" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="432" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="432" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="460" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="460" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="462" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="462" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="490" y="339" width="22" height="72">
-			</bounds>
+			<bounds x="490" y="339" width="22" height="72"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="492" y="341" width="18" height="68">
-			</bounds>
+			<bounds x="492" y="341" width="18" height="68"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="414" y="291" width="82" height="42">
-			</bounds>
+			<bounds x="414" y="291" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="416" y="293" width="78" height="38">
-			</bounds>
+			<bounds x="416" y="293" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="360" y="305" width="42" height="22">
-			</bounds>
+			<bounds x="360" y="305" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="362" y="307" width="38" height="18">
-			</bounds>
+			<bounds x="362" y="307" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="266" y="291" width="82" height="42">
-			</bounds>
+			<bounds x="266" y="291" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="268" y="293" width="78" height="38">
-			</bounds>
+			<bounds x="268" y="293" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="317" y="454" width="62" height="32">
-			</bounds>
+			<bounds x="317" y="454" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="319" y="456" width="58" height="28">
-			</bounds>
+			<bounds x="319" y="456" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="317" y="423" width="62" height="32">
-			</bounds>
+			<bounds x="317" y="423" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="319" y="425" width="58" height="28">
-			</bounds>
+			<bounds x="319" y="425" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="504" y="423" width="62" height="32">
-			</bounds>
+			<bounds x="504" y="423" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="506" y="425" width="58" height="28">
-			</bounds>
+			<bounds x="506" y="425" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="504" y="454" width="62" height="32">
-			</bounds>
+			<bounds x="504" y="454" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="506" y="456" width="58" height="28">
-			</bounds>
+			<bounds x="506" y="456" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="691" y="454" width="62" height="32">
-			</bounds>
+			<bounds x="691" y="454" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="693" y="456" width="58" height="28">
-			</bounds>
+			<bounds x="693" y="456" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="691" y="423" width="62" height="32">
-			</bounds>
+			<bounds x="691" y="423" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="693" y="425" width="58" height="28">
-			</bounds>
+			<bounds x="693" y="425" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="130" y="423" width="62" height="32">
-			</bounds>
+			<bounds x="130" y="423" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="132" y="425" width="58" height="28">
-			</bounds>
+			<bounds x="132" y="425" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="130" y="454" width="62" height="32">
-			</bounds>
+			<bounds x="130" y="454" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="132" y="456" width="58" height="28">
-			</bounds>
+			<bounds x="132" y="456" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="502" y="551" width="104" height="20">
-			</bounds>
+			<bounds x="502" y="551" width="104" height="20"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="504" y="553" width="100" height="16">
-			</bounds>
+			<bounds x="504" y="553" width="100" height="16"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="502" y="496" width="44" height="53">
-			</bounds>
+			<bounds x="502" y="496" width="44" height="53"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="504" y="498" width="40" height="49">
-			</bounds>
+			<bounds x="504" y="498" width="40" height="49"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="666" y="496" width="44" height="53">
-			</bounds>
+			<bounds x="666" y="496" width="44" height="53"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="668" y="498" width="40" height="49">
-			</bounds>
+			<bounds x="668" y="498" width="40" height="49"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="584" y="496" width="44" height="53">
-			</bounds>
+			<bounds x="584" y="496" width="44" height="53"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="586" y="498" width="40" height="49">
-			</bounds>
+			<bounds x="586" y="498" width="40" height="49"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="190" y="3" width="382" height="61">
-			</bounds>
+			<bounds x="190" y="3" width="382" height="61"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="192" y="5" width="378" height="57">
-			</bounds>
+			<bounds x="192" y="5" width="378" height="57"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="62" y="54" width="36" height="36">
-			</bounds>
+			<bounds x="62" y="54" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="64" y="56" width="32" height="32">
-			</bounds>
+			<bounds x="64" y="56" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="284" y="65" width="73" height="56">
-			</bounds>
+			<bounds x="284" y="65" width="73" height="56"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="286" y="67" width="69" height="52">
-			</bounds>
+			<bounds x="286" y="67" width="69" height="52"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="405" y="65" width="73" height="56">
-			</bounds>
+			<bounds x="405" y="65" width="73" height="56"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="407" y="67" width="69" height="52">
-			</bounds>
+			<bounds x="407" y="67" width="69" height="52"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="163" y="100" width="73" height="56">
-			</bounds>
+			<bounds x="163" y="100" width="73" height="56"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="165" y="102" width="69" height="52">
-			</bounds>
+			<bounds x="165" y="102" width="69" height="52"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="42" y="135" width="73" height="56">
-			</bounds>
+			<bounds x="42" y="135" width="73" height="56"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="44" y="137" width="69" height="52">
-			</bounds>
+			<bounds x="44" y="137" width="69" height="52"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="526" y="100" width="73" height="56">
-			</bounds>
+			<bounds x="526" y="100" width="73" height="56"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="528" y="102" width="69" height="52">
-			</bounds>
+			<bounds x="528" y="102" width="69" height="52"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="647" y="135" width="73" height="56">
-			</bounds>
+			<bounds x="647" y="135" width="73" height="56"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="649" y="137" width="69" height="52">
-			</bounds>
+			<bounds x="649" y="137" width="69" height="52"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_89_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="670" y="604" width="62" height="42">
-			</bounds>
+			<bounds x="670" y="604" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_89" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="672" y="606" width="58" height="38">
-			</bounds>
+			<bounds x="672" y="606" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_90_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="586" y="604" width="62" height="42">
-			</bounds>
+			<bounds x="586" y="604" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_90" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="588" y="606" width="58" height="38">
-			</bounds>
+			<bounds x="588" y="606" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_91_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="496" y="604" width="68" height="42">
-			</bounds>
+			<bounds x="496" y="604" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_91" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="498" y="606" width="64" height="38">
-			</bounds>
+			<bounds x="498" y="606" width="64" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_92_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="388" y="604" width="62" height="42">
-			</bounds>
+			<bounds x="388" y="604" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_92" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="390" y="606" width="58" height="38">
-			</bounds>
+			<bounds x="390" y="606" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_93_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="258" y="604" width="62" height="42">
-			</bounds>
+			<bounds x="258" y="604" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_93" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="260" y="606" width="58" height="38">
-			</bounds>
+			<bounds x="260" y="606" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_94_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="128" y="604" width="62" height="42">
-			</bounds>
+			<bounds x="128" y="604" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_94" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="130" y="606" width="58" height="38">
-			</bounds>
+			<bounds x="130" y="606" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_95_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="11" y="604" width="62" height="42">
-			</bounds>
+			<bounds x="11" y="604" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_95" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="13" y="606" width="58" height="38">
-			</bounds>
+			<bounds x="13" y="606" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_96_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="626" y="11" width="46" height="62">
-			</bounds>
+			<bounds x="626" y="11" width="46" height="62"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_96" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="628" y="13" width="42" height="58">
-			</bounds>
+			<bounds x="628" y="13" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="261" y="218" width="60" height="55">
-			</bounds>
+			<bounds x="261" y="218" width="60" height="55"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="269" y="223" width="42" height="5">
-			</bounds>
+			<bounds x="269" y="223" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="303" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="303" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="303" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="303" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="269" y="263" width="42" height="5">
-			</bounds>
+			<bounds x="269" y="263" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="269" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="269" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="269" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="269" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_off">
-			<bounds x="269" y="243" width="42" height="5">
-			</bounds>
+			<bounds x="269" y="243" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_dot_off">
-			<bounds x="312" y="263" width="8" height="5">
-			</bounds>
+			<bounds x="312" y="263" width="8" height="5"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="269" y="223" width="42" height="5">
-			</bounds>
+			<bounds x="269" y="223" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="303" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="303" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="303" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="303" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="269" y="263" width="42" height="5">
-			</bounds>
+			<bounds x="269" y="263" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="269" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="269" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="269" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="269" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_on">
-			<bounds x="269" y="243" width="42" height="5">
-			</bounds>
+			<bounds x="269" y="243" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_dot_on">
-			<bounds x="312" y="263" width="8" height="5">
-			</bounds>
+			<bounds x="312" y="263" width="8" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="381" y="218" width="60" height="55">
-			</bounds>
+			<bounds x="381" y="218" width="60" height="55"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="389" y="223" width="42" height="5">
-			</bounds>
+			<bounds x="389" y="223" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="423" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="423" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="423" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="423" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="389" y="263" width="42" height="5">
-			</bounds>
+			<bounds x="389" y="263" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="389" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="389" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="389" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="389" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="389" y="243" width="42" height="5">
-			</bounds>
+			<bounds x="389" y="243" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="432" y="263" width="8" height="5">
-			</bounds>
+			<bounds x="432" y="263" width="8" height="5"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="389" y="223" width="42" height="5">
-			</bounds>
+			<bounds x="389" y="223" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="423" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="423" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="423" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="423" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="389" y="263" width="42" height="5">
-			</bounds>
+			<bounds x="389" y="263" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="389" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="389" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="389" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="389" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="389" y="243" width="42" height="5">
-			</bounds>
+			<bounds x="389" y="243" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="432" y="263" width="8" height="5">
-			</bounds>
+			<bounds x="432" y="263" width="8" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="321" y="218" width="60" height="55">
-			</bounds>
+			<bounds x="321" y="218" width="60" height="55"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="329" y="223" width="42" height="5">
-			</bounds>
+			<bounds x="329" y="223" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="363" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="363" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="363" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="363" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="329" y="263" width="42" height="5">
-			</bounds>
+			<bounds x="329" y="263" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="329" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="329" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="329" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="329" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="329" y="243" width="42" height="5">
-			</bounds>
+			<bounds x="329" y="243" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="372" y="263" width="8" height="5">
-			</bounds>
+			<bounds x="372" y="263" width="8" height="5"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="329" y="223" width="42" height="5">
-			</bounds>
+			<bounds x="329" y="223" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="363" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="363" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="363" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="363" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="329" y="263" width="42" height="5">
-			</bounds>
+			<bounds x="329" y="263" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="329" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="329" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="329" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="329" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="329" y="243" width="42" height="5">
-			</bounds>
+			<bounds x="329" y="243" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="372" y="263" width="8" height="5">
-			</bounds>
+			<bounds x="372" y="263" width="8" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="441" y="218" width="60" height="55">
-			</bounds>
+			<bounds x="441" y="218" width="60" height="55"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="449" y="223" width="42" height="5">
-			</bounds>
+			<bounds x="449" y="223" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="483" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="483" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="483" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="483" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="449" y="263" width="42" height="5">
-			</bounds>
+			<bounds x="449" y="263" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="449" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="449" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="449" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="449" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="449" y="243" width="42" height="5">
-			</bounds>
+			<bounds x="449" y="243" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="492" y="263" width="8" height="5">
-			</bounds>
+			<bounds x="492" y="263" width="8" height="5"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="449" y="223" width="42" height="5">
-			</bounds>
+			<bounds x="449" y="223" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="483" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="483" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="483" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="483" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="449" y="263" width="42" height="5">
-			</bounds>
+			<bounds x="449" y="263" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="449" y="243" width="8" height="25">
-			</bounds>
+			<bounds x="449" y="243" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="449" y="223" width="8" height="25">
-			</bounds>
+			<bounds x="449" y="223" width="8" height="25"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="449" y="243" width="42" height="5">
-			</bounds>
+			<bounds x="449" y="243" width="42" height="5"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="492" y="263" width="8" height="5">
-			</bounds>
+			<bounds x="492" y="263" width="8" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="688" y="566" width="24" height="32">
-			</bounds>
+			<bounds x="688" y="566" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off153" element="led_off">
-			<bounds x="691" y="568" width="17" height="2">
-			</bounds>
+			<bounds x="691" y="568" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off154" element="led_off">
-			<bounds x="705" y="568" width="3" height="14">
-			</bounds>
+			<bounds x="705" y="568" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off155" element="led_off">
-			<bounds x="705" y="580" width="3" height="14">
-			</bounds>
+			<bounds x="705" y="580" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off156" element="led_off">
-			<bounds x="691" y="592" width="17" height="2">
-			</bounds>
+			<bounds x="691" y="592" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off157" element="led_off">
-			<bounds x="691" y="580" width="3" height="14">
-			</bounds>
+			<bounds x="691" y="580" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off158" element="led_off">
-			<bounds x="691" y="568" width="3" height="14">
-			</bounds>
+			<bounds x="691" y="568" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off159" element="led_off">
-			<bounds x="691" y="580" width="17" height="2">
-			</bounds>
+			<bounds x="691" y="580" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off152" element="led_dot_off">
-			<bounds x="708" y="592" width="3" height="2">
-			</bounds>
+			<bounds x="708" y="592" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp153" element="led_on">
-			<bounds x="691" y="568" width="17" height="2">
-			</bounds>
+			<bounds x="691" y="568" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp154" element="led_on">
-			<bounds x="705" y="568" width="3" height="14">
-			</bounds>
+			<bounds x="705" y="568" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp155" element="led_on">
-			<bounds x="705" y="580" width="3" height="14">
-			</bounds>
+			<bounds x="705" y="580" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp156" element="led_on">
-			<bounds x="691" y="592" width="17" height="2">
-			</bounds>
+			<bounds x="691" y="592" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp157" element="led_on">
-			<bounds x="691" y="580" width="3" height="14">
-			</bounds>
+			<bounds x="691" y="580" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp158" element="led_on">
-			<bounds x="691" y="568" width="3" height="14">
-			</bounds>
+			<bounds x="691" y="568" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp159" element="led_on">
-			<bounds x="691" y="580" width="17" height="2">
-			</bounds>
+			<bounds x="691" y="580" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp152" element="led_dot_on">
-			<bounds x="708" y="592" width="3" height="2">
-			</bounds>
+			<bounds x="708" y="592" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="665" y="566" width="24" height="32">
-			</bounds>
+			<bounds x="665" y="566" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="led_off169" element="led_off">
-			<bounds x="668" y="568" width="17" height="2">
-			</bounds>
+			<bounds x="668" y="568" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off170" element="led_off">
-			<bounds x="682" y="568" width="3" height="14">
-			</bounds>
+			<bounds x="682" y="568" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off171" element="led_off">
-			<bounds x="682" y="580" width="3" height="14">
-			</bounds>
+			<bounds x="682" y="580" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off172" element="led_off">
-			<bounds x="668" y="592" width="17" height="2">
-			</bounds>
+			<bounds x="668" y="592" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off173" element="led_off">
-			<bounds x="668" y="580" width="3" height="14">
-			</bounds>
+			<bounds x="668" y="580" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off174" element="led_off">
-			<bounds x="668" y="568" width="3" height="14">
-			</bounds>
+			<bounds x="668" y="568" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="led_off175" element="led_off">
-			<bounds x="668" y="580" width="17" height="2">
-			</bounds>
+			<bounds x="668" y="580" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="led_off168" element="led_dot_off">
-			<bounds x="685" y="592" width="3" height="2">
-			</bounds>
+			<bounds x="685" y="592" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="lamp169" element="led_on">
-			<bounds x="668" y="568" width="17" height="2">
-			</bounds>
+			<bounds x="668" y="568" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp170" element="led_on">
-			<bounds x="682" y="568" width="3" height="14">
-			</bounds>
+			<bounds x="682" y="568" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp171" element="led_on">
-			<bounds x="682" y="580" width="3" height="14">
-			</bounds>
+			<bounds x="682" y="580" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp172" element="led_on">
-			<bounds x="668" y="592" width="17" height="2">
-			</bounds>
+			<bounds x="668" y="592" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp173" element="led_on">
-			<bounds x="668" y="580" width="3" height="14">
-			</bounds>
+			<bounds x="668" y="580" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp174" element="led_on">
-			<bounds x="668" y="568" width="3" height="14">
-			</bounds>
+			<bounds x="668" y="568" width="3" height="14"/>
 		</backdrop>
 		<backdrop name="lamp175" element="led_on">
-			<bounds x="668" y="580" width="17" height="2">
-			</bounds>
+			<bounds x="668" y="580" width="17" height="2"/>
 		</backdrop>
 		<backdrop name="lamp168" element="led_dot_on">
-			<bounds x="685" y="592" width="3" height="2">
-			</bounds>
+			<bounds x="685" y="592" width="3" height="2"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="363" y="137" width="36" height="42">
-			</bounds>
+			<bounds x="363" y="137" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="368" y="140" width="25" height="3">
-			</bounds>
+			<bounds x="368" y="140" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="388" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="388" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="388" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="388" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="368" y="171" width="25" height="3">
-			</bounds>
+			<bounds x="368" y="171" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="368" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="368" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="368" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="368" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="368" y="156" width="25" height="3">
-			</bounds>
+			<bounds x="368" y="156" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="393" y="171" width="5" height="3">
-			</bounds>
+			<bounds x="393" y="171" width="5" height="3"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="368" y="140" width="25" height="3">
-			</bounds>
+			<bounds x="368" y="140" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="388" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="388" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="388" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="388" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="368" y="171" width="25" height="3">
-			</bounds>
+			<bounds x="368" y="171" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="368" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="368" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="368" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="368" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="368" y="156" width="25" height="3">
-			</bounds>
+			<bounds x="368" y="156" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="393" y="171" width="5" height="3">
-			</bounds>
+			<bounds x="393" y="171" width="5" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="399" y="137" width="36" height="42">
-			</bounds>
+			<bounds x="399" y="137" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="404" y="140" width="25" height="3">
-			</bounds>
+			<bounds x="404" y="140" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="424" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="424" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="424" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="424" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="404" y="171" width="25" height="3">
-			</bounds>
+			<bounds x="404" y="171" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="404" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="404" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="404" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="404" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="404" y="156" width="25" height="3">
-			</bounds>
+			<bounds x="404" y="156" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="429" y="171" width="5" height="3">
-			</bounds>
+			<bounds x="429" y="171" width="5" height="3"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="404" y="140" width="25" height="3">
-			</bounds>
+			<bounds x="404" y="140" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="424" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="424" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="424" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="424" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="404" y="171" width="25" height="3">
-			</bounds>
+			<bounds x="404" y="171" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="404" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="404" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="404" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="404" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="404" y="156" width="25" height="3">
-			</bounds>
+			<bounds x="404" y="156" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="429" y="171" width="5" height="3">
-			</bounds>
+			<bounds x="429" y="171" width="5" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="327" y="137" width="36" height="42">
-			</bounds>
+			<bounds x="327" y="137" width="36" height="42"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="332" y="140" width="25" height="3">
-			</bounds>
+			<bounds x="332" y="140" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="352" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="352" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="352" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="352" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="332" y="171" width="25" height="3">
-			</bounds>
+			<bounds x="332" y="171" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="332" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="332" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="332" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="332" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="332" y="156" width="25" height="3">
-			</bounds>
+			<bounds x="332" y="156" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="357" y="171" width="5" height="3">
-			</bounds>
+			<bounds x="357" y="171" width="5" height="3"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="332" y="140" width="25" height="3">
-			</bounds>
+			<bounds x="332" y="140" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="352" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="352" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="352" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="352" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="332" y="171" width="25" height="3">
-			</bounds>
+			<bounds x="332" y="171" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="332" y="156" width="5" height="19">
-			</bounds>
+			<bounds x="332" y="156" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="332" y="140" width="5" height="19">
-			</bounds>
+			<bounds x="332" y="140" width="5" height="19"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="332" y="156" width="25" height="3">
-			</bounds>
+			<bounds x="332" y="156" width="25" height="3"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="357" y="171" width="5" height="3">
-			</bounds>
+			<bounds x="357" y="171" width="5" height="3"/>
 		</backdrop>
 		<backdrop name="label55" element="label_55">
-			<bounds x="334" y="176" width="97" height="49">
-			</bounds>
+			<bounds x="334" y="176" width="97" height="49"/>
 		</backdrop>
 		<backdrop name="label62" element="label_62">
-			<bounds x="665" y="548" width="47" height="21">
-			</bounds>
+			<bounds x="665" y="548" width="47" height="21"/>
 		</backdrop>
 		<backdrop name="label74" element="label_74">
-			<bounds x="82" y="300" width="16" height="24">
-			</bounds>
+			<bounds x="82" y="300" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label75" element="label_75">
-			<bounds x="82" y="347" width="16" height="24">
-			</bounds>
+			<bounds x="82" y="347" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label76" element="label_76">
-			<bounds x="591" y="347" width="16" height="24">
-			</bounds>
+			<bounds x="591" y="347" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="591" y="300" width="16" height="24">
-			</bounds>
+			<bounds x="591" y="300" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="666" y="347" width="16" height="24">
-			</bounds>
+			<bounds x="666" y="347" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label79" element="label_79">
-			<bounds x="666" y="300" width="16" height="24">
-			</bounds>
+			<bounds x="666" y="300" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label80" element="label_80">
-			<bounds x="155" y="347" width="16" height="24">
-			</bounds>
+			<bounds x="155" y="347" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label81" element="label_81">
-			<bounds x="155" y="300" width="16" height="24">
-			</bounds>
+			<bounds x="155" y="300" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label85" element="label_85">
-			<bounds x="801" y="14" width="89" height="23">
-			</bounds>
+			<bounds x="801" y="14" width="89" height="23"/>
 		</backdrop>
 		<backdrop name="label87" element="label_87">
-			<bounds x="28" y="96" width="95" height="32">
-			</bounds>
+			<bounds x="28" y="96" width="95" height="32"/>
 		</backdrop>
 		<backdrop name="label88" element="label_88">
-			<bounds x="5" y="645" width="37" height="16">
-			</bounds>
+			<bounds x="5" y="645" width="37" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2prem2.lay
+++ b/src/mame/layout/sc2prem2.lay
@@ -8,12286 +8,7726 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Press Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="For Winning Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Press Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="For Winning Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="After Losing Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Day">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Day">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Champs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Champs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Fantasy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fantasy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Soccer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shocker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Soccer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Shocker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Champs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Champs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Champs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Champs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Day">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Day">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Fantasy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fantasy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Soccer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shocker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Soccer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Shocker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Champs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Champs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Sponsership">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Deal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Sponsership">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Deal">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" SACKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string=" SACKED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Backed By">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="The Board">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Backed By">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="The Board">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Vote Of">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Confidence">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Vote Of">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Confidence">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="F.A.Fine">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="And Exit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="F.A.Fine">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="And Exit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rise">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rise">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Retire">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Retire">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Resign In">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Disgrace">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Resign In">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Disgrace">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Sacked">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Sacked">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHAMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHAMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHAMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHAMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHAMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHAMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHAMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHAMP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Day">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pay">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Day">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now !">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now !">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4 Footballs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Champions">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 Footballs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Champions">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="League">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_101_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_101_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3 Footballs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 Footballs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_176_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_176">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_177_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_177">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string=" START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_178_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_178">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string=" EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_179_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_179">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_180_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_180">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_181_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_181">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_182_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_182">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD    HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_183_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_183">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD    LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Bell,Cherry(*),Lemon,Orange,Bar,Cherry,Grape,Orange,Melon,Orange,Cherry(*),Orange,Cashpot,Cherry,Lemon,Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Bell,Cherry,Orange,Melon,Bar,Grape,Cherry(*),Orange,Cherry,Melon,Grape,Cashpot,Lemon,Cherry,Lemon(*),Orange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Bell,Cherry,Lemon,Orange(*),Bar,Grape,Orange,Cherry,Melon,Cherry,Grape,Orange(*),Lemon,Cashpot,Lemon,Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="Bell,Cherry,Lemon,Grape,Bar,Lemon(*),Grape,Orange,Melon,Cherry,Cashpot,Orange,Lemon,Cherry(*),Lemon,Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="6,1,2,3,4,5,6,1,2,3,4,5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
+	</element>
+	<element name="dmd_background">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_15">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_16">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_33">
 		<text string="Cashpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_34">
 		<text string="Reserve">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_35">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_36">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_66">
 		<text string="Soccer shocker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_73">
 		<text string="Board room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Crsis">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_77">
 		<text string="pay meter">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_78">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_79">
 		<text string="1 - 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_81">
 		<text string="CHAMPIONS LEAGUE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_128">
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_131">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_152">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_153">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_154">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_155">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_156">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_157">
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_158">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_159">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="792" height="646">
-			</bounds>
+			<bounds x="0" y="0" width="792" height="646"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="236" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="236" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="236.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="239.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="242.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="246.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="249.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="252.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="236.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="239.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="242.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="246.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="249.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="252.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="236.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="236.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="239.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="239.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="242.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="242.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="246.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="249.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="249.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="252.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="252.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="236" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="236" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="318" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="318" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="318.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="321.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="324.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="328.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="331.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="334.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="318.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="321.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="324.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="328.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="331.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="334.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="318.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="321.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="324.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="328.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="331.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="334.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="318" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="318" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="400" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="400" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="400.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="400.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="403.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="406.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="406.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="410.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="410.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="413.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="413.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="416.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="416.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="400.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="400.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="403.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="406.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="406.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="410.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="410.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="413.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="413.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="416.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="416.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="400.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="400.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="403.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="406.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="406.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="410.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="410.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="413.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="413.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="416.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="416.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="400" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="400" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="482" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="482" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="482.0000" y="413.0000" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="482.0000" y="413.0000" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="485.3333" y="415.6389" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="485.3333" y="415.6389" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="488.6667" y="418.2778" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="488.6667" y="418.2778" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="492.0000" y="420.9167" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="492.0000" y="420.9167" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="495.3333" y="423.5555" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="495.3333" y="423.5555" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="498.6667" y="426.1945" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="498.6667" y="426.1945" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="482.0000" y="476.3333" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="482.0000" y="476.3333" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="485.3333" y="478.9722" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="485.3333" y="478.9722" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="488.6667" y="481.6111" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="488.6667" y="481.6111" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="492.0000" y="484.2500" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="492.0000" y="484.2500" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="495.3333" y="486.8889" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="495.3333" y="486.8889" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="498.6667" y="489.5278" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="498.6667" y="489.5278" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="482.0000" y="539.6667" width="80.0000" height="63.3333">
-			</bounds>
+			<bounds x="482.0000" y="539.6667" width="80.0000" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="485.3333" y="542.3056" width="73.3333" height="58.0556">
-			</bounds>
+			<bounds x="485.3333" y="542.3056" width="73.3333" height="58.0556"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="488.6667" y="544.9445" width="66.6667" height="52.7778">
-			</bounds>
+			<bounds x="488.6667" y="544.9445" width="66.6667" height="52.7778"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="492.0000" y="547.5834" width="60.0000" height="47.5000">
-			</bounds>
+			<bounds x="492.0000" y="547.5834" width="60.0000" height="47.5000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="495.3333" y="550.2222" width="53.3333" height="42.2222">
-			</bounds>
+			<bounds x="495.3333" y="550.2222" width="53.3333" height="42.2222"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="498.6667" y="552.8611" width="46.6667" height="36.9444">
-			</bounds>
+			<bounds x="498.6667" y="552.8611" width="46.6667" height="36.9444"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="482" y="413" width="80" height="190">
-			</bounds>
+			<bounds x="482" y="413" width="80" height="190"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="276" y="159" width="70" height="70">
-			</bounds>
+			<bounds x="276" y="159" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="276" y="159" width="70" height="70">
-			</bounds>
+			<bounds x="276" y="159" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="620" y="354" width="132" height="47">
-			</bounds>
+			<bounds x="620" y="354" width="132" height="47"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="622" y="356" width="128" height="43">
-			</bounds>
+			<bounds x="622" y="356" width="128" height="43"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="604" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="606" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="658" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="660" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="712" y="542" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="542" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="714" y="544" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="544" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="658" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="660" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="712" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="714" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="604" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="606" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="604" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="606" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="604" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="606" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="604" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="606" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="658" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="660" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="658" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="660" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="658" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="660" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="658" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="658" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="660" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="660" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="712" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="714" y="414" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="414" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="712" y="438" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="438" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="714" y="440" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="440" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="712" y="464" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="464" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="714" y="466" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="466" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="712" y="490" width="54" height="26">
-			</bounds>
+			<bounds x="712" y="490" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="714" y="492" width="50" height="22">
-			</bounds>
+			<bounds x="714" y="492" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="531" y="256" width="56" height="32">
-			</bounds>
+			<bounds x="531" y="256" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="533" y="258" width="52" height="28">
-			</bounds>
+			<bounds x="533" y="258" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="531" y="288" width="56" height="32">
-			</bounds>
+			<bounds x="531" y="288" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="533" y="290" width="52" height="28">
-			</bounds>
+			<bounds x="533" y="290" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="252" y="96" width="56" height="32">
-			</bounds>
+			<bounds x="252" y="96" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="254" y="98" width="52" height="28">
-			</bounds>
+			<bounds x="254" y="98" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="308" y="96" width="56" height="32">
-			</bounds>
+			<bounds x="308" y="96" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="310" y="98" width="52" height="28">
-			</bounds>
+			<bounds x="310" y="98" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="196" y="96" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="96" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="198" y="98" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="98" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="252" y="320" width="56" height="32">
-			</bounds>
+			<bounds x="252" y="320" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="254" y="322" width="52" height="28">
-			</bounds>
+			<bounds x="254" y="322" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="308" y="320" width="56" height="32">
-			</bounds>
+			<bounds x="308" y="320" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="310" y="322" width="52" height="28">
-			</bounds>
+			<bounds x="310" y="322" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="364" y="320" width="56" height="32">
-			</bounds>
+			<bounds x="364" y="320" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="366" y="322" width="52" height="28">
-			</bounds>
+			<bounds x="366" y="322" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="420" y="320" width="56" height="32">
-			</bounds>
+			<bounds x="420" y="320" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="422" y="322" width="52" height="28">
-			</bounds>
+			<bounds x="422" y="322" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="196" y="320" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="320" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="198" y="322" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="322" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="196" y="288" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="288" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="198" y="290" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="290" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="196" y="256" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="256" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="198" y="258" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="258" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="196" y="224" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="224" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="198" y="226" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="226" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="476" y="320" width="56" height="32">
-			</bounds>
+			<bounds x="476" y="320" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="478" y="322" width="52" height="28">
-			</bounds>
+			<bounds x="478" y="322" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="531" y="320" width="56" height="32">
-			</bounds>
+			<bounds x="531" y="320" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="533" y="322" width="52" height="28">
-			</bounds>
+			<bounds x="533" y="322" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="196" y="192" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="192" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="198" y="194" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="194" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="420" y="96" width="56" height="32">
-			</bounds>
+			<bounds x="420" y="96" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="422" y="98" width="52" height="28">
-			</bounds>
+			<bounds x="422" y="98" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="364" y="96" width="56" height="32">
-			</bounds>
+			<bounds x="364" y="96" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="366" y="98" width="52" height="28">
-			</bounds>
+			<bounds x="366" y="98" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="196" y="128" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="128" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="198" y="130" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="130" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="196" y="160" width="56" height="32">
-			</bounds>
+			<bounds x="196" y="160" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="198" y="162" width="52" height="28">
-			</bounds>
+			<bounds x="198" y="162" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="476" y="96" width="56" height="32">
-			</bounds>
+			<bounds x="476" y="96" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="478" y="98" width="52" height="28">
-			</bounds>
+			<bounds x="478" y="98" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="531" y="96" width="56" height="32">
-			</bounds>
+			<bounds x="531" y="96" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="533" y="98" width="52" height="28">
-			</bounds>
+			<bounds x="533" y="98" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="531" y="128" width="56" height="32">
-			</bounds>
+			<bounds x="531" y="128" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="533" y="130" width="52" height="28">
-			</bounds>
+			<bounds x="533" y="130" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="531" y="160" width="56" height="32">
-			</bounds>
+			<bounds x="531" y="160" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="533" y="162" width="52" height="28">
-			</bounds>
+			<bounds x="533" y="162" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="531" y="192" width="56" height="32">
-			</bounds>
+			<bounds x="531" y="192" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="533" y="194" width="52" height="28">
-			</bounds>
+			<bounds x="533" y="194" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="531" y="224" width="56" height="32">
-			</bounds>
+			<bounds x="531" y="224" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="533" y="226" width="52" height="28">
-			</bounds>
+			<bounds x="533" y="226" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="267" y="375" width="88" height="32">
-			</bounds>
+			<bounds x="267" y="375" width="88" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="269" y="377" width="84" height="28">
-			</bounds>
+			<bounds x="269" y="377" width="84" height="28"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="355" y="375" width="88" height="32">
-			</bounds>
+			<bounds x="355" y="375" width="88" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="357" y="377" width="84" height="28">
-			</bounds>
+			<bounds x="357" y="377" width="84" height="28"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="443" y="375" width="88" height="32">
-			</bounds>
+			<bounds x="443" y="375" width="88" height="32"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="445" y="377" width="84" height="28">
-			</bounds>
+			<bounds x="445" y="377" width="84" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="371" y="134" width="76" height="32">
-			</bounds>
+			<bounds x="371" y="134" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="373" y="136" width="72" height="28">
-			</bounds>
+			<bounds x="373" y="136" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="371" y="166" width="76" height="32">
-			</bounds>
+			<bounds x="371" y="166" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="373" y="168" width="72" height="28">
-			</bounds>
+			<bounds x="373" y="168" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="371" y="198" width="76" height="32">
-			</bounds>
+			<bounds x="371" y="198" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="373" y="200" width="72" height="28">
-			</bounds>
+			<bounds x="373" y="200" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="447" y="198" width="76" height="32">
-			</bounds>
+			<bounds x="447" y="198" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="449" y="200" width="72" height="28">
-			</bounds>
+			<bounds x="449" y="200" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="447" y="166" width="76" height="32">
-			</bounds>
+			<bounds x="447" y="166" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="449" y="168" width="72" height="28">
-			</bounds>
+			<bounds x="449" y="168" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="447" y="134" width="76" height="32">
-			</bounds>
+			<bounds x="447" y="134" width="76" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="449" y="136" width="72" height="28">
-			</bounds>
+			<bounds x="449" y="136" width="72" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="604" y="516" width="54" height="26">
-			</bounds>
+			<bounds x="604" y="516" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="606" y="518" width="50" height="22">
-			</bounds>
+			<bounds x="606" y="518" width="50" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="660" y="223" width="52" height="22">
-			</bounds>
+			<bounds x="660" y="223" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="662" y="225" width="48" height="18">
-			</bounds>
+			<bounds x="662" y="225" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="660" y="245" width="52" height="22">
-			</bounds>
+			<bounds x="660" y="245" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="662" y="247" width="48" height="18">
-			</bounds>
+			<bounds x="662" y="247" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="660" y="267" width="52" height="22">
-			</bounds>
+			<bounds x="660" y="267" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="662" y="269" width="48" height="18">
-			</bounds>
+			<bounds x="662" y="269" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="660" y="289" width="52" height="22">
-			</bounds>
+			<bounds x="660" y="289" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="662" y="291" width="48" height="18">
-			</bounds>
+			<bounds x="662" y="291" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="599" y="315" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="315" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="601" y="317" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="317" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="599" y="283" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="283" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="601" y="285" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="285" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="599" y="251" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="251" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="601" y="253" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="253" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="599" y="219" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="219" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="601" y="221" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="221" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="599" y="187" width="56" height="32">
-			</bounds>
+			<bounds x="599" y="187" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="601" y="189" width="52" height="28">
-			</bounds>
+			<bounds x="601" y="189" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="655" y="187" width="62" height="32">
-			</bounds>
+			<bounds x="655" y="187" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="657" y="189" width="58" height="28">
-			</bounds>
+			<bounds x="657" y="189" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="717" y="187" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="187" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="719" y="189" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="189" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="717" y="219" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="219" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="719" y="221" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="221" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="717" y="251" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="251" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="719" y="253" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="253" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="717" y="283" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="283" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="719" y="285" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="285" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="717" y="315" width="56" height="32">
-			</bounds>
+			<bounds x="717" y="315" width="56" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="719" y="317" width="52" height="28">
-			</bounds>
+			<bounds x="719" y="317" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="655" y="315" width="62" height="32">
-			</bounds>
+			<bounds x="655" y="315" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="657" y="317" width="58" height="28">
-			</bounds>
+			<bounds x="657" y="317" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="88" y="443" width="52" height="32">
-			</bounds>
+			<bounds x="88" y="443" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="90" y="445" width="48" height="28">
-			</bounds>
+			<bounds x="90" y="445" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="525" y="42" width="82" height="47">
-			</bounds>
+			<bounds x="525" y="42" width="82" height="47"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="527" y="44" width="78" height="43">
-			</bounds>
+			<bounds x="527" y="44" width="78" height="43"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_2_border" state="0">
-			<bounds x="525" y="9" width="82" height="32">
-			</bounds>
+			<bounds x="525" y="9" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_2" state="0">
-			<bounds x="527" y="11" width="78" height="28">
-			</bounds>
+			<bounds x="527" y="11" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_176_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="744" y="595" width="42" height="27">
-			</bounds>
+			<bounds x="744" y="595" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_176" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="746" y="597" width="38" height="23">
-			</bounds>
+			<bounds x="746" y="597" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_177_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="654" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="654" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_177" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="656" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="656" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_178_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="571" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="571" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_178" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="573" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="573" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_179_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="152" y="604" width="78" height="38">
-			</bounds>
+			<bounds x="152" y="604" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_179" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="154" y="606" width="74" height="34">
-			</bounds>
+			<bounds x="154" y="606" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_180_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="235" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="235" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_180" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="237" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="237" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_181_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="317" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="317" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_181" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="319" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="319" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_182_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="399" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="399" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_182" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="401" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="401" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_183_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="481" y="604" width="82" height="38">
-			</bounds>
+			<bounds x="481" y="604" width="82" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_183" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="483" y="606" width="78" height="34">
-			</bounds>
+			<bounds x="483" y="606" width="78" height="34"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="657" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="657" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off9" element="led_off">
-			<bounds x="661" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off10" element="led_off">
-			<bounds x="678" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off11" element="led_off">
-			<bounds x="678" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off12" element="led_off">
-			<bounds x="661" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off13" element="led_off">
-			<bounds x="661" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off14" element="led_off">
-			<bounds x="661" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off15" element="led_off">
-			<bounds x="661" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off8" element="led_dot_off">
-			<bounds x="682" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp9" element="led_on">
-			<bounds x="661" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp10" element="led_on">
-			<bounds x="678" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp11" element="led_on">
-			<bounds x="678" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp12" element="led_on">
-			<bounds x="661" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp13" element="led_on">
-			<bounds x="661" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp14" element="led_on">
-			<bounds x="661" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp15" element="led_on">
-			<bounds x="661" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp8" element="led_dot_on">
-			<bounds x="682" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="687" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="687" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off25" element="led_off">
-			<bounds x="691" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off26" element="led_off">
-			<bounds x="708" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off27" element="led_off">
-			<bounds x="708" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off28" element="led_off">
-			<bounds x="691" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off29" element="led_off">
-			<bounds x="691" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off30" element="led_off">
-			<bounds x="691" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off31" element="led_off">
-			<bounds x="691" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off24" element="led_dot_off">
-			<bounds x="712" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="712" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp25" element="led_on">
-			<bounds x="691" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp26" element="led_on">
-			<bounds x="708" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp27" element="led_on">
-			<bounds x="708" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="708" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp28" element="led_on">
-			<bounds x="691" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp29" element="led_on">
-			<bounds x="691" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp30" element="led_on">
-			<bounds x="691" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="691" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp31" element="led_on">
-			<bounds x="691" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="691" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp24" element="led_dot_on">
-			<bounds x="712" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="712" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="716" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="716" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="720" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="737" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="737" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="720" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="720" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="720" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="720" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="741" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="741" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="720" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="737" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="737" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="720" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="720" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="720" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="720" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="741" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="741" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="746" y="27" width="30" height="40">
-			</bounds>
+			<bounds x="746" y="27" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="750" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="767" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="767" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="750" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="750" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="750" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="750" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="771" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="771" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="750" y="30" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="30" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="767" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="767" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="750" y="59" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="59" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="750" y="45" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="45" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="750" y="30" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="30" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="750" y="45" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="45" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="771" y="59" width="4" height="3">
-			</bounds>
+			<bounds x="771" y="59" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="657" y="101" width="30" height="40">
-			</bounds>
+			<bounds x="657" y="101" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="661" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="678" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="678" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="661" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="661" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="661" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="661" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off256" element="led_dot_off">
-			<bounds x="682" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="661" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="678" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="678" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="678" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="661" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="661" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="661" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="661" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="661" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="661" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp256" element="led_dot_on">
-			<bounds x="682" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="682" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="686" y="101" width="30" height="40">
-			</bounds>
+			<bounds x="686" y="101" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="690" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="707" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="707" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="707" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="707" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="690" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="690" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="690" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="690" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="690" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="690" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="711" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="711" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="690" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="707" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="707" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="707" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="707" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="690" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="690" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="690" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="690" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="690" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="690" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="690" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="711" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="711" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="716" y="101" width="30" height="40">
-			</bounds>
+			<bounds x="716" y="101" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off105" element="led_off">
-			<bounds x="720" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off106" element="led_off">
-			<bounds x="737" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off107" element="led_off">
-			<bounds x="737" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off108" element="led_off">
-			<bounds x="720" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off109" element="led_off">
-			<bounds x="720" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off110" element="led_off">
-			<bounds x="720" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off111" element="led_off">
-			<bounds x="720" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off104" element="led_dot_off">
-			<bounds x="741" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="741" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp105" element="led_on">
-			<bounds x="720" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp106" element="led_on">
-			<bounds x="737" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="led_on">
-			<bounds x="737" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="737" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp108" element="led_on">
-			<bounds x="720" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp109" element="led_on">
-			<bounds x="720" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp110" element="led_on">
-			<bounds x="720" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="720" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp111" element="led_on">
-			<bounds x="720" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="720" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp104" element="led_dot_on">
-			<bounds x="741" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="741" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="746" y="101" width="30" height="40">
-			</bounds>
+			<bounds x="746" y="101" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off121" element="led_off">
-			<bounds x="750" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off122" element="led_off">
-			<bounds x="767" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off123" element="led_off">
-			<bounds x="767" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off124" element="led_off">
-			<bounds x="750" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off125" element="led_off">
-			<bounds x="750" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off126" element="led_off">
-			<bounds x="750" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off127" element="led_off">
-			<bounds x="750" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off120" element="led_dot_off">
-			<bounds x="771" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="771" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp121" element="led_on">
-			<bounds x="750" y="104" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="104" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp122" element="led_on">
-			<bounds x="767" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp123" element="led_on">
-			<bounds x="767" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="767" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp124" element="led_on">
-			<bounds x="750" y="133" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="133" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp125" element="led_on">
-			<bounds x="750" y="119" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="119" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp126" element="led_on">
-			<bounds x="750" y="104" width="4" height="18">
-			</bounds>
+			<bounds x="750" y="104" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp127" element="led_on">
-			<bounds x="750" y="119" width="21" height="3">
-			</bounds>
+			<bounds x="750" y="119" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp120" element="led_dot_on">
-			<bounds x="771" y="133" width="4" height="3">
-			</bounds>
+			<bounds x="771" y="133" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="363" y="256" width="30" height="40">
-			</bounds>
+			<bounds x="363" y="256" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off137" element="led_off">
-			<bounds x="367" y="259" width="21" height="3">
-			</bounds>
+			<bounds x="367" y="259" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off138" element="led_off">
-			<bounds x="384" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="384" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off139" element="led_off">
-			<bounds x="384" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="384" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off140" element="led_off">
-			<bounds x="367" y="288" width="21" height="3">
-			</bounds>
+			<bounds x="367" y="288" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off141" element="led_off">
-			<bounds x="367" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="367" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off142" element="led_off">
-			<bounds x="367" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="367" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off143" element="led_off">
-			<bounds x="367" y="274" width="21" height="3">
-			</bounds>
+			<bounds x="367" y="274" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off136" element="led_dot_off">
-			<bounds x="388" y="288" width="4" height="3">
-			</bounds>
+			<bounds x="388" y="288" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp137" element="led_on">
-			<bounds x="367" y="259" width="21" height="3">
-			</bounds>
+			<bounds x="367" y="259" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp138" element="led_on">
-			<bounds x="384" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="384" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="led_on">
-			<bounds x="384" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="384" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="led_on">
-			<bounds x="367" y="288" width="21" height="3">
-			</bounds>
+			<bounds x="367" y="288" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp141" element="led_on">
-			<bounds x="367" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="367" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp142" element="led_on">
-			<bounds x="367" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="367" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp143" element="led_on">
-			<bounds x="367" y="274" width="21" height="3">
-			</bounds>
+			<bounds x="367" y="274" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp136" element="led_dot_on">
-			<bounds x="388" y="288" width="4" height="3">
-			</bounds>
+			<bounds x="388" y="288" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="333" y="256" width="30" height="40">
-			</bounds>
+			<bounds x="333" y="256" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off153" element="led_off">
-			<bounds x="337" y="259" width="21" height="3">
-			</bounds>
+			<bounds x="337" y="259" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off154" element="led_off">
-			<bounds x="354" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="354" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off155" element="led_off">
-			<bounds x="354" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="354" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off156" element="led_off">
-			<bounds x="337" y="288" width="21" height="3">
-			</bounds>
+			<bounds x="337" y="288" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off157" element="led_off">
-			<bounds x="337" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="337" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off158" element="led_off">
-			<bounds x="337" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="337" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off159" element="led_off">
-			<bounds x="337" y="274" width="21" height="3">
-			</bounds>
+			<bounds x="337" y="274" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off152" element="led_dot_off">
-			<bounds x="358" y="288" width="4" height="3">
-			</bounds>
+			<bounds x="358" y="288" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp153" element="led_on">
-			<bounds x="337" y="259" width="21" height="3">
-			</bounds>
+			<bounds x="337" y="259" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp154" element="led_on">
-			<bounds x="354" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="354" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="led_on">
-			<bounds x="354" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="354" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp156" element="led_on">
-			<bounds x="337" y="288" width="21" height="3">
-			</bounds>
+			<bounds x="337" y="288" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp157" element="led_on">
-			<bounds x="337" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="337" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp158" element="led_on">
-			<bounds x="337" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="337" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp159" element="led_on">
-			<bounds x="337" y="274" width="21" height="3">
-			</bounds>
+			<bounds x="337" y="274" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp152" element="led_dot_on">
-			<bounds x="358" y="288" width="4" height="3">
-			</bounds>
+			<bounds x="358" y="288" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="303" y="256" width="30" height="40">
-			</bounds>
+			<bounds x="303" y="256" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="led_off169" element="led_off">
-			<bounds x="307" y="259" width="21" height="3">
-			</bounds>
+			<bounds x="307" y="259" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off170" element="led_off">
-			<bounds x="324" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="324" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off171" element="led_off">
-			<bounds x="324" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="324" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off172" element="led_off">
-			<bounds x="307" y="288" width="21" height="3">
-			</bounds>
+			<bounds x="307" y="288" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off173" element="led_off">
-			<bounds x="307" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="307" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off174" element="led_off">
-			<bounds x="307" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="307" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="led_off175" element="led_off">
-			<bounds x="307" y="274" width="21" height="3">
-			</bounds>
+			<bounds x="307" y="274" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="led_off168" element="led_dot_off">
-			<bounds x="328" y="288" width="4" height="3">
-			</bounds>
+			<bounds x="328" y="288" width="4" height="3"/>
 		</backdrop>
 		<backdrop name="lamp169" element="led_on">
-			<bounds x="307" y="259" width="21" height="3">
-			</bounds>
+			<bounds x="307" y="259" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp170" element="led_on">
-			<bounds x="324" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="324" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="led_on">
-			<bounds x="324" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="324" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp172" element="led_on">
-			<bounds x="307" y="288" width="21" height="3">
-			</bounds>
+			<bounds x="307" y="288" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp173" element="led_on">
-			<bounds x="307" y="274" width="4" height="18">
-			</bounds>
+			<bounds x="307" y="274" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp174" element="led_on">
-			<bounds x="307" y="259" width="4" height="18">
-			</bounds>
+			<bounds x="307" y="259" width="4" height="18"/>
 		</backdrop>
 		<backdrop name="lamp175" element="led_on">
-			<bounds x="307" y="274" width="21" height="3">
-			</bounds>
+			<bounds x="307" y="274" width="21" height="3"/>
 		</backdrop>
 		<backdrop name="lamp168" element="led_dot_on">
-			<bounds x="328" y="288" width="4" height="3">
-			</bounds>
+			<bounds x="328" y="288" width="4" height="3"/>
 		</backdrop>
-		<!-- The DMD -->
-	<screen index="0">
-			<bounds left="261" top="6" right="523" bottom="92" />
+		<backdrop element="dmd_background">
+			<bounds x="261" y="6" width="262" height="86"/>
+		</backdrop>
+		<screen index="0">
+			<bounds left="261" top="6" right="523" bottom="92"/>
+		</screen>
+		<screen index="0">
+			<bounds left="261" top="6" right="523" bottom="92"/>
+		</screen>
+		<screen index="0">
+			<bounds left="261" top="6" right="523" bottom="92"/>
 		</screen>
 		<backdrop name="label15" element="label_15">
-			<bounds x="619" y="85" width="38" height="67">
-			</bounds>
+			<bounds x="619" y="85" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label16" element="label_16">
-			<bounds x="619" y="11" width="38" height="67">
-			</bounds>
+			<bounds x="619" y="11" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label33" element="label_33">
-			<bounds x="660" y="77" width="85" height="24">
-			</bounds>
+			<bounds x="660" y="77" width="85" height="24"/>
 		</backdrop>
 		<backdrop name="label34" element="label_34">
-			<bounds x="667" y="3" width="84" height="24">
-			</bounds>
+			<bounds x="667" y="3" width="84" height="24"/>
 		</backdrop>
 		<backdrop name="label35" element="label_35">
-			<bounds x="209" y="495" width="25" height="26">
-			</bounds>
+			<bounds x="209" y="495" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label36" element="label_36">
-			<bounds x="564" y="495" width="25" height="26">
-			</bounds>
+			<bounds x="564" y="495" width="25" height="26"/>
 		</backdrop>
 		<backdrop name="label66" element="label_66">
-			<bounds x="307" y="353" width="147" height="22">
-			</bounds>
+			<bounds x="307" y="353" width="147" height="22"/>
 		</backdrop>
 		<backdrop name="label73" element="label_73">
-			<bounds x="384" y="231" width="91" height="38">
-			</bounds>
+			<bounds x="384" y="231" width="91" height="38"/>
 		</backdrop>
 		<backdrop name="label77" element="label_77">
-			<bounds x="293" y="296" width="75" height="19">
-			</bounds>
+			<bounds x="293" y="296" width="75" height="19"/>
 		</backdrop>
 		<backdrop name="label78" element="label_78">
-			<bounds x="266" y="240" width="38" height="67">
-			</bounds>
+			<bounds x="266" y="240" width="38" height="67"/>
 		</backdrop>
 		<backdrop name="label79" element="label_79">
-			<bounds x="291" y="137" width="38" height="22">
-			</bounds>
+			<bounds x="291" y="137" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="label81" element="label_81">
-			<bounds x="625" y="174" width="110" height="14">
-			</bounds>
+			<bounds x="625" y="174" width="110" height="14"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="117" y="10" width="44" height="22">
-			</bounds>
+			<bounds x="117" y="10" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="117" y="36" width="33" height="22">
-			</bounds>
+			<bounds x="117" y="36" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="118" y="64" width="33" height="22">
-			</bounds>
+			<bounds x="118" y="64" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="122" y="93" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="93" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="122" y="119" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="119" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="122" y="147" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="147" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="122" y="174" width="33" height="22">
-			</bounds>
+			<bounds x="122" y="174" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label152" element="label_152">
-			<bounds x="107" y="389" width="22" height="22">
-			</bounds>
+			<bounds x="107" y="389" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label153" element="label_153">
-			<bounds x="107" y="363" width="40" height="19">
-			</bounds>
+			<bounds x="107" y="363" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label154" element="label_154">
-			<bounds x="107" y="335" width="22" height="22">
-			</bounds>
+			<bounds x="107" y="335" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label155" element="label_155">
-			<bounds x="107" y="308" width="22" height="22">
-			</bounds>
+			<bounds x="107" y="308" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label156" element="label_156">
-			<bounds x="107" y="281" width="22" height="22">
-			</bounds>
+			<bounds x="107" y="281" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label157" element="label_157">
-			<bounds x="107" y="253" width="22" height="22">
-			</bounds>
+			<bounds x="107" y="253" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label158" element="label_158">
-			<bounds x="107" y="227" width="33" height="22">
-			</bounds>
+			<bounds x="107" y="227" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label159" element="label_159">
-			<bounds x="107" y="200" width="33" height="22">
-			</bounds>
+			<bounds x="107" y="200" width="33" height="22"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
+		<screen index="0">
+			<bounds left="1400" top="400" right="1790" bottom="526"/>
+		</screen>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2prom.lay
+++ b/src/mame/layout/sc2prom.lay
@@ -8,9891 +8,6298 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="PIER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="GAMES ROOM ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="PIER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="GAMES ROOM ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BEST WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FROM NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BEST WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FROM NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="  &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="  &#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="PUBLIC TOILETS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="  GENTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="PUBLIC TOILETS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="  GENTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="GOOD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NEWS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="GOOD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NEWS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NEWS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NEWS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="FORTUNE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TELLER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="FORTUNE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TELLER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="ROCK SHOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="ROCK SHOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" 60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" 60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="ICE CREAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string=" SHOP  1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="ICE CREAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string=" SHOP  1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="PRIZE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="PRIZE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TRAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RIDE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="TRAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RIDE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="TRIVIA QUIZ AND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="KARAOKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="NIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRIVIA QUIZ AND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="KARAOKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="NIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BURGER BAR 2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BURGER BAR 2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string=" 3 BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HAPPY HOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string=" 3 BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HAPPY HOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="TALENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CONTEST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="TALENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CONTEST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOST ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WALLET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOST ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WALLET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="PAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LANDLA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="PAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LANDLA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="GIFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="GIFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WEEK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WEEK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="CASHPOINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MYSTERY WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="CASHPOINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MYSTERY WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="  40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="  40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LAST DAY TRAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LAST DAY TRAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="LAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="LAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="PRIZE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="PRIZE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="T SHOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="I NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="T SHOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="I NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string=" ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" 40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string=" ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" 40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="FRED'S CHIPPY 1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="FRED'S CHIPPY 1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ARCADE  20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARCADE  20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" 20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" 20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="SEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="FOOD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="I NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="SEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="FOOD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="I NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="LAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="LAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_195_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_195">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_197_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_197">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_198_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_198">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_199_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_199">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_200_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_200">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_201_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_201">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
-
+	<element name="dmd_background">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
+	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_66">
 		<text string="ON WINLINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STARTS FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_72">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_73">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_127">
 		<text string="Thanks to dave and tommy.c">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="763" height="859">
-			</bounds>
+			<bounds x="0" y="0" width="763" height="859"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="101" y="564" width="89" height="145">
-			</bounds>
+			<bounds x="101" y="564" width="89" height="145"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="564.0000" width="89.0000" height="48.3333">
-			</bounds>
+			<bounds x="101.0000" y="564.0000" width="89.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.7083" y="566.0139" width="81.5833" height="44.3056">
-			</bounds>
+			<bounds x="104.7083" y="566.0139" width="81.5833" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.4167" y="568.0278" width="74.1667" height="40.2778">
-			</bounds>
+			<bounds x="108.4167" y="568.0278" width="74.1667" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.1250" y="570.0417" width="66.7500" height="36.2500">
-			</bounds>
+			<bounds x="112.1250" y="570.0417" width="66.7500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.8333" y="572.0555" width="59.3333" height="32.2222">
-			</bounds>
+			<bounds x="115.8333" y="572.0555" width="59.3333" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="119.5417" y="574.0695" width="51.9167" height="28.1944">
-			</bounds>
+			<bounds x="119.5417" y="574.0695" width="51.9167" height="28.1944"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="612.3333" width="89.0000" height="48.3333">
-			</bounds>
+			<bounds x="101.0000" y="612.3333" width="89.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.7083" y="614.3472" width="81.5833" height="44.3056">
-			</bounds>
+			<bounds x="104.7083" y="614.3472" width="81.5833" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.4167" y="616.3611" width="74.1667" height="40.2778">
-			</bounds>
+			<bounds x="108.4167" y="616.3611" width="74.1667" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.1250" y="618.3750" width="66.7500" height="36.2500">
-			</bounds>
+			<bounds x="112.1250" y="618.3750" width="66.7500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.8333" y="620.3889" width="59.3333" height="32.2222">
-			</bounds>
+			<bounds x="115.8333" y="620.3889" width="59.3333" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="119.5417" y="622.4028" width="51.9167" height="28.1944">
-			</bounds>
+			<bounds x="119.5417" y="622.4028" width="51.9167" height="28.1944"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="660.6667" width="89.0000" height="48.3333">
-			</bounds>
+			<bounds x="101.0000" y="660.6667" width="89.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.7083" y="662.6806" width="81.5833" height="44.3056">
-			</bounds>
+			<bounds x="104.7083" y="662.6806" width="81.5833" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="108.4167" y="664.6945" width="74.1667" height="40.2778">
-			</bounds>
+			<bounds x="108.4167" y="664.6945" width="74.1667" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="112.1250" y="666.7084" width="66.7500" height="36.2500">
-			</bounds>
+			<bounds x="112.1250" y="666.7084" width="66.7500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="115.8333" y="668.7222" width="59.3333" height="32.2222">
-			</bounds>
+			<bounds x="115.8333" y="668.7222" width="59.3333" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="119.5417" y="670.7361" width="51.9167" height="28.1944">
-			</bounds>
+			<bounds x="119.5417" y="670.7361" width="51.9167" height="28.1944"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="101" y="564" width="89" height="145">
-			</bounds>
+			<bounds x="101" y="564" width="89" height="145"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="195" y="564" width="87" height="145">
-			</bounds>
+			<bounds x="195" y="564" width="87" height="145"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="564.0000" width="87.0000" height="48.3333">
-			</bounds>
+			<bounds x="195.0000" y="564.0000" width="87.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="198.6250" y="566.0139" width="79.7500" height="44.3056">
-			</bounds>
+			<bounds x="198.6250" y="566.0139" width="79.7500" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="202.2500" y="568.0278" width="72.5000" height="40.2778">
-			</bounds>
+			<bounds x="202.2500" y="568.0278" width="72.5000" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="205.8750" y="570.0417" width="65.2500" height="36.2500">
-			</bounds>
+			<bounds x="205.8750" y="570.0417" width="65.2500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="209.5000" y="572.0555" width="58.0000" height="32.2222">
-			</bounds>
+			<bounds x="209.5000" y="572.0555" width="58.0000" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="213.1250" y="574.0695" width="50.7500" height="28.1944">
-			</bounds>
+			<bounds x="213.1250" y="574.0695" width="50.7500" height="28.1944"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="612.3333" width="87.0000" height="48.3333">
-			</bounds>
+			<bounds x="195.0000" y="612.3333" width="87.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="198.6250" y="614.3472" width="79.7500" height="44.3056">
-			</bounds>
+			<bounds x="198.6250" y="614.3472" width="79.7500" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="202.2500" y="616.3611" width="72.5000" height="40.2778">
-			</bounds>
+			<bounds x="202.2500" y="616.3611" width="72.5000" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="205.8750" y="618.3750" width="65.2500" height="36.2500">
-			</bounds>
+			<bounds x="205.8750" y="618.3750" width="65.2500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="209.5000" y="620.3889" width="58.0000" height="32.2222">
-			</bounds>
+			<bounds x="209.5000" y="620.3889" width="58.0000" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="213.1250" y="622.4028" width="50.7500" height="28.1944">
-			</bounds>
+			<bounds x="213.1250" y="622.4028" width="50.7500" height="28.1944"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="195.0000" y="660.6667" width="87.0000" height="48.3333">
-			</bounds>
+			<bounds x="195.0000" y="660.6667" width="87.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="198.6250" y="662.6806" width="79.7500" height="44.3056">
-			</bounds>
+			<bounds x="198.6250" y="662.6806" width="79.7500" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="202.2500" y="664.6945" width="72.5000" height="40.2778">
-			</bounds>
+			<bounds x="202.2500" y="664.6945" width="72.5000" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="205.8750" y="666.7084" width="65.2500" height="36.2500">
-			</bounds>
+			<bounds x="205.8750" y="666.7084" width="65.2500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="209.5000" y="668.7222" width="58.0000" height="32.2222">
-			</bounds>
+			<bounds x="209.5000" y="668.7222" width="58.0000" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="213.1250" y="670.7361" width="50.7500" height="28.1944">
-			</bounds>
+			<bounds x="213.1250" y="670.7361" width="50.7500" height="28.1944"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="195" y="564" width="87" height="145">
-			</bounds>
+			<bounds x="195" y="564" width="87" height="145"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="288" y="563" width="87" height="145">
-			</bounds>
+			<bounds x="288" y="563" width="87" height="145"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="288.0000" y="563.0000" width="87.0000" height="48.3333">
-			</bounds>
+			<bounds x="288.0000" y="563.0000" width="87.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="291.6250" y="565.0139" width="79.7500" height="44.3056">
-			</bounds>
+			<bounds x="291.6250" y="565.0139" width="79.7500" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="295.2500" y="567.0278" width="72.5000" height="40.2778">
-			</bounds>
+			<bounds x="295.2500" y="567.0278" width="72.5000" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="298.8750" y="569.0417" width="65.2500" height="36.2500">
-			</bounds>
+			<bounds x="298.8750" y="569.0417" width="65.2500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="302.5000" y="571.0555" width="58.0000" height="32.2222">
-			</bounds>
+			<bounds x="302.5000" y="571.0555" width="58.0000" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="306.1250" y="573.0695" width="50.7500" height="28.1944">
-			</bounds>
+			<bounds x="306.1250" y="573.0695" width="50.7500" height="28.1944"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="288.0000" y="611.3333" width="87.0000" height="48.3333">
-			</bounds>
+			<bounds x="288.0000" y="611.3333" width="87.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="291.6250" y="613.3472" width="79.7500" height="44.3056">
-			</bounds>
+			<bounds x="291.6250" y="613.3472" width="79.7500" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="295.2500" y="615.3611" width="72.5000" height="40.2778">
-			</bounds>
+			<bounds x="295.2500" y="615.3611" width="72.5000" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="298.8750" y="617.3750" width="65.2500" height="36.2500">
-			</bounds>
+			<bounds x="298.8750" y="617.3750" width="65.2500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="302.5000" y="619.3889" width="58.0000" height="32.2222">
-			</bounds>
+			<bounds x="302.5000" y="619.3889" width="58.0000" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="306.1250" y="621.4028" width="50.7500" height="28.1944">
-			</bounds>
+			<bounds x="306.1250" y="621.4028" width="50.7500" height="28.1944"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="288.0000" y="659.6667" width="87.0000" height="48.3333">
-			</bounds>
+			<bounds x="288.0000" y="659.6667" width="87.0000" height="48.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="291.6250" y="661.6806" width="79.7500" height="44.3056">
-			</bounds>
+			<bounds x="291.6250" y="661.6806" width="79.7500" height="44.3056"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="295.2500" y="663.6945" width="72.5000" height="40.2778">
-			</bounds>
+			<bounds x="295.2500" y="663.6945" width="72.5000" height="40.2778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="298.8750" y="665.7084" width="65.2500" height="36.2500">
-			</bounds>
+			<bounds x="298.8750" y="665.7084" width="65.2500" height="36.2500"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="302.5000" y="667.7222" width="58.0000" height="32.2222">
-			</bounds>
+			<bounds x="302.5000" y="667.7222" width="58.0000" height="32.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="306.1250" y="669.7361" width="50.7500" height="28.1944">
-			</bounds>
+			<bounds x="306.1250" y="669.7361" width="50.7500" height="28.1944"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="288" y="563" width="87" height="145">
-			</bounds>
+			<bounds x="288" y="563" width="87" height="145"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="257" y="165" width="62" height="68">
-			</bounds>
+			<bounds x="257" y="165" width="62" height="68"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_0" state="0">
-			<bounds x="257.0000" y="165.0000" width="62.0000" height="68.0000">
-			</bounds>
+			<bounds x="257.0000" y="165.0000" width="62.0000" height="68.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_1" state="0">
-			<bounds x="259.5833" y="167.8333" width="56.8333" height="62.3333">
-			</bounds>
+			<bounds x="259.5833" y="167.8333" width="56.8333" height="62.3333"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_2" state="0">
-			<bounds x="262.1667" y="170.6667" width="51.6667" height="56.6667">
-			</bounds>
+			<bounds x="262.1667" y="170.6667" width="51.6667" height="56.6667"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_3" state="0">
-			<bounds x="264.7500" y="173.5000" width="46.5000" height="51.0000">
-			</bounds>
+			<bounds x="264.7500" y="173.5000" width="46.5000" height="51.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_4" state="0">
-			<bounds x="267.3333" y="176.3333" width="41.3333" height="45.3333">
-			</bounds>
+			<bounds x="267.3333" y="176.3333" width="41.3333" height="45.3333"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_5" state="0">
-			<bounds x="269.9167" y="179.1667" width="36.1667" height="39.6667">
-			</bounds>
+			<bounds x="269.9167" y="179.1667" width="36.1667" height="39.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="257" y="165" width="62" height="68">
-			</bounds>
+			<bounds x="257" y="165" width="62" height="68"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="175" y="39" width="172" height="96">
-			</bounds>
+			<bounds x="175" y="39" width="172" height="96"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="177" y="41" width="168" height="92">
-			</bounds>
+			<bounds x="177" y="41" width="168" height="92"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="5" y="763" width="50" height="24">
-			</bounds>
+			<bounds x="5" y="763" width="50" height="24"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="7" y="765" width="46" height="20">
-			</bounds>
+			<bounds x="7" y="765" width="46" height="20"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="489" y="699" width="74" height="30">
-			</bounds>
+			<bounds x="489" y="699" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="491" y="701" width="70" height="26">
-			</bounds>
+			<bounds x="491" y="701" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="470" y="628" width="102" height="47">
-			</bounds>
+			<bounds x="470" y="628" width="102" height="47"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="472" y="630" width="98" height="43">
-			</bounds>
+			<bounds x="472" y="630" width="98" height="43"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="496" y="592" width="58" height="18">
-			</bounds>
+			<bounds x="496" y="592" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="498" y="594" width="54" height="14">
-			</bounds>
+			<bounds x="498" y="594" width="54" height="14"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="491" y="568" width="68" height="26">
-			</bounds>
+			<bounds x="491" y="568" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="493" y="570" width="64" height="22">
-			</bounds>
+			<bounds x="493" y="570" width="64" height="22"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="97" y="39" width="74" height="102">
-			</bounds>
+			<bounds x="97" y="39" width="74" height="102"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="99" y="41" width="70" height="98">
-			</bounds>
+			<bounds x="99" y="41" width="70" height="98"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="97" y="149" width="74" height="98">
-			</bounds>
+			<bounds x="97" y="149" width="74" height="98"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="99" y="151" width="70" height="94">
-			</bounds>
+			<bounds x="99" y="151" width="70" height="94"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="482" y="396" width="52" height="40">
-			</bounds>
+			<bounds x="482" y="396" width="52" height="40"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="484" y="398" width="48" height="36">
-			</bounds>
+			<bounds x="484" y="398" width="48" height="36"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="482" y="355" width="52" height="40">
-			</bounds>
+			<bounds x="482" y="355" width="52" height="40"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="484" y="357" width="48" height="36">
-			</bounds>
+			<bounds x="484" y="357" width="48" height="36"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="394" y="380" width="74" height="58">
-			</bounds>
+			<bounds x="394" y="380" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="396" y="382" width="70" height="54">
-			</bounds>
+			<bounds x="396" y="382" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="319" y="380" width="74" height="58">
-			</bounds>
+			<bounds x="319" y="380" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="321" y="382" width="70" height="54">
-			</bounds>
+			<bounds x="321" y="382" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="245" y="380" width="74" height="58">
-			</bounds>
+			<bounds x="245" y="380" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="247" y="382" width="70" height="54">
-			</bounds>
+			<bounds x="247" y="382" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="169" y="380" width="74" height="58">
-			</bounds>
+			<bounds x="169" y="380" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="171" y="382" width="70" height="54">
-			</bounds>
+			<bounds x="171" y="382" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="94" y="380" width="74" height="58">
-			</bounds>
+			<bounds x="94" y="380" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="96" y="382" width="70" height="54">
-			</bounds>
+			<bounds x="96" y="382" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="621" y="383" width="74" height="58">
-			</bounds>
+			<bounds x="621" y="383" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="623" y="385" width="70" height="54">
-			</bounds>
+			<bounds x="623" y="385" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="621" y="324" width="74" height="58">
-			</bounds>
+			<bounds x="621" y="324" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="623" y="326" width="70" height="54">
-			</bounds>
+			<bounds x="623" y="326" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="621" y="265" width="74" height="58">
-			</bounds>
+			<bounds x="621" y="265" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="623" y="267" width="70" height="54">
-			</bounds>
+			<bounds x="623" y="267" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="621" y="206" width="74" height="58">
-			</bounds>
+			<bounds x="621" y="206" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="623" y="208" width="70" height="54">
-			</bounds>
+			<bounds x="623" y="208" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="225" y="284" width="64" height="40">
-			</bounds>
+			<bounds x="225" y="284" width="64" height="40"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="227" y="286" width="60" height="36">
-			</bounds>
+			<bounds x="227" y="286" width="60" height="36"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="292" y="283" width="56" height="40">
-			</bounds>
+			<bounds x="292" y="283" width="56" height="40"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="294" y="285" width="52" height="36">
-			</bounds>
+			<bounds x="294" y="285" width="52" height="36"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="149" y="284" width="76" height="40">
-			</bounds>
+			<bounds x="149" y="284" width="76" height="40"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="151" y="286" width="72" height="36">
-			</bounds>
+			<bounds x="151" y="286" width="72" height="36"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="350" y="282" width="66" height="40">
-			</bounds>
+			<bounds x="350" y="282" width="66" height="40"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="352" y="284" width="62" height="36">
-			</bounds>
+			<bounds x="352" y="284" width="62" height="36"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="417" y="282" width="55" height="40">
-			</bounds>
+			<bounds x="417" y="282" width="55" height="40"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="419" y="284" width="51" height="36">
-			</bounds>
+			<bounds x="419" y="284" width="51" height="36"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="473" y="282" width="56" height="40">
-			</bounds>
+			<bounds x="473" y="282" width="56" height="40"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="475" y="284" width="52" height="36">
-			</bounds>
+			<bounds x="475" y="284" width="52" height="36"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="439" y="147" width="90" height="58">
-			</bounds>
+			<bounds x="439" y="147" width="90" height="58"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="441" y="149" width="86" height="54">
-			</bounds>
+			<bounds x="441" y="149" width="86" height="54"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="530" y="147" width="90" height="58">
-			</bounds>
+			<bounds x="530" y="147" width="90" height="58"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="532" y="149" width="86" height="54">
-			</bounds>
+			<bounds x="532" y="149" width="86" height="54"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="621" y="147" width="74" height="58">
-			</bounds>
+			<bounds x="621" y="147" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="623" y="149" width="70" height="54">
-			</bounds>
+			<bounds x="623" y="149" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="349" y="39" width="90" height="50">
-			</bounds>
+			<bounds x="349" y="39" width="90" height="50"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="351" y="41" width="86" height="46">
-			</bounds>
+			<bounds x="351" y="41" width="86" height="46"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="349" y="90" width="90" height="54">
-			</bounds>
+			<bounds x="349" y="90" width="90" height="54"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="351" y="92" width="86" height="50">
-			</bounds>
+			<bounds x="351" y="92" width="86" height="50"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="349" y="147" width="90" height="58">
-			</bounds>
+			<bounds x="349" y="147" width="90" height="58"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="351" y="149" width="86" height="54">
-			</bounds>
+			<bounds x="351" y="149" width="86" height="54"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="676" y="741" width="64" height="34">
-			</bounds>
+			<bounds x="676" y="741" width="64" height="34"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="678" y="743" width="60" height="30">
-			</bounds>
+			<bounds x="678" y="743" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="676" y="706" width="64" height="34">
-			</bounds>
+			<bounds x="676" y="706" width="64" height="34"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="678" y="708" width="60" height="30">
-			</bounds>
+			<bounds x="678" y="708" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="676" y="671" width="64" height="34">
-			</bounds>
+			<bounds x="676" y="671" width="64" height="34"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="678" y="673" width="60" height="30">
-			</bounds>
+			<bounds x="678" y="673" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="676" y="636" width="64" height="34">
-			</bounds>
+			<bounds x="676" y="636" width="64" height="34"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="678" y="638" width="60" height="30">
-			</bounds>
+			<bounds x="678" y="638" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="676" y="601" width="64" height="34">
-			</bounds>
+			<bounds x="676" y="601" width="64" height="34"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="678" y="603" width="60" height="30">
-			</bounds>
+			<bounds x="678" y="603" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="676" y="566" width="64" height="34">
-			</bounds>
+			<bounds x="676" y="566" width="64" height="34"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="678" y="568" width="60" height="30">
-			</bounds>
+			<bounds x="678" y="568" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="676" y="531" width="64" height="34">
-			</bounds>
+			<bounds x="676" y="531" width="64" height="34"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="678" y="533" width="60" height="30">
-			</bounds>
+			<bounds x="678" y="533" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="74" y="730" width="82" height="26">
-			</bounds>
+			<bounds x="74" y="730" width="82" height="26"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="76" y="732" width="78" height="22">
-			</bounds>
+			<bounds x="76" y="732" width="78" height="22"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="54" y="757" width="34" height="34">
-			</bounds>
+			<bounds x="54" y="757" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="56" y="759" width="30" height="30">
-			</bounds>
+			<bounds x="56" y="759" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="89" y="757" width="34" height="34">
-			</bounds>
+			<bounds x="89" y="757" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="91" y="759" width="30" height="30">
-			</bounds>
+			<bounds x="91" y="759" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="124" y="757" width="34" height="34">
-			</bounds>
+			<bounds x="124" y="757" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="126" y="759" width="30" height="30">
-			</bounds>
+			<bounds x="126" y="759" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="159" y="757" width="34" height="34">
-			</bounds>
+			<bounds x="159" y="757" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="161" y="759" width="30" height="30">
-			</bounds>
+			<bounds x="161" y="759" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="395" y="441" width="74" height="58">
-			</bounds>
+			<bounds x="395" y="441" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="397" y="443" width="70" height="54">
-			</bounds>
+			<bounds x="397" y="443" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="470" y="441" width="74" height="58">
-			</bounds>
+			<bounds x="470" y="441" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="472" y="443" width="70" height="54">
-			</bounds>
+			<bounds x="472" y="443" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="545" y="441" width="74" height="58">
-			</bounds>
+			<bounds x="545" y="441" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="547" y="443" width="70" height="54">
-			</bounds>
+			<bounds x="547" y="443" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="621" y="441" width="74" height="58">
-			</bounds>
+			<bounds x="621" y="441" width="74" height="58"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="623" y="443" width="70" height="54">
-			</bounds>
+			<bounds x="623" y="443" width="70" height="54"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="18" y="248" width="74" height="96">
-			</bounds>
+			<bounds x="18" y="248" width="74" height="96"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="20" y="250" width="70" height="92">
-			</bounds>
+			<bounds x="20" y="250" width="70" height="92"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="18" y="149" width="74" height="98">
-			</bounds>
+			<bounds x="18" y="149" width="74" height="98"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="20" y="151" width="70" height="94">
-			</bounds>
+			<bounds x="20" y="151" width="70" height="94"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="18" y="345" width="74" height="96">
-			</bounds>
+			<bounds x="18" y="345" width="74" height="96"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="20" y="347" width="70" height="92">
-			</bounds>
+			<bounds x="20" y="347" width="70" height="92"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_193_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="716" y="2" width="45" height="36">
-			</bounds>
+			<bounds x="716" y="2" width="45" height="36"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_193" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="718" y="4" width="41" height="32">
-			</bounds>
+			<bounds x="718" y="4" width="41" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_195_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="557" y="822" width="75" height="37">
-			</bounds>
+			<bounds x="557" y="822" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_195" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="559" y="824" width="71" height="33">
-			</bounds>
+			<bounds x="559" y="824" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_196_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="11" y="822" width="75" height="37">
-			</bounds>
+			<bounds x="11" y="822" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_196" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="13" y="824" width="71" height="33">
-			</bounds>
+			<bounds x="13" y="824" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_197_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="293" y="822" width="75" height="37">
-			</bounds>
+			<bounds x="293" y="822" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_197" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="295" y="824" width="71" height="33">
-			</bounds>
+			<bounds x="295" y="824" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_198_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="200" y="822" width="75" height="37">
-			</bounds>
+			<bounds x="200" y="822" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_198" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="202" y="824" width="71" height="33">
-			</bounds>
+			<bounds x="202" y="824" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_199_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="108" y="822" width="75" height="37">
-			</bounds>
+			<bounds x="108" y="822" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_199" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="110" y="824" width="71" height="33">
-			</bounds>
+			<bounds x="110" y="824" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_200_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="473" y="822" width="78" height="37">
-			</bounds>
+			<bounds x="473" y="822" width="78" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_200" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="475" y="824" width="74" height="33">
-			</bounds>
+			<bounds x="475" y="824" width="74" height="33"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_201_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="393" y="822" width="75" height="37">
-			</bounds>
+			<bounds x="393" y="822" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_201" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="395" y="824" width="71" height="33">
-			</bounds>
+			<bounds x="395" y="824" width="71" height="33"/>
 		</backdrop>
-
-	<!-- The DMD -->
-	<screen index="0">
-	  <bounds left="65" top="451" right="392" bottom="558" />
-	</screen>
-
+		<backdrop element="dmd_background">
+			<bounds x="65" y="451" width="327" height="107"/>
+		</backdrop>
+		<screen index="0">
+			<bounds left="65" top="451" right="392" bottom="558"/>
+		</screen>
+		<screen index="0">
+			<bounds left="65" top="451" right="392" bottom="558"/>
+		</screen>
+		<screen index="0">
+			<bounds left="65" top="451" right="392" bottom="558"/>
+		</screen>
 		<backdrop name="label66" element="label_66">
-			<bounds x="232" y="780" width="111" height="26">
-			</bounds>
+			<bounds x="232" y="780" width="111" height="26"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="318" y="744" width="13" height="20">
-			</bounds>
+			<bounds x="318" y="744" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="label73" element="label_73">
-			<bounds x="253" y="744" width="13" height="20">
-			</bounds>
+			<bounds x="253" y="744" width="13" height="20"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="378" y="628" width="34" height="16">
-			</bounds>
+			<bounds x="378" y="628" width="34" height="16"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="68" y="628" width="30" height="16">
-			</bounds>
+			<bounds x="68" y="628" width="30" height="16"/>
 		</backdrop>
 		<backdrop name="label127" element="label_127">
-			<bounds x="544" y="12" width="149" height="48">
-			</bounds>
+			<bounds x="544" y="12" width="149" height="48"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
+		<screen index="0">
+			<bounds left="1400" top="400" right="1790" bottom="526"/>
+		</screen>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2ptytm1.lay
+++ b/src/mame/layout/sc2ptytm1.lay
@@ -8,7835 +8,5746 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lucky Dip">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lucky Dip">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pull-A-Cracker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pull-A-Cracker">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Balloon Buster">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Balloon Buster">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pass The Parcel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pass The Parcel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="Flashing ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="Flashing ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="PARTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="PARTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="DG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="DG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_70_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_70">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_71_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_71">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_72_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_72">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_73_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_73">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_74_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_74">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_75_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_75">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_76_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_76">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_77_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_77">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_78_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_78">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_79_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_79">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
-
+	<element name="dmd_background">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
+	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_10">
 		<text string="1-12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_11">
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_13">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_14">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_15">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="797" height="869">
-			</bounds>
+			<bounds x="0" y="0" width="797" height="869"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="130" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="130" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="130.0000" y="475.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="130.0000" y="475.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="133.3333" y="476.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="133.3333" y="476.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="136.6667" y="478.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="136.6667" y="478.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="140.0000" y="480.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="140.0000" y="480.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="143.3333" y="482.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="143.3333" y="482.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="146.6667" y="484.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="146.6667" y="484.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="130.0000" y="521.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="130.0000" y="521.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="133.3333" y="523.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="133.3333" y="523.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="136.6667" y="525.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="136.6667" y="525.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="140.0000" y="527.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="140.0000" y="527.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="143.3333" y="529.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="143.3333" y="529.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="146.6667" y="531.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="146.6667" y="531.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="130.0000" y="568.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="130.0000" y="568.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="133.3333" y="570.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="133.3333" y="570.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="136.6667" y="572.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="136.6667" y="572.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="140.0000" y="574.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="140.0000" y="574.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="143.3333" y="576.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="143.3333" y="576.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="146.6667" y="578.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="146.6667" y="578.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="130" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="130" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="225" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="225" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="225.0000" y="475.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="225.0000" y="475.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.3333" y="476.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="228.3333" y="476.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="231.6667" y="478.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="231.6667" y="478.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="235.0000" y="480.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="235.0000" y="480.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="238.3333" y="482.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="238.3333" y="482.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="241.6667" y="484.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="241.6667" y="484.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="225.0000" y="521.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="225.0000" y="521.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.3333" y="523.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="228.3333" y="523.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="231.6667" y="525.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="231.6667" y="525.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="235.0000" y="527.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="235.0000" y="527.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="238.3333" y="529.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="238.3333" y="529.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="241.6667" y="531.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="241.6667" y="531.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="225.0000" y="568.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="225.0000" y="568.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.3333" y="570.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="228.3333" y="570.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="231.6667" y="572.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="231.6667" y="572.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="235.0000" y="574.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="235.0000" y="574.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="238.3333" y="576.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="238.3333" y="576.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="241.6667" y="578.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="241.6667" y="578.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="225" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="225" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="320" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="320" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="475.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="320.0000" y="475.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="323.3333" y="476.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="323.3333" y="476.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="326.6667" y="478.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="326.6667" y="478.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="330.0000" y="480.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="330.0000" y="480.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="333.3333" y="482.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="333.3333" y="482.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="336.6667" y="484.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="336.6667" y="484.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="521.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="320.0000" y="521.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="323.3333" y="523.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="323.3333" y="523.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="326.6667" y="525.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="326.6667" y="525.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="330.0000" y="527.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="330.0000" y="527.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="333.3333" y="529.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="333.3333" y="529.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="336.6667" y="531.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="336.6667" y="531.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="568.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="320.0000" y="568.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="323.3333" y="570.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="323.3333" y="570.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="326.6667" y="572.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="326.6667" y="572.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="330.0000" y="574.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="330.0000" y="574.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="333.3333" y="576.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="333.3333" y="576.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="336.6667" y="578.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="336.6667" y="578.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="320" y="475" width="80" height="140">
-			</bounds>
+			<bounds x="320" y="475" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="56" y="136" width="80" height="76">
-			</bounds>
+			<bounds x="56" y="136" width="80" height="76"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="56.0000" y="136.0000" width="80.0000" height="76.0000">
-			</bounds>
+			<bounds x="56.0000" y="136.0000" width="80.0000" height="76.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="59.3333" y="139.1667" width="73.3333" height="69.6667">
-			</bounds>
+			<bounds x="59.3333" y="139.1667" width="73.3333" height="69.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="62.6667" y="142.3333" width="66.6667" height="63.3333">
-			</bounds>
+			<bounds x="62.6667" y="142.3333" width="66.6667" height="63.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="66.0000" y="145.5000" width="60.0000" height="57.0000">
-			</bounds>
+			<bounds x="66.0000" y="145.5000" width="60.0000" height="57.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="69.3333" y="148.6667" width="53.3333" height="50.6667">
-			</bounds>
+			<bounds x="69.3333" y="148.6667" width="53.3333" height="50.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="72.6667" y="151.8333" width="46.6667" height="44.3333">
-			</bounds>
+			<bounds x="72.6667" y="151.8333" width="46.6667" height="44.3333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="56" y="136" width="80" height="76">
-			</bounds>
+			<bounds x="56" y="136" width="80" height="76"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="349" y="264" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="264" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="351" y="266" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="266" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="349" y="264" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="264" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="351" y="266" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="266" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="230" y="51" width="62" height="32">
-			</bounds>
+			<bounds x="230" y="51" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="232" y="53" width="58" height="28">
-			</bounds>
+			<bounds x="232" y="53" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="230" y="51" width="62" height="32">
-			</bounds>
+			<bounds x="230" y="51" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="232" y="53" width="58" height="28">
-			</bounds>
+			<bounds x="232" y="53" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="349" y="84" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="84" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="351" y="86" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="86" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="349" y="84" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="84" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="351" y="86" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="86" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="349" y="129" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="129" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="351" y="131" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="131" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="349" y="129" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="129" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="351" y="131" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="131" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="349" y="174" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="174" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="351" y="176" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="176" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="349" y="174" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="174" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="351" y="176" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="176" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="349" y="219" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="219" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="351" y="221" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="221" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="349" y="219" width="62" height="42">
-			</bounds>
+			<bounds x="349" y="219" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="351" y="221" width="58" height="38">
-			</bounds>
+			<bounds x="351" y="221" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="451" y="429" width="48" height="37">
-			</bounds>
+			<bounds x="451" y="429" width="48" height="37"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="453" y="431" width="44" height="33">
-			</bounds>
+			<bounds x="453" y="431" width="44" height="33"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="424" y="135" width="135" height="32">
-			</bounds>
+			<bounds x="424" y="135" width="135" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="426" y="137" width="131" height="28">
-			</bounds>
+			<bounds x="426" y="137" width="131" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="424" y="135" width="135" height="32">
-			</bounds>
+			<bounds x="424" y="135" width="135" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="426" y="137" width="131" height="28">
-			</bounds>
+			<bounds x="426" y="137" width="131" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="424" y="179" width="135" height="32">
-			</bounds>
+			<bounds x="424" y="179" width="135" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="426" y="181" width="131" height="28">
-			</bounds>
+			<bounds x="426" y="181" width="131" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="424" y="179" width="135" height="32">
-			</bounds>
+			<bounds x="424" y="179" width="135" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="426" y="181" width="131" height="28">
-			</bounds>
+			<bounds x="426" y="181" width="131" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="424" y="224" width="135" height="32">
-			</bounds>
+			<bounds x="424" y="224" width="135" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="426" y="226" width="131" height="28">
-			</bounds>
+			<bounds x="426" y="226" width="131" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="424" y="224" width="135" height="32">
-			</bounds>
+			<bounds x="424" y="224" width="135" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="426" y="226" width="131" height="28">
-			</bounds>
+			<bounds x="426" y="226" width="131" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="424" y="268" width="135" height="32">
-			</bounds>
+			<bounds x="424" y="268" width="135" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="426" y="270" width="131" height="28">
-			</bounds>
+			<bounds x="426" y="270" width="131" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="424" y="268" width="135" height="32">
-			</bounds>
+			<bounds x="424" y="268" width="135" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="426" y="270" width="131" height="28">
-			</bounds>
+			<bounds x="426" y="270" width="131" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="82" y="95" width="35" height="27">
-			</bounds>
+			<bounds x="82" y="95" width="35" height="27"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="84" y="97" width="31" height="23">
-			</bounds>
+			<bounds x="84" y="97" width="31" height="23"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="82" y="239" width="35" height="27">
-			</bounds>
+			<bounds x="82" y="239" width="35" height="27"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="84" y="241" width="31" height="23">
-			</bounds>
+			<bounds x="84" y="241" width="31" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="497" y="76" width="62" height="57">
-			</bounds>
+			<bounds x="497" y="76" width="62" height="57"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="499" y="78" width="58" height="53">
-			</bounds>
+			<bounds x="499" y="78" width="58" height="53"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="139" y="429" width="127" height="37">
-			</bounds>
+			<bounds x="139" y="429" width="127" height="37"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="141" y="431" width="123" height="33">
-			</bounds>
+			<bounds x="141" y="431" width="123" height="33"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="139" y="429" width="127" height="37">
-			</bounds>
+			<bounds x="139" y="429" width="127" height="37"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="141" y="431" width="123" height="33">
-			</bounds>
+			<bounds x="141" y="431" width="123" height="33"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="280" y="429" width="107" height="37">
-			</bounds>
+			<bounds x="280" y="429" width="107" height="37"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="282" y="431" width="103" height="33">
-			</bounds>
+			<bounds x="282" y="431" width="103" height="33"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="280" y="429" width="107" height="37">
-			</bounds>
+			<bounds x="280" y="429" width="107" height="37"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="282" y="431" width="103" height="33">
-			</bounds>
+			<bounds x="282" y="431" width="103" height="33"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="496" y="429" width="47" height="37">
-			</bounds>
+			<bounds x="496" y="429" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="498" y="431" width="43" height="33">
-			</bounds>
+			<bounds x="498" y="431" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="540" y="429" width="48" height="37">
-			</bounds>
+			<bounds x="540" y="429" width="48" height="37"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="542" y="431" width="44" height="33">
-			</bounds>
+			<bounds x="542" y="431" width="44" height="33"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="424" y="76" width="62" height="26">
-			</bounds>
+			<bounds x="424" y="76" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="426" y="78" width="58" height="22">
-			</bounds>
+			<bounds x="426" y="78" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="424" y="107" width="62" height="26">
-			</bounds>
+			<bounds x="424" y="107" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="426" y="109" width="58" height="22">
-			</bounds>
+			<bounds x="426" y="109" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_70_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="604" y="639" width="82" height="42">
-			</bounds>
+			<bounds x="604" y="639" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_70" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="606" y="641" width="78" height="38">
-			</bounds>
+			<bounds x="606" y="641" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_71_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="509" y="639" width="82" height="42">
-			</bounds>
+			<bounds x="509" y="639" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_71" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="511" y="641" width="78" height="38">
-			</bounds>
+			<bounds x="511" y="641" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_72_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="414" y="639" width="82" height="42">
-			</bounds>
+			<bounds x="414" y="639" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_72" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="416" y="641" width="78" height="38">
-			</bounds>
+			<bounds x="416" y="641" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_73_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="319" y="639" width="82" height="42">
-			</bounds>
+			<bounds x="319" y="639" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_73" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="321" y="641" width="78" height="38">
-			</bounds>
+			<bounds x="321" y="641" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_74_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="225" y="639" width="82" height="42">
-			</bounds>
+			<bounds x="225" y="639" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_74" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="227" y="641" width="78" height="38">
-			</bounds>
+			<bounds x="227" y="641" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_75_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="130" y="640" width="82" height="42">
-			</bounds>
+			<bounds x="130" y="640" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_75" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="132" y="642" width="78" height="38">
-			</bounds>
+			<bounds x="132" y="642" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_76_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="34" y="639" width="82" height="42">
-			</bounds>
+			<bounds x="34" y="639" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_76" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="36" y="641" width="78" height="38">
-			</bounds>
+			<bounds x="36" y="641" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_77_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="694" y="29" width="50" height="16">
-			</bounds>
+			<bounds x="694" y="29" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_77" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="696" y="31" width="46" height="12">
-			</bounds>
+			<bounds x="696" y="31" width="46" height="12"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_78_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="694" y="49" width="50" height="16">
-			</bounds>
+			<bounds x="694" y="49" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_78" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="696" y="51" width="46" height="12">
-			</bounds>
+			<bounds x="696" y="51" width="46" height="12"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_79_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="694" y="9" width="50" height="16">
-			</bounds>
+			<bounds x="694" y="9" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_79" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="696" y="11" width="46" height="12">
-			</bounds>
+			<bounds x="696" y="11" width="46" height="12"/>
 		</backdrop>
-
-	<!-- The DMD -->
-	<screen index="0">
-	  <bounds left="134" top="325" right="396" bottom="421" />
-	</screen>
-
+		<backdrop element="dmd_background">
+			<bounds x="134" y="325" width="262" height="86"/>
+		</backdrop>
+		<screen index="0">
+			<bounds left="134" top="325" right="396" bottom="411"/>
+		</screen>
+		<screen index="0">
+			<bounds left="134" top="325" right="396" bottom="411"/>
+		</screen>
+		<screen index="0">
+			<bounds left="134" top="325" right="396" bottom="411"/>
+		</screen>
 		<backdrop name="label10" element="label_10">
-			<bounds x="12" y="162" width="32" height="19">
-			</bounds>
+			<bounds x="12" y="162" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="750" y="50" width="19" height="14">
-			</bounds>
+			<bounds x="750" y="50" width="19" height="14"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="750" y="30" width="19" height="14">
-			</bounds>
+			<bounds x="750" y="30" width="19" height="14"/>
 		</backdrop>
 		<backdrop name="label13" element="label_13">
-			<bounds x="750" y="10" width="12" height="14">
-			</bounds>
+			<bounds x="750" y="10" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label14" element="label_14">
-			<bounds x="100" y="530" width="24" height="28">
-			</bounds>
+			<bounds x="100" y="530" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label15" element="label_15">
-			<bounds x="403" y="530" width="24" height="28">
-			</bounds>
+			<bounds x="403" y="530" width="24" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
+		<screen index="0">
+			<bounds left="1400" top="400" right="1790" bottom="526"/>
+		</screen>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2suprz1.lay
+++ b/src/mame/layout/sc2suprz1.lay
@@ -8,9068 +8,6087 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_5_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_5_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_4_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_4_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nud">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nud">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="w!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="w!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Z">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Z">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_66_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_66">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p tkn">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_67_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_67">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_68_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_68">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_69_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_69">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_75_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_75">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_76_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_76">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_77_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_77">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_78_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_78">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_79_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_79">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_80_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_80">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="620" height="554">
-			</bounds>
+			<bounds x="0" y="0" width="620" height="554"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="190" y="367" width="70" height="140">
-			</bounds>
+			<bounds x="190" y="367" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="190.0000" y="367.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="190.0000" y="367.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.9167" y="368.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="192.9167" y="368.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.8333" y="370.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="195.8333" y="370.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="198.7500" y="372.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="198.7500" y="372.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="201.6667" y="374.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="201.6667" y="374.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="204.5833" y="376.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="204.5833" y="376.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="190.0000" y="413.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="190.0000" y="413.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.9167" y="415.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="192.9167" y="415.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.8333" y="417.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="195.8333" y="417.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="198.7500" y="419.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="198.7500" y="419.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="201.6667" y="421.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="201.6667" y="421.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="204.5833" y="423.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="204.5833" y="423.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="190.0000" y="460.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="190.0000" y="460.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="192.9167" y="462.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="192.9167" y="462.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="195.8333" y="464.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="195.8333" y="464.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="198.7500" y="466.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="198.7500" y="466.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="201.6667" y="468.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="201.6667" y="468.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="204.5833" y="470.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="204.5833" y="470.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="190" y="367" width="70" height="140">
-			</bounds>
+			<bounds x="190" y="367" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="264" y="367" width="70" height="140">
-			</bounds>
+			<bounds x="264" y="367" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="264.0000" y="367.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="264.0000" y="367.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="266.9167" y="368.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="266.9167" y="368.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="269.8333" y="370.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="269.8333" y="370.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="272.7500" y="372.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="272.7500" y="372.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="275.6667" y="374.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="275.6667" y="374.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="278.5833" y="376.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="278.5833" y="376.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="264.0000" y="413.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="264.0000" y="413.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="266.9167" y="415.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="266.9167" y="415.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="269.8333" y="417.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="269.8333" y="417.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="272.7500" y="419.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="272.7500" y="419.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="275.6667" y="421.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="275.6667" y="421.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="278.5833" y="423.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="278.5833" y="423.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="264.0000" y="460.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="264.0000" y="460.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="266.9167" y="462.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="266.9167" y="462.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="269.8333" y="464.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="269.8333" y="464.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="272.7500" y="466.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="272.7500" y="466.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="275.6667" y="468.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="275.6667" y="468.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="278.5833" y="470.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="278.5833" y="470.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="264" y="367" width="70" height="140">
-			</bounds>
+			<bounds x="264" y="367" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="338" y="367" width="70" height="140">
-			</bounds>
+			<bounds x="338" y="367" width="70" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="338.0000" y="367.0000" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="338.0000" y="367.0000" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="340.9167" y="368.9445" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="340.9167" y="368.9445" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="343.8333" y="370.8889" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="343.8333" y="370.8889" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="346.7500" y="372.8333" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="346.7500" y="372.8333" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="349.6667" y="374.7778" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="349.6667" y="374.7778" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="352.5833" y="376.7222" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="352.5833" y="376.7222" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="338.0000" y="413.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="338.0000" y="413.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="340.9167" y="415.6111" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="340.9167" y="415.6111" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="343.8333" y="417.5555" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="343.8333" y="417.5555" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="346.7500" y="419.5000" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="346.7500" y="419.5000" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="349.6667" y="421.4444" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="349.6667" y="421.4444" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="352.5833" y="423.3889" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="352.5833" y="423.3889" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="338.0000" y="460.3333" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="338.0000" y="460.3333" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="340.9167" y="462.2778" width="64.1667" height="42.7778">
-			</bounds>
+			<bounds x="340.9167" y="462.2778" width="64.1667" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="343.8333" y="464.2222" width="58.3333" height="38.8889">
-			</bounds>
+			<bounds x="343.8333" y="464.2222" width="58.3333" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="346.7500" y="466.1667" width="52.5000" height="35.0000">
-			</bounds>
+			<bounds x="346.7500" y="466.1667" width="52.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="349.6667" y="468.1111" width="46.6667" height="31.1111">
-			</bounds>
+			<bounds x="349.6667" y="468.1111" width="46.6667" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="352.5833" y="470.0556" width="40.8333" height="27.2222">
-			</bounds>
+			<bounds x="352.5833" y="470.0556" width="40.8333" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="338" y="367" width="70" height="140">
-			</bounds>
+			<bounds x="338" y="367" width="70" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="35" y="151" width="80" height="60">
-			</bounds>
+			<bounds x="35" y="151" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="35.0000" y="151.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="35.0000" y="151.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="38.3333" y="153.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="38.3333" y="153.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="41.6667" y="156.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="41.6667" y="156.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="45.0000" y="158.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="45.0000" y="158.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="48.3333" y="161.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="48.3333" y="161.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="51.6667" y="163.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="51.6667" y="163.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="35" y="151" width="80" height="60">
-			</bounds>
+			<bounds x="35" y="151" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp5" element="lamp_5_1_border" state="0">
-			<bounds x="64" y="121" width="19" height="19">
-			</bounds>
+			<bounds x="64" y="121" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp5" element="lamp_5_1" state="0">
-			<bounds x="66" y="123" width="15" height="15">
-			</bounds>
+			<bounds x="66" y="123" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1_border" state="0">
-			<bounds x="65" y="223" width="19" height="19">
-			</bounds>
+			<bounds x="65" y="223" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1" state="0">
-			<bounds x="67" y="225" width="15" height="15">
-			</bounds>
+			<bounds x="67" y="225" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="330" y="80" width="63" height="37">
-			</bounds>
+			<bounds x="330" y="80" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="332" y="82" width="59" height="33">
-			</bounds>
+			<bounds x="332" y="82" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="395" y="80" width="63" height="37">
-			</bounds>
+			<bounds x="395" y="80" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="397" y="82" width="59" height="33">
-			</bounds>
+			<bounds x="397" y="82" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="330" y="120" width="63" height="37">
-			</bounds>
+			<bounds x="330" y="120" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="332" y="122" width="59" height="33">
-			</bounds>
+			<bounds x="332" y="122" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="395" y="120" width="63" height="37">
-			</bounds>
+			<bounds x="395" y="120" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="397" y="122" width="59" height="33">
-			</bounds>
+			<bounds x="397" y="122" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="330" y="160" width="63" height="37">
-			</bounds>
+			<bounds x="330" y="160" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="332" y="162" width="59" height="33">
-			</bounds>
+			<bounds x="332" y="162" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="395" y="160" width="63" height="37">
-			</bounds>
+			<bounds x="395" y="160" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="397" y="162" width="59" height="33">
-			</bounds>
+			<bounds x="397" y="162" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="331" y="200" width="63" height="37">
-			</bounds>
+			<bounds x="331" y="200" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="333" y="202" width="59" height="33">
-			</bounds>
+			<bounds x="333" y="202" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="395" y="200" width="63" height="37">
-			</bounds>
+			<bounds x="395" y="200" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="397" y="202" width="59" height="33">
-			</bounds>
+			<bounds x="397" y="202" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="330" y="240" width="63" height="37">
-			</bounds>
+			<bounds x="330" y="240" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="332" y="242" width="59" height="33">
-			</bounds>
+			<bounds x="332" y="242" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="395" y="240" width="63" height="37">
-			</bounds>
+			<bounds x="395" y="240" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="397" y="242" width="59" height="33">
-			</bounds>
+			<bounds x="397" y="242" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="330" y="280" width="63" height="37">
-			</bounds>
+			<bounds x="330" y="280" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="332" y="282" width="59" height="33">
-			</bounds>
+			<bounds x="332" y="282" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="395" y="280" width="63" height="37">
-			</bounds>
+			<bounds x="395" y="280" width="63" height="37"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="397" y="282" width="59" height="33">
-			</bounds>
+			<bounds x="397" y="282" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="74" y="385" width="27" height="19">
-			</bounds>
+			<bounds x="74" y="385" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="76" y="387" width="23" height="15">
-			</bounds>
+			<bounds x="76" y="387" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="50" y="385" width="27" height="19">
-			</bounds>
+			<bounds x="50" y="385" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="52" y="387" width="23" height="15">
-			</bounds>
+			<bounds x="52" y="387" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="58" y="401" width="19" height="19">
-			</bounds>
+			<bounds x="58" y="401" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="60" y="403" width="15" height="15">
-			</bounds>
+			<bounds x="60" y="403" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="74" y="401" width="19" height="19">
-			</bounds>
+			<bounds x="74" y="401" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="76" y="403" width="15" height="15">
-			</bounds>
+			<bounds x="76" y="403" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="43" y="460" width="62" height="19">
-			</bounds>
+			<bounds x="43" y="460" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="45" y="462" width="58" height="15">
-			</bounds>
+			<bounds x="45" y="462" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="43" y="424" width="19" height="19">
-			</bounds>
+			<bounds x="43" y="424" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="45" y="426" width="15" height="15">
-			</bounds>
+			<bounds x="45" y="426" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="59" y="424" width="46" height="19">
-			</bounds>
+			<bounds x="59" y="424" width="46" height="19"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="61" y="426" width="42" height="15">
-			</bounds>
+			<bounds x="61" y="426" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="43" y="442" width="19" height="19">
-			</bounds>
+			<bounds x="43" y="442" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="45" y="444" width="15" height="15">
-			</bounds>
+			<bounds x="45" y="444" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="59" y="442" width="46" height="19">
-			</bounds>
+			<bounds x="59" y="442" width="46" height="19"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="61" y="444" width="42" height="15">
-			</bounds>
+			<bounds x="61" y="444" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="428" y="389" width="19" height="19">
-			</bounds>
+			<bounds x="428" y="389" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="430" y="391" width="15" height="15">
-			</bounds>
+			<bounds x="430" y="391" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="448" y="394" width="19" height="19">
-			</bounds>
+			<bounds x="448" y="394" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="450" y="396" width="15" height="15">
-			</bounds>
+			<bounds x="450" y="396" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="468" y="389" width="19" height="19">
-			</bounds>
+			<bounds x="468" y="389" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="470" y="391" width="15" height="15">
-			</bounds>
+			<bounds x="470" y="391" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="488" y="394" width="19" height="19">
-			</bounds>
+			<bounds x="488" y="394" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="490" y="396" width="15" height="15">
-			</bounds>
+			<bounds x="490" y="396" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="508" y="389" width="19" height="19">
-			</bounds>
+			<bounds x="508" y="389" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="510" y="391" width="15" height="15">
-			</bounds>
+			<bounds x="510" y="391" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="528" y="394" width="19" height="19">
-			</bounds>
+			<bounds x="528" y="394" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="530" y="396" width="15" height="15">
-			</bounds>
+			<bounds x="530" y="396" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="548" y="389" width="19" height="19">
-			</bounds>
+			<bounds x="548" y="389" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="550" y="391" width="15" height="15">
-			</bounds>
+			<bounds x="550" y="391" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="568" y="394" width="19" height="19">
-			</bounds>
+			<bounds x="568" y="394" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="570" y="396" width="15" height="15">
-			</bounds>
+			<bounds x="570" y="396" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="427" y="424" width="19" height="19">
-			</bounds>
+			<bounds x="427" y="424" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="429" y="426" width="15" height="15">
-			</bounds>
+			<bounds x="429" y="426" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="448" y="419" width="19" height="19">
-			</bounds>
+			<bounds x="448" y="419" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="450" y="421" width="15" height="15">
-			</bounds>
+			<bounds x="450" y="421" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="468" y="424" width="19" height="19">
-			</bounds>
+			<bounds x="468" y="424" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="470" y="426" width="15" height="15">
-			</bounds>
+			<bounds x="470" y="426" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="488" y="419" width="19" height="19">
-			</bounds>
+			<bounds x="488" y="419" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="490" y="421" width="15" height="15">
-			</bounds>
+			<bounds x="490" y="421" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="508" y="424" width="19" height="19">
-			</bounds>
+			<bounds x="508" y="424" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="510" y="426" width="15" height="15">
-			</bounds>
+			<bounds x="510" y="426" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="528" y="419" width="19" height="19">
-			</bounds>
+			<bounds x="528" y="419" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="530" y="421" width="15" height="15">
-			</bounds>
+			<bounds x="530" y="421" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="548" y="424" width="19" height="19">
-			</bounds>
+			<bounds x="548" y="424" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="550" y="426" width="15" height="15">
-			</bounds>
+			<bounds x="550" y="426" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="568" y="419" width="19" height="19">
-			</bounds>
+			<bounds x="568" y="419" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="570" y="421" width="15" height="15">
-			</bounds>
+			<bounds x="570" y="421" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_66_border" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="531" y="85" width="75" height="27">
-			</bounds>
+			<bounds x="531" y="85" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_66" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="533" y="87" width="71" height="23">
-			</bounds>
+			<bounds x="533" y="87" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_67_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="531" y="1" width="75" height="27">
-			</bounds>
+			<bounds x="531" y="1" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_67" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="533" y="3" width="71" height="23">
-			</bounds>
+			<bounds x="533" y="3" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_68_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="531" y="29" width="75" height="27">
-			</bounds>
+			<bounds x="531" y="29" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_68" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="533" y="31" width="71" height="23">
-			</bounds>
+			<bounds x="533" y="31" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_69_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="531" y="57" width="75" height="27">
-			</bounds>
+			<bounds x="531" y="57" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_69" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="533" y="59" width="71" height="23">
-			</bounds>
+			<bounds x="533" y="59" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_75_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="510" y="517" width="63" height="27">
-			</bounds>
+			<bounds x="510" y="517" width="63" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_75" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="512" y="519" width="59" height="23">
-			</bounds>
+			<bounds x="512" y="519" width="59" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_76_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="424" y="517" width="63" height="27">
-			</bounds>
+			<bounds x="424" y="517" width="63" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_76" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="426" y="519" width="59" height="23">
-			</bounds>
+			<bounds x="426" y="519" width="59" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_77_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="342" y="517" width="63" height="27">
-			</bounds>
+			<bounds x="342" y="517" width="63" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_77" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="344" y="519" width="59" height="23">
-			</bounds>
+			<bounds x="344" y="519" width="59" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_78_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="266" y="517" width="63" height="27">
-			</bounds>
+			<bounds x="266" y="517" width="63" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_78" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="268" y="519" width="59" height="23">
-			</bounds>
+			<bounds x="268" y="519" width="59" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_79_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="195" y="517" width="63" height="27">
-			</bounds>
+			<bounds x="195" y="517" width="63" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_79" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="197" y="519" width="59" height="23">
-			</bounds>
+			<bounds x="197" y="519" width="59" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_80_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="109" y="517" width="63" height="27">
-			</bounds>
+			<bounds x="109" y="517" width="63" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_80" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="111" y="519" width="59" height="23">
-			</bounds>
+			<bounds x="111" y="519" width="59" height="23"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="343" y="8" width="48" height="64">
-			</bounds>
+			<bounds x="343" y="8" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off41" element="led_off">
-			<bounds x="349" y="13" width="34" height="5">
-			</bounds>
+			<bounds x="349" y="13" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off42" element="led_off">
-			<bounds x="377" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="377" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off43" element="led_off">
-			<bounds x="377" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="377" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off44" element="led_off">
-			<bounds x="349" y="60" width="34" height="5">
-			</bounds>
+			<bounds x="349" y="60" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off45" element="led_off">
-			<bounds x="349" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="349" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off46" element="led_off">
-			<bounds x="349" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="349" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off47" element="led_off">
-			<bounds x="349" y="37" width="34" height="5">
-			</bounds>
+			<bounds x="349" y="37" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off40" element="led_dot_off">
-			<bounds x="384" y="60" width="6" height="5">
-			</bounds>
+			<bounds x="384" y="60" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp41" element="led_on">
-			<bounds x="349" y="13" width="34" height="5">
-			</bounds>
+			<bounds x="349" y="13" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp42" element="led_on">
-			<bounds x="377" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="377" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp43" element="led_on">
-			<bounds x="377" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="377" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp44" element="led_on">
-			<bounds x="349" y="60" width="34" height="5">
-			</bounds>
+			<bounds x="349" y="60" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp45" element="led_on">
-			<bounds x="349" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="349" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp46" element="led_on">
-			<bounds x="349" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="349" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp47" element="led_on">
-			<bounds x="349" y="37" width="34" height="5">
-			</bounds>
+			<bounds x="349" y="37" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp40" element="led_dot_on">
-			<bounds x="384" y="60" width="6" height="5">
-			</bounds>
+			<bounds x="384" y="60" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="295" y="8" width="48" height="64">
-			</bounds>
+			<bounds x="295" y="8" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off57" element="led_off">
-			<bounds x="301" y="13" width="34" height="5">
-			</bounds>
+			<bounds x="301" y="13" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off58" element="led_off">
-			<bounds x="329" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="329" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off59" element="led_off">
-			<bounds x="329" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="329" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off60" element="led_off">
-			<bounds x="301" y="60" width="34" height="5">
-			</bounds>
+			<bounds x="301" y="60" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off61" element="led_off">
-			<bounds x="301" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="301" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off62" element="led_off">
-			<bounds x="301" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="301" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off63" element="led_off">
-			<bounds x="301" y="37" width="34" height="5">
-			</bounds>
+			<bounds x="301" y="37" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off56" element="led_dot_off">
-			<bounds x="336" y="60" width="6" height="5">
-			</bounds>
+			<bounds x="336" y="60" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp57" element="led_on">
-			<bounds x="301" y="13" width="34" height="5">
-			</bounds>
+			<bounds x="301" y="13" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp58" element="led_on">
-			<bounds x="329" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="329" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp59" element="led_on">
-			<bounds x="329" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="329" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp60" element="led_on">
-			<bounds x="301" y="60" width="34" height="5">
-			</bounds>
+			<bounds x="301" y="60" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp61" element="led_on">
-			<bounds x="301" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="301" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp62" element="led_on">
-			<bounds x="301" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="301" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp63" element="led_on">
-			<bounds x="301" y="37" width="34" height="5">
-			</bounds>
+			<bounds x="301" y="37" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp56" element="led_dot_on">
-			<bounds x="336" y="60" width="6" height="5">
-			</bounds>
+			<bounds x="336" y="60" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="247" y="8" width="48" height="64">
-			</bounds>
+			<bounds x="247" y="8" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off73" element="led_off">
-			<bounds x="253" y="13" width="34" height="5">
-			</bounds>
+			<bounds x="253" y="13" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off74" element="led_off">
-			<bounds x="281" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="281" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off75" element="led_off">
-			<bounds x="281" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="281" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off76" element="led_off">
-			<bounds x="253" y="60" width="34" height="5">
-			</bounds>
+			<bounds x="253" y="60" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off77" element="led_off">
-			<bounds x="253" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="253" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off78" element="led_off">
-			<bounds x="253" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="253" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off79" element="led_off">
-			<bounds x="253" y="37" width="34" height="5">
-			</bounds>
+			<bounds x="253" y="37" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off72" element="led_dot_off">
-			<bounds x="288" y="60" width="6" height="5">
-			</bounds>
+			<bounds x="288" y="60" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp73" element="led_on">
-			<bounds x="253" y="13" width="34" height="5">
-			</bounds>
+			<bounds x="253" y="13" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp74" element="led_on">
-			<bounds x="281" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="281" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp75" element="led_on">
-			<bounds x="281" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="281" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp76" element="led_on">
-			<bounds x="253" y="60" width="34" height="5">
-			</bounds>
+			<bounds x="253" y="60" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp77" element="led_on">
-			<bounds x="253" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="253" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp78" element="led_on">
-			<bounds x="253" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="253" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp79" element="led_on">
-			<bounds x="253" y="37" width="34" height="5">
-			</bounds>
+			<bounds x="253" y="37" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp72" element="led_dot_on">
-			<bounds x="288" y="60" width="6" height="5">
-			</bounds>
+			<bounds x="288" y="60" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="led_background" element="led_background">
-			<bounds x="199" y="8" width="48" height="64">
-			</bounds>
+			<bounds x="199" y="8" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="led_off89" element="led_off">
-			<bounds x="205" y="13" width="34" height="5">
-			</bounds>
+			<bounds x="205" y="13" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off90" element="led_off">
-			<bounds x="233" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="233" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off91" element="led_off">
-			<bounds x="233" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="233" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off92" element="led_off">
-			<bounds x="205" y="60" width="34" height="5">
-			</bounds>
+			<bounds x="205" y="60" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off93" element="led_off">
-			<bounds x="205" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="205" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off94" element="led_off">
-			<bounds x="205" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="205" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="led_off95" element="led_off">
-			<bounds x="205" y="37" width="34" height="5">
-			</bounds>
+			<bounds x="205" y="37" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="led_off88" element="led_dot_off">
-			<bounds x="240" y="60" width="6" height="5">
-			</bounds>
+			<bounds x="240" y="60" width="6" height="5"/>
 		</backdrop>
 		<backdrop name="lamp89" element="led_on">
-			<bounds x="205" y="13" width="34" height="5">
-			</bounds>
+			<bounds x="205" y="13" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp90" element="led_on">
-			<bounds x="233" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="233" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp91" element="led_on">
-			<bounds x="233" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="233" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp92" element="led_on">
-			<bounds x="205" y="60" width="34" height="5">
-			</bounds>
+			<bounds x="205" y="60" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp93" element="led_on">
-			<bounds x="205" y="37" width="6" height="29">
-			</bounds>
+			<bounds x="205" y="37" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp94" element="led_on">
-			<bounds x="205" y="13" width="6" height="29">
-			</bounds>
+			<bounds x="205" y="13" width="6" height="29"/>
 		</backdrop>
 		<backdrop name="lamp95" element="led_on">
-			<bounds x="205" y="37" width="34" height="5">
-			</bounds>
+			<bounds x="205" y="37" width="34" height="5"/>
 		</backdrop>
 		<backdrop name="lamp88" element="led_dot_on">
-			<bounds x="240" y="60" width="6" height="5">
-			</bounds>
+			<bounds x="240" y="60" width="6" height="5"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="162" y="323" width="272" height="30">
-			</bounds>
+			<bounds x="162" y="323" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="162" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="162" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="179" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="179" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="196" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="196" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="213" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="213" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="230" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="230" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="247" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="247" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="264" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="264" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="281" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="281" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="298" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="298" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="315" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="315" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="332" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="332" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="349" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="349" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="366" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="366" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="383" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="383" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="400" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="400" y="323" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="417" y="323" width="17" height="30">
-			</bounds>
+			<bounds x="417" y="323" width="17" height="30"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_segment" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_segment" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_segment" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_segment" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_segment" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_segment" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_segment" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_12" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc2town2.lay
+++ b/src/mame/layout/sc2town2.lay
@@ -8,10661 +8,6687 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Pick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Pocket">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Pick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Pocket">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Raffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Raffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Lost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Wallet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Lost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Wallet">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Pay For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Last Order">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Pay For">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Last Order">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Lost At">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cards">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Lost At">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cards">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Turned Away By Bouncer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Turned Away By Bouncer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="Drunk 'N'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Disorderly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="Drunk 'N'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Disorderly">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Cash Point">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Cash Point">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_167_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Rose And Crown">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Rose And Crown">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Fun Pub">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Fun Pub">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Trivia And Karaoke">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Trivia And Karaoke">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Police">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Patrol">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Police">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Patrol">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Taxi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Taxi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Red Lion">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red Lion">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
+			<color red="0.06" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_178_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
+			<color red="0.13" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Freds Chippy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Freds Chippy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_179_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Cheer's Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Cheer's Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Rovers Return">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Rovers Return">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Three Bells">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Three Bells">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="60p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Indian Takeaway">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Indian Takeaway">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Spit And Saw">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Spit And Saw">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Chinese">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chinese">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Boozy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Baz">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boozy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Baz">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Public Loo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Public Loo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_209_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Dog 'N' Duck">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Dog 'N' Duck">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_182_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Town Arms">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Town Arms">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Kebab House">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Kebab House">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Burger Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Burger Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Happy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Happy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Hour">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_2" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Pizza">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pizza">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Boozy Baz">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boozy Baz">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_164_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Queen Vic">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Queen Vic">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Games Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Games Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Nag's Head">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Nag's Head">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_162_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Woolpack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Woolpack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Gents">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Gents">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Sober">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Sober">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Drunk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Drunk">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Exchange For Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Exchange For Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Best Win From Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Best Win From Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_131_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_131">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gamble">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_132_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_132">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_133_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_133">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_135_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_135">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="2730" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-1365" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
-
+	<element name="dmd_background">
+		<rect>
+			<color red="0.0" green="0.0" blue="0.0"/>
+		</rect>
+	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_66">
 		<text string="1 - 6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_67">
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_68">
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_69">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_70">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_71">
 		<text string="Starts Round The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Town Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_75">
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="782" height="641">
-			</bounds>
+			<bounds x="0" y="0" width="782" height="641"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="130" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="130" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="130.0000" y="435.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="130.0000" y="435.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="133.3333" y="436.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="133.3333" y="436.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="136.6667" y="438.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="136.6667" y="438.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="140.0000" y="440.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="140.0000" y="440.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="143.3333" y="442.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="143.3333" y="442.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="146.6667" y="444.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="146.6667" y="444.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="130.0000" y="481.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="130.0000" y="481.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="133.3333" y="483.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="133.3333" y="483.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="136.6667" y="485.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="136.6667" y="485.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="140.0000" y="487.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="140.0000" y="487.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="143.3333" y="489.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="143.3333" y="489.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="146.6667" y="491.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="146.6667" y="491.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="130.0000" y="528.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="130.0000" y="528.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="133.3333" y="530.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="133.3333" y="530.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="136.6667" y="532.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="136.6667" y="532.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="140.0000" y="534.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="140.0000" y="534.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="143.3333" y="536.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="143.3333" y="536.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="146.6667" y="538.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="146.6667" y="538.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="130" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="130" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="225" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="225" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="225.0000" y="435.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="225.0000" y="435.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.3333" y="436.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="228.3333" y="436.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="231.6667" y="438.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="231.6667" y="438.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="235.0000" y="440.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="235.0000" y="440.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="238.3333" y="442.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="238.3333" y="442.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="241.6667" y="444.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="241.6667" y="444.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="225.0000" y="481.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="225.0000" y="481.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.3333" y="483.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="228.3333" y="483.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="231.6667" y="485.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="231.6667" y="485.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="235.0000" y="487.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="235.0000" y="487.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="238.3333" y="489.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="238.3333" y="489.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="241.6667" y="491.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="241.6667" y="491.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="225.0000" y="528.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="225.0000" y="528.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.3333" y="530.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="228.3333" y="530.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="231.6667" y="532.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="231.6667" y="532.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="235.0000" y="534.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="235.0000" y="534.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="238.3333" y="536.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="238.3333" y="536.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="241.6667" y="538.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="241.6667" y="538.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="225" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="225" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="320" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="320" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="435.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="320.0000" y="435.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="323.3333" y="436.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="323.3333" y="436.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="326.6667" y="438.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="326.6667" y="438.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="330.0000" y="440.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="330.0000" y="440.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="333.3333" y="442.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="333.3333" y="442.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="336.6667" y="444.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="336.6667" y="444.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="481.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="320.0000" y="481.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="323.3333" y="483.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="323.3333" y="483.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="326.6667" y="485.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="326.6667" y="485.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="330.0000" y="487.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="330.0000" y="487.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="333.3333" y="489.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="333.3333" y="489.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="336.6667" y="491.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="336.6667" y="491.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="528.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="320.0000" y="528.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="323.3333" y="530.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="323.3333" y="530.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="326.6667" y="532.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="326.6667" y="532.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="330.0000" y="534.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="330.0000" y="534.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="333.3333" y="536.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="333.3333" y="536.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="336.6667" y="538.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="336.6667" y="538.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="320" y="435" width="80" height="140">
-			</bounds>
+			<bounds x="320" y="435" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="585" y="220" width="70" height="70">
-			</bounds>
+			<bounds x="585" y="220" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_0" state="0">
-			<bounds x="585.0000" y="220.0000" width="70.0000" height="70.0000">
-			</bounds>
+			<bounds x="585.0000" y="220.0000" width="70.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_1" state="0">
-			<bounds x="587.9167" y="222.9167" width="64.1667" height="64.1667">
-			</bounds>
+			<bounds x="587.9167" y="222.9167" width="64.1667" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_2" state="0">
-			<bounds x="590.8333" y="225.8333" width="58.3333" height="58.3333">
-			</bounds>
+			<bounds x="590.8333" y="225.8333" width="58.3333" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_3" state="0">
-			<bounds x="593.7500" y="228.7500" width="52.5000" height="52.5000">
-			</bounds>
+			<bounds x="593.7500" y="228.7500" width="52.5000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_4" state="0">
-			<bounds x="596.6667" y="231.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="596.6667" y="231.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_5" state="0">
-			<bounds x="599.5833" y="234.5833" width="40.8333" height="40.8333">
-			</bounds>
+			<bounds x="599.5833" y="234.5833" width="40.8333" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="585" y="220" width="70" height="70">
-			</bounds>
+			<bounds x="585" y="220" width="70" height="70"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="139" y="149" width="82" height="42">
-			</bounds>
+			<bounds x="139" y="149" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="141" y="151" width="78" height="38">
-			</bounds>
+			<bounds x="141" y="151" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="224" y="149" width="82" height="42">
-			</bounds>
+			<bounds x="224" y="149" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="226" y="151" width="78" height="38">
-			</bounds>
+			<bounds x="226" y="151" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="309" y="149" width="82" height="42">
-			</bounds>
+			<bounds x="309" y="149" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="311" y="151" width="78" height="38">
-			</bounds>
+			<bounds x="311" y="151" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="394" y="149" width="82" height="42">
-			</bounds>
+			<bounds x="394" y="149" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="396" y="151" width="78" height="38">
-			</bounds>
+			<bounds x="396" y="151" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="479" y="149" width="82" height="42">
-			</bounds>
+			<bounds x="479" y="149" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="481" y="151" width="78" height="38">
-			</bounds>
+			<bounds x="481" y="151" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="564" y="149" width="82" height="42">
-			</bounds>
+			<bounds x="564" y="149" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="566" y="151" width="78" height="38">
-			</bounds>
+			<bounds x="566" y="151" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="689" y="74" width="82" height="62">
-			</bounds>
+			<bounds x="689" y="74" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="691" y="76" width="78" height="58">
-			</bounds>
+			<bounds x="691" y="76" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="604" y="94" width="82" height="42">
-			</bounds>
+			<bounds x="604" y="94" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="606" y="96" width="78" height="38">
-			</bounds>
+			<bounds x="606" y="96" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="519" y="74" width="82" height="23">
-			</bounds>
+			<bounds x="519" y="74" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="521" y="76" width="78" height="19">
-			</bounds>
+			<bounds x="521" y="76" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_2_border" state="0">
-			<bounds x="604" y="74" width="82" height="23">
-			</bounds>
+			<bounds x="604" y="74" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_2" state="0">
-			<bounds x="606" y="76" width="78" height="19">
-			</bounds>
+			<bounds x="606" y="76" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="689" y="269" width="82" height="23">
-			</bounds>
+			<bounds x="689" y="269" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="691" y="271" width="78" height="19">
-			</bounds>
+			<bounds x="691" y="271" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_2_border" state="0">
-			<bounds x="689" y="289" width="82" height="42">
-			</bounds>
+			<bounds x="689" y="289" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_2" state="0">
-			<bounds x="691" y="291" width="78" height="38">
-			</bounds>
+			<bounds x="691" y="291" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="349" y="269" width="82" height="62">
-			</bounds>
+			<bounds x="349" y="269" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="351" y="271" width="78" height="58">
-			</bounds>
+			<bounds x="351" y="271" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="689" y="334" width="82" height="62">
-			</bounds>
+			<bounds x="689" y="334" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="691" y="336" width="78" height="58">
-			</bounds>
+			<bounds x="691" y="336" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="349" y="354" width="82" height="42">
-			</bounds>
+			<bounds x="349" y="354" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="351" y="356" width="78" height="38">
-			</bounds>
+			<bounds x="351" y="356" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="434" y="354" width="82" height="42">
-			</bounds>
+			<bounds x="434" y="354" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="436" y="356" width="78" height="38">
-			</bounds>
+			<bounds x="436" y="356" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="604" y="354" width="82" height="42">
-			</bounds>
+			<bounds x="604" y="354" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="606" y="356" width="78" height="38">
-			</bounds>
+			<bounds x="606" y="356" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="519" y="334" width="82" height="23">
-			</bounds>
+			<bounds x="519" y="334" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="521" y="336" width="78" height="19">
-			</bounds>
+			<bounds x="521" y="336" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_2_border" state="0">
-			<bounds x="434" y="334" width="82" height="23">
-			</bounds>
+			<bounds x="434" y="334" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_2" state="0">
-			<bounds x="436" y="336" width="78" height="19">
-			</bounds>
+			<bounds x="436" y="336" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_2_border" state="0">
-			<bounds x="349" y="334" width="82" height="23">
-			</bounds>
+			<bounds x="349" y="334" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_2" state="0">
-			<bounds x="351" y="336" width="78" height="19">
-			</bounds>
+			<bounds x="351" y="336" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_2_border" state="0">
-			<bounds x="604" y="334" width="82" height="23">
-			</bounds>
+			<bounds x="604" y="334" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_2" state="0">
-			<bounds x="606" y="336" width="78" height="19">
-			</bounds>
+			<bounds x="606" y="336" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="689" y="139" width="82" height="23">
-			</bounds>
+			<bounds x="689" y="139" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="691" y="141" width="78" height="19">
-			</bounds>
+			<bounds x="691" y="141" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="689" y="224" width="82" height="42">
-			</bounds>
+			<bounds x="689" y="224" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="691" y="226" width="78" height="38">
-			</bounds>
+			<bounds x="691" y="226" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="264" y="224" width="82" height="42">
-			</bounds>
+			<bounds x="264" y="224" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="266" y="226" width="78" height="38">
-			</bounds>
+			<bounds x="266" y="226" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="179" y="204" width="82" height="23">
-			</bounds>
+			<bounds x="179" y="204" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="181" y="206" width="78" height="19">
-			</bounds>
+			<bounds x="181" y="206" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="94" y="224" width="82" height="42">
-			</bounds>
+			<bounds x="94" y="224" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="96" y="226" width="78" height="38">
-			</bounds>
+			<bounds x="96" y="226" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="9" y="139" width="82" height="23">
-			</bounds>
+			<bounds x="9" y="139" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="11" y="141" width="78" height="19">
-			</bounds>
+			<bounds x="11" y="141" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="9" y="94" width="82" height="42">
-			</bounds>
+			<bounds x="9" y="94" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="11" y="96" width="78" height="38">
-			</bounds>
+			<bounds x="11" y="96" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_2_border" state="0">
-			<bounds x="9" y="74" width="82" height="23">
-			</bounds>
+			<bounds x="9" y="74" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_2" state="0">
-			<bounds x="11" y="76" width="78" height="19">
-			</bounds>
+			<bounds x="11" y="76" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_2_border" state="0">
-			<bounds x="9" y="159" width="82" height="42">
-			</bounds>
+			<bounds x="9" y="159" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_2" state="0">
-			<bounds x="11" y="161" width="78" height="38">
-			</bounds>
+			<bounds x="11" y="161" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="9" y="204" width="82" height="62">
-			</bounds>
+			<bounds x="9" y="204" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="11" y="206" width="78" height="58">
-			</bounds>
+			<bounds x="11" y="206" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="94" y="74" width="82" height="23">
-			</bounds>
+			<bounds x="94" y="74" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="96" y="76" width="78" height="19">
-			</bounds>
+			<bounds x="96" y="76" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_2_border" state="0">
-			<bounds x="94" y="204" width="82" height="23">
-			</bounds>
+			<bounds x="94" y="204" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_2" state="0">
-			<bounds x="96" y="206" width="78" height="19">
-			</bounds>
+			<bounds x="96" y="206" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_2_border" state="0">
-			<bounds x="179" y="224" width="82" height="42">
-			</bounds>
+			<bounds x="179" y="224" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_2" state="0">
-			<bounds x="181" y="226" width="78" height="38">
-			</bounds>
+			<bounds x="181" y="226" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_2_border" state="0">
-			<bounds x="264" y="204" width="82" height="23">
-			</bounds>
+			<bounds x="264" y="204" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_2" state="0">
-			<bounds x="266" y="206" width="78" height="19">
-			</bounds>
+			<bounds x="266" y="206" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="349" y="204" width="82" height="23">
-			</bounds>
+			<bounds x="349" y="204" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="351" y="206" width="78" height="19">
-			</bounds>
+			<bounds x="351" y="206" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_2_border" state="0">
-			<bounds x="349" y="224" width="82" height="42">
-			</bounds>
+			<bounds x="349" y="224" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_2" state="0">
-			<bounds x="351" y="226" width="78" height="38">
-			</bounds>
+			<bounds x="351" y="226" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2_border" state="0">
-			<bounds x="689" y="204" width="82" height="23">
-			</bounds>
+			<bounds x="689" y="204" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_2" state="0">
-			<bounds x="691" y="206" width="78" height="19">
-			</bounds>
+			<bounds x="691" y="206" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_2_border" state="0">
-			<bounds x="689" y="159" width="82" height="42">
-			</bounds>
+			<bounds x="689" y="159" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_2" state="0">
-			<bounds x="691" y="161" width="78" height="38">
-			</bounds>
+			<bounds x="691" y="161" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="434" y="29" width="82" height="42">
-			</bounds>
+			<bounds x="434" y="29" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="436" y="31" width="78" height="38">
-			</bounds>
+			<bounds x="436" y="31" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="519" y="29" width="82" height="42">
-			</bounds>
+			<bounds x="519" y="29" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="521" y="31" width="78" height="38">
-			</bounds>
+			<bounds x="521" y="31" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_2_border" state="0">
-			<bounds x="519" y="9" width="82" height="23">
-			</bounds>
+			<bounds x="519" y="9" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_2" state="0">
-			<bounds x="521" y="11" width="78" height="19">
-			</bounds>
+			<bounds x="521" y="11" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="349" y="9" width="82" height="62">
-			</bounds>
+			<bounds x="349" y="9" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="351" y="11" width="78" height="58">
-			</bounds>
+			<bounds x="351" y="11" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_2_border" state="0">
-			<bounds x="434" y="9" width="82" height="23">
-			</bounds>
+			<bounds x="434" y="9" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_2" state="0">
-			<bounds x="436" y="11" width="78" height="19">
-			</bounds>
+			<bounds x="436" y="11" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="179" y="29" width="167" height="42">
-			</bounds>
+			<bounds x="179" y="29" width="167" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="181" y="31" width="163" height="38">
-			</bounds>
+			<bounds x="181" y="31" width="163" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="94" y="9" width="82" height="23">
-			</bounds>
+			<bounds x="94" y="9" width="82" height="23"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="96" y="11" width="78" height="19">
-			</bounds>
+			<bounds x="96" y="11" width="78" height="19"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_2_border" state="0">
-			<bounds x="94" y="29" width="82" height="42">
-			</bounds>
+			<bounds x="94" y="29" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_2" state="0">
-			<bounds x="96" y="31" width="78" height="38">
-			</bounds>
+			<bounds x="96" y="31" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_2_border" state="0">
-			<bounds x="179" y="9" width="167" height="23">
-			</bounds>
+			<bounds x="179" y="9" width="167" height="23"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_2" state="0">
-			<bounds x="181" y="11" width="163" height="19">
-			</bounds>
+			<bounds x="181" y="11" width="163" height="19"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_2_border" state="0">
-			<bounds x="519" y="354" width="82" height="42">
-			</bounds>
+			<bounds x="519" y="354" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_2" state="0">
-			<bounds x="521" y="356" width="78" height="38">
-			</bounds>
+			<bounds x="521" y="356" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2_border" state="0">
-			<bounds x="94" y="94" width="82" height="42">
-			</bounds>
+			<bounds x="94" y="94" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2" state="0">
-			<bounds x="96" y="96" width="78" height="38">
-			</bounds>
+			<bounds x="96" y="96" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_2_border" state="0">
-			<bounds x="519" y="94" width="82" height="42">
-			</bounds>
+			<bounds x="519" y="94" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_2" state="0">
-			<bounds x="521" y="96" width="78" height="38">
-			</bounds>
+			<bounds x="521" y="96" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="464" y="264" width="82" height="42">
-			</bounds>
+			<bounds x="464" y="264" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="466" y="266" width="78" height="38">
-			</bounds>
+			<bounds x="466" y="266" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="464" y="219" width="82" height="42">
-			</bounds>
+			<bounds x="464" y="219" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="466" y="221" width="78" height="38">
-			</bounds>
+			<bounds x="466" y="221" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="584" y="534" width="62" height="42">
-			</bounds>
+			<bounds x="584" y="534" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="586" y="536" width="58" height="38">
-			</bounds>
+			<bounds x="586" y="536" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="584" y="484" width="62" height="47">
-			</bounds>
+			<bounds x="584" y="484" width="62" height="47"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="586" y="486" width="58" height="43">
-			</bounds>
+			<bounds x="586" y="486" width="58" height="43"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="714" y="554" width="62" height="22">
-			</bounds>
+			<bounds x="714" y="554" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="716" y="556" width="58" height="18">
-			</bounds>
+			<bounds x="716" y="556" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="714" y="404" width="62" height="22">
-			</bounds>
+			<bounds x="714" y="404" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="716" y="406" width="58" height="18">
-			</bounds>
+			<bounds x="716" y="406" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="714" y="429" width="62" height="22">
-			</bounds>
+			<bounds x="714" y="429" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="716" y="431" width="58" height="18">
-			</bounds>
+			<bounds x="716" y="431" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="714" y="454" width="62" height="22">
-			</bounds>
+			<bounds x="714" y="454" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="716" y="456" width="58" height="18">
-			</bounds>
+			<bounds x="716" y="456" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="714" y="479" width="62" height="22">
-			</bounds>
+			<bounds x="714" y="479" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="716" y="481" width="58" height="18">
-			</bounds>
+			<bounds x="716" y="481" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="714" y="504" width="62" height="22">
-			</bounds>
+			<bounds x="714" y="504" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="716" y="506" width="58" height="18">
-			</bounds>
+			<bounds x="716" y="506" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="714" y="529" width="62" height="22">
-			</bounds>
+			<bounds x="714" y="529" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="716" y="531" width="58" height="18">
-			</bounds>
+			<bounds x="716" y="531" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="584" y="404" width="62" height="37">
-			</bounds>
+			<bounds x="584" y="404" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="586" y="406" width="58" height="33">
-			</bounds>
+			<bounds x="586" y="406" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="584" y="444" width="62" height="37">
-			</bounds>
+			<bounds x="584" y="444" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="586" y="446" width="58" height="33">
-			</bounds>
+			<bounds x="586" y="446" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="14" y="419" width="77" height="22">
-			</bounds>
+			<bounds x="14" y="419" width="77" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="16" y="421" width="73" height="18">
-			</bounds>
+			<bounds x="16" y="421" width="73" height="18"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="54" y="554" width="37" height="22">
-			</bounds>
+			<bounds x="54" y="554" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="56" y="556" width="33" height="18">
-			</bounds>
+			<bounds x="56" y="556" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_131_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="604" y="589" width="82" height="42">
-			</bounds>
+			<bounds x="604" y="589" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_131" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="606" y="591" width="78" height="38">
-			</bounds>
+			<bounds x="606" y="591" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_132_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="509" y="589" width="82" height="42">
-			</bounds>
+			<bounds x="509" y="589" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_132" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="511" y="591" width="78" height="38">
-			</bounds>
+			<bounds x="511" y="591" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_133_border" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="414" y="589" width="82" height="42">
-			</bounds>
+			<bounds x="414" y="589" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_133" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="416" y="591" width="78" height="38">
-			</bounds>
+			<bounds x="416" y="591" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_134_border" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="319" y="589" width="82" height="42">
-			</bounds>
+			<bounds x="319" y="589" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_134" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="321" y="591" width="78" height="38">
-			</bounds>
+			<bounds x="321" y="591" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_135_border" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="224" y="589" width="82" height="42">
-			</bounds>
+			<bounds x="224" y="589" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_135" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="226" y="591" width="78" height="38">
-			</bounds>
+			<bounds x="226" y="591" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_136_border" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="129" y="589" width="82" height="42">
-			</bounds>
+			<bounds x="129" y="589" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_136" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="131" y="591" width="78" height="38">
-			</bounds>
+			<bounds x="131" y="591" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_137_border" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="34" y="589" width="82" height="42">
-			</bounds>
+			<bounds x="34" y="589" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_137" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="36" y="591" width="78" height="38">
-			</bounds>
+			<bounds x="36" y="591" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_138_border" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="694" y="29" width="50" height="16">
-			</bounds>
+			<bounds x="694" y="29" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_138" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="696" y="31" width="46" height="12">
-			</bounds>
+			<bounds x="696" y="31" width="46" height="12"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_139_border" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="694" y="49" width="50" height="16">
-			</bounds>
+			<bounds x="694" y="49" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_139" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="696" y="51" width="46" height="12">
-			</bounds>
+			<bounds x="696" y="51" width="46" height="12"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_140_border" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="694" y="9" width="50" height="16">
-			</bounds>
+			<bounds x="694" y="9" width="50" height="16"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_140" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="696" y="11" width="46" height="12">
-			</bounds>
+			<bounds x="696" y="11" width="46" height="12"/>
 		</backdrop>
-
-	<!-- The DMD -->
-	<screen index="0">
-	  <bounds left="10" top="285" right="337" bottom="392" />
-	</screen>
-
+		<backdrop element="dmd_background">
+			<bounds x="10" y="285" width="327" height="107"/>
+		</backdrop>
+		<screen index="0">
+			<bounds left="10" top="285" right="337" bottom="392"/>
+		</screen>
+		<screen index="0">
+			<bounds left="10" top="285" right="337" bottom="392"/>
+		</screen>
+		<screen index="0">
+			<bounds left="10" top="285" right="337" bottom="392"/>
+		</screen>
 		<backdrop name="label66" element="label_66">
-			<bounds x="605" y="300" width="31" height="19">
-			</bounds>
+			<bounds x="605" y="300" width="31" height="19"/>
 		</backdrop>
 		<backdrop name="label67" element="label_67">
-			<bounds x="750" y="50" width="19" height="14">
-			</bounds>
+			<bounds x="750" y="50" width="19" height="14"/>
 		</backdrop>
 		<backdrop name="label68" element="label_68">
-			<bounds x="750" y="30" width="19" height="14">
-			</bounds>
+			<bounds x="750" y="30" width="19" height="14"/>
 		</backdrop>
 		<backdrop name="label69" element="label_69">
-			<bounds x="750" y="10" width="12" height="14">
-			</bounds>
+			<bounds x="750" y="10" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label70" element="label_70">
-			<bounds x="100" y="495" width="24" height="28">
-			</bounds>
+			<bounds x="100" y="495" width="24" height="28"/>
 		</backdrop>
 		<backdrop name="label71" element="label_71">
-			<bounds x="430" y="535" width="109" height="32">
-			</bounds>
+			<bounds x="430" y="535" width="109" height="32"/>
 		</backdrop>
 		<backdrop name="label75" element="label_75">
-			<bounds x="403" y="495" width="24" height="28">
-			</bounds>
+			<bounds x="403" y="495" width="24" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="STROBE0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="STROBE1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="STROBE1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="STROBE2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="STROBE2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="STROBE3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="STROBE4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="STROBE5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="STROBE6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="STROBE7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp111" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
+		<screen index="0">
+			<bounds left="1400" top="400" right="1790" bottom="526"/>
+		</screen>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4acesh.lay
+++ b/src/mame/layout/sc4acesh.lay
@@ -8,12098 +8,7400 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Stalled">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Stalled">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Mayday Payday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Mayday Payday">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Aces">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="High">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Aces">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="High">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Kamikazi Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Kamikazi Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="High Flyer ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="High Flyer ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Dog Fight">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Dog Fight">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Chocs Away">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Chocs Away">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Dive! Dive! Dosh!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Dive! Dive! Dosh!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Loop The ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Loop The ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Loot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Runway">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Runway">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="In A Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="In A Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Para Shoot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Para Shoot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Bonus Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Bonus Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+  1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+  1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Tally">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Ho">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Tally">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Ho">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Featur">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Featur">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+  2 Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+  2 Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Lucky 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Lucky 7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="No Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="No Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Extra Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Extra Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Reel Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Reel Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Good ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Number">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Good ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Number">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Stopper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Stopper">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Step To Nearest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Step To Nearest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Wild Winner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Wild Winner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Nudge Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Nudge Time">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Cherry Spinner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Cherry Spinner">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Reel Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Reel Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_149_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_149">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold / lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_152_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_152">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold / Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_154_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_154">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel5" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="5" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_128">
 		<text string="27 Ways to Start Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_129">
 		<text string="On winline Starts Super Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_142">
 		<text string="Light All For Aces High">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_5">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="671">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="671"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="229" y="484" width="80" height="140">
-			</bounds>
+			<bounds x="229" y="484" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="229.0000" y="484.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="229.0000" y="484.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="232.3333" y="485.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="232.3333" y="485.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="235.6667" y="487.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="235.6667" y="487.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="239.0000" y="489.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="239.0000" y="489.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="242.3333" y="491.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="242.3333" y="491.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="245.6667" y="493.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="245.6667" y="493.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="229.0000" y="530.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="229.0000" y="530.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="232.3333" y="532.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="232.3333" y="532.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="235.6667" y="534.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="235.6667" y="534.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="239.0000" y="536.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="239.0000" y="536.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="242.3333" y="538.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="242.3333" y="538.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="245.6667" y="540.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="245.6667" y="540.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="229.0000" y="577.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="229.0000" y="577.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="232.3333" y="579.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="232.3333" y="579.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="235.6667" y="581.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="235.6667" y="581.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="239.0000" y="583.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="239.0000" y="583.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="242.3333" y="585.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="242.3333" y="585.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="245.6667" y="587.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="245.6667" y="587.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="229" y="484" width="80" height="140">
-			</bounds>
+			<bounds x="229" y="484" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="335" y="484" width="80" height="140">
-			</bounds>
+			<bounds x="335" y="484" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="484.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="335.0000" y="484.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="485.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="338.3333" y="485.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="487.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="341.6667" y="487.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="489.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="345.0000" y="489.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="491.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="348.3333" y="491.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="493.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="351.6667" y="493.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="530.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="335.0000" y="530.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="532.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="338.3333" y="532.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="534.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="341.6667" y="534.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="536.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="345.0000" y="536.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="538.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="348.3333" y="538.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="540.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="351.6667" y="540.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="577.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="335.0000" y="577.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="579.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="338.3333" y="579.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="581.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="341.6667" y="581.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="583.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="345.0000" y="583.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="585.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="348.3333" y="585.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="587.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="351.6667" y="587.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="335" y="484" width="80" height="140">
-			</bounds>
+			<bounds x="335" y="484" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="436" y="483" width="80" height="140">
-			</bounds>
+			<bounds x="436" y="483" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="483.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="483.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="484.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="484.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="486.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="486.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="488.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="488.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="490.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="490.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="492.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="492.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="529.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="529.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="531.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="531.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="533.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="533.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="535.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="535.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="537.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="537.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="539.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="539.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="436.0000" y="576.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="436.0000" y="576.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="439.3333" y="578.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="439.3333" y="578.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="442.6667" y="580.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="442.6667" y="580.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="446.0000" y="582.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="446.0000" y="582.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="449.3333" y="584.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="449.3333" y="584.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="452.6667" y="586.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="452.6667" y="586.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="436" y="483" width="80" height="140">
-			</bounds>
+			<bounds x="436" y="483" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="331" y="344" width="80" height="70">
-			</bounds>
+			<bounds x="331" y="344" width="80" height="70"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="331.0000" y="344.0000" width="80.0000" height="70.0000">
-			</bounds>
+			<bounds x="331.0000" y="344.0000" width="80.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="334.3333" y="346.9167" width="73.3333" height="64.1667">
-			</bounds>
+			<bounds x="334.3333" y="346.9167" width="73.3333" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="337.6667" y="349.8333" width="66.6667" height="58.3333">
-			</bounds>
+			<bounds x="337.6667" y="349.8333" width="66.6667" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="341.0000" y="352.7500" width="60.0000" height="52.5000">
-			</bounds>
+			<bounds x="341.0000" y="352.7500" width="60.0000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="344.3333" y="355.6667" width="53.3333" height="46.6667">
-			</bounds>
+			<bounds x="344.3333" y="355.6667" width="53.3333" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="347.6667" y="358.5833" width="46.6667" height="40.8333">
-			</bounds>
+			<bounds x="347.6667" y="358.5833" width="46.6667" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="331" y="344" width="80" height="70">
-			</bounds>
+			<bounds x="331" y="344" width="80" height="70"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="226" y="238" width="280" height="56">
-			</bounds>
+			<bounds x="226" y="238" width="280" height="56"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="226.0000" y="238.0000" width="280.0000" height="11.2000">
-			</bounds>
+			<bounds x="226.0000" y="238.0000" width="280.0000" height="11.2000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="237.6667" y="238.4667" width="256.6667" height="10.2667">
-			</bounds>
+			<bounds x="237.6667" y="238.4667" width="256.6667" height="10.2667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="249.3333" y="238.9333" width="233.3333" height="9.3333">
-			</bounds>
+			<bounds x="249.3333" y="238.9333" width="233.3333" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="261.0000" y="239.4000" width="210.0000" height="8.4000">
-			</bounds>
+			<bounds x="261.0000" y="239.4000" width="210.0000" height="8.4000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="272.6667" y="239.8667" width="186.6667" height="7.4667">
-			</bounds>
+			<bounds x="272.6667" y="239.8667" width="186.6667" height="7.4667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="284.3333" y="240.3333" width="163.3333" height="6.5333">
-			</bounds>
+			<bounds x="284.3333" y="240.3333" width="163.3333" height="6.5333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="226.0000" y="249.2000" width="280.0000" height="11.2000">
-			</bounds>
+			<bounds x="226.0000" y="249.2000" width="280.0000" height="11.2000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="237.6667" y="249.6667" width="256.6667" height="10.2667">
-			</bounds>
+			<bounds x="237.6667" y="249.6667" width="256.6667" height="10.2667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="249.3333" y="250.1333" width="233.3333" height="9.3333">
-			</bounds>
+			<bounds x="249.3333" y="250.1333" width="233.3333" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="261.0000" y="250.6000" width="210.0000" height="8.4000">
-			</bounds>
+			<bounds x="261.0000" y="250.6000" width="210.0000" height="8.4000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="272.6667" y="251.0667" width="186.6667" height="7.4667">
-			</bounds>
+			<bounds x="272.6667" y="251.0667" width="186.6667" height="7.4667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="284.3333" y="251.5333" width="163.3333" height="6.5333">
-			</bounds>
+			<bounds x="284.3333" y="251.5333" width="163.3333" height="6.5333"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="226.0000" y="260.4000" width="280.0000" height="11.2000">
-			</bounds>
+			<bounds x="226.0000" y="260.4000" width="280.0000" height="11.2000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="237.6667" y="260.8667" width="256.6667" height="10.2667">
-			</bounds>
+			<bounds x="237.6667" y="260.8667" width="256.6667" height="10.2667"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="249.3333" y="261.3333" width="233.3333" height="9.3333">
-			</bounds>
+			<bounds x="249.3333" y="261.3333" width="233.3333" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="261.0000" y="261.8000" width="210.0000" height="8.4000">
-			</bounds>
+			<bounds x="261.0000" y="261.8000" width="210.0000" height="8.4000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="272.6667" y="262.2667" width="186.6667" height="7.4667">
-			</bounds>
+			<bounds x="272.6667" y="262.2667" width="186.6667" height="7.4667"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="284.3333" y="262.7333" width="163.3333" height="6.5333">
-			</bounds>
+			<bounds x="284.3333" y="262.7333" width="163.3333" height="6.5333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="226.0000" y="271.6000" width="280.0000" height="11.2000">
-			</bounds>
+			<bounds x="226.0000" y="271.6000" width="280.0000" height="11.2000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="237.6667" y="272.0667" width="256.6667" height="10.2667">
-			</bounds>
+			<bounds x="237.6667" y="272.0667" width="256.6667" height="10.2667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="249.3333" y="272.5333" width="233.3333" height="9.3333">
-			</bounds>
+			<bounds x="249.3333" y="272.5333" width="233.3333" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="261.0000" y="273.0000" width="210.0000" height="8.4000">
-			</bounds>
+			<bounds x="261.0000" y="273.0000" width="210.0000" height="8.4000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="272.6667" y="273.4667" width="186.6667" height="7.4667">
-			</bounds>
+			<bounds x="272.6667" y="273.4667" width="186.6667" height="7.4667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="284.3333" y="273.9333" width="163.3333" height="6.5333">
-			</bounds>
+			<bounds x="284.3333" y="273.9333" width="163.3333" height="6.5333"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="226.0000" y="282.8000" width="280.0000" height="11.2000">
-			</bounds>
+			<bounds x="226.0000" y="282.8000" width="280.0000" height="11.2000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="237.6667" y="283.2667" width="256.6667" height="10.2667">
-			</bounds>
+			<bounds x="237.6667" y="283.2667" width="256.6667" height="10.2667"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="249.3333" y="283.7333" width="233.3333" height="9.3333">
-			</bounds>
+			<bounds x="249.3333" y="283.7333" width="233.3333" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="261.0000" y="284.2000" width="210.0000" height="8.4000">
-			</bounds>
+			<bounds x="261.0000" y="284.2000" width="210.0000" height="8.4000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="272.6667" y="284.6667" width="186.6667" height="7.4667">
-			</bounds>
+			<bounds x="272.6667" y="284.6667" width="186.6667" height="7.4667"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="284.3333" y="285.1333" width="163.3333" height="6.5333">
-			</bounds>
+			<bounds x="284.3333" y="285.1333" width="163.3333" height="6.5333"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="226" y="238" width="280" height="56">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="226" y="238" width="280" height="56"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="656" y="485" width="44" height="22">
-			</bounds>
+			<bounds x="656" y="485" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="658" y="487" width="40" height="18">
-			</bounds>
+			<bounds x="658" y="487" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="657" y="135" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="135" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="659" y="137" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="137" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="43" y="382" width="44" height="22">
-			</bounds>
+			<bounds x="43" y="382" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="45" y="384" width="40" height="18">
-			</bounds>
+			<bounds x="45" y="384" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="12" y="285" width="44" height="22">
-			</bounds>
+			<bounds x="12" y="285" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="14" y="287" width="40" height="18">
-			</bounds>
+			<bounds x="14" y="287" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="7" y="253" width="44" height="22">
-			</bounds>
+			<bounds x="7" y="253" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="9" y="255" width="40" height="18">
-			</bounds>
+			<bounds x="9" y="255" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="4" y="221" width="44" height="22">
-			</bounds>
+			<bounds x="4" y="221" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="6" y="223" width="40" height="18">
-			</bounds>
+			<bounds x="6" y="223" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="7" y="189" width="44" height="22">
-			</bounds>
+			<bounds x="7" y="189" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="9" y="191" width="40" height="18">
-			</bounds>
+			<bounds x="9" y="191" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="12" y="157" width="44" height="22">
-			</bounds>
+			<bounds x="12" y="157" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="14" y="159" width="40" height="18">
-			</bounds>
+			<bounds x="14" y="159" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="19" y="125" width="44" height="22">
-			</bounds>
+			<bounds x="19" y="125" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="21" y="127" width="40" height="18">
-			</bounds>
+			<bounds x="21" y="127" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="28" y="93" width="44" height="22">
-			</bounds>
+			<bounds x="28" y="93" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="30" y="95" width="40" height="18">
-			</bounds>
+			<bounds x="30" y="95" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="482" y="35" width="57" height="19">
-			</bounds>
+			<bounds x="482" y="35" width="57" height="19"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="484" y="37" width="53" height="15">
-			</bounds>
+			<bounds x="484" y="37" width="53" height="15"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="14" y="5" width="52" height="27">
-			</bounds>
+			<bounds x="14" y="5" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="16" y="7" width="48" height="23">
-			</bounds>
+			<bounds x="16" y="7" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="68" y="1" width="52" height="27">
-			</bounds>
+			<bounds x="68" y="1" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="70" y="3" width="48" height="23">
-			</bounds>
+			<bounds x="70" y="3" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="122" y="5" width="52" height="27">
-			</bounds>
+			<bounds x="122" y="5" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="124" y="7" width="48" height="23">
-			</bounds>
+			<bounds x="124" y="7" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="177" y="1" width="52" height="27">
-			</bounds>
+			<bounds x="177" y="1" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="179" y="3" width="48" height="23">
-			</bounds>
+			<bounds x="179" y="3" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="230" y="5" width="52" height="27">
-			</bounds>
+			<bounds x="230" y="5" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="232" y="7" width="48" height="23">
-			</bounds>
+			<bounds x="232" y="7" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="284" y="1" width="52" height="27">
-			</bounds>
+			<bounds x="284" y="1" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="286" y="3" width="48" height="23">
-			</bounds>
+			<bounds x="286" y="3" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="338" y="5" width="52" height="27">
-			</bounds>
+			<bounds x="338" y="5" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="340" y="7" width="48" height="23">
-			</bounds>
+			<bounds x="340" y="7" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="393" y="4" width="52" height="27">
-			</bounds>
+			<bounds x="393" y="4" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="395" y="6" width="48" height="23">
-			</bounds>
+			<bounds x="395" y="6" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="446" y="5" width="52" height="27">
-			</bounds>
+			<bounds x="446" y="5" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="448" y="7" width="48" height="23">
-			</bounds>
+			<bounds x="448" y="7" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="72" y="88" width="102" height="32">
-			</bounds>
+			<bounds x="72" y="88" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="74" y="90" width="98" height="28">
-			</bounds>
+			<bounds x="74" y="90" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="36" y="35" width="152" height="52">
-			</bounds>
+			<bounds x="36" y="35" width="152" height="52"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="38" y="37" width="148" height="48">
-			</bounds>
+			<bounds x="38" y="37" width="148" height="48"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="63" y="120" width="102" height="32">
-			</bounds>
+			<bounds x="63" y="120" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="65" y="122" width="98" height="28">
-			</bounds>
+			<bounds x="65" y="122" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="56" y="152" width="102" height="32">
-			</bounds>
+			<bounds x="56" y="152" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="58" y="154" width="98" height="28">
-			</bounds>
+			<bounds x="58" y="154" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="51" y="184" width="102" height="32">
-			</bounds>
+			<bounds x="51" y="184" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="53" y="186" width="98" height="28">
-			</bounds>
+			<bounds x="53" y="186" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="48" y="216" width="102" height="32">
-			</bounds>
+			<bounds x="48" y="216" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="50" y="218" width="98" height="28">
-			</bounds>
+			<bounds x="50" y="218" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="51" y="248" width="102" height="32">
-			</bounds>
+			<bounds x="51" y="248" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="53" y="250" width="98" height="28">
-			</bounds>
+			<bounds x="53" y="250" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="56" y="280" width="102" height="32">
-			</bounds>
+			<bounds x="56" y="280" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="58" y="282" width="98" height="28">
-			</bounds>
+			<bounds x="58" y="282" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="63" y="312" width="102" height="32">
-			</bounds>
+			<bounds x="63" y="312" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="65" y="314" width="98" height="28">
-			</bounds>
+			<bounds x="65" y="314" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="72" y="344" width="102" height="32">
-			</bounds>
+			<bounds x="72" y="344" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="74" y="346" width="98" height="28">
-			</bounds>
+			<bounds x="74" y="346" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="87" y="376" width="102" height="32">
-			</bounds>
+			<bounds x="87" y="376" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="89" y="378" width="98" height="28">
-			</bounds>
+			<bounds x="89" y="378" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="19" y="317" width="44" height="22">
-			</bounds>
+			<bounds x="19" y="317" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="21" y="319" width="40" height="18">
-			</bounds>
+			<bounds x="21" y="319" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="28" y="350" width="44" height="22">
-			</bounds>
+			<bounds x="28" y="350" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="30" y="352" width="40" height="18">
-			</bounds>
+			<bounds x="30" y="352" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="336" y="417" width="67" height="32">
-			</bounds>
+			<bounds x="336" y="417" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="338" y="419" width="63" height="28">
-			</bounds>
+			<bounds x="338" y="419" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="267" y="417" width="67" height="32">
-			</bounds>
+			<bounds x="267" y="417" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="269" y="419" width="63" height="28">
-			</bounds>
+			<bounds x="269" y="419" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="474" y="417" width="67" height="32">
-			</bounds>
+			<bounds x="474" y="417" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="476" y="419" width="63" height="28">
-			</bounds>
+			<bounds x="476" y="419" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="474" y="380" width="67" height="32">
-			</bounds>
+			<bounds x="474" y="380" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="476" y="382" width="63" height="28">
-			</bounds>
+			<bounds x="476" y="382" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="474" y="343" width="67" height="32">
-			</bounds>
+			<bounds x="474" y="343" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="476" y="345" width="63" height="28">
-			</bounds>
+			<bounds x="476" y="345" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="474" y="307" width="67" height="32">
-			</bounds>
+			<bounds x="474" y="307" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="476" y="309" width="63" height="28">
-			</bounds>
+			<bounds x="476" y="309" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="405" y="307" width="67" height="32">
-			</bounds>
+			<bounds x="405" y="307" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="407" y="309" width="63" height="28">
-			</bounds>
+			<bounds x="407" y="309" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="336" y="307" width="67" height="32">
-			</bounds>
+			<bounds x="336" y="307" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="338" y="309" width="63" height="28">
-			</bounds>
+			<bounds x="338" y="309" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="267" y="307" width="67" height="32">
-			</bounds>
+			<bounds x="267" y="307" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="269" y="309" width="63" height="28">
-			</bounds>
+			<bounds x="269" y="309" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="198" y="307" width="67" height="32">
-			</bounds>
+			<bounds x="198" y="307" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="200" y="309" width="63" height="28">
-			</bounds>
+			<bounds x="200" y="309" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="198" y="343" width="67" height="32">
-			</bounds>
+			<bounds x="198" y="343" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="200" y="345" width="63" height="28">
-			</bounds>
+			<bounds x="200" y="345" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="198" y="380" width="67" height="32">
-			</bounds>
+			<bounds x="198" y="380" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="200" y="382" width="63" height="28">
-			</bounds>
+			<bounds x="200" y="382" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="198" y="417" width="67" height="32">
-			</bounds>
+			<bounds x="198" y="417" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="200" y="419" width="63" height="28">
-			</bounds>
+			<bounds x="200" y="419" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="419" y="393" width="52" height="19">
-			</bounds>
+			<bounds x="419" y="393" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="421" y="395" width="48" height="15">
-			</bounds>
+			<bounds x="421" y="395" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="270" y="394" width="52" height="19">
-			</bounds>
+			<bounds x="270" y="394" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="272" y="396" width="48" height="15">
-			</bounds>
+			<bounds x="272" y="396" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="270" y="367" width="52" height="27">
-			</bounds>
+			<bounds x="270" y="367" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="272" y="369" width="48" height="23">
-			</bounds>
+			<bounds x="272" y="369" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="419" y="345" width="52" height="27">
-			</bounds>
+			<bounds x="419" y="345" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="421" y="347" width="48" height="23">
-			</bounds>
+			<bounds x="421" y="347" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="270" y="340" width="52" height="27">
-			</bounds>
+			<bounds x="270" y="340" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="272" y="342" width="48" height="23">
-			</bounds>
+			<bounds x="272" y="342" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="419" y="373" width="52" height="19">
-			</bounds>
+			<bounds x="419" y="373" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="421" y="375" width="48" height="15">
-			</bounds>
+			<bounds x="421" y="375" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="555" y="128" width="102" height="32">
-			</bounds>
+			<bounds x="555" y="128" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="557" y="130" width="98" height="28">
-			</bounds>
+			<bounds x="557" y="130" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="555" y="224" width="102" height="32">
-			</bounds>
+			<bounds x="555" y="224" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="557" y="226" width="98" height="28">
-			</bounds>
+			<bounds x="557" y="226" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="657" y="166" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="166" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="659" y="168" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="168" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="657" y="197" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="197" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="659" y="199" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="199" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="657" y="229" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="229" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="659" y="231" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="231" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="657" y="261" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="261" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="659" y="263" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="263" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="657" y="294" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="294" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="659" y="296" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="296" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="657" y="359" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="359" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="659" y="361" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="361" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="657" y="325" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="325" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="659" y="327" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="327" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="657" y="389" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="389" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="659" y="391" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="391" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="657" y="453" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="453" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="659" y="455" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="455" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="657" y="421" width="44" height="22">
-			</bounds>
+			<bounds x="657" y="421" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="659" y="423" width="40" height="18">
-			</bounds>
+			<bounds x="659" y="423" width="40" height="18"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="400" y="117" width="32" height="27">
-			</bounds>
+			<bounds x="400" y="117" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="402" y="119" width="28" height="23">
-			</bounds>
+			<bounds x="402" y="119" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="400" y="144" width="32" height="27">
-			</bounds>
+			<bounds x="400" y="144" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="402" y="146" width="28" height="23">
-			</bounds>
+			<bounds x="402" y="146" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="400" y="171" width="32" height="27">
-			</bounds>
+			<bounds x="400" y="171" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="402" y="173" width="28" height="23">
-			</bounds>
+			<bounds x="402" y="173" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="400" y="198" width="32" height="27">
-			</bounds>
+			<bounds x="400" y="198" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="402" y="200" width="28" height="23">
-			</bounds>
+			<bounds x="402" y="200" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="433" y="201" width="22" height="22">
-			</bounds>
+			<bounds x="433" y="201" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="435" y="203" width="18" height="18">
-			</bounds>
+			<bounds x="435" y="203" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="433" y="173" width="22" height="22">
-			</bounds>
+			<bounds x="433" y="173" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="435" y="175" width="18" height="18">
-			</bounds>
+			<bounds x="435" y="175" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="433" y="147" width="22" height="22">
-			</bounds>
+			<bounds x="433" y="147" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="435" y="149" width="18" height="18">
-			</bounds>
+			<bounds x="435" y="149" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="433" y="120" width="22" height="22">
-			</bounds>
+			<bounds x="433" y="120" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="435" y="122" width="18" height="18">
-			</bounds>
+			<bounds x="435" y="122" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="433" y="93" width="22" height="22">
-			</bounds>
+			<bounds x="433" y="93" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="435" y="95" width="18" height="18">
-			</bounds>
+			<bounds x="435" y="95" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="400" y="90" width="32" height="27">
-			</bounds>
+			<bounds x="400" y="90" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="402" y="92" width="28" height="23">
-			</bounds>
+			<bounds x="402" y="92" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="187" y="455" width="19" height="19">
-			</bounds>
+			<bounds x="187" y="455" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="189" y="457" width="15" height="15">
-			</bounds>
+			<bounds x="189" y="457" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="121" y="562" width="52" height="25">
-			</bounds>
+			<bounds x="121" y="562" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="123" y="564" width="48" height="21">
-			</bounds>
+			<bounds x="123" y="564" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="123" y="537" width="52" height="25">
-			</bounds>
+			<bounds x="123" y="537" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="125" y="539" width="48" height="21">
-			</bounds>
+			<bounds x="125" y="539" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="124" y="512" width="52" height="25">
-			</bounds>
+			<bounds x="124" y="512" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="126" y="514" width="48" height="21">
-			</bounds>
+			<bounds x="126" y="514" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="126" y="487" width="52" height="25">
-			</bounds>
+			<bounds x="126" y="487" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="128" y="489" width="48" height="21">
-			</bounds>
+			<bounds x="128" y="489" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="130" y="462" width="52" height="25">
-			</bounds>
+			<bounds x="130" y="462" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="132" y="464" width="48" height="21">
-			</bounds>
+			<bounds x="132" y="464" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="118" y="587" width="52" height="25">
-			</bounds>
+			<bounds x="118" y="587" width="52" height="25"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="120" y="589" width="48" height="21">
-			</bounds>
+			<bounds x="120" y="589" width="48" height="21"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="38" y="550" width="37" height="32">
-			</bounds>
+			<bounds x="38" y="550" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="40" y="552" width="33" height="28">
-			</bounds>
+			<bounds x="40" y="552" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="38" y="516" width="37" height="32">
-			</bounds>
+			<bounds x="38" y="516" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="40" y="518" width="33" height="28">
-			</bounds>
+			<bounds x="40" y="518" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="38" y="482" width="37" height="32">
-			</bounds>
+			<bounds x="38" y="482" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="40" y="484" width="33" height="28">
-			</bounds>
+			<bounds x="40" y="484" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="38" y="448" width="37" height="32">
-			</bounds>
+			<bounds x="38" y="448" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="40" y="450" width="33" height="28">
-			</bounds>
+			<bounds x="40" y="450" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="34" y="586" width="47" height="29">
-			</bounds>
+			<bounds x="34" y="586" width="47" height="29"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="36" y="588" width="43" height="25">
-			</bounds>
+			<bounds x="36" y="588" width="43" height="25"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_148_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="572" y="17" width="75" height="27">
-			</bounds>
+			<bounds x="572" y="17" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_148" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="574" y="19" width="71" height="23">
-			</bounds>
+			<bounds x="574" y="19" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_149_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="633" y="631" width="75" height="27">
-			</bounds>
+			<bounds x="633" y="631" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_149" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="635" y="633" width="71" height="23">
-			</bounds>
+			<bounds x="635" y="633" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_150_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="538" y="631" width="79" height="27">
-			</bounds>
+			<bounds x="538" y="631" width="79" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_150" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="540" y="633" width="75" height="23">
-			</bounds>
+			<bounds x="540" y="633" width="75" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_151_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="441" y="631" width="75" height="27">
-			</bounds>
+			<bounds x="441" y="631" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_151" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="443" y="633" width="71" height="23">
-			</bounds>
+			<bounds x="443" y="633" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_152_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="338" y="631" width="75" height="27">
-			</bounds>
+			<bounds x="338" y="631" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_152" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="340" y="633" width="71" height="23">
-			</bounds>
+			<bounds x="340" y="633" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_153_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="232" y="631" width="75" height="27">
-			</bounds>
+			<bounds x="232" y="631" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_153" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="234" y="633" width="71" height="23">
-			</bounds>
+			<bounds x="234" y="633" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_154_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="140" y="631" width="75" height="27">
-			</bounds>
+			<bounds x="140" y="631" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_154" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="142" y="633" width="71" height="23">
-			</bounds>
+			<bounds x="142" y="633" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_155_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="39" y="631" width="75" height="27">
-			</bounds>
+			<bounds x="39" y="631" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_155" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="41" y="633" width="71" height="23">
-			</bounds>
+			<bounds x="41" y="633" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp123" element="colour_button_156_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="220" y="51" width="75" height="27">
-			</bounds>
+			<bounds x="220" y="51" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp123" element="colour_button_156" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="222" y="53" width="71" height="23">
-			</bounds>
+			<bounds x="222" y="53" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="299" y="42" width="35" height="45">
-			</bounds>
+			<bounds x="299" y="42" width="35" height="45"/>
 		</backdrop>
 		<backdrop name="digit23" element="led_digit_red">
-			<bounds x="299" y="42" width="35" height="45">
-			</bounds>
+			<bounds x="299" y="42" width="35" height="45"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="299" y="42" width="35" height="45">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="299" y="42" width="35" height="45"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="334" y="42" width="35" height="45">
-			</bounds>
+			<bounds x="334" y="42" width="35" height="45"/>
 		</backdrop>
 		<backdrop name="digit21" element="led_digit_red">
-			<bounds x="334" y="42" width="35" height="45">
-			</bounds>
+			<bounds x="334" y="42" width="35" height="45"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="334" y="42" width="35" height="45">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="334" y="42" width="35" height="45"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="369" y="42" width="35" height="45">
-			</bounds>
+			<bounds x="369" y="42" width="35" height="45"/>
 		</backdrop>
 		<backdrop name="digit19" element="led_digit_red">
-			<bounds x="369" y="42" width="35" height="45">
-			</bounds>
+			<bounds x="369" y="42" width="35" height="45"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="369" y="42" width="35" height="45">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="369" y="42" width="35" height="45"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="404" y="42" width="35" height="45">
-			</bounds>
+			<bounds x="404" y="42" width="35" height="45"/>
 		</backdrop>
 		<backdrop name="digit17" element="led_digit_red">
-			<bounds x="404" y="42" width="35" height="45">
-			</bounds>
+			<bounds x="404" y="42" width="35" height="45"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="404" y="42" width="35" height="45">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="404" y="42" width="35" height="45"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="209" y="452" width="323" height="27">
-			</bounds>
+			<bounds x="209" y="452" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="209" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="209" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="229" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="229" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="249" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="249" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="269" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="269" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="289" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="289" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="309" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="309" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="329" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="329" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="349" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="349" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="369" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="369" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="389" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="389" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="409" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="409" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="429" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="429" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="449" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="449" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="469" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="469" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="489" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="489" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="509" y="452" width="20" height="27">
-			</bounds>
+			<bounds x="509" y="452" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label128" element="label_128">
-			<bounds x="557" y="545" width="40" height="33">
-			</bounds>
+			<bounds x="557" y="545" width="40" height="33"/>
 		</backdrop>
 		<backdrop name="label129" element="label_129">
-			<bounds x="622" y="544" width="59" height="33">
-			</bounds>
+			<bounds x="622" y="544" width="59" height="33"/>
 		</backdrop>
 		<backdrop name="label142" element="label_142">
-			<bounds x="198" y="199" width="60" height="22">
-			</bounds>
+			<bounds x="198" y="199" width="60" height="22"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_button" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="312.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="312.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="314.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="314.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="316.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="316.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="318.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="318.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="320.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="320.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="322.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="322.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="360.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="360.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="362.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="362.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="364.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="364.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="366.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="366.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="368.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="368.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="370.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="370.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="408.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="408.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="410.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="410.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="412.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="412.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="414.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="414.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="416.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="416.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="418.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="418.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="456.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="456.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="458.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="458.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="460.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="460.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="462.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="462.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="464.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="464.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="466.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="466.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="504.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="504.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="506.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="506.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="508.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="508.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="510.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="510.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="512.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="512.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="514.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="514.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel6" element="debug_stepper_value">
-			<bounds x="1100" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="552" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_5">
-			<bounds x="1180" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="552" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4bantm.lay
+++ b/src/mame/layout/sc4bantm.lay
@@ -8,13726 +8,8541 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="trail held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="trail held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="super cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="super cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="extra shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="extra shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="super feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="super feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="mask">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="mask">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="super cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="super cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="mask">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="mask">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="extra shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="extra shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</disk>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="OF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="OF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="50P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="50P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.50 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.50 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.50 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.50 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="50P REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="50P REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25. REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25. REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;12.00 REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="plucky streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="plucky streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="OPERA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="OPERA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="swop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="swop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="red">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="extra shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="extra shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="no lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="no lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="extra life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="extra life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="hi 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="hi 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="mask">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="mask">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FOWL PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FOWL PLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PICK A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PICK A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPER HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPER HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ROOSTER BOOSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ROOSTER BOOSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CRAZY PAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CRAZY PAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PLUCKY STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PLUCKY STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HIGH NOTES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HIGH NOTES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="IN THE SPOTLIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="IN THE SPOTLIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MASKED MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MASKED MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FUNKY CHICKEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FUNKY CHICKEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WILD THNG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WILD THNG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BLOW YER TOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BLOW YER TOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MONEY MAYHEM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MONEY MAYHEM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="b lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="c lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="f lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="f hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="b hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="c hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_170_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_170">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_171_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_171">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="trans">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_172_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_172">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_173_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_173">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_174_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_174">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_175_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_175">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hold ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_176_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_176">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="shoot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_177_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_177">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_178_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_178">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_179_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_179">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="5" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_150">
 		<text string="light any 3 for bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_157">
 		<text string="LIGHT ALL FOR big money shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="854" height="682">
-			</bounds>
+			<bounds x="0" y="0" width="854" height="682"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="187" y="457" width="80" height="140">
-			</bounds>
+			<bounds x="187" y="457" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="187.0000" y="457.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="187.0000" y="457.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="190.3333" y="458.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="190.3333" y="458.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="193.6667" y="460.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="193.6667" y="460.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.0000" y="462.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="197.0000" y="462.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.3333" y="464.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="200.3333" y="464.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6667" y="466.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="203.6667" y="466.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="187.0000" y="503.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="187.0000" y="503.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="190.3333" y="505.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="190.3333" y="505.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="193.6667" y="507.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="193.6667" y="507.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.0000" y="509.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="197.0000" y="509.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.3333" y="511.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="200.3333" y="511.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6667" y="513.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="203.6667" y="513.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="187.0000" y="550.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="187.0000" y="550.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="190.3333" y="552.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="190.3333" y="552.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="193.6667" y="554.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="193.6667" y="554.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.0000" y="556.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="197.0000" y="556.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.3333" y="558.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="200.3333" y="558.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6667" y="560.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="203.6667" y="560.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="187" y="457" width="80" height="140">
-			</bounds>
+			<bounds x="187" y="457" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="271" y="457" width="80" height="140">
-			</bounds>
+			<bounds x="271" y="457" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="271.0000" y="457.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="271.0000" y="457.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="274.3333" y="458.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="274.3333" y="458.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="277.6667" y="460.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="277.6667" y="460.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="281.0000" y="462.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="281.0000" y="462.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="284.3333" y="464.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="284.3333" y="464.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="287.6667" y="466.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="287.6667" y="466.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="271.0000" y="503.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="271.0000" y="503.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="274.3333" y="505.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="274.3333" y="505.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="277.6667" y="507.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="277.6667" y="507.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="281.0000" y="509.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="281.0000" y="509.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="284.3333" y="511.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="284.3333" y="511.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="287.6667" y="513.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="287.6667" y="513.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="271.0000" y="550.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="271.0000" y="550.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="274.3333" y="552.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="274.3333" y="552.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="277.6667" y="554.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="277.6667" y="554.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="281.0000" y="556.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="281.0000" y="556.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="284.3333" y="558.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="284.3333" y="558.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="287.6667" y="560.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="287.6667" y="560.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="271" y="457" width="80" height="140">
-			</bounds>
+			<bounds x="271" y="457" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="355" y="457" width="80" height="140">
-			</bounds>
+			<bounds x="355" y="457" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="355.0000" y="457.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="355.0000" y="457.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="358.3333" y="458.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="358.3333" y="458.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="361.6667" y="460.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="361.6667" y="460.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.0000" y="462.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="365.0000" y="462.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.3333" y="464.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="368.3333" y="464.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.6667" y="466.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="371.6667" y="466.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="355.0000" y="503.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="355.0000" y="503.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="358.3333" y="505.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="358.3333" y="505.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="361.6667" y="507.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="361.6667" y="507.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.0000" y="509.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="365.0000" y="509.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.3333" y="511.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="368.3333" y="511.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.6667" y="513.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="371.6667" y="513.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="355.0000" y="550.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="355.0000" y="550.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="358.3333" y="552.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="358.3333" y="552.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="361.6667" y="554.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="361.6667" y="554.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="365.0000" y="556.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="365.0000" y="556.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.3333" y="558.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="368.3333" y="558.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="371.6667" y="560.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="371.6667" y="560.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="355" y="457" width="80" height="140">
-			</bounds>
+			<bounds x="355" y="457" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="197" y="211" width="220" height="60">
-			</bounds>
+			<bounds x="197" y="211" width="220" height="60"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="197.0000" y="211.0000" width="220.0000" height="12.0000">
-			</bounds>
+			<bounds x="197.0000" y="211.0000" width="220.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.1667" y="211.5000" width="201.6667" height="11.0000">
-			</bounds>
+			<bounds x="206.1667" y="211.5000" width="201.6667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="215.3333" y="212.0000" width="183.3333" height="10.0000">
-			</bounds>
+			<bounds x="215.3333" y="212.0000" width="183.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="224.5000" y="212.5000" width="165.0000" height="9.0000">
-			</bounds>
+			<bounds x="224.5000" y="212.5000" width="165.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.6667" y="213.0000" width="146.6667" height="8.0000">
-			</bounds>
+			<bounds x="233.6667" y="213.0000" width="146.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="242.8333" y="213.5000" width="128.3333" height="7.0000">
-			</bounds>
+			<bounds x="242.8333" y="213.5000" width="128.3333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="197.0000" y="223.0000" width="220.0000" height="12.0000">
-			</bounds>
+			<bounds x="197.0000" y="223.0000" width="220.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.1667" y="223.5000" width="201.6667" height="11.0000">
-			</bounds>
+			<bounds x="206.1667" y="223.5000" width="201.6667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="215.3333" y="224.0000" width="183.3333" height="10.0000">
-			</bounds>
+			<bounds x="215.3333" y="224.0000" width="183.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="224.5000" y="224.5000" width="165.0000" height="9.0000">
-			</bounds>
+			<bounds x="224.5000" y="224.5000" width="165.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.6667" y="225.0000" width="146.6667" height="8.0000">
-			</bounds>
+			<bounds x="233.6667" y="225.0000" width="146.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="242.8333" y="225.5000" width="128.3333" height="7.0000">
-			</bounds>
+			<bounds x="242.8333" y="225.5000" width="128.3333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="197.0000" y="235.0000" width="220.0000" height="12.0000">
-			</bounds>
+			<bounds x="197.0000" y="235.0000" width="220.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.1667" y="235.5000" width="201.6667" height="11.0000">
-			</bounds>
+			<bounds x="206.1667" y="235.5000" width="201.6667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="215.3333" y="236.0000" width="183.3333" height="10.0000">
-			</bounds>
+			<bounds x="215.3333" y="236.0000" width="183.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="224.5000" y="236.5000" width="165.0000" height="9.0000">
-			</bounds>
+			<bounds x="224.5000" y="236.5000" width="165.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.6667" y="237.0000" width="146.6667" height="8.0000">
-			</bounds>
+			<bounds x="233.6667" y="237.0000" width="146.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="242.8333" y="237.5000" width="128.3333" height="7.0000">
-			</bounds>
+			<bounds x="242.8333" y="237.5000" width="128.3333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="197.0000" y="247.0000" width="220.0000" height="12.0000">
-			</bounds>
+			<bounds x="197.0000" y="247.0000" width="220.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.1667" y="247.5000" width="201.6667" height="11.0000">
-			</bounds>
+			<bounds x="206.1667" y="247.5000" width="201.6667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="215.3333" y="248.0000" width="183.3333" height="10.0000">
-			</bounds>
+			<bounds x="215.3333" y="248.0000" width="183.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="224.5000" y="248.5000" width="165.0000" height="9.0000">
-			</bounds>
+			<bounds x="224.5000" y="248.5000" width="165.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.6667" y="249.0000" width="146.6667" height="8.0000">
-			</bounds>
+			<bounds x="233.6667" y="249.0000" width="146.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="242.8333" y="249.5000" width="128.3333" height="7.0000">
-			</bounds>
+			<bounds x="242.8333" y="249.5000" width="128.3333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="197.0000" y="259.0000" width="220.0000" height="12.0000">
-			</bounds>
+			<bounds x="197.0000" y="259.0000" width="220.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.1667" y="259.5000" width="201.6667" height="11.0000">
-			</bounds>
+			<bounds x="206.1667" y="259.5000" width="201.6667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="215.3333" y="260.0000" width="183.3333" height="10.0000">
-			</bounds>
+			<bounds x="215.3333" y="260.0000" width="183.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="224.5000" y="260.5000" width="165.0000" height="9.0000">
-			</bounds>
+			<bounds x="224.5000" y="260.5000" width="165.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.6667" y="261.0000" width="146.6667" height="8.0000">
-			</bounds>
+			<bounds x="233.6667" y="261.0000" width="146.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="242.8333" y="261.5000" width="128.3333" height="7.0000">
-			</bounds>
+			<bounds x="242.8333" y="261.5000" width="128.3333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="197" y="211" width="220" height="60">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="197" y="211" width="220" height="60"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="70" y="612" width="42" height="29">
-			</bounds>
+			<bounds x="70" y="612" width="42" height="29"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="72" y="614" width="38" height="25">
-			</bounds>
+			<bounds x="72" y="614" width="38" height="25"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="115" y="611" width="42" height="32">
-			</bounds>
+			<bounds x="115" y="611" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="117" y="613" width="38" height="28">
-			</bounds>
+			<bounds x="117" y="613" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="159" y="611" width="42" height="32">
-			</bounds>
+			<bounds x="159" y="611" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="161" y="613" width="38" height="28">
-			</bounds>
+			<bounds x="161" y="613" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="203" y="611" width="42" height="32">
-			</bounds>
+			<bounds x="203" y="611" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="205" y="613" width="38" height="28">
-			</bounds>
+			<bounds x="205" y="613" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="247" y="611" width="57" height="32">
-			</bounds>
+			<bounds x="247" y="611" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="249" y="613" width="53" height="28">
-			</bounds>
+			<bounds x="249" y="613" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="438" y="611" width="42" height="32">
-			</bounds>
+			<bounds x="438" y="611" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="440" y="613" width="38" height="28">
-			</bounds>
+			<bounds x="440" y="613" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="394" y="611" width="42" height="32">
-			</bounds>
+			<bounds x="394" y="611" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="396" y="613" width="38" height="28">
-			</bounds>
+			<bounds x="396" y="613" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="350" y="611" width="42" height="32">
-			</bounds>
+			<bounds x="350" y="611" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="352" y="613" width="38" height="28">
-			</bounds>
+			<bounds x="352" y="613" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="306" y="611" width="42" height="32">
-			</bounds>
+			<bounds x="306" y="611" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="308" y="613" width="38" height="28">
-			</bounds>
+			<bounds x="308" y="613" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="184" y="309" width="52" height="32">
-			</bounds>
+			<bounds x="184" y="309" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="186" y="311" width="48" height="28">
-			</bounds>
+			<bounds x="186" y="311" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="184" y="341" width="52" height="32">
-			</bounds>
+			<bounds x="184" y="341" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="186" y="343" width="48" height="28">
-			</bounds>
+			<bounds x="186" y="343" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="184" y="373" width="52" height="32">
-			</bounds>
+			<bounds x="184" y="373" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="186" y="375" width="48" height="28">
-			</bounds>
+			<bounds x="186" y="375" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="236" y="373" width="52" height="32">
-			</bounds>
+			<bounds x="236" y="373" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="238" y="375" width="48" height="28">
-			</bounds>
+			<bounds x="238" y="375" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="288" y="373" width="52" height="32">
-			</bounds>
+			<bounds x="288" y="373" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="290" y="375" width="48" height="28">
-			</bounds>
+			<bounds x="290" y="375" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="340" y="373" width="52" height="32">
-			</bounds>
+			<bounds x="340" y="373" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="342" y="375" width="48" height="28">
-			</bounds>
+			<bounds x="342" y="375" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="340" y="373" width="52" height="32">
-			</bounds>
+			<bounds x="340" y="373" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="342" y="375" width="48" height="28">
-			</bounds>
+			<bounds x="342" y="375" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="288" y="309" width="52" height="32">
-			</bounds>
+			<bounds x="288" y="309" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="290" y="311" width="48" height="28">
-			</bounds>
+			<bounds x="290" y="311" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="236" y="309" width="52" height="32">
-			</bounds>
+			<bounds x="236" y="309" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="238" y="311" width="48" height="28">
-			</bounds>
+			<bounds x="238" y="311" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="236" y="309" width="52" height="32">
-			</bounds>
+			<bounds x="236" y="309" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="238" y="311" width="48" height="28">
-			</bounds>
+			<bounds x="238" y="311" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="340" y="309" width="52" height="32">
-			</bounds>
+			<bounds x="340" y="309" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="342" y="311" width="48" height="28">
-			</bounds>
+			<bounds x="342" y="311" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="392" y="309" width="52" height="32">
-			</bounds>
+			<bounds x="392" y="309" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="394" y="311" width="48" height="28">
-			</bounds>
+			<bounds x="394" y="311" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="392" y="341" width="52" height="32">
-			</bounds>
+			<bounds x="392" y="341" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="394" y="343" width="48" height="28">
-			</bounds>
+			<bounds x="394" y="343" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="392" y="373" width="52" height="32">
-			</bounds>
+			<bounds x="392" y="373" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="394" y="375" width="48" height="28">
-			</bounds>
+			<bounds x="394" y="375" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="439" y="580" width="19" height="19">
-			</bounds>
+			<bounds x="439" y="580" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="441" y="582" width="15" height="15">
-			</bounds>
+			<bounds x="441" y="582" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="439" y="556" width="19" height="19">
-			</bounds>
+			<bounds x="439" y="556" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="441" y="558" width="15" height="15">
-			</bounds>
+			<bounds x="441" y="558" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="439" y="518" width="19" height="19">
-			</bounds>
+			<bounds x="439" y="518" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="441" y="520" width="15" height="15">
-			</bounds>
+			<bounds x="441" y="520" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="439" y="478" width="19" height="19">
-			</bounds>
+			<bounds x="439" y="478" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="441" y="480" width="15" height="15">
-			</bounds>
+			<bounds x="441" y="480" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="439" y="452" width="19" height="19">
-			</bounds>
+			<bounds x="439" y="452" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="441" y="454" width="15" height="15">
-			</bounds>
+			<bounds x="441" y="454" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="165" y="452" width="19" height="19">
-			</bounds>
+			<bounds x="165" y="452" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="167" y="454" width="15" height="15">
-			</bounds>
+			<bounds x="167" y="454" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="164" y="479" width="19" height="19">
-			</bounds>
+			<bounds x="164" y="479" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="166" y="481" width="15" height="15">
-			</bounds>
+			<bounds x="166" y="481" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="165" y="520" width="19" height="19">
-			</bounds>
+			<bounds x="165" y="520" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="167" y="522" width="15" height="15">
-			</bounds>
+			<bounds x="167" y="522" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="165" y="557" width="19" height="19">
-			</bounds>
+			<bounds x="165" y="557" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="167" y="559" width="15" height="15">
-			</bounds>
+			<bounds x="167" y="559" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="165" y="579" width="19" height="19">
-			</bounds>
+			<bounds x="165" y="579" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="167" y="581" width="15" height="15">
-			</bounds>
+			<bounds x="167" y="581" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="381" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="381" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="383" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="383" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="360" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="360" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="362" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="362" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="339" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="339" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="341" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="341" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="318" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="318" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="320" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="320" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="297" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="297" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="299" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="299" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="276" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="276" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="278" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="278" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="255" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="255" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="257" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="257" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="234" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="234" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="236" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="236" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="213" y="48" width="19" height="19">
-			</bounds>
+			<bounds x="213" y="48" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="215" y="50" width="15" height="15">
-			</bounds>
+			<bounds x="215" y="50" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="478" y="50" width="58" height="48">
-			</bounds>
+			<bounds x="478" y="50" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="480" y="52" width="54" height="44">
-			</bounds>
+			<bounds x="480" y="52" width="54" height="44"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="786" y="167" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="167" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="788" y="169" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="169" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="719" y="167" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="167" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="721" y="169" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="169" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="719" y="199" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="199" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="721" y="201" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="201" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="719" y="231" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="231" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="721" y="233" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="233" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="719" y="263" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="263" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="721" y="265" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="265" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="719" y="295" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="295" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="721" y="297" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="297" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="719" y="327" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="327" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="721" y="329" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="329" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="786" y="199" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="199" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="788" y="201" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="201" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="786" y="231" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="231" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="788" y="233" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="233" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="786" y="263" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="263" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="788" y="265" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="265" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="786" y="295" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="295" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="788" y="297" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="297" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="786" y="327" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="327" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="788" y="329" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="329" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="719" y="359" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="359" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="721" y="361" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="361" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="719" y="423" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="423" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="721" y="425" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="425" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="719" y="455" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="455" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="721" y="457" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="457" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="719" y="487" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="487" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="721" y="489" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="489" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="719" y="391" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="391" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="721" y="393" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="393" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="786" y="359" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="359" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="788" y="361" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="361" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="786" y="391" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="391" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="788" y="393" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="393" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="786" y="423" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="423" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="788" y="425" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="425" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="786" y="455" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="455" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="788" y="457" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="457" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="786" y="487" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="487" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="788" y="489" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="489" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="763" y="523" width="46" height="19">
-			</bounds>
+			<bounds x="763" y="523" width="46" height="19"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="765" y="525" width="42" height="15">
-			</bounds>
+			<bounds x="765" y="525" width="42" height="15"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="786" y="7" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="7" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="788" y="9" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="9" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="786" y="39" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="39" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="788" y="41" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="41" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="786" y="71" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="71" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="788" y="73" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="73" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="786" y="103" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="103" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="788" y="105" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="105" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="786" y="135" width="67" height="32">
-			</bounds>
+			<bounds x="786" y="135" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="788" y="137" width="63" height="28">
-			</bounds>
+			<bounds x="788" y="137" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="719" y="39" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="39" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="721" y="41" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="41" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="719" y="7" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="7" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="721" y="9" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="9" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="719" y="71" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="71" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="721" y="73" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="73" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="719" y="103" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="103" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="721" y="105" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="105" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="719" y="135" width="67" height="32">
-			</bounds>
+			<bounds x="719" y="135" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="721" y="137" width="63" height="28">
-			</bounds>
+			<bounds x="721" y="137" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="504" y="98" width="112" height="48">
-			</bounds>
+			<bounds x="504" y="98" width="112" height="48"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="506" y="100" width="108" height="44">
-			</bounds>
+			<bounds x="506" y="100" width="108" height="44"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="426" y="98" width="78" height="48">
-			</bounds>
+			<bounds x="426" y="98" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="428" y="100" width="74" height="44">
-			</bounds>
+			<bounds x="428" y="100" width="74" height="44"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="508" y="3" width="78" height="48">
-			</bounds>
+			<bounds x="508" y="3" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="510" y="5" width="74" height="44">
-			</bounds>
+			<bounds x="510" y="5" width="74" height="44"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="430" y="3" width="78" height="48">
-			</bounds>
+			<bounds x="430" y="3" width="78" height="48"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="432" y="5" width="74" height="44">
-			</bounds>
+			<bounds x="432" y="5" width="74" height="44"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="622" y="553" width="58" height="27">
-			</bounds>
+			<bounds x="622" y="553" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="624" y="555" width="54" height="23">
-			</bounds>
+			<bounds x="624" y="555" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="506" y="580" width="58" height="27">
-			</bounds>
+			<bounds x="506" y="580" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="508" y="582" width="54" height="23">
-			</bounds>
+			<bounds x="508" y="582" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="506" y="553" width="58" height="27">
-			</bounds>
+			<bounds x="506" y="553" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="508" y="555" width="54" height="23">
-			</bounds>
+			<bounds x="508" y="555" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="564" y="580" width="58" height="27">
-			</bounds>
+			<bounds x="564" y="580" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="566" y="582" width="54" height="23">
-			</bounds>
+			<bounds x="566" y="582" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="564" y="553" width="58" height="27">
-			</bounds>
+			<bounds x="564" y="553" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="566" y="555" width="54" height="23">
-			</bounds>
+			<bounds x="566" y="555" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="622" y="580" width="58" height="27">
-			</bounds>
+			<bounds x="622" y="580" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="624" y="582" width="54" height="23">
-			</bounds>
+			<bounds x="624" y="582" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="506" y="526" width="58" height="27">
-			</bounds>
+			<bounds x="506" y="526" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="508" y="528" width="54" height="23">
-			</bounds>
+			<bounds x="508" y="528" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="564" y="526" width="58" height="27">
-			</bounds>
+			<bounds x="564" y="526" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="566" y="528" width="54" height="23">
-			</bounds>
+			<bounds x="566" y="528" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="622" y="526" width="58" height="27">
-			</bounds>
+			<bounds x="622" y="526" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="624" y="528" width="54" height="23">
-			</bounds>
+			<bounds x="624" y="528" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="622" y="526" width="58" height="27">
-			</bounds>
+			<bounds x="622" y="526" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="624" y="528" width="54" height="23">
-			</bounds>
+			<bounds x="624" y="528" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="3" y="378" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="378" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="5" y="380" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="380" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="3" y="378" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="378" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="5" y="380" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="380" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="3" y="346" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="346" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="5" y="348" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="348" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="3" y="346" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="346" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="5" y="348" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="348" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="3" y="410" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="410" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="5" y="412" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="412" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="3" y="410" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="410" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="5" y="412" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="412" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="3" y="87" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="87" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="5" y="89" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="89" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="3" y="87" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="87" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="5" y="89" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="89" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="3" y="55" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="55" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="5" y="57" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="57" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="3" y="55" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="55" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="5" y="57" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="57" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="3" y="23" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="23" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="5" y="25" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="25" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="3" y="23" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="23" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="5" y="25" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="25" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="3" y="314" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="314" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="5" y="316" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="316" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="3" y="314" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="314" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="5" y="316" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="316" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="3" y="250" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="250" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="5" y="252" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="252" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="3" y="250" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="250" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="5" y="252" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="252" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="3" y="217" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="217" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="5" y="219" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="219" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="3" y="217" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="217" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="5" y="219" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="219" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="3" y="185" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="185" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="5" y="187" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="187" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="3" y="185" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="185" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="5" y="187" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="187" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="3" y="153" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="153" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="5" y="155" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="155" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="3" y="153" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="153" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="5" y="155" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="155" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="3" y="120" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="120" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="5" y="122" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="122" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="3" y="120" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="120" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="5" y="122" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="122" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="3" y="282" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="282" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="5" y="284" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="284" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="3" y="282" width="86" height="32">
-			</bounds>
+			<bounds x="3" y="282" width="86" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="5" y="284" width="82" height="28">
-			</bounds>
+			<bounds x="5" y="284" width="82" height="28"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="598" y="467" width="19" height="19">
-			</bounds>
+			<bounds x="598" y="467" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="600" y="469" width="15" height="15">
-			</bounds>
+			<bounds x="600" y="469" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="577" y="467" width="19" height="19">
-			</bounds>
+			<bounds x="577" y="467" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="579" y="469" width="15" height="15">
-			</bounds>
+			<bounds x="579" y="469" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="556" y="467" width="19" height="19">
-			</bounds>
+			<bounds x="556" y="467" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="558" y="469" width="15" height="15">
-			</bounds>
+			<bounds x="558" y="469" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="556" y="499" width="19" height="19">
-			</bounds>
+			<bounds x="556" y="499" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="558" y="501" width="15" height="15">
-			</bounds>
+			<bounds x="558" y="501" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="577" y="499" width="19" height="19">
-			</bounds>
+			<bounds x="577" y="499" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="579" y="501" width="15" height="15">
-			</bounds>
+			<bounds x="579" y="501" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="598" y="499" width="19" height="19">
-			</bounds>
+			<bounds x="598" y="499" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="600" y="501" width="15" height="15">
-			</bounds>
+			<bounds x="600" y="501" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="488" y="253" width="19" height="19">
-			</bounds>
+			<bounds x="488" y="253" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="490" y="255" width="15" height="15">
-			</bounds>
+			<bounds x="490" y="255" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="467" y="253" width="19" height="19">
-			</bounds>
+			<bounds x="467" y="253" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="469" y="255" width="15" height="15">
-			</bounds>
+			<bounds x="469" y="255" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="446" y="253" width="19" height="19">
-			</bounds>
+			<bounds x="446" y="253" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="448" y="255" width="15" height="15">
-			</bounds>
+			<bounds x="448" y="255" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_162_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="622" y="4" width="75" height="27">
-			</bounds>
+			<bounds x="622" y="4" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_162" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="624" y="6" width="71" height="23">
-			</bounds>
+			<bounds x="624" y="6" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp233" element="colour_button_164_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="283" y="273" width="52" height="27">
-			</bounds>
+			<bounds x="283" y="273" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp233" element="colour_button_164" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="285" y="275" width="48" height="23">
-			</bounds>
+			<bounds x="285" y="275" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp237" element="colour_button_165_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="367" y="274" width="52" height="27">
-			</bounds>
+			<bounds x="367" y="274" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp237" element="colour_button_165" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="369" y="276" width="48" height="23">
-			</bounds>
+			<bounds x="369" y="276" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp228" element="colour_button_166_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="196" y="274" width="52" height="27">
-			</bounds>
+			<bounds x="196" y="274" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp228" element="colour_button_166" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="198" y="276" width="48" height="23">
-			</bounds>
+			<bounds x="198" y="276" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="colour_button_167_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="196" y="182" width="52" height="27">
-			</bounds>
+			<bounds x="196" y="182" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp227" element="colour_button_167" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="198" y="184" width="48" height="23">
-			</bounds>
+			<bounds x="198" y="184" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp232" element="colour_button_168_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="284" y="182" width="52" height="27">
-			</bounds>
+			<bounds x="284" y="182" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp232" element="colour_button_168" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="286" y="184" width="48" height="23">
-			</bounds>
+			<bounds x="286" y="184" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp240" element="colour_button_169_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="367" y="180" width="52" height="27">
-			</bounds>
+			<bounds x="367" y="180" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp240" element="colour_button_169" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="369" y="182" width="48" height="23">
-			</bounds>
+			<bounds x="369" y="182" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_170_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="669" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="669" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_170" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="671" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="671" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_171_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="471" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="471" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_171" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="473" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="473" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_172_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="102" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="102" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_172" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="104" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="104" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_173_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="564" y="655" width="75" height="27">
-			</bounds>
+			<bounds x="564" y="655" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_173" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="566" y="657" width="71" height="23">
-			</bounds>
+			<bounds x="566" y="657" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_174_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="7" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="7" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_174" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="9" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="9" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_175_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="366" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="366" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_175" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="368" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="368" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp167" element="colour_button_176_border" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="265" y="122" width="75" height="27">
-			</bounds>
+			<bounds x="265" y="122" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="colour_button_176" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="267" y="124" width="71" height="23">
-			</bounds>
+			<bounds x="267" y="124" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_177_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="186" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="186" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_177" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="188" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="188" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_178_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="277" y="654" width="75" height="27">
-			</bounds>
+			<bounds x="277" y="654" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_178" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="279" y="656" width="71" height="23">
-			</bounds>
+			<bounds x="279" y="656" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp203" element="colour_button_179_border" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="440" y="272" width="75" height="27">
-			</bounds>
+			<bounds x="440" y="272" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp203" element="colour_button_179" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="442" y="274" width="71" height="23">
-			</bounds>
+			<bounds x="442" y="274" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="277" y="85" width="24" height="32">
-			</bounds>
+			<bounds x="277" y="85" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit10" element="led_digit_red">
-			<bounds x="277" y="85" width="24" height="32">
-			</bounds>
+			<bounds x="277" y="85" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="277" y="85" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="277" y="85" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="301" y="85" width="24" height="32">
-			</bounds>
+			<bounds x="301" y="85" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit8" element="led_digit_red">
-			<bounds x="301" y="85" width="24" height="32">
-			</bounds>
+			<bounds x="301" y="85" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="301" y="85" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="301" y="85" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="257" y="4" width="24" height="32">
-			</bounds>
+			<bounds x="257" y="4" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="257" y="4" width="24" height="32">
-			</bounds>
+			<bounds x="257" y="4" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="257" y="4" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="257" y="4" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="281" y="4" width="24" height="32">
-			</bounds>
+			<bounds x="281" y="4" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit4" element="led_digit_red">
-			<bounds x="281" y="4" width="24" height="32">
-			</bounds>
+			<bounds x="281" y="4" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="281" y="4" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="281" y="4" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="329" y="4" width="24" height="32">
-			</bounds>
+			<bounds x="329" y="4" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="329" y="4" width="24" height="32">
-			</bounds>
+			<bounds x="329" y="4" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="329" y="4" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="329" y="4" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="305" y="4" width="24" height="32">
-			</bounds>
+			<bounds x="305" y="4" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="305" y="4" width="24" height="32">
-			</bounds>
+			<bounds x="305" y="4" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="305" y="4" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="305" y="4" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="150" y="417" width="323" height="27">
-			</bounds>
+			<bounds x="150" y="417" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="150" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="150" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="170" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="170" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="190" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="190" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="210" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="210" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="230" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="230" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="250" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="250" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="270" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="270" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="290" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="290" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="310" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="310" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="330" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="330" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="350" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="350" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="370" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="370" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="390" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="390" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="410" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="410" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="430" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="430" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="450" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="450" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label150" element="label_150">
-			<bounds x="523" y="427" width="112" height="14">
-			</bounds>
+			<bounds x="523" y="427" width="112" height="14"/>
 		</backdrop>
 		<backdrop name="label157" element="label_157">
-			<bounds x="562" y="197" width="104" height="28">
-			</bounds>
+			<bounds x="562" y="197" width="104" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_button" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_button" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_button" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_button" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_button" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_button" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_button" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_button" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4bedcl.lay
+++ b/src/mame/layout/sc4bedcl.lay
@@ -8,17242 +8,9533 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="LS           ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="LS           ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="MBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="MBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3 SY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 SY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="ENTERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="URE      ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="ENTERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="URE      ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="LS   ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="LS   ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="MBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ER   ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="MBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ER   ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4 SY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 SY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="PRESS STOP WHEN LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="PRESS STOP WHEN LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="DOUBLE OR NOTHING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="DOUBLE OR NOTHING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="HOT SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="HOT SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="GOING DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="GOING DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="ON THE UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="ON THE UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="CROSSFIRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="CROSSFIRE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="MAZOOMA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="MAZOOMA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="INSUFICENT COINS TO PAY MAJOR PRIZE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="INSUFICENT COINS TO PAY MAJOR PRIZE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROUL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROUL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TRI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HILO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="HILO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TRI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2 SP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2 SP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SRZ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SRZ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MIX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MIX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CZY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="JPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="JPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="5 SP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="5 SP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CLUB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="CLUB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="ED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="ED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="ZLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="ZLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="DAZ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="DAZ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MEG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MEG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KNC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3 SP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3 SP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PICKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PICKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string=" ALL LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="    BIG M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string=" ALL LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="    BIG M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="AWARDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ONEY     ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="AWARDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ONEY     ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="1 MILLION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="1 MILLION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRIDENT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PICKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PICKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="DEVIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_198_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_198">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_199_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_199">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_200_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_200">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_201_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_201">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_202_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_202">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_203_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_203">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_204_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_204">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="TRANSFER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_205_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_205">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_207_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_207">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_208_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_208">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_209_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_209">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_210_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_210">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_211_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_211">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_172">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_173">
 		<text string="LIGHT ALL 3 DEVILS TO ACTIVATE PICKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_178">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_179">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1006" height="679">
-			</bounds>
+			<bounds x="0" y="0" width="1006" height="679"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="192" y="470" width="70" height="120">
-			</bounds>
+			<bounds x="192" y="470" width="70" height="120"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="192.0000" y="470.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="192.0000" y="470.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="194.9167" y="471.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="194.9167" y="471.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="197.8333" y="473.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="197.8333" y="473.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="200.7500" y="475.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="200.7500" y="475.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="203.6667" y="476.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="203.6667" y="476.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="206.5833" y="478.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="206.5833" y="478.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="192.0000" y="510.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="192.0000" y="510.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="194.9167" y="511.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="194.9167" y="511.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="197.8333" y="513.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="197.8333" y="513.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="200.7500" y="515.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="200.7500" y="515.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="203.6667" y="516.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="203.6667" y="516.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="206.5833" y="518.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="206.5833" y="518.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="192.0000" y="550.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="192.0000" y="550.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="194.9167" y="551.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="194.9167" y="551.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="197.8333" y="553.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="197.8333" y="553.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="200.7500" y="555.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="200.7500" y="555.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="203.6667" y="556.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="203.6667" y="556.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="206.5833" y="558.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="206.5833" y="558.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="192" y="470" width="70" height="120">
-			</bounds>
+			<bounds x="192" y="470" width="70" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="292" y="470" width="70" height="120">
-			</bounds>
+			<bounds x="292" y="470" width="70" height="120"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="292.0000" y="470.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="292.0000" y="470.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="294.9167" y="471.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="294.9167" y="471.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="297.8333" y="473.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="297.8333" y="473.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="300.7500" y="475.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="300.7500" y="475.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="303.6667" y="476.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="303.6667" y="476.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="306.5833" y="478.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="306.5833" y="478.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="292.0000" y="510.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="292.0000" y="510.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="294.9167" y="511.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="294.9167" y="511.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="297.8333" y="513.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="297.8333" y="513.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="300.7500" y="515.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="300.7500" y="515.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="303.6667" y="516.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="303.6667" y="516.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="306.5833" y="518.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="306.5833" y="518.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="292.0000" y="550.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="292.0000" y="550.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="294.9167" y="551.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="294.9167" y="551.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="297.8333" y="553.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="297.8333" y="553.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="300.7500" y="555.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="300.7500" y="555.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="303.6667" y="556.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="303.6667" y="556.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="306.5833" y="558.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="306.5833" y="558.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="292" y="470" width="70" height="120">
-			</bounds>
+			<bounds x="292" y="470" width="70" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="390" y="470" width="70" height="120">
-			</bounds>
+			<bounds x="390" y="470" width="70" height="120"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="390.0000" y="470.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="390.0000" y="470.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="392.9167" y="471.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="392.9167" y="471.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.8333" y="473.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="395.8333" y="473.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="398.7500" y="475.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="398.7500" y="475.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="401.6667" y="476.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="401.6667" y="476.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="404.5833" y="478.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="404.5833" y="478.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="390.0000" y="510.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="390.0000" y="510.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="392.9167" y="511.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="392.9167" y="511.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.8333" y="513.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="395.8333" y="513.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="398.7500" y="515.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="398.7500" y="515.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="401.6667" y="516.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="401.6667" y="516.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="404.5833" y="518.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="404.5833" y="518.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="390.0000" y="550.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="390.0000" y="550.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="392.9167" y="551.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="392.9167" y="551.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="395.8333" y="553.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="395.8333" y="553.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="398.7500" y="555.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="398.7500" y="555.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="401.6667" y="556.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="401.6667" y="556.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="404.5833" y="558.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="404.5833" y="558.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="390" y="470" width="70" height="120">
-			</bounds>
+			<bounds x="390" y="470" width="70" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="487" y="470" width="70" height="120">
-			</bounds>
+			<bounds x="487" y="470" width="70" height="120"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="487.0000" y="470.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="487.0000" y="470.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="489.9167" y="471.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="489.9167" y="471.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="492.8333" y="473.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="492.8333" y="473.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="495.7500" y="475.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="495.7500" y="475.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="498.6667" y="476.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="498.6667" y="476.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="501.5833" y="478.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="501.5833" y="478.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="487.0000" y="510.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="487.0000" y="510.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="489.9167" y="511.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="489.9167" y="511.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="492.8333" y="513.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="492.8333" y="513.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="495.7500" y="515.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="495.7500" y="515.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="498.6667" y="516.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="498.6667" y="516.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="501.5833" y="518.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="501.5833" y="518.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="487.0000" y="550.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="487.0000" y="550.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="489.9167" y="551.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="489.9167" y="551.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="492.8333" y="553.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="492.8333" y="553.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="495.7500" y="555.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="495.7500" y="555.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="498.6667" y="556.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="498.6667" y="556.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="501.5833" y="558.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="501.5833" y="558.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="487" y="470" width="70" height="120">
-			</bounds>
+			<bounds x="487" y="470" width="70" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="370" y="173" width="50" height="50">
-			</bounds>
+			<bounds x="370" y="173" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="370.0000" y="173.0000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="370.0000" y="173.0000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="372.0833" y="175.0833" width="45.8333" height="45.8333">
-			</bounds>
+			<bounds x="372.0833" y="175.0833" width="45.8333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="374.1667" y="177.1667" width="41.6667" height="41.6667">
-			</bounds>
+			<bounds x="374.1667" y="177.1667" width="41.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="376.2500" y="179.2500" width="37.5000" height="37.5000">
-			</bounds>
+			<bounds x="376.2500" y="179.2500" width="37.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="378.3333" y="181.3333" width="33.3333" height="33.3333">
-			</bounds>
+			<bounds x="378.3333" y="181.3333" width="33.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="380.4167" y="183.4167" width="29.1667" height="29.1667">
-			</bounds>
+			<bounds x="380.4167" y="183.4167" width="29.1667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="370" y="173" width="50" height="50">
-			</bounds>
+			<bounds x="370" y="173" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="68" y="583" width="37" height="19">
-			</bounds>
+			<bounds x="68" y="583" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="70" y="585" width="33" height="15">
-			</bounds>
+			<bounds x="70" y="585" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="758" y="464" width="87" height="47">
-			</bounds>
+			<bounds x="758" y="464" width="87" height="47"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="760" y="466" width="83" height="43">
-			</bounds>
+			<bounds x="760" y="466" width="83" height="43"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="712" y="464" width="47" height="47">
-			</bounds>
+			<bounds x="712" y="464" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="714" y="466" width="43" height="43">
-			</bounds>
+			<bounds x="714" y="466" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="666" y="464" width="47" height="47">
-			</bounds>
+			<bounds x="666" y="464" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="668" y="466" width="43" height="43">
-			</bounds>
+			<bounds x="668" y="466" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="804" y="510" width="77" height="47">
-			</bounds>
+			<bounds x="804" y="510" width="77" height="47"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="806" y="512" width="73" height="43">
-			</bounds>
+			<bounds x="806" y="512" width="73" height="43"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="758" y="510" width="47" height="47">
-			</bounds>
+			<bounds x="758" y="510" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="760" y="512" width="43" height="43">
-			</bounds>
+			<bounds x="760" y="512" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="712" y="510" width="47" height="47">
-			</bounds>
+			<bounds x="712" y="510" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="714" y="512" width="43" height="43">
-			</bounds>
+			<bounds x="714" y="512" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="666" y="510" width="47" height="47">
-			</bounds>
+			<bounds x="666" y="510" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="668" y="512" width="43" height="43">
-			</bounds>
+			<bounds x="668" y="512" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="585" y="583" width="102" height="27">
-			</bounds>
+			<bounds x="585" y="583" width="102" height="27"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="587" y="585" width="98" height="23">
-			</bounds>
+			<bounds x="587" y="585" width="98" height="23"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="885" y="490" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="490" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="887" y="492" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="492" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="911" y="490" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="490" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="913" y="492" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="492" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="911" y="464" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="464" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="913" y="466" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="466" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="885" y="464" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="464" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="887" y="466" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="466" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="574" y="444" width="87" height="27">
-			</bounds>
+			<bounds x="574" y="444" width="87" height="27"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="576" y="446" width="83" height="23">
-			</bounds>
+			<bounds x="576" y="446" width="83" height="23"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="574" y="470" width="87" height="27">
-			</bounds>
+			<bounds x="574" y="470" width="87" height="27"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="576" y="472" width="83" height="23">
-			</bounds>
+			<bounds x="576" y="472" width="83" height="23"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="885" y="438" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="438" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="887" y="440" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="440" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="911" y="438" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="438" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="913" y="440" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="440" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="911" y="412" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="412" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="913" y="414" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="414" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="885" y="412" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="412" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="887" y="414" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="414" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="574" y="496" width="87" height="27">
-			</bounds>
+			<bounds x="574" y="496" width="87" height="27"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="576" y="498" width="83" height="23">
-			</bounds>
+			<bounds x="576" y="498" width="83" height="23"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="574" y="522" width="87" height="27">
-			</bounds>
+			<bounds x="574" y="522" width="87" height="27"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="576" y="524" width="83" height="23">
-			</bounds>
+			<bounds x="576" y="524" width="83" height="23"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="885" y="386" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="386" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="887" y="388" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="388" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="911" y="386" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="386" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="913" y="388" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="388" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="911" y="360" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="360" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="913" y="362" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="362" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="885" y="360" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="360" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="887" y="362" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="362" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="574" y="548" width="87" height="27">
-			</bounds>
+			<bounds x="574" y="548" width="87" height="27"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="576" y="550" width="83" height="23">
-			</bounds>
+			<bounds x="576" y="550" width="83" height="23"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="688" y="439" width="67" height="19">
-			</bounds>
+			<bounds x="688" y="439" width="67" height="19"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="690" y="441" width="63" height="15">
-			</bounds>
+			<bounds x="690" y="441" width="63" height="15"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="885" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="887" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="911" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="913" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="911" y="308" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="308" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="913" y="310" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="310" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="885" y="308" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="308" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="887" y="310" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="310" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="885" y="282" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="282" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="887" y="284" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="284" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="911" y="282" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="282" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="913" y="284" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="284" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="911" y="256" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="256" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="913" y="258" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="258" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="885" y="256" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="256" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="887" y="258" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="258" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="885" y="230" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="230" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="887" y="232" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="232" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="911" y="230" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="230" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="913" y="232" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="232" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="911" y="204" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="204" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="913" y="206" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="206" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="885" y="204" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="204" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="887" y="206" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="206" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="885" y="178" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="178" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="887" y="180" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="180" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="911" y="178" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="178" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="913" y="180" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="180" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="911" y="152" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="152" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="913" y="154" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="154" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="885" y="152" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="152" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="887" y="154" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="154" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="885" y="126" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="126" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="887" y="128" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="128" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="911" y="126" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="126" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="913" y="128" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="128" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="911" y="100" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="100" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="913" y="102" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="102" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="885" y="100" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="100" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="887" y="102" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="102" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="885" y="74" width="27" height="27">
-			</bounds>
+			<bounds x="885" y="74" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="887" y="76" width="23" height="23">
-			</bounds>
+			<bounds x="887" y="76" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="911" y="74" width="27" height="27">
-			</bounds>
+			<bounds x="911" y="74" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="913" y="76" width="23" height="23">
-			</bounds>
+			<bounds x="913" y="76" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="884" y="48" width="27" height="27">
-			</bounds>
+			<bounds x="884" y="48" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="886" y="50" width="23" height="23">
-			</bounds>
+			<bounds x="886" y="50" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="858" y="48" width="27" height="27">
-			</bounds>
+			<bounds x="858" y="48" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="860" y="50" width="23" height="23">
-			</bounds>
+			<bounds x="860" y="50" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="936" y="48" width="27" height="27">
-			</bounds>
+			<bounds x="936" y="48" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="938" y="50" width="23" height="23">
-			</bounds>
+			<bounds x="938" y="50" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="910" y="48" width="27" height="27">
-			</bounds>
+			<bounds x="910" y="48" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="912" y="50" width="23" height="23">
-			</bounds>
+			<bounds x="912" y="50" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="860" y="1" width="97" height="47">
-			</bounds>
+			<bounds x="860" y="1" width="97" height="47"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="862" y="3" width="93" height="43">
-			</bounds>
+			<bounds x="862" y="3" width="93" height="43"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="831" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="831" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="833" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="833" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="831" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="831" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="833" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="833" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="831" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="831" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="833" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="833" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="812" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="812" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="814" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="814" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="771" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="771" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="773" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="773" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="797" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="797" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="799" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="799" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="797" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="797" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="799" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="799" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="797" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="797" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="799" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="799" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="763" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="763" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="765" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="765" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="763" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="763" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="765" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="765" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="763" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="763" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="765" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="765" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="730" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="730" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="732" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="732" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="689" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="689" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="691" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="691" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="695" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="695" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="697" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="697" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="729" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="729" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="731" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="731" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="729" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="729" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="731" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="731" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="695" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="695" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="697" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="697" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="695" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="695" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="697" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="697" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="729" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="729" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="731" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="731" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="729" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="729" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="731" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="731" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="763" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="763" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="765" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="765" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="797" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="797" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="799" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="799" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="831" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="831" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="833" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="833" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="831" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="831" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="833" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="833" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="797" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="797" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="799" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="799" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="763" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="763" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="765" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="765" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="729" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="729" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="731" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="731" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="695" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="695" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="697" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="697" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="695" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="695" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="697" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="697" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="661" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="661" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="663" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="663" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="661" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="661" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="663" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="663" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="627" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="627" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="629" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="629" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="627" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="627" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="629" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="629" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="627" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="627" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="629" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="629" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="661" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="661" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="663" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="663" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="661" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="661" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="663" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="663" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="661" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="661" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="663" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="663" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="648" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="648" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="650" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="650" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="607" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="607" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="609" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="609" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="627" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="627" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="629" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="629" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="627" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="627" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="629" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="629" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="593" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="593" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="595" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="595" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="593" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="593" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="595" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="595" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="566" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="566" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="568" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="568" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="5" y="16" width="52" height="27">
-			</bounds>
+			<bounds x="5" y="16" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="7" y="18" width="48" height="23">
-			</bounds>
+			<bounds x="7" y="18" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="56" y="16" width="42" height="42">
-			</bounds>
+			<bounds x="56" y="16" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="58" y="18" width="38" height="38">
-			</bounds>
+			<bounds x="58" y="18" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="97" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="97" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="99" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="99" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="56" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="56" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="58" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="58" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="15" y="57" width="42" height="42">
-			</bounds>
+			<bounds x="15" y="57" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="17" y="59" width="38" height="38">
-			</bounds>
+			<bounds x="17" y="59" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="558" y="105" width="32" height="32">
-			</bounds>
+			<bounds x="558" y="105" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="560" y="107" width="28" height="28">
-			</bounds>
+			<bounds x="560" y="107" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="558" y="136" width="32" height="22">
-			</bounds>
+			<bounds x="558" y="136" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="560" y="138" width="28" height="18">
-			</bounds>
+			<bounds x="560" y="138" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="133" y="133" width="62" height="19">
-			</bounds>
+			<bounds x="133" y="133" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="135" y="135" width="58" height="15">
-			</bounds>
+			<bounds x="135" y="135" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="72" y="133" width="62" height="19">
-			</bounds>
+			<bounds x="72" y="133" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="74" y="135" width="58" height="15">
-			</bounds>
+			<bounds x="74" y="135" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="41" y="115" width="62" height="19">
-			</bounds>
+			<bounds x="41" y="115" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="43" y="117" width="58" height="15">
-			</bounds>
+			<bounds x="43" y="117" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="102" y="115" width="62" height="19">
-			</bounds>
+			<bounds x="102" y="115" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="104" y="117" width="58" height="15">
-			</bounds>
+			<bounds x="104" y="117" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="11" y="133" width="62" height="19">
-			</bounds>
+			<bounds x="11" y="133" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="13" y="135" width="58" height="15">
-			</bounds>
+			<bounds x="13" y="135" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="558" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="558" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="560" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="560" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="593" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="593" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="595" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="595" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="593" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="593" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="595" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="595" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="557" y="193" width="32" height="22">
-			</bounds>
+			<bounds x="557" y="193" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="559" y="195" width="28" height="18">
-			</bounds>
+			<bounds x="559" y="195" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="593" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="593" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="595" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="595" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="558" y="220" width="32" height="32">
-			</bounds>
+			<bounds x="558" y="220" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="560" y="222" width="28" height="28">
-			</bounds>
+			<bounds x="560" y="222" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="664" y="37" width="47" height="19">
-			</bounds>
+			<bounds x="664" y="37" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="666" y="39" width="43" height="15">
-			</bounds>
+			<bounds x="666" y="39" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="710" y="37" width="47" height="19">
-			</bounds>
+			<bounds x="710" y="37" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="712" y="39" width="43" height="15">
-			</bounds>
+			<bounds x="712" y="39" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="236" y="118" width="57" height="37">
-			</bounds>
+			<bounds x="236" y="118" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="238" y="120" width="53" height="33">
-			</bounds>
+			<bounds x="238" y="120" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="301" y="118" width="57" height="37">
-			</bounds>
+			<bounds x="301" y="118" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="303" y="120" width="53" height="33">
-			</bounds>
+			<bounds x="303" y="120" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="366" y="118" width="57" height="37">
-			</bounds>
+			<bounds x="366" y="118" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="368" y="120" width="53" height="33">
-			</bounds>
+			<bounds x="368" y="120" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="431" y="118" width="57" height="37">
-			</bounds>
+			<bounds x="431" y="118" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="433" y="120" width="53" height="33">
-			</bounds>
+			<bounds x="433" y="120" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="496" y="118" width="57" height="37">
-			</bounds>
+			<bounds x="496" y="118" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="498" y="120" width="53" height="33">
-			</bounds>
+			<bounds x="498" y="120" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="496" y="162" width="57" height="37">
-			</bounds>
+			<bounds x="496" y="162" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="498" y="164" width="53" height="33">
-			</bounds>
+			<bounds x="498" y="164" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="496" y="206" width="57" height="37">
-			</bounds>
+			<bounds x="496" y="206" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="498" y="208" width="53" height="33">
-			</bounds>
+			<bounds x="498" y="208" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="441" y="182" width="32" height="32">
-			</bounds>
+			<bounds x="441" y="182" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="443" y="184" width="28" height="28">
-			</bounds>
+			<bounds x="443" y="184" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="316" y="182" width="32" height="32">
-			</bounds>
+			<bounds x="316" y="182" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="318" y="184" width="28" height="28">
-			</bounds>
+			<bounds x="318" y="184" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="236" y="162" width="57" height="37">
-			</bounds>
+			<bounds x="236" y="162" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="238" y="164" width="53" height="33">
-			</bounds>
+			<bounds x="238" y="164" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="236" y="206" width="57" height="37">
-			</bounds>
+			<bounds x="236" y="206" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="238" y="208" width="53" height="33">
-			</bounds>
+			<bounds x="238" y="208" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="236" y="251" width="57" height="37">
-			</bounds>
+			<bounds x="236" y="251" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="238" y="253" width="53" height="33">
-			</bounds>
+			<bounds x="238" y="253" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="90" y="344" width="42" height="32">
-			</bounds>
+			<bounds x="90" y="344" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="92" y="346" width="38" height="28">
-			</bounds>
+			<bounds x="92" y="346" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="49" y="344" width="42" height="32">
-			</bounds>
+			<bounds x="49" y="344" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="51" y="346" width="38" height="28">
-			</bounds>
+			<bounds x="51" y="346" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="8" y="344" width="42" height="32">
-			</bounds>
+			<bounds x="8" y="344" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="10" y="346" width="38" height="28">
-			</bounds>
+			<bounds x="10" y="346" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="45" y="151" width="57" height="47">
-			</bounds>
+			<bounds x="45" y="151" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="47" y="153" width="53" height="43">
-			</bounds>
+			<bounds x="47" y="153" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="101" y="151" width="57" height="47">
-			</bounds>
+			<bounds x="101" y="151" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="103" y="153" width="53" height="43">
-			</bounds>
+			<bounds x="103" y="153" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="236" y="297" width="57" height="37">
-			</bounds>
+			<bounds x="236" y="297" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="238" y="299" width="53" height="33">
-			</bounds>
+			<bounds x="238" y="299" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="302" y="248" width="67" height="22">
-			</bounds>
+			<bounds x="302" y="248" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="304" y="250" width="63" height="18">
-			</bounds>
+			<bounds x="304" y="250" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="302" y="268" width="67" height="22">
-			</bounds>
+			<bounds x="302" y="268" width="67" height="22"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="304" y="270" width="63" height="18">
-			</bounds>
+			<bounds x="304" y="270" width="63" height="18"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="376" y="276" width="27" height="27">
-			</bounds>
+			<bounds x="376" y="276" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="378" y="278" width="23" height="23">
-			</bounds>
+			<bounds x="378" y="278" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="409" y="284" width="27" height="27">
-			</bounds>
+			<bounds x="409" y="284" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="411" y="286" width="23" height="23">
-			</bounds>
+			<bounds x="411" y="286" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="426" y="236" width="47" height="37">
-			</bounds>
+			<bounds x="426" y="236" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="428" y="238" width="43" height="33">
-			</bounds>
+			<bounds x="428" y="238" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="496" y="251" width="57" height="37">
-			</bounds>
+			<bounds x="496" y="251" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="498" y="253" width="53" height="33">
-			</bounds>
+			<bounds x="498" y="253" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="496" y="297" width="57" height="37">
-			</bounds>
+			<bounds x="496" y="297" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="498" y="299" width="53" height="33">
-			</bounds>
+			<bounds x="498" y="299" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="443" y="303" width="22" height="22">
-			</bounds>
+			<bounds x="443" y="303" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="445" y="305" width="18" height="18">
-			</bounds>
+			<bounds x="445" y="305" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="421" y="315" width="22" height="22">
-			</bounds>
+			<bounds x="421" y="315" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="423" y="317" width="18" height="18">
-			</bounds>
+			<bounds x="423" y="317" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="398" y="318" width="22" height="22">
-			</bounds>
+			<bounds x="398" y="318" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="400" y="320" width="18" height="18">
-			</bounds>
+			<bounds x="400" y="320" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="375" y="320" width="22" height="22">
-			</bounds>
+			<bounds x="375" y="320" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="377" y="322" width="18" height="18">
-			</bounds>
+			<bounds x="377" y="322" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="352" y="322" width="22" height="22">
-			</bounds>
+			<bounds x="352" y="322" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="354" y="324" width="18" height="18">
-			</bounds>
+			<bounds x="354" y="324" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="330" y="335" width="22" height="22">
-			</bounds>
+			<bounds x="330" y="335" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="332" y="337" width="18" height="18">
-			</bounds>
+			<bounds x="332" y="337" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="352" y="346" width="22" height="22">
-			</bounds>
+			<bounds x="352" y="346" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="354" y="348" width="18" height="18">
-			</bounds>
+			<bounds x="354" y="348" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="236" y="342" width="57" height="37">
-			</bounds>
+			<bounds x="236" y="342" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="238" y="344" width="53" height="33">
-			</bounds>
+			<bounds x="238" y="344" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="236" y="387" width="57" height="37">
-			</bounds>
+			<bounds x="236" y="387" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="238" y="389" width="53" height="33">
-			</bounds>
+			<bounds x="238" y="389" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="301" y="387" width="57" height="37">
-			</bounds>
+			<bounds x="301" y="387" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="303" y="389" width="53" height="33">
-			</bounds>
+			<bounds x="303" y="389" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="366" y="387" width="57" height="37">
-			</bounds>
+			<bounds x="366" y="387" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="368" y="389" width="53" height="33">
-			</bounds>
+			<bounds x="368" y="389" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="431" y="387" width="57" height="37">
-			</bounds>
+			<bounds x="431" y="387" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="433" y="389" width="53" height="33">
-			</bounds>
+			<bounds x="433" y="389" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="496" y="387" width="57" height="37">
-			</bounds>
+			<bounds x="496" y="387" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="498" y="389" width="53" height="33">
-			</bounds>
+			<bounds x="498" y="389" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="496" y="342" width="57" height="37">
-			</bounds>
+			<bounds x="496" y="342" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="498" y="344" width="53" height="33">
-			</bounds>
+			<bounds x="498" y="344" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="444" y="350" width="22" height="22">
-			</bounds>
+			<bounds x="444" y="350" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="446" y="352" width="18" height="18">
-			</bounds>
+			<bounds x="446" y="352" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="421" y="349" width="22" height="22">
-			</bounds>
+			<bounds x="421" y="349" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="423" y="351" width="18" height="18">
-			</bounds>
+			<bounds x="423" y="351" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="398" y="348" width="22" height="22">
-			</bounds>
+			<bounds x="398" y="348" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="400" y="350" width="18" height="18">
-			</bounds>
+			<bounds x="400" y="350" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="375" y="347" width="22" height="22">
-			</bounds>
+			<bounds x="375" y="347" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="377" y="349" width="18" height="18">
-			</bounds>
+			<bounds x="377" y="349" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="68" y="437" width="37" height="37">
-			</bounds>
+			<bounds x="68" y="437" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="70" y="439" width="33" height="33">
-			</bounds>
+			<bounds x="70" y="439" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="68" y="473" width="37" height="37">
-			</bounds>
+			<bounds x="68" y="473" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="70" y="475" width="33" height="33">
-			</bounds>
+			<bounds x="70" y="475" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="68" y="509" width="37" height="37">
-			</bounds>
+			<bounds x="68" y="509" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="70" y="511" width="33" height="33">
-			</bounds>
+			<bounds x="70" y="511" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="68" y="545" width="37" height="37">
-			</bounds>
+			<bounds x="68" y="545" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="70" y="547" width="33" height="33">
-			</bounds>
+			<bounds x="70" y="547" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_198_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="54" y="613" width="72" height="37">
-			</bounds>
+			<bounds x="54" y="613" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_198" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="56" y="615" width="68" height="33">
-			</bounds>
+			<bounds x="56" y="615" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_199_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="191" y="614" width="72" height="37">
-			</bounds>
+			<bounds x="191" y="614" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_199" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="193" y="616" width="68" height="33">
-			</bounds>
+			<bounds x="193" y="616" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_200_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="291" y="613" width="72" height="37">
-			</bounds>
+			<bounds x="291" y="613" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_200" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="293" y="615" width="68" height="33">
-			</bounds>
+			<bounds x="293" y="615" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_201_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="389" y="613" width="72" height="37">
-			</bounds>
+			<bounds x="389" y="613" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_201" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="391" y="615" width="68" height="33">
-			</bounds>
+			<bounds x="391" y="615" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_202_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="486" y="613" width="72" height="37">
-			</bounds>
+			<bounds x="486" y="613" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_202" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="488" y="615" width="68" height="33">
-			</bounds>
+			<bounds x="488" y="615" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_203_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="602" y="613" width="72" height="37">
-			</bounds>
+			<bounds x="602" y="613" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_203" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="604" y="615" width="68" height="33">
-			</bounds>
+			<bounds x="604" y="615" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_204_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="688" y="613" width="77" height="37">
-			</bounds>
+			<bounds x="688" y="613" width="77" height="37"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_204" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="690" y="615" width="73" height="33">
-			</bounds>
+			<bounds x="690" y="615" width="73" height="33"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_205_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="770" y="613" width="77" height="37">
-			</bounds>
+			<bounds x="770" y="613" width="77" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_205" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="772" y="615" width="73" height="33">
-			</bounds>
+			<bounds x="772" y="615" width="73" height="33"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_207_border" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="853" y="613" width="72" height="37">
-			</bounds>
+			<bounds x="853" y="613" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp16" element="colour_button_207" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="855" y="615" width="68" height="33">
-			</bounds>
+			<bounds x="855" y="615" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp230" element="colour_button_208_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="302" y="291" width="47" height="47">
-			</bounds>
+			<bounds x="302" y="291" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp230" element="colour_button_208" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="304" y="293" width="43" height="43">
-			</bounds>
+			<bounds x="304" y="293" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp194" element="colour_button_209_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="104" y="274" width="47" height="47">
-			</bounds>
+			<bounds x="104" y="274" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp194" element="colour_button_209" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="106" y="276" width="43" height="43">
-			</bounds>
+			<bounds x="106" y="276" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp180" element="colour_button_210_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="134" y="206" width="57" height="37">
-			</bounds>
+			<bounds x="134" y="206" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp180" element="colour_button_210" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="136" y="208" width="53" height="33">
-			</bounds>
+			<bounds x="136" y="208" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_211_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="967" y="10" width="27" height="27">
-			</bounds>
+			<bounds x="967" y="10" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_211" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="969" y="12" width="23" height="23">
-			</bounds>
+			<bounds x="969" y="12" width="23" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="75" y="242" width="24" height="32">
-			</bounds>
+			<bounds x="75" y="242" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="75" y="242" width="24" height="32">
-			</bounds>
+			<bounds x="75" y="242" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="75" y="242" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="75" y="242" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="51" y="242" width="24" height="32">
-			</bounds>
+			<bounds x="51" y="242" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="51" y="242" width="24" height="32">
-			</bounds>
+			<bounds x="51" y="242" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="51" y="242" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="51" y="242" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="212" y="442" width="323" height="20">
-			</bounds>
+			<bounds x="212" y="442" width="323" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="212" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="212" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="232" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="232" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="252" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="252" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="272" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="272" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="292" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="292" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="312" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="312" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="332" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="332" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="352" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="352" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="372" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="372" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="392" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="392" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="412" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="412" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="432" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="432" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="452" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="452" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="472" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="472" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="492" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="492" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="512" y="442" width="20" height="20">
-			</bounds>
+			<bounds x="512" y="442" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="label172" element="label_172">
-			<bounds x="160" y="517" width="29" height="26">
-			</bounds>
+			<bounds x="160" y="517" width="29" height="26"/>
 		</backdrop>
 		<backdrop name="label173" element="label_173">
-			<bounds x="6" y="376" width="127" height="26">
-			</bounds>
+			<bounds x="6" y="376" width="127" height="26"/>
 		</backdrop>
 		<backdrop name="label178" element="label_178">
-			<bounds x="217" y="429" width="34" height="13">
-			</bounds>
+			<bounds x="217" y="429" width="34" height="13"/>
 		</backdrop>
 		<backdrop name="label179" element="label_179">
-			<bounds x="476" y="429" width="55" height="13">
-			</bounds>
+			<bounds x="476" y="429" width="55" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_button" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_button" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_button" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_button" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_button" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4blast.lay
+++ b/src/mame/layout/sc4blast.lay
@@ -8,14950 +8,8675 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BLAST IT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BLAST IT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SHOOTING STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOOTING STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ASTEROID BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ASTEROID BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHERRY BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHERRY BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH TEROIDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH TEROIDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MOON SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="MOON SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SPACE HOPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SPACE HOPPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TRACTOR BEAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRACTOR BEAM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH ENCOUNTERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH ENCOUNTERS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="ROCKET FUEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROCKET FUEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HYPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="HYPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;25.00 REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;25.00 REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
+			<color red="0.03" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
+			<color red="0.06" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;4 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;4 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;25 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;25 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;5 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;5 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;3 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;3 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;1 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;1 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;2 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;2 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="AST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="AST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.13">
-			</color>
+			<color red="0.50" green="0.31" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
+			<color red="0.12" green="0.07" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.25">
-			</color>
+			<color red="1.00" green="0.62" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
+			<color red="0.25" green="0.15" blue="0.06"/>
 		</rect>
 		<text string="OFF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
-		</rect>
-		<text string="OFF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="QPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="QPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="GAMES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="GAMES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2 SUPER SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 SUPER SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="STAR SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="STAR SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1 SUPER SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 SUPER SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1 SUPER SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 SUPER SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COMET CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="COMET CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2 SUPER SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 SUPER SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2 SUPER SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 SUPER SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+3 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+3 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TRIAL RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRIAL RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="OUTER LIMITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="OUTER LIMITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1 SUPER SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 SUPER SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BOARD LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOARD LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MYSTERY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MYSTERY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+1 SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+1 SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="GAME OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="GAME OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+2 SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2 SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MYSTERY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MYSTERY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+3 SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+3 SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MYSTERY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MYSTERY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+2 FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+2 SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2 SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="16 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="16 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="12 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="12 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BARCODE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BARCODE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LIFT OFF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIFT OFF">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MOON RAKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MOON RAKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GALAXY QUEST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GALAXY QUEST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLANET OF GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLANET OF GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MARS BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MARS BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MERCURY RISING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MERCURY RISING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;5 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;5 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;3 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;3 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;4 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;4 +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;25  +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;25  +R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLANET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER ROCKET">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_173_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_173">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_174_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_174">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_175_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_175">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_176_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_176">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_177_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_177">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_178_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_178">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_179_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_179">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CAN/COL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_180_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_180">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="TAKE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_181_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_181">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TAKE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_182_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_182">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_183_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_183">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_131">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_132">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_133">
 		<text string="27 WAYS TO ENTER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_148">
 		<text string="PAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_149">
 		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_150">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_151">
 		<text string="SUPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_152">
 		<text string="LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_153">
 		<text string="ALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_154">
 		<text string="STARTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_155">
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_156">
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_157">
 		<text string="LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_158">
 		<text string="ALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1022" height="679">
-			</bounds>
+			<bounds x="0" y="0" width="1022" height="679"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="358" y="495" width="80" height="140">
-			</bounds>
+			<bounds x="358" y="495" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="358.0000" y="495.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="358.0000" y="495.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="361.3333" y="496.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="361.3333" y="496.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="364.6667" y="498.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="364.6667" y="498.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="368.0000" y="500.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="368.0000" y="500.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="371.3333" y="502.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="371.3333" y="502.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="374.6667" y="504.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="374.6667" y="504.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="358.0000" y="541.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="358.0000" y="541.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="361.3333" y="543.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="361.3333" y="543.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="364.6667" y="545.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="364.6667" y="545.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="368.0000" y="547.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="368.0000" y="547.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="371.3333" y="549.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="371.3333" y="549.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="374.6667" y="551.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="374.6667" y="551.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="358.0000" y="588.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="358.0000" y="588.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="361.3333" y="590.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="361.3333" y="590.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="364.6667" y="592.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="364.6667" y="592.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="368.0000" y="594.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="368.0000" y="594.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="371.3333" y="596.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="371.3333" y="596.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="374.6667" y="598.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="374.6667" y="598.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="358" y="495" width="80" height="140">
-			</bounds>
+			<bounds x="358" y="495" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="440" y="495" width="80" height="140">
-			</bounds>
+			<bounds x="440" y="495" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="440.0000" y="495.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="440.0000" y="495.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="443.3333" y="496.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="443.3333" y="496.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="446.6667" y="498.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="446.6667" y="498.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="450.0000" y="500.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="450.0000" y="500.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="453.3333" y="502.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="453.3333" y="502.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="456.6667" y="504.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="456.6667" y="504.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="440.0000" y="541.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="440.0000" y="541.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="443.3333" y="543.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="443.3333" y="543.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="446.6667" y="545.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="446.6667" y="545.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="450.0000" y="547.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="450.0000" y="547.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="453.3333" y="549.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="453.3333" y="549.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="456.6667" y="551.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="456.6667" y="551.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="440.0000" y="588.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="440.0000" y="588.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="443.3333" y="590.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="443.3333" y="590.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="446.6667" y="592.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="446.6667" y="592.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="450.0000" y="594.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="450.0000" y="594.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="453.3333" y="596.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="453.3333" y="596.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="456.6667" y="598.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="456.6667" y="598.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="440" y="495" width="80" height="140">
-			</bounds>
+			<bounds x="440" y="495" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="522" y="495" width="80" height="140">
-			</bounds>
+			<bounds x="522" y="495" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="522.0000" y="495.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="522.0000" y="495.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="525.3333" y="496.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="525.3333" y="496.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="528.6667" y="498.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="528.6667" y="498.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="532.0000" y="500.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="532.0000" y="500.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="535.3333" y="502.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="535.3333" y="502.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="538.6667" y="504.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="538.6667" y="504.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="522.0000" y="541.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="522.0000" y="541.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="525.3333" y="543.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="525.3333" y="543.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="528.6667" y="545.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="528.6667" y="545.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="532.0000" y="547.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="532.0000" y="547.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="535.3333" y="549.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="535.3333" y="549.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="538.6667" y="551.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="538.6667" y="551.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="522.0000" y="588.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="522.0000" y="588.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="525.3333" y="590.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="525.3333" y="590.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="528.6667" y="592.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="528.6667" y="592.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="532.0000" y="594.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="532.0000" y="594.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="535.3333" y="596.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="535.3333" y="596.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="538.6667" y="598.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="538.6667" y="598.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="522" y="495" width="80" height="140">
-			</bounds>
+			<bounds x="522" y="495" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1045" y="191" width="80" height="140">
-			</bounds>
+			<bounds x="1045" y="191" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1045.0000" y="191.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="1045.0000" y="191.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1048.3334" y="192.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="1048.3334" y="192.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1051.6666" y="194.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="1051.6666" y="194.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1055.0000" y="196.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="1055.0000" y="196.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1058.3334" y="198.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="1058.3334" y="198.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1061.6666" y="200.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="1061.6666" y="200.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1045.0000" y="237.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="1045.0000" y="237.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1048.3334" y="239.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="1048.3334" y="239.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1051.6666" y="241.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="1051.6666" y="241.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1055.0000" y="243.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="1055.0000" y="243.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1058.3334" y="245.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="1058.3334" y="245.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1061.6666" y="247.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="1061.6666" y="247.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1045.0000" y="284.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="1045.0000" y="284.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1048.3334" y="286.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="1048.3334" y="286.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1051.6666" y="288.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="1051.6666" y="288.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1055.0000" y="290.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="1055.0000" y="290.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1058.3334" y="292.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="1058.3334" y="292.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1061.6666" y="294.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="1061.6666" y="294.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1045" y="191" width="80" height="140">
-			</bounds>
+			<bounds x="1045" y="191" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="440" y="350" width="80" height="80">
-			</bounds>
+			<bounds x="440" y="350" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="440.0000" y="350.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="440.0000" y="350.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="443.3333" y="353.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="443.3333" y="353.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="446.6667" y="356.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="446.6667" y="356.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="450.0000" y="360.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="450.0000" y="360.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="453.3333" y="363.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="453.3333" y="363.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="456.6667" y="366.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="456.6667" y="366.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="440" y="350" width="80" height="80">
-			</bounds>
+			<bounds x="440" y="350" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="17" y="9" width="92" height="34">
-			</bounds>
+			<bounds x="17" y="9" width="92" height="34"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="19" y="11" width="88" height="30">
-			</bounds>
+			<bounds x="19" y="11" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="21" y="239" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="239" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="23" y="241" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="241" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="21" y="267" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="267" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="23" y="269" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="269" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="21" y="295" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="295" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="23" y="297" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="297" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="21" y="323" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="323" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="23" y="325" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="325" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="21" y="43" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="43" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="23" y="45" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="45" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="21" y="71" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="71" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="23" y="73" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="73" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="21" y="99" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="99" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="23" y="101" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="101" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="21" y="127" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="127" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="23" y="129" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="129" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="21" y="155" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="155" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="23" y="157" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="157" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="21" y="211" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="211" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="23" y="213" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="213" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="21" y="183" width="78" height="28">
-			</bounds>
+			<bounds x="21" y="183" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="23" y="185" width="74" height="24">
-			</bounds>
+			<bounds x="23" y="185" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="955" y="395" width="62" height="34">
-			</bounds>
+			<bounds x="955" y="395" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="957" y="397" width="58" height="30">
-			</bounds>
+			<bounds x="957" y="397" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="955" y="429" width="48" height="26">
-			</bounds>
+			<bounds x="955" y="429" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="957" y="431" width="44" height="22">
-			</bounds>
+			<bounds x="957" y="431" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="955" y="457" width="42" height="26">
-			</bounds>
+			<bounds x="955" y="457" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="957" y="459" width="38" height="22">
-			</bounds>
+			<bounds x="957" y="459" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="955" y="622" width="42" height="26">
-			</bounds>
+			<bounds x="955" y="622" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="957" y="624" width="38" height="22">
-			</bounds>
+			<bounds x="957" y="624" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="955" y="650" width="42" height="26">
-			</bounds>
+			<bounds x="955" y="650" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="957" y="652" width="38" height="22">
-			</bounds>
+			<bounds x="957" y="652" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="955" y="595" width="42" height="26">
-			</bounds>
+			<bounds x="955" y="595" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="957" y="597" width="38" height="22">
-			</bounds>
+			<bounds x="957" y="597" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="955" y="569" width="42" height="26">
-			</bounds>
+			<bounds x="955" y="569" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="957" y="571" width="38" height="22">
-			</bounds>
+			<bounds x="957" y="571" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="955" y="514" width="42" height="26">
-			</bounds>
+			<bounds x="955" y="514" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="957" y="516" width="38" height="22">
-			</bounds>
+			<bounds x="957" y="516" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="955" y="542" width="42" height="26">
-			</bounds>
+			<bounds x="955" y="542" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="957" y="544" width="38" height="22">
-			</bounds>
+			<bounds x="957" y="544" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="955" y="486" width="42" height="26">
-			</bounds>
+			<bounds x="955" y="486" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="957" y="488" width="38" height="22">
-			</bounds>
+			<bounds x="957" y="488" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="821" y="302" width="30" height="30">
-			</bounds>
+			<bounds x="821" y="302" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="823" y="304" width="26" height="26">
-			</bounds>
+			<bounds x="823" y="304" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="755" y="398" width="30" height="30">
-			</bounds>
+			<bounds x="755" y="398" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="757" y="400" width="26" height="26">
-			</bounds>
+			<bounds x="757" y="400" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="755" y="300" width="30" height="30">
-			</bounds>
+			<bounds x="755" y="300" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="757" y="302" width="26" height="26">
-			</bounds>
+			<bounds x="757" y="302" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="811" y="332" width="30" height="30">
-			</bounds>
+			<bounds x="811" y="332" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="813" y="334" width="26" height="26">
-			</bounds>
+			<bounds x="813" y="334" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="743" y="368" width="30" height="30">
-			</bounds>
+			<bounds x="743" y="368" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="745" y="370" width="26" height="26">
-			</bounds>
+			<bounds x="745" y="370" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="713" y="374" width="30" height="30">
-			</bounds>
+			<bounds x="713" y="374" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="715" y="376" width="26" height="26">
-			</bounds>
+			<bounds x="715" y="376" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="744" y="326" width="30" height="30">
-			</bounds>
+			<bounds x="744" y="326" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="746" y="328" width="26" height="26">
-			</bounds>
+			<bounds x="746" y="328" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="781" y="374" width="30" height="30">
-			</bounds>
+			<bounds x="781" y="374" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="783" y="376" width="26" height="26">
-			</bounds>
+			<bounds x="783" y="376" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="711" y="337" width="30" height="30">
-			</bounds>
+			<bounds x="711" y="337" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="713" y="339" width="26" height="26">
-			</bounds>
+			<bounds x="713" y="339" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="839" y="347" width="30" height="30">
-			</bounds>
+			<bounds x="839" y="347" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="841" y="349" width="26" height="26">
-			</bounds>
+			<bounds x="841" y="349" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="783" y="315" width="30" height="30">
-			</bounds>
+			<bounds x="783" y="315" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="785" y="317" width="26" height="26">
-			</bounds>
+			<bounds x="785" y="317" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="814" y="366" width="30" height="30">
-			</bounds>
+			<bounds x="814" y="366" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="816" y="368" width="26" height="26">
-			</bounds>
+			<bounds x="816" y="368" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="804" y="395" width="30" height="30">
-			</bounds>
+			<bounds x="804" y="395" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="806" y="397" width="26" height="26">
-			</bounds>
+			<bounds x="806" y="397" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="721" y="306" width="30" height="30">
-			</bounds>
+			<bounds x="721" y="306" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="723" y="308" width="26" height="26">
-			</bounds>
+			<bounds x="723" y="308" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="789" y="285" width="30" height="30">
-			</bounds>
+			<bounds x="789" y="285" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="791" y="287" width="26" height="26">
-			</bounds>
+			<bounds x="791" y="287" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="725" y="406" width="30" height="30">
-			</bounds>
+			<bounds x="725" y="406" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="727" y="408" width="26" height="26">
-			</bounds>
+			<bounds x="727" y="408" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="328" y="12" width="50" height="38">
-			</bounds>
+			<bounds x="328" y="12" width="50" height="38"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="330" y="14" width="46" height="34">
-			</bounds>
+			<bounds x="330" y="14" width="46" height="34"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="376" y="12" width="78" height="38">
-			</bounds>
+			<bounds x="376" y="12" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="378" y="14" width="74" height="34">
-			</bounds>
+			<bounds x="378" y="14" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="452" y="12" width="78" height="38">
-			</bounds>
+			<bounds x="452" y="12" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="454" y="14" width="74" height="34">
-			</bounds>
+			<bounds x="454" y="14" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="576" y="13" width="78" height="30">
-			</bounds>
+			<bounds x="576" y="13" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="578" y="15" width="74" height="26">
-			</bounds>
+			<bounds x="578" y="15" width="74" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="576" y="42" width="78" height="30">
-			</bounds>
+			<bounds x="576" y="42" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="578" y="44" width="74" height="26">
-			</bounds>
+			<bounds x="578" y="44" width="74" height="26"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="130" y="210" width="62" height="30">
-			</bounds>
+			<bounds x="130" y="210" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="132" y="212" width="58" height="26">
-			</bounds>
+			<bounds x="132" y="212" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="130" y="161" width="62" height="30">
-			</bounds>
+			<bounds x="130" y="161" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="132" y="163" width="58" height="26">
-			</bounds>
+			<bounds x="132" y="163" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="760" y="210" width="62" height="30">
-			</bounds>
+			<bounds x="760" y="210" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="762" y="212" width="58" height="26">
-			</bounds>
+			<bounds x="762" y="212" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="760" y="161" width="62" height="30">
-			</bounds>
+			<bounds x="760" y="161" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="762" y="163" width="58" height="26">
-			</bounds>
+			<bounds x="762" y="163" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="560" y="260" width="62" height="30">
-			</bounds>
+			<bounds x="560" y="260" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="562" y="262" width="58" height="26">
-			</bounds>
+			<bounds x="562" y="262" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="640" y="270" width="62" height="30">
-			</bounds>
+			<bounds x="640" y="270" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="642" y="272" width="58" height="26">
-			</bounds>
+			<bounds x="642" y="272" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="714" y="255" width="62" height="30">
-			</bounds>
+			<bounds x="714" y="255" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="716" y="257" width="58" height="26">
-			</bounds>
+			<bounds x="716" y="257" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="713" y="115" width="62" height="30">
-			</bounds>
+			<bounds x="713" y="115" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="715" y="117" width="58" height="26">
-			</bounds>
+			<bounds x="715" y="117" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="640" y="104" width="62" height="30">
-			</bounds>
+			<bounds x="640" y="104" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="642" y="106" width="58" height="26">
-			</bounds>
+			<bounds x="642" y="106" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="560" y="109" width="62" height="30">
-			</bounds>
+			<bounds x="560" y="109" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="562" y="111" width="58" height="26">
-			</bounds>
+			<bounds x="562" y="111" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="412" y="122" width="62" height="30">
-			</bounds>
+			<bounds x="412" y="122" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="414" y="124" width="58" height="26">
-			</bounds>
+			<bounds x="414" y="124" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="337" y="109" width="62" height="30">
-			</bounds>
+			<bounds x="337" y="109" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="339" y="111" width="58" height="26">
-			</bounds>
+			<bounds x="339" y="111" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="483" y="122" width="62" height="30">
-			</bounds>
+			<bounds x="483" y="122" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="485" y="124" width="58" height="26">
-			</bounds>
+			<bounds x="485" y="124" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="154" y="115" width="62" height="30">
-			</bounds>
+			<bounds x="154" y="115" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="156" y="117" width="58" height="26">
-			</bounds>
+			<bounds x="156" y="117" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="249" y="104" width="62" height="30">
-			</bounds>
+			<bounds x="249" y="104" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="251" y="106" width="58" height="26">
-			</bounds>
+			<bounds x="251" y="106" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="412" y="249" width="62" height="30">
-			</bounds>
+			<bounds x="412" y="249" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="414" y="251" width="58" height="26">
-			</bounds>
+			<bounds x="414" y="251" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="249" y="270" width="62" height="30">
-			</bounds>
+			<bounds x="249" y="270" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="251" y="272" width="58" height="26">
-			</bounds>
+			<bounds x="251" y="272" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="164" y="255" width="62" height="30">
-			</bounds>
+			<bounds x="164" y="255" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="166" y="257" width="58" height="26">
-			</bounds>
+			<bounds x="166" y="257" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="337" y="260" width="62" height="30">
-			</bounds>
+			<bounds x="337" y="260" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="339" y="262" width="58" height="26">
-			</bounds>
+			<bounds x="339" y="262" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="483" y="249" width="62" height="30">
-			</bounds>
+			<bounds x="483" y="249" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="485" y="251" width="58" height="26">
-			</bounds>
+			<bounds x="485" y="251" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="508" y="186" width="62" height="30">
-			</bounds>
+			<bounds x="508" y="186" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="510" y="188" width="58" height="26">
-			</bounds>
+			<bounds x="510" y="188" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="384" y="185" width="62" height="30">
-			</bounds>
+			<bounds x="384" y="185" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="386" y="187" width="58" height="26">
-			</bounds>
+			<bounds x="386" y="187" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="298" y="186" width="48" height="30">
-			</bounds>
+			<bounds x="298" y="186" width="48" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="300" y="188" width="44" height="26">
-			</bounds>
+			<bounds x="300" y="188" width="44" height="26"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="605" y="186" width="48" height="30">
-			</bounds>
+			<bounds x="605" y="186" width="48" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="607" y="188" width="44" height="26">
-			</bounds>
+			<bounds x="607" y="188" width="44" height="26"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="692" y="186" width="62" height="30">
-			</bounds>
+			<bounds x="692" y="186" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="694" y="188" width="58" height="26">
-			</bounds>
+			<bounds x="694" y="188" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="692" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="692" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="694" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="694" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="258" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="258" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="260" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="260" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="320" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="320" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="322" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="322" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="444" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="444" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="446" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="446" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="568" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="568" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="570" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="570" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="506" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="506" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="508" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="508" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="382" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="382" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="384" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="384" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="630" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="630" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="632" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="632" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="630" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="630" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="632" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="632" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="444" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="444" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="446" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="446" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="506" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="506" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="508" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="508" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="568" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="568" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="570" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="570" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="382" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="382" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="384" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="384" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="692" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="692" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="694" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="694" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="196" y="186" width="62" height="30">
-			</bounds>
+			<bounds x="196" y="186" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="198" y="188" width="58" height="26">
-			</bounds>
+			<bounds x="198" y="188" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="196" y="156" width="62" height="30">
-			</bounds>
+			<bounds x="196" y="156" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="198" y="158" width="58" height="26">
-			</bounds>
+			<bounds x="198" y="158" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="196" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="196" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="198" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="198" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="258" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="258" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="260" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="260" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="320" y="216" width="62" height="30">
-			</bounds>
+			<bounds x="320" y="216" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="322" y="218" width="58" height="26">
-			</bounds>
+			<bounds x="322" y="218" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="884" y="9" width="92" height="34">
-			</bounds>
+			<bounds x="884" y="9" width="92" height="34"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="886" y="11" width="88" height="30">
-			</bounds>
+			<bounds x="886" y="11" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="891" y="43" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="43" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="893" y="45" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="45" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="891" y="71" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="71" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="893" y="73" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="73" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="891" y="99" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="99" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="893" y="101" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="101" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="891" y="155" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="155" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="893" y="157" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="157" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="891" y="127" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="127" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="893" y="129" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="129" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="891" y="323" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="323" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="893" y="325" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="325" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="891" y="267" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="267" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="893" y="269" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="269" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="891" y="239" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="239" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="893" y="241" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="241" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="891" y="211" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="211" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="893" y="213" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="213" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="891" y="183" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="183" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="893" y="185" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="185" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="891" y="295" width="78" height="28">
-			</bounds>
+			<bounds x="891" y="295" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="893" y="297" width="74" height="24">
-			</bounds>
+			<bounds x="893" y="297" width="74" height="24"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="78" y="588" width="74" height="19">
-			</bounds>
+			<bounds x="78" y="588" width="74" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="80" y="590" width="70" height="15">
-			</bounds>
+			<bounds x="80" y="590" width="70" height="15"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="27" y="545" width="58" height="42">
-			</bounds>
+			<bounds x="27" y="545" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="29" y="547" width="54" height="38">
-			</bounds>
+			<bounds x="29" y="547" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="85" y="545" width="58" height="42">
-			</bounds>
+			<bounds x="85" y="545" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="87" y="547" width="54" height="38">
-			</bounds>
+			<bounds x="87" y="547" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="27" y="504" width="58" height="42">
-			</bounds>
+			<bounds x="27" y="504" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="29" y="506" width="54" height="38">
-			</bounds>
+			<bounds x="29" y="506" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="143" y="545" width="58" height="42">
-			</bounds>
+			<bounds x="143" y="545" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="145" y="547" width="54" height="38">
-			</bounds>
+			<bounds x="145" y="547" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="85" y="504" width="58" height="42">
-			</bounds>
+			<bounds x="85" y="504" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="87" y="506" width="54" height="38">
-			</bounds>
+			<bounds x="87" y="506" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="143" y="504" width="58" height="42">
-			</bounds>
+			<bounds x="143" y="504" width="58" height="42"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="145" y="506" width="54" height="38">
-			</bounds>
+			<bounds x="145" y="506" width="54" height="38"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="241" y="484" width="26" height="26">
-			</bounds>
+			<bounds x="241" y="484" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="243" y="486" width="22" height="22">
-			</bounds>
+			<bounds x="243" y="486" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="265" y="509" width="26" height="26">
-			</bounds>
+			<bounds x="265" y="509" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="267" y="511" width="22" height="22">
-			</bounds>
+			<bounds x="267" y="511" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="240" y="532" width="26" height="26">
-			</bounds>
+			<bounds x="240" y="532" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="242" y="534" width="22" height="22">
-			</bounds>
+			<bounds x="242" y="534" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="239" y="580" width="26" height="26">
-			</bounds>
+			<bounds x="239" y="580" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="241" y="582" width="22" height="22">
-			</bounds>
+			<bounds x="241" y="582" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="264" y="557" width="26" height="26">
-			</bounds>
+			<bounds x="264" y="557" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="266" y="559" width="22" height="22">
-			</bounds>
+			<bounds x="266" y="559" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="186" y="607" width="50" height="30">
-			</bounds>
+			<bounds x="186" y="607" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="188" y="609" width="46" height="26">
-			</bounds>
+			<bounds x="188" y="609" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="238" y="607" width="50" height="30">
-			</bounds>
+			<bounds x="238" y="607" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="240" y="609" width="46" height="26">
-			</bounds>
+			<bounds x="240" y="609" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="203" y="398" width="30" height="30">
-			</bounds>
+			<bounds x="203" y="398" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="205" y="400" width="26" height="26">
-			</bounds>
+			<bounds x="205" y="400" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="128" y="339" width="30" height="30">
-			</bounds>
+			<bounds x="128" y="339" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="130" y="341" width="26" height="26">
-			</bounds>
+			<bounds x="130" y="341" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="206" y="333" width="30" height="30">
-			</bounds>
+			<bounds x="206" y="333" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="208" y="335" width="26" height="26">
-			</bounds>
+			<bounds x="208" y="335" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="213" y="366" width="30" height="30">
-			</bounds>
+			<bounds x="213" y="366" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="215" y="368" width="26" height="26">
-			</bounds>
+			<bounds x="215" y="368" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="153" y="321" width="30" height="30">
-			</bounds>
+			<bounds x="153" y="321" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="155" y="323" width="26" height="26">
-			</bounds>
+			<bounds x="155" y="323" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="182" y="315" width="30" height="30">
-			</bounds>
+			<bounds x="182" y="315" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="184" y="317" width="26" height="26">
-			</bounds>
+			<bounds x="184" y="317" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="124" y="370" width="30" height="30">
-			</bounds>
+			<bounds x="124" y="370" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="126" y="372" width="26" height="26">
-			</bounds>
+			<bounds x="126" y="372" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="143" y="396" width="30" height="30">
-			</bounds>
+			<bounds x="143" y="396" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="145" y="398" width="26" height="26">
-			</bounds>
+			<bounds x="145" y="398" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="174" y="410" width="30" height="30">
-			</bounds>
+			<bounds x="174" y="410" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="176" y="412" width="26" height="26">
-			</bounds>
+			<bounds x="176" y="412" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="269" y="355" width="46" height="26">
-			</bounds>
+			<bounds x="269" y="355" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="271" y="357" width="42" height="22">
-			</bounds>
+			<bounds x="271" y="357" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="315" y="355" width="46" height="26">
-			</bounds>
+			<bounds x="315" y="355" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="317" y="357" width="42" height="22">
-			</bounds>
+			<bounds x="317" y="357" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="361" y="355" width="46" height="26">
-			</bounds>
+			<bounds x="361" y="355" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="363" y="357" width="42" height="22">
-			</bounds>
+			<bounds x="363" y="357" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="344" y="383" width="48" height="26">
-			</bounds>
+			<bounds x="344" y="383" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="346" y="385" width="44" height="22">
-			</bounds>
+			<bounds x="346" y="385" width="44" height="22"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="302" y="383" width="42" height="26">
-			</bounds>
+			<bounds x="302" y="383" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="304" y="385" width="38" height="22">
-			</bounds>
+			<bounds x="304" y="385" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="651" y="384" width="48" height="30">
-			</bounds>
+			<bounds x="651" y="384" width="48" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="653" y="386" width="44" height="26">
-			</bounds>
+			<bounds x="653" y="386" width="44" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="604" y="384" width="48" height="30">
-			</bounds>
+			<bounds x="604" y="384" width="48" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="606" y="386" width="44" height="26">
-			</bounds>
+			<bounds x="606" y="386" width="44" height="26"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="557" y="384" width="48" height="30">
-			</bounds>
+			<bounds x="557" y="384" width="48" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="559" y="386" width="44" height="26">
-			</bounds>
+			<bounds x="559" y="386" width="44" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="604" y="351" width="48" height="34">
-			</bounds>
+			<bounds x="604" y="351" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="606" y="353" width="44" height="30">
-			</bounds>
+			<bounds x="606" y="353" width="44" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="557" y="351" width="48" height="34">
-			</bounds>
+			<bounds x="557" y="351" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="559" y="353" width="44" height="30">
-			</bounds>
+			<bounds x="559" y="353" width="44" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="651" y="351" width="48" height="34">
-			</bounds>
+			<bounds x="651" y="351" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="653" y="353" width="44" height="30">
-			</bounds>
+			<bounds x="653" y="353" width="44" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="411" y="377" width="26" height="26">
-			</bounds>
+			<bounds x="411" y="377" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="413" y="379" width="22" height="22">
-			</bounds>
+			<bounds x="413" y="379" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="524" y="377" width="26" height="26">
-			</bounds>
+			<bounds x="524" y="377" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="526" y="379" width="22" height="22">
-			</bounds>
+			<bounds x="526" y="379" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_173_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="804" y="8" width="48" height="27">
-			</bounds>
+			<bounds x="804" y="8" width="48" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_173" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="806" y="10" width="44" height="23">
-			</bounds>
+			<bounds x="806" y="10" width="44" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_174_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="707" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="707" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_174" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="709" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="709" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_175_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="610" y="642" width="94" height="27">
-			</bounds>
+			<bounds x="610" y="642" width="94" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_175" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="612" y="644" width="90" height="23">
-			</bounds>
+			<bounds x="612" y="644" width="90" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_176_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="529" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="529" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_176" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="531" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="531" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_177_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="447" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="447" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_177" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="449" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="449" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_178_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="362" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="362" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_178" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="364" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="364" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_179_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="277" y="642" width="80" height="27">
-			</bounds>
+			<bounds x="277" y="642" width="80" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_179" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="279" y="644" width="76" height="23">
-			</bounds>
+			<bounds x="279" y="644" width="76" height="23"/>
 		</backdrop>
 		<backdrop name="lamp89" element="colour_button_180_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="23" y="354" width="78" height="38">
-			</bounds>
+			<bounds x="23" y="354" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp89" element="colour_button_180" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="25" y="356" width="74" height="34">
-			</bounds>
+			<bounds x="25" y="356" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp203" element="colour_button_181_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="892" y="353" width="78" height="38">
-			</bounds>
+			<bounds x="892" y="353" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp203" element="colour_button_181" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="894" y="355" width="74" height="34">
-			</bounds>
+			<bounds x="894" y="355" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp81" element="colour_button_182_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="765" y="346" width="50" height="30">
-			</bounds>
+			<bounds x="765" y="346" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="colour_button_182" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="767" y="348" width="46" height="26">
-			</bounds>
+			<bounds x="767" y="348" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp162" element="colour_button_183_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="160" y="366" width="50" height="30">
-			</bounds>
+			<bounds x="160" y="366" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="colour_button_183" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="162" y="368" width="46" height="26">
-			</bounds>
+			<bounds x="162" y="368" width="46" height="26"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="323" y="454" width="323" height="27">
-			</bounds>
+			<bounds x="323" y="454" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="323" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="323" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="343" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="343" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="363" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="363" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="383" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="383" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="403" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="403" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="423" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="423" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="443" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="443" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="463" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="463" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="483" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="483" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="503" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="503" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="523" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="523" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="543" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="543" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="563" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="563" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="583" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="583" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="603" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="603" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="623" y="454" width="20" height="27">
-			</bounds>
+			<bounds x="623" y="454" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label131" element="label_131">
-			<bounds x="317" y="558" width="30" height="16">
-			</bounds>
+			<bounds x="317" y="558" width="30" height="16"/>
 		</backdrop>
 		<backdrop name="label132" element="label_132">
-			<bounds x="615" y="558" width="34" height="16">
-			</bounds>
+			<bounds x="615" y="558" width="34" height="16"/>
 		</backdrop>
 		<backdrop name="label133" element="label_133">
-			<bounds x="677" y="540" width="72" height="48">
-			</bounds>
+			<bounds x="677" y="540" width="72" height="48"/>
 		</backdrop>
 		<backdrop name="label148" element="label_148">
-			<bounds x="293" y="334" width="28" height="13">
-			</bounds>
+			<bounds x="293" y="334" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="label149" element="label_149">
-			<bounds x="389" y="334" width="43" height="13">
-			</bounds>
+			<bounds x="389" y="334" width="43" height="13"/>
 		</backdrop>
 		<backdrop name="label150" element="label_150">
-			<bounds x="365" y="334" width="22" height="13">
-			</bounds>
+			<bounds x="365" y="334" width="22" height="13"/>
 		</backdrop>
 		<backdrop name="label151" element="label_151">
-			<bounds x="323" y="334" width="40" height="13">
-			</bounds>
+			<bounds x="323" y="334" width="40" height="13"/>
 		</backdrop>
 		<backdrop name="label152" element="label_152">
-			<bounds x="275" y="334" width="16" height="13">
-			</bounds>
+			<bounds x="275" y="334" width="16" height="13"/>
 		</backdrop>
 		<backdrop name="label153" element="label_153">
-			<bounds x="254" y="334" width="19" height="13">
-			</bounds>
+			<bounds x="254" y="334" width="19" height="13"/>
 		</backdrop>
 		<backdrop name="label154" element="label_154">
-			<bounds x="583" y="334" width="43" height="13">
-			</bounds>
+			<bounds x="583" y="334" width="43" height="13"/>
 		</backdrop>
 		<backdrop name="label155" element="label_155">
-			<bounds x="667" y="334" width="38" height="13">
-			</bounds>
+			<bounds x="667" y="334" width="38" height="13"/>
 		</backdrop>
 		<backdrop name="label156" element="label_156">
-			<bounds x="628" y="334" width="37" height="13">
-			</bounds>
+			<bounds x="628" y="334" width="37" height="13"/>
 		</backdrop>
 		<backdrop name="label157" element="label_157">
-			<bounds x="565" y="334" width="16" height="13">
-			</bounds>
+			<bounds x="565" y="334" width="16" height="13"/>
 		</backdrop>
 		<backdrop name="label158" element="label_158">
-			<bounds x="544" y="334" width="19" height="13">
-			</bounds>
+			<bounds x="544" y="334" width="19" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_button" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_button" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_button" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_button" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_9" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4blokq.lay
+++ b/src/mame/layout/sc4blokq.lay
@@ -8,19698 +8,10851 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CHERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SUPRIZE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CHERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SUPRIZE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="REEL SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="REEL SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="PICK A ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="PICK A ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="MEGA HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="MEGA HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="FOLLOW ME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="FOLLOW ME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="MIX N MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="MIX N MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CRAZY REELS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CRAZY REELS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CASH ATTACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH ATTACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="QUICK NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="QUICK NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="MULTI FILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="MULTI FILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SHUFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHUFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="REEL SELECTOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL SELECTOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="NUDGE SPINNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE SPINNER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="STRIKE A LIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="STRIKE A LIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HI LO CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI LO CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SKILL SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BLOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BUSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BLOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BUSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_284_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_284_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_275_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_275_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_274_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_274_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_273_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_273_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_272_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_272_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_271_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_271_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_269_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_269_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_267_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_267_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_266_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_266_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_264_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_264_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_263_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_263_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_262_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_262_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_261_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_261_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_260_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_260_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_6_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_6_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_277_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_277_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BLOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BUSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BLOCK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BUSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_287_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_287_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_248_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_248">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_249_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_249">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_250_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_250">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_251_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_251">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_252_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_252">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_253_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_253">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_254_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_254">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_255_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_255">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_256_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_256">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_257_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_257">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_258_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_258">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_260_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_260">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RIGHT HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_261_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_261">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RIGHT LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_262_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_262">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LEFT LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_263_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_263">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LEFT HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_264_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_264">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="UP HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_265_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_265">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="UP LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="5" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_226">
 		<text string="LIGHT ALL 3 FOR BIG MONEY!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_227">
 		<text string="With thanks to Bugs!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_228">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_229">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_230">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_231">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_232">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_233">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_234">
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_235">
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_236">
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_237">
 		<text string="`">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_238">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_239">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_240">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_241">
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_242">
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_243">
 		<text string="SPACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_244">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_245">
 		<text string="3 WAY HI LO VIA NUMNER PAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="619" height="758">
-			</bounds>
+			<bounds x="0" y="0" width="619" height="758"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="134" y="562" width="80" height="140">
-			</bounds>
+			<bounds x="134" y="562" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="134.0000" y="562.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="134.0000" y="562.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="137.3333" y="563.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="137.3333" y="563.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="140.6667" y="565.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="140.6667" y="565.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="144.0000" y="567.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="144.0000" y="567.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="147.3333" y="569.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="147.3333" y="569.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="150.6667" y="571.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="150.6667" y="571.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="134.0000" y="608.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="134.0000" y="608.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="137.3333" y="610.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="137.3333" y="610.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="140.6667" y="612.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="140.6667" y="612.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="144.0000" y="614.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="144.0000" y="614.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="147.3333" y="616.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="147.3333" y="616.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="150.6667" y="618.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="150.6667" y="618.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="134.0000" y="655.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="134.0000" y="655.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="137.3333" y="657.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="137.3333" y="657.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="140.6667" y="659.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="140.6667" y="659.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="144.0000" y="661.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="144.0000" y="661.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="147.3333" y="663.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="147.3333" y="663.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="150.6667" y="665.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="150.6667" y="665.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="134" y="562" width="80" height="140">
-			</bounds>
+			<bounds x="134" y="562" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="220" y="561" width="80" height="140">
-			</bounds>
+			<bounds x="220" y="561" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="220.0000" y="561.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="220.0000" y="561.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="223.3333" y="562.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="223.3333" y="562.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="226.6667" y="564.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="226.6667" y="564.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="230.0000" y="566.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="230.0000" y="566.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.3333" y="568.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="233.3333" y="568.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="236.6667" y="570.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="236.6667" y="570.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="220.0000" y="607.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="220.0000" y="607.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="223.3333" y="609.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="223.3333" y="609.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="226.6667" y="611.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="226.6667" y="611.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="230.0000" y="613.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="230.0000" y="613.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.3333" y="615.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="233.3333" y="615.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="236.6667" y="617.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="236.6667" y="617.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="220.0000" y="654.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="220.0000" y="654.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="223.3333" y="656.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="223.3333" y="656.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="226.6667" y="658.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="226.6667" y="658.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="230.0000" y="660.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="230.0000" y="660.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.3333" y="662.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="233.3333" y="662.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="236.6667" y="664.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="236.6667" y="664.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="220" y="561" width="80" height="140">
-			</bounds>
+			<bounds x="220" y="561" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="304" y="561" width="80" height="140">
-			</bounds>
+			<bounds x="304" y="561" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="304.0000" y="561.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="304.0000" y="561.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="307.3333" y="562.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="307.3333" y="562.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="310.6667" y="564.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="310.6667" y="564.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="314.0000" y="566.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="314.0000" y="566.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="317.3333" y="568.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="317.3333" y="568.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="320.6667" y="570.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="320.6667" y="570.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="304.0000" y="607.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="304.0000" y="607.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="307.3333" y="609.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="307.3333" y="609.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="310.6667" y="611.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="310.6667" y="611.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="314.0000" y="613.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="314.0000" y="613.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="317.3333" y="615.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="317.3333" y="615.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="320.6667" y="617.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="320.6667" y="617.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="304.0000" y="654.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="304.0000" y="654.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="307.3333" y="656.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="307.3333" y="656.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="310.6667" y="658.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="310.6667" y="658.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="314.0000" y="660.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="314.0000" y="660.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="317.3333" y="662.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="317.3333" y="662.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="320.6667" y="664.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="320.6667" y="664.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="304" y="561" width="80" height="140">
-			</bounds>
+			<bounds x="304" y="561" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="198" y="408" width="200" height="80">
-			</bounds>
+			<bounds x="198" y="408" width="200" height="80"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="408.0000" width="200.0000" height="16.0000">
-			</bounds>
+			<bounds x="198.0000" y="408.0000" width="200.0000" height="16.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="408.6667" width="183.3333" height="14.6667">
-			</bounds>
+			<bounds x="206.3333" y="408.6667" width="183.3333" height="14.6667"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="214.6667" y="409.3333" width="166.6667" height="13.3333">
-			</bounds>
+			<bounds x="214.6667" y="409.3333" width="166.6667" height="13.3333"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="223.0000" y="410.0000" width="150.0000" height="12.0000">
-			</bounds>
+			<bounds x="223.0000" y="410.0000" width="150.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="231.3333" y="410.6667" width="133.3333" height="10.6667">
-			</bounds>
+			<bounds x="231.3333" y="410.6667" width="133.3333" height="10.6667"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="239.6667" y="411.3333" width="116.6667" height="9.3333">
-			</bounds>
+			<bounds x="239.6667" y="411.3333" width="116.6667" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="424.0000" width="200.0000" height="16.0000">
-			</bounds>
+			<bounds x="198.0000" y="424.0000" width="200.0000" height="16.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="424.6667" width="183.3333" height="14.6667">
-			</bounds>
+			<bounds x="206.3333" y="424.6667" width="183.3333" height="14.6667"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_2" state="0">
-			<bounds x="214.6667" y="425.3333" width="166.6667" height="13.3333">
-			</bounds>
+			<bounds x="214.6667" y="425.3333" width="166.6667" height="13.3333"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_3" state="0">
-			<bounds x="223.0000" y="426.0000" width="150.0000" height="12.0000">
-			</bounds>
+			<bounds x="223.0000" y="426.0000" width="150.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_4" state="0">
-			<bounds x="231.3333" y="426.6667" width="133.3333" height="10.6667">
-			</bounds>
+			<bounds x="231.3333" y="426.6667" width="133.3333" height="10.6667"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_5" state="0">
-			<bounds x="239.6667" y="427.3333" width="116.6667" height="9.3333">
-			</bounds>
+			<bounds x="239.6667" y="427.3333" width="116.6667" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="440.0000" width="200.0000" height="16.0000">
-			</bounds>
+			<bounds x="198.0000" y="440.0000" width="200.0000" height="16.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="440.6667" width="183.3333" height="14.6667">
-			</bounds>
+			<bounds x="206.3333" y="440.6667" width="183.3333" height="14.6667"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="214.6667" y="441.3333" width="166.6667" height="13.3333">
-			</bounds>
+			<bounds x="214.6667" y="441.3333" width="166.6667" height="13.3333"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="223.0000" y="442.0000" width="150.0000" height="12.0000">
-			</bounds>
+			<bounds x="223.0000" y="442.0000" width="150.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="231.3333" y="442.6667" width="133.3333" height="10.6667">
-			</bounds>
+			<bounds x="231.3333" y="442.6667" width="133.3333" height="10.6667"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="239.6667" y="443.3333" width="116.6667" height="9.3333">
-			</bounds>
+			<bounds x="239.6667" y="443.3333" width="116.6667" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="456.0000" width="200.0000" height="16.0000">
-			</bounds>
+			<bounds x="198.0000" y="456.0000" width="200.0000" height="16.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="456.6667" width="183.3333" height="14.6667">
-			</bounds>
+			<bounds x="206.3333" y="456.6667" width="183.3333" height="14.6667"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_2" state="0">
-			<bounds x="214.6667" y="457.3333" width="166.6667" height="13.3333">
-			</bounds>
+			<bounds x="214.6667" y="457.3333" width="166.6667" height="13.3333"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_3" state="0">
-			<bounds x="223.0000" y="458.0000" width="150.0000" height="12.0000">
-			</bounds>
+			<bounds x="223.0000" y="458.0000" width="150.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_4" state="0">
-			<bounds x="231.3333" y="458.6667" width="133.3333" height="10.6667">
-			</bounds>
+			<bounds x="231.3333" y="458.6667" width="133.3333" height="10.6667"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_5" state="0">
-			<bounds x="239.6667" y="459.3333" width="116.6667" height="9.3333">
-			</bounds>
+			<bounds x="239.6667" y="459.3333" width="116.6667" height="9.3333"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="198.0000" y="472.0000" width="200.0000" height="16.0000">
-			</bounds>
+			<bounds x="198.0000" y="472.0000" width="200.0000" height="16.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="472.6667" width="183.3333" height="14.6667">
-			</bounds>
+			<bounds x="206.3333" y="472.6667" width="183.3333" height="14.6667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="214.6667" y="473.3333" width="166.6667" height="13.3333">
-			</bounds>
+			<bounds x="214.6667" y="473.3333" width="166.6667" height="13.3333"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="223.0000" y="474.0000" width="150.0000" height="12.0000">
-			</bounds>
+			<bounds x="223.0000" y="474.0000" width="150.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="231.3333" y="474.6667" width="133.3333" height="10.6667">
-			</bounds>
+			<bounds x="231.3333" y="474.6667" width="133.3333" height="10.6667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="239.6667" y="475.3333" width="116.6667" height="9.3333">
-			</bounds>
+			<bounds x="239.6667" y="475.3333" width="116.6667" height="9.3333"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="198" y="408" width="200" height="80">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="198" y="408" width="200" height="80"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="454" y="379" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="379" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="456" y="381" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="381" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="454" y="350" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="350" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="456" y="352" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="352" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="454" y="321" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="321" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="456" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="454" y="292" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="292" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="456" y="294" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="294" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="454" y="263" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="263" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="456" y="265" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="265" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="454" y="234" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="234" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="456" y="236" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="236" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="454" y="205" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="205" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="456" y="207" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="207" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="454" y="176" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="176" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="456" y="178" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="178" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="454" y="147" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="147" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="456" y="149" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="149" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="454" y="118" width="62" height="32">
-			</bounds>
+			<bounds x="454" y="118" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="456" y="120" width="58" height="28">
-			</bounds>
+			<bounds x="456" y="120" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="96" y="119" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="119" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="98" y="121" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="121" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="96" y="148" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="148" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="98" y="150" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="150" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="96" y="177" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="177" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="98" y="179" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="179" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="96" y="206" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="206" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="98" y="208" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="208" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="96" y="235" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="235" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="98" y="237" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="237" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="96" y="264" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="264" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="98" y="266" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="266" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="96" y="293" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="293" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="98" y="295" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="295" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="96" y="322" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="322" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="98" y="324" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="324" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="96" y="351" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="351" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="98" y="353" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="353" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="96" y="380" width="62" height="32">
-			</bounds>
+			<bounds x="96" y="380" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="98" y="382" width="58" height="28">
-			</bounds>
+			<bounds x="98" y="382" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="350" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="352" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="350" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="352" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="326" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="328" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="326" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="328" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="197" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="199" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="173" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="175" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="173" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="175" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="224" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="226" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="248" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="250" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="224" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="226" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="248" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="250" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="275" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="277" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="299" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="301" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="275" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="277" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="326" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="328" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="350" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="352" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="350" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="352" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="326" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="328" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="197" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="199" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="173" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="175" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="197" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="199" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="173" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="175" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="248" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="250" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="248" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="250" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="224" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="226" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="275" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="277" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="299" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="301" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="275" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="277" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="299" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="301" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="350" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="352" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="326" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="328" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="326" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="328" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="197" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="199" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="173" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="175" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="173" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="175" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="248" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="250" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="224" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="226" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="224" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="226" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="275" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="277" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="299" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="301" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="299" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="301" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="350" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="352" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="350" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="352" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="326" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="328" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="401" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="403" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="401" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="403" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="377" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="379" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="401" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="403" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="401" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="403" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="377" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="379" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="377" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="379" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="401" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="403" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="401" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="403" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="377" y="181" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="181" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="379" y="183" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="183" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="377" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="379" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="377" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="379" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="401" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="403" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="401" y="232" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="232" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="403" y="234" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="234" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="401" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="403" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="377" y="283" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="283" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="379" y="285" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="285" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="401" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="403" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="275" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="277" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="299" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="301" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="299" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="301" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="275" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="277" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="377" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="379" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="401" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="403" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="401" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="403" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="377" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="379" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="326" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="328" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="350" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="352" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="326" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="328" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="224" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="226" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="224" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="226" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="197" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="199" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="173" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="175" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="197" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="199" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="173" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="175" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="248" y="310" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="310" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="250" y="312" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="312" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="401" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="403" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="377" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="379" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="377" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="379" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="401" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="401" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="403" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="403" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="350" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="352" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="350" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="352" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="326" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="328" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="326" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="328" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="326" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="328" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="350" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="352" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="350" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="352" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="299" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="301" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="275" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="277" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="299" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="301" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="275" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="277" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="299" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="301" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="299" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="301" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="275" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="277" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="248" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="250" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="224" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="226" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="248" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="250" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="224" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="226" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="197" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="199" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="173" y="130" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="130" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="175" y="132" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="132" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="197" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="199" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="173" y="106" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="106" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="175" y="108" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="108" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="224" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="226" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="224" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="226" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="248" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="250" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="248" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="250" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="173" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="175" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="197" y="79" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="79" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="199" y="81" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="81" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="173" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="175" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="299" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="301" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="299" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="301" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="275" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="277" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="275" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="277" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="224" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="226" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="248" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="250" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="224" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="226" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="197" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="199" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="173" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="175" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="197" y="28" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="28" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="199" y="30" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="30" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="173" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="173" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="175" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="175" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="542" y="300" width="62" height="32">
-			</bounds>
+			<bounds x="542" y="300" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="544" y="302" width="58" height="28">
-			</bounds>
+			<bounds x="544" y="302" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="542" y="269" width="62" height="32">
-			</bounds>
+			<bounds x="542" y="269" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="544" y="271" width="58" height="28">
-			</bounds>
+			<bounds x="544" y="271" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="542" y="238" width="62" height="32">
-			</bounds>
+			<bounds x="542" y="238" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="544" y="240" width="58" height="28">
-			</bounds>
+			<bounds x="544" y="240" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="542" y="114" width="62" height="32">
-			</bounds>
+			<bounds x="542" y="114" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="544" y="116" width="58" height="28">
-			</bounds>
+			<bounds x="544" y="116" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="542" y="145" width="62" height="32">
-			</bounds>
+			<bounds x="542" y="145" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="544" y="147" width="58" height="28">
-			</bounds>
+			<bounds x="544" y="147" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="542" y="176" width="62" height="32">
-			</bounds>
+			<bounds x="542" y="176" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="544" y="178" width="58" height="28">
-			</bounds>
+			<bounds x="544" y="178" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="542" y="207" width="62" height="32">
-			</bounds>
+			<bounds x="542" y="207" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="544" y="209" width="58" height="28">
-			</bounds>
+			<bounds x="544" y="209" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="422" y="589" width="102" height="19">
-			</bounds>
+			<bounds x="422" y="589" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="424" y="591" width="98" height="15">
-			</bounds>
+			<bounds x="424" y="591" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="422" y="607" width="102" height="19">
-			</bounds>
+			<bounds x="422" y="607" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="424" y="609" width="98" height="15">
-			</bounds>
+			<bounds x="424" y="609" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="422" y="625" width="102" height="19">
-			</bounds>
+			<bounds x="422" y="625" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="424" y="627" width="98" height="15">
-			</bounds>
+			<bounds x="424" y="627" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="422" y="643" width="102" height="19">
-			</bounds>
+			<bounds x="422" y="643" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="424" y="645" width="98" height="15">
-			</bounds>
+			<bounds x="424" y="645" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="422" y="553" width="102" height="19">
-			</bounds>
+			<bounds x="422" y="553" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="424" y="555" width="98" height="15">
-			</bounds>
+			<bounds x="424" y="555" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="422" y="571" width="102" height="19">
-			</bounds>
+			<bounds x="422" y="571" width="102" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="424" y="573" width="98" height="15">
-			</bounds>
+			<bounds x="424" y="573" width="98" height="15"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="10" y="662" width="42" height="42">
-			</bounds>
+			<bounds x="10" y="662" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="12" y="664" width="38" height="38">
-			</bounds>
+			<bounds x="12" y="664" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="3" y="701" width="42" height="22">
-			</bounds>
+			<bounds x="3" y="701" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="5" y="703" width="38" height="18">
-			</bounds>
+			<bounds x="5" y="703" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="40" y="545" width="42" height="42">
-			</bounds>
+			<bounds x="40" y="545" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="42" y="547" width="38" height="38">
-			</bounds>
+			<bounds x="42" y="547" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="30" y="584" width="42" height="42">
-			</bounds>
+			<bounds x="30" y="584" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="32" y="586" width="38" height="38">
-			</bounds>
+			<bounds x="32" y="586" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="19" y="623" width="42" height="42">
-			</bounds>
+			<bounds x="19" y="623" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="21" y="625" width="38" height="38">
-			</bounds>
+			<bounds x="21" y="625" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="542" y="387" width="62" height="52">
-			</bounds>
+			<bounds x="542" y="387" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="544" y="389" width="58" height="48">
-			</bounds>
+			<bounds x="544" y="389" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0">
-			<bounds x="542" y="338" width="62" height="52">
-			</bounds>
+			<bounds x="542" y="338" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0">
-			<bounds x="544" y="340" width="58" height="48">
-			</bounds>
+			<bounds x="544" y="340" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="542" y="436" width="62" height="52">
-			</bounds>
+			<bounds x="542" y="436" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="544" y="438" width="58" height="48">
-			</bounds>
+			<bounds x="544" y="438" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="542" y="485" width="62" height="52">
-			</bounds>
+			<bounds x="542" y="485" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="544" y="487" width="58" height="48">
-			</bounds>
+			<bounds x="544" y="487" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="542" y="678" width="62" height="27">
-			</bounds>
+			<bounds x="542" y="678" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="544" y="680" width="58" height="23">
-			</bounds>
+			<bounds x="544" y="680" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="542" y="654" width="62" height="27">
-			</bounds>
+			<bounds x="542" y="654" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="544" y="656" width="58" height="23">
-			</bounds>
+			<bounds x="544" y="656" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="542" y="630" width="62" height="27">
-			</bounds>
+			<bounds x="542" y="630" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="544" y="632" width="58" height="23">
-			</bounds>
+			<bounds x="544" y="632" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="542" y="606" width="62" height="27">
-			</bounds>
+			<bounds x="542" y="606" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="544" y="608" width="58" height="23">
-			</bounds>
+			<bounds x="544" y="608" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="542" y="582" width="62" height="27">
-			</bounds>
+			<bounds x="542" y="582" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="544" y="584" width="58" height="23">
-			</bounds>
+			<bounds x="544" y="584" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="542" y="558" width="62" height="27">
-			</bounds>
+			<bounds x="542" y="558" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="544" y="560" width="58" height="23">
-			</bounds>
+			<bounds x="544" y="560" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="542" y="534" width="62" height="27">
-			</bounds>
+			<bounds x="542" y="534" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="544" y="536" width="58" height="23">
-			</bounds>
+			<bounds x="544" y="536" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="503" y="673" width="42" height="32">
-			</bounds>
+			<bounds x="503" y="673" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="505" y="675" width="38" height="28">
-			</bounds>
+			<bounds x="505" y="675" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="398" y="437" width="27" height="27">
-			</bounds>
+			<bounds x="398" y="437" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="400" y="439" width="23" height="23">
-			</bounds>
+			<bounds x="400" y="439" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="171" y="437" width="27" height="27">
-			</bounds>
+			<bounds x="171" y="437" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="173" y="439" width="23" height="23">
-			</bounds>
+			<bounds x="173" y="439" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="114" y="6" width="27" height="27">
-			</bounds>
+			<bounds x="114" y="6" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="116" y="8" width="23" height="23">
-			</bounds>
+			<bounds x="116" y="8" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="90" y="6" width="27" height="27">
-			</bounds>
+			<bounds x="90" y="6" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="92" y="8" width="23" height="23">
-			</bounds>
+			<bounds x="92" y="8" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="42" y="6" width="27" height="27">
-			</bounds>
+			<bounds x="42" y="6" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="44" y="8" width="23" height="23">
-			</bounds>
+			<bounds x="44" y="8" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="66" y="6" width="27" height="27">
-			</bounds>
+			<bounds x="66" y="6" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="68" y="8" width="23" height="23">
-			</bounds>
+			<bounds x="68" y="8" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="18" y="6" width="27" height="27">
-			</bounds>
+			<bounds x="18" y="6" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="20" y="8" width="23" height="23">
-			</bounds>
+			<bounds x="20" y="8" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="114" y="30" width="52" height="27">
-			</bounds>
+			<bounds x="114" y="30" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="116" y="32" width="48" height="23">
-			</bounds>
+			<bounds x="116" y="32" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="90" y="30" width="27" height="27">
-			</bounds>
+			<bounds x="90" y="30" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="92" y="32" width="23" height="23">
-			</bounds>
+			<bounds x="92" y="32" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="42" y="30" width="27" height="27">
-			</bounds>
+			<bounds x="42" y="30" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="44" y="32" width="23" height="23">
-			</bounds>
+			<bounds x="44" y="32" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="66" y="30" width="27" height="27">
-			</bounds>
+			<bounds x="66" y="30" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="68" y="32" width="23" height="23">
-			</bounds>
+			<bounds x="68" y="32" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="18" y="30" width="27" height="27">
-			</bounds>
+			<bounds x="18" y="30" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="20" y="32" width="23" height="23">
-			</bounds>
+			<bounds x="20" y="32" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="454" y="39" width="151" height="62">
-			</bounds>
+			<bounds x="454" y="39" width="151" height="62"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="456" y="41" width="147" height="58">
-			</bounds>
+			<bounds x="456" y="41" width="147" height="58"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="454" y="39" width="151" height="62">
-			</bounds>
+			<bounds x="454" y="39" width="151" height="62"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="456" y="41" width="147" height="58">
-			</bounds>
+			<bounds x="456" y="41" width="147" height="58"/>
 		</backdrop>
 		<backdrop name="lamp284" element="lamp_284_1_border" state="0">
-			<bounds x="275" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp284" element="lamp_284_1" state="0">
-			<bounds x="277" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp275" element="lamp_275_1_border" state="0">
-			<bounds x="350" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp275" element="lamp_275_1" state="0">
-			<bounds x="352" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp274" element="lamp_274_1_border" state="0">
-			<bounds x="197" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp274" element="lamp_274_1" state="0">
-			<bounds x="199" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp273" element="lamp_273_1_border" state="0">
-			<bounds x="248" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp273" element="lamp_273_1" state="0">
-			<bounds x="250" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp272" element="lamp_272_1_border" state="0">
-			<bounds x="377" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp272" element="lamp_272_1" state="0">
-			<bounds x="379" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp271" element="lamp_271_1_border" state="0">
-			<bounds x="299" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="299" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp271" element="lamp_271_1" state="0">
-			<bounds x="301" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="301" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp269" element="lamp_269_1_border" state="0">
-			<bounds x="326" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp269" element="lamp_269_1" state="0">
-			<bounds x="328" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp267" element="lamp_267_1_border" state="0">
-			<bounds x="377" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp267" element="lamp_267_1" state="0">
-			<bounds x="379" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp266" element="lamp_266_1_border" state="0">
-			<bounds x="248" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp266" element="lamp_266_1" state="0">
-			<bounds x="250" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp264" element="lamp_264_1_border" state="0">
-			<bounds x="326" y="4" width="27" height="27">
-			</bounds>
+			<bounds x="326" y="4" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp264" element="lamp_264_1" state="0">
-			<bounds x="328" y="6" width="23" height="23">
-			</bounds>
+			<bounds x="328" y="6" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp263" element="lamp_263_1_border" state="0">
-			<bounds x="197" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp263" element="lamp_263_1" state="0">
-			<bounds x="199" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp262" element="lamp_262_1_border" state="0">
-			<bounds x="224" y="208" width="27" height="27">
-			</bounds>
+			<bounds x="224" y="208" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp262" element="lamp_262_1" state="0">
-			<bounds x="226" y="210" width="23" height="23">
-			</bounds>
+			<bounds x="226" y="210" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp261" element="lamp_261_1_border" state="0">
-			<bounds x="197" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="197" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp261" element="lamp_261_1" state="0">
-			<bounds x="199" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="199" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp260" element="lamp_260_1_border" state="0">
-			<bounds x="377" y="157" width="27" height="27">
-			</bounds>
+			<bounds x="377" y="157" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp260" element="lamp_260_1" state="0">
-			<bounds x="379" y="159" width="23" height="23">
-			</bounds>
+			<bounds x="379" y="159" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1_border" state="0">
-			<bounds x="248" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="248" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1" state="0">
-			<bounds x="250" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="250" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp277" element="lamp_277_1_border" state="0">
-			<bounds x="350" y="334" width="27" height="27">
-			</bounds>
+			<bounds x="350" y="334" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp277" element="lamp_277_1" state="0">
-			<bounds x="352" y="336" width="23" height="23">
-			</bounds>
+			<bounds x="352" y="336" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="52" y="60" width="27" height="27">
-			</bounds>
+			<bounds x="52" y="60" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="54" y="62" width="23" height="23">
-			</bounds>
+			<bounds x="54" y="62" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="78" y="60" width="27" height="27">
-			</bounds>
+			<bounds x="78" y="60" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="80" y="62" width="23" height="23">
-			</bounds>
+			<bounds x="80" y="62" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="104" y="60" width="27" height="27">
-			</bounds>
+			<bounds x="104" y="60" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="106" y="62" width="23" height="23">
-			</bounds>
+			<bounds x="106" y="62" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="13" y="458" width="151" height="62">
-			</bounds>
+			<bounds x="13" y="458" width="151" height="62"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="15" y="460" width="147" height="58">
-			</bounds>
+			<bounds x="15" y="460" width="147" height="58"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="13" y="458" width="151" height="62">
-			</bounds>
+			<bounds x="13" y="458" width="151" height="62"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="15" y="460" width="147" height="58">
-			</bounds>
+			<bounds x="15" y="460" width="147" height="58"/>
 		</backdrop>
 		<backdrop name="lamp287" element="lamp_287_1_border" state="0">
-			<bounds x="275" y="55" width="27" height="27">
-			</bounds>
+			<bounds x="275" y="55" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp287" element="lamp_287_1" state="0">
-			<bounds x="277" y="57" width="23" height="23">
-			</bounds>
+			<bounds x="277" y="57" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp45" element="colour_button_248_border" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="447" y="415" width="75" height="27">
-			</bounds>
+			<bounds x="447" y="415" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp45" element="colour_button_248" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="449" y="417" width="71" height="23">
-			</bounds>
+			<bounds x="449" y="417" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp47" element="colour_button_249_border" state="0" inputtag="IN-9" inputmask="0x08">
-			<bounds x="90" y="412" width="75" height="27">
-			</bounds>
+			<bounds x="90" y="412" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp47" element="colour_button_249" state="0" inputtag="IN-9" inputmask="0x08">
-			<bounds x="92" y="414" width="71" height="23">
-			</bounds>
+			<bounds x="92" y="414" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp46" element="colour_button_250_border" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="8" y="412" width="75" height="27">
-			</bounds>
+			<bounds x="8" y="412" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp46" element="colour_button_250" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="10" y="414" width="71" height="23">
-			</bounds>
+			<bounds x="10" y="414" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_251_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="528" y="1" width="75" height="27">
-			</bounds>
+			<bounds x="528" y="1" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_251" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="530" y="3" width="71" height="23">
-			</bounds>
+			<bounds x="530" y="3" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_252_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="460" y="711" width="75" height="27">
-			</bounds>
+			<bounds x="460" y="711" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_252" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="462" y="713" width="71" height="23">
-			</bounds>
+			<bounds x="462" y="713" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_253_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="537" y="711" width="75" height="27">
-			</bounds>
+			<bounds x="537" y="711" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_253" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="539" y="713" width="71" height="23">
-			</bounds>
+			<bounds x="539" y="713" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_254_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="382" y="711" width="75" height="27">
-			</bounds>
+			<bounds x="382" y="711" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_254" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="384" y="713" width="71" height="23">
-			</bounds>
+			<bounds x="384" y="713" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_255_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="302" y="711" width="75" height="27">
-			</bounds>
+			<bounds x="302" y="711" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_255" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="304" y="713" width="71" height="23">
-			</bounds>
+			<bounds x="304" y="713" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_256_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="222" y="711" width="75" height="27">
-			</bounds>
+			<bounds x="222" y="711" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_256" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="224" y="713" width="71" height="23">
-			</bounds>
+			<bounds x="224" y="713" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_257_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="142" y="711" width="75" height="27">
-			</bounds>
+			<bounds x="142" y="711" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_257" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="144" y="713" width="71" height="23">
-			</bounds>
+			<bounds x="144" y="713" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_258_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="62" y="711" width="75" height="27">
-			</bounds>
+			<bounds x="62" y="711" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_258" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="64" y="713" width="71" height="23">
-			</bounds>
+			<bounds x="64" y="713" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp69" element="colour_button_260_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="354" y="381" width="75" height="27">
-			</bounds>
+			<bounds x="354" y="381" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp69" element="colour_button_260" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="356" y="383" width="71" height="23">
-			</bounds>
+			<bounds x="356" y="383" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp42" element="colour_button_261_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="354" y="489" width="75" height="27">
-			</bounds>
+			<bounds x="354" y="489" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp42" element="colour_button_261" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="356" y="491" width="71" height="23">
-			</bounds>
+			<bounds x="356" y="491" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp44" element="colour_button_262_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="170" y="489" width="75" height="27">
-			</bounds>
+			<bounds x="170" y="489" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp44" element="colour_button_262" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="172" y="491" width="71" height="23">
-			</bounds>
+			<bounds x="172" y="491" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp67" element="colour_button_263_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="170" y="381" width="75" height="27">
-			</bounds>
+			<bounds x="170" y="381" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp67" element="colour_button_263" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="172" y="383" width="71" height="23">
-			</bounds>
+			<bounds x="172" y="383" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp68" element="colour_button_264_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="262" y="381" width="75" height="27">
-			</bounds>
+			<bounds x="262" y="381" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="colour_button_264" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="264" y="383" width="71" height="23">
-			</bounds>
+			<bounds x="264" y="383" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp43" element="colour_button_265_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="262" y="489" width="75" height="27">
-			</bounds>
+			<bounds x="262" y="489" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp43" element="colour_button_265" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="264" y="491" width="71" height="23">
-			</bounds>
+			<bounds x="264" y="491" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="84" y="530" width="323" height="27">
-			</bounds>
+			<bounds x="84" y="530" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="84" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="84" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="104" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="104" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="124" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="124" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="144" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="144" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="164" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="164" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="184" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="184" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="204" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="204" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="224" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="224" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="244" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="244" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="264" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="264" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="284" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="284" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="304" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="304" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="324" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="324" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="344" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="344" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="364" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="364" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="384" y="530" width="20" height="27">
-			</bounds>
+			<bounds x="384" y="530" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label226" element="label_226">
-			<bounds x="37" y="88" width="114" height="28">
-			</bounds>
+			<bounds x="37" y="88" width="114" height="28"/>
 		</backdrop>
 		<backdrop name="label227" element="label_227">
-			<bounds x="81" y="632" width="38" height="56">
-			</bounds>
+			<bounds x="81" y="632" width="38" height="56"/>
 		</backdrop>
 		<backdrop name="label228" element="label_228">
-			<bounds x="204" y="369" width="6" height="14">
-			</bounds>
+			<bounds x="204" y="369" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label229" element="label_229">
-			<bounds x="294" y="369" width="6" height="14">
-			</bounds>
+			<bounds x="294" y="369" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label230" element="label_230">
-			<bounds x="387" y="369" width="6" height="14">
-			</bounds>
+			<bounds x="387" y="369" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label231" element="label_231">
-			<bounds x="201" y="514" width="6" height="14">
-			</bounds>
+			<bounds x="201" y="514" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label232" element="label_232">
-			<bounds x="292" y="514" width="6" height="14">
-			</bounds>
+			<bounds x="292" y="514" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label233" element="label_233">
-			<bounds x="388" y="514" width="6" height="14">
-			</bounds>
+			<bounds x="388" y="514" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label234" element="label_234">
-			<bounds x="479" y="441" width="6" height="14">
-			</bounds>
+			<bounds x="479" y="441" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label235" element="label_235">
-			<bounds x="43" y="438" width="7" height="14">
-			</bounds>
+			<bounds x="43" y="438" width="7" height="14"/>
 		</backdrop>
 		<backdrop name="label236" element="label_236">
-			<bounds x="123" y="437" width="7" height="14">
-			</bounds>
+			<bounds x="123" y="437" width="7" height="14"/>
 		</backdrop>
 		<backdrop name="label237" element="label_237">
-			<bounds x="94" y="741" width="4" height="14">
-			</bounds>
+			<bounds x="94" y="741" width="4" height="14"/>
 		</backdrop>
 		<backdrop name="label238" element="label_238">
-			<bounds x="176" y="738" width="6" height="14">
-			</bounds>
+			<bounds x="176" y="738" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label239" element="label_239">
-			<bounds x="257" y="737" width="6" height="14">
-			</bounds>
+			<bounds x="257" y="737" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label240" element="label_240">
-			<bounds x="336" y="736" width="6" height="14">
-			</bounds>
+			<bounds x="336" y="736" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label241" element="label_241">
-			<bounds x="413" y="738" width="8" height="14">
-			</bounds>
+			<bounds x="413" y="738" width="8" height="14"/>
 		</backdrop>
 		<backdrop name="label242" element="label_242">
-			<bounds x="491" y="738" width="6" height="14">
-			</bounds>
+			<bounds x="491" y="738" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label243" element="label_243">
-			<bounds x="558" y="738" width="35" height="14">
-			</bounds>
+			<bounds x="558" y="738" width="35" height="14"/>
 		</backdrop>
 		<backdrop name="label244" element="label_244">
-			<bounds x="517" y="7" width="6" height="14">
-			</bounds>
+			<bounds x="517" y="7" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label245" element="label_245">
-			<bounds x="432" y="482" width="47" height="56">
-			</bounds>
+			<bounds x="432" y="482" width="47" height="56"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_segment" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_reel" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_reel" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_reel" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_reel" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_reel" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_reel" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_button" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_button" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_button" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_button" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_button" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_button" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_button" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_button" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_button" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp256" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4bobcl.lay
+++ b/src/mame/layout/sc4bobcl.lay
@@ -8,14582 +8,9682 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3 Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3 Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Multplie">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Multplie">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;40 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;40 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Climber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Climber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Attack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Attack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hi Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hi Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="15 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="15 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="10 cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="10 cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mega Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mega Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Turbo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Turbo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Fast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Fast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3 Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Hot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Hot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;6 +">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 steps">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 steps">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 steps">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 steps">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
 		<text string="+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="? Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="? Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bobby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dazzler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bobby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dazzler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bobby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dazzler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bobby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dazzler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Taxi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Taxi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Run">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bobby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dazzler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bobby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dazzler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Bobby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dazzler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bobby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dazzler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Multi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Multi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="Skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Red Boxes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Awards">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Extra Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Red Boxes">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Awards">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Extra Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="One">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Millio">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="One">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Millio">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Z">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Z">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Z">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Z">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Club">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Club">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Whirl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Wind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Whirl">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Wind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bang">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bang">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fire">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fire">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Crazy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Crazy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_194_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_194">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_195_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_195">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_197_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_197">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_198_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_198">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Down">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_200_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_200">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_201_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_201">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_202_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_202">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Transfer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_203_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_203">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_204_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_204">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_205_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_205">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_206_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_206">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_207_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_207">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel-take">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_208_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_208">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_209_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_209">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_166">
 		<text string="Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_167">
 		<text string="Light all for">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Features Matrix">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_173">
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="971" height="677">
-			</bounds>
+			<bounds x="0" y="0" width="971" height="677"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="293" y="509" width="80" height="120">
-			</bounds>
+			<bounds x="293" y="509" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="293.0000" y="509.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="293.0000" y="509.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="296.3333" y="510.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="296.3333" y="510.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="299.6667" y="512.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="299.6667" y="512.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="303.0000" y="514.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="303.0000" y="514.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="306.3333" y="515.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="306.3333" y="515.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="309.6667" y="517.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="309.6667" y="517.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="293.0000" y="549.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="293.0000" y="549.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="296.3333" y="550.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="296.3333" y="550.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="299.6667" y="552.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="299.6667" y="552.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="303.0000" y="554.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="303.0000" y="554.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="306.3333" y="555.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="306.3333" y="555.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="309.6667" y="557.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="309.6667" y="557.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="293.0000" y="589.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="293.0000" y="589.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="296.3333" y="590.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="296.3333" y="590.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="299.6667" y="592.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="299.6667" y="592.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="303.0000" y="594.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="303.0000" y="594.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="306.3333" y="595.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="306.3333" y="595.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="309.6667" y="597.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="309.6667" y="597.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="293" y="509" width="80" height="120">
-			</bounds>
+			<bounds x="293" y="509" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="376" y="510" width="80" height="120">
-			</bounds>
+			<bounds x="376" y="510" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="376.0000" y="510.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="376.0000" y="510.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="379.3333" y="511.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="379.3333" y="511.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="382.6667" y="513.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="382.6667" y="513.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="386.0000" y="515.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="386.0000" y="515.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="389.3333" y="516.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="389.3333" y="516.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="392.6667" y="518.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="392.6667" y="518.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="376.0000" y="550.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="376.0000" y="550.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="379.3333" y="551.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="379.3333" y="551.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="382.6667" y="553.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="382.6667" y="553.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="386.0000" y="555.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="386.0000" y="555.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="389.3333" y="556.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="389.3333" y="556.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="392.6667" y="558.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="392.6667" y="558.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="376.0000" y="590.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="376.0000" y="590.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="379.3333" y="591.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="379.3333" y="591.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="382.6667" y="593.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="382.6667" y="593.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="386.0000" y="595.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="386.0000" y="595.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="389.3333" y="596.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="389.3333" y="596.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="392.6667" y="598.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="392.6667" y="598.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="376" y="510" width="80" height="120">
-			</bounds>
+			<bounds x="376" y="510" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="459" y="509" width="80" height="120">
-			</bounds>
+			<bounds x="459" y="509" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="459.0000" y="509.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="459.0000" y="509.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="462.3333" y="510.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="462.3333" y="510.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="465.6667" y="512.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="465.6667" y="512.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="469.0000" y="514.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="469.0000" y="514.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="472.3333" y="515.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="472.3333" y="515.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="475.6667" y="517.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="475.6667" y="517.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="459.0000" y="549.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="459.0000" y="549.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="462.3333" y="550.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="462.3333" y="550.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="465.6667" y="552.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="465.6667" y="552.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="469.0000" y="554.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="469.0000" y="554.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="472.3333" y="555.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="472.3333" y="555.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="475.6667" y="557.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="475.6667" y="557.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="459.0000" y="589.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="459.0000" y="589.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="462.3333" y="590.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="462.3333" y="590.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="465.6667" y="592.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="465.6667" y="592.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="469.0000" y="594.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="469.0000" y="594.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="472.3333" y="595.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="472.3333" y="595.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="475.6667" y="597.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="475.6667" y="597.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="459" y="509" width="80" height="120">
-			</bounds>
+			<bounds x="459" y="509" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="542" y="509" width="80" height="120">
-			</bounds>
+			<bounds x="542" y="509" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="542.0000" y="509.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="542.0000" y="509.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="545.3333" y="510.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="545.3333" y="510.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="548.6667" y="512.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="548.6667" y="512.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="552.0000" y="514.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="552.0000" y="514.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="555.3333" y="515.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="555.3333" y="515.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="558.6667" y="517.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="558.6667" y="517.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="542.0000" y="549.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="542.0000" y="549.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="545.3333" y="550.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="545.3333" y="550.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="548.6667" y="552.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="548.6667" y="552.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="552.0000" y="554.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="552.0000" y="554.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="555.3333" y="555.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="555.3333" y="555.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="558.6667" y="557.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="558.6667" y="557.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="542.0000" y="589.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="542.0000" y="589.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="545.3333" y="590.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="545.3333" y="590.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="548.6667" y="592.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="548.6667" y="592.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="552.0000" y="594.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="552.0000" y="594.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="555.3333" y="595.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="555.3333" y="595.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="558.6667" y="597.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="558.6667" y="597.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="542" y="509" width="80" height="120">
-			</bounds>
+			<bounds x="542" y="509" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="373" y="296" width="80" height="80">
-			</bounds>
+			<bounds x="373" y="296" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="373.0000" y="296.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="373.0000" y="296.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="376.3333" y="299.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="376.3333" y="299.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="379.6667" y="302.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="379.6667" y="302.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="383.0000" y="306.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="383.0000" y="306.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="386.3333" y="309.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="386.3333" y="309.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="389.6667" y="312.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="389.6667" y="312.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="373" y="296" width="80" height="80">
-			</bounds>
+			<bounds x="373" y="296" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="666" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="666" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="668" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="668" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="666" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="666" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="668" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="668" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="606" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="606" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="608" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="608" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="606" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="606" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="608" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="608" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="546" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="546" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="548" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="548" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="546" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="546" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="548" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="548" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="546" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="546" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="548" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="548" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="546" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="546" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="548" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="548" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="486" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="486" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="488" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="488" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="486" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="486" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="488" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="488" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="426" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="428" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="426" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="428" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="366" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="366" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="368" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="368" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="366" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="366" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="368" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="368" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="306" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="306" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="308" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="308" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="306" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="306" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="308" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="308" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="246" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="246" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="248" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="248" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="246" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="246" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="248" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="248" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="186" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="186" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="188" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="188" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="186" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="186" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="188" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="188" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="606" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="606" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="608" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="608" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="606" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="606" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="608" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="608" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="666" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="666" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="668" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="668" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="666" y="76" width="62" height="42">
-			</bounds>
+			<bounds x="666" y="76" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="668" y="78" width="58" height="38">
-			</bounds>
+			<bounds x="668" y="78" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="186" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="186" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="188" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="188" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="186" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="186" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="188" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="188" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="246" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="246" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="248" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="248" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="246" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="246" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="248" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="248" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="306" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="306" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="308" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="308" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="306" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="306" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="308" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="308" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="366" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="366" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="368" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="368" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="366" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="366" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="368" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="368" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="426" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="428" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="426" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="428" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="486" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="486" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="488" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="488" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="486" y="36" width="62" height="42">
-			</bounds>
+			<bounds x="486" y="36" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="488" y="38" width="58" height="38">
-			</bounds>
+			<bounds x="488" y="38" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="186" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="186" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="188" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="188" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="186" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="186" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="188" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="188" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="246" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="246" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="248" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="248" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="246" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="246" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="248" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="248" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="306" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="306" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="308" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="308" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="306" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="306" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="308" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="308" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="366" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="366" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="368" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="368" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="366" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="366" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="368" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="368" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="426" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="428" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="426" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="428" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="486" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="486" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="488" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="488" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="486" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="486" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="488" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="488" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="546" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="546" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="548" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="548" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="546" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="546" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="548" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="548" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="606" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="606" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="608" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="608" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="606" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="606" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="608" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="608" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="666" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="666" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="668" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="668" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="666" y="116" width="62" height="42">
-			</bounds>
+			<bounds x="666" y="116" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="668" y="118" width="58" height="38">
-			</bounds>
+			<bounds x="668" y="118" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="186" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="186" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="188" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="188" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="186" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="186" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="188" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="188" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="246" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="246" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="248" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="248" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="246" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="246" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="248" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="248" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="366" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="366" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="368" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="368" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="366" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="366" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="368" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="368" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="426" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="428" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="426" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="428" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="486" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="486" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="488" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="488" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="486" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="486" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="488" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="488" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="546" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="546" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="548" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="548" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="546" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="546" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="548" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="548" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="606" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="606" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="608" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="608" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="606" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="606" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="608" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="608" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="666" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="666" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="668" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="668" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="666" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="666" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="668" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="668" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="306" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="306" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="308" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="308" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="306" y="156" width="62" height="42">
-			</bounds>
+			<bounds x="306" y="156" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="308" y="158" width="58" height="38">
-			</bounds>
+			<bounds x="308" y="158" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="487" y="345" width="52" height="27">
-			</bounds>
+			<bounds x="487" y="345" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="489" y="347" width="48" height="23">
-			</bounds>
+			<bounds x="489" y="347" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="487" y="293" width="52" height="27">
-			</bounds>
+			<bounds x="487" y="293" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="489" y="295" width="48" height="23">
-			</bounds>
+			<bounds x="489" y="295" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="487" y="319" width="52" height="27">
-			</bounds>
+			<bounds x="487" y="319" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="489" y="321" width="48" height="23">
-			</bounds>
+			<bounds x="489" y="321" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="254" y="414" width="52" height="37">
-			</bounds>
+			<bounds x="254" y="414" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="256" y="416" width="48" height="33">
-			</bounds>
+			<bounds x="256" y="416" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="356" y="450" width="52" height="37">
-			</bounds>
+			<bounds x="356" y="450" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="358" y="452" width="48" height="33">
-			</bounds>
+			<bounds x="358" y="452" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="406" y="450" width="52" height="37">
-			</bounds>
+			<bounds x="406" y="450" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="408" y="452" width="48" height="33">
-			</bounds>
+			<bounds x="408" y="452" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="456" y="450" width="52" height="37">
-			</bounds>
+			<bounds x="456" y="450" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="458" y="452" width="48" height="33">
-			</bounds>
+			<bounds x="458" y="452" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="505" y="450" width="52" height="37">
-			</bounds>
+			<bounds x="505" y="450" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="507" y="452" width="48" height="33">
-			</bounds>
+			<bounds x="507" y="452" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="303" y="415" width="52" height="37">
-			</bounds>
+			<bounds x="303" y="415" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="305" y="417" width="48" height="33">
-			</bounds>
+			<bounds x="305" y="417" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="303" y="448" width="52" height="37">
-			</bounds>
+			<bounds x="303" y="448" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="305" y="450" width="48" height="33">
-			</bounds>
+			<bounds x="305" y="450" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="254" y="448" width="52" height="37">
-			</bounds>
+			<bounds x="254" y="448" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="256" y="450" width="48" height="33">
-			</bounds>
+			<bounds x="256" y="450" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="255" y="377" width="52" height="37">
-			</bounds>
+			<bounds x="255" y="377" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="257" y="379" width="48" height="33">
-			</bounds>
+			<bounds x="257" y="379" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="255" y="342" width="52" height="37">
-			</bounds>
+			<bounds x="255" y="342" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="257" y="344" width="48" height="33">
-			</bounds>
+			<bounds x="257" y="344" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="255" y="307" width="52" height="37">
-			</bounds>
+			<bounds x="255" y="307" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="257" y="309" width="48" height="33">
-			</bounds>
+			<bounds x="257" y="309" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="607" y="377" width="52" height="37">
-			</bounds>
+			<bounds x="607" y="377" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="609" y="379" width="48" height="33">
-			</bounds>
+			<bounds x="609" y="379" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="558" y="416" width="52" height="37">
-			</bounds>
+			<bounds x="558" y="416" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="560" y="418" width="48" height="33">
-			</bounds>
+			<bounds x="560" y="418" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="608" y="416" width="52" height="37">
-			</bounds>
+			<bounds x="608" y="416" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="610" y="418" width="48" height="33">
-			</bounds>
+			<bounds x="610" y="418" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="557" y="450" width="52" height="37">
-			</bounds>
+			<bounds x="557" y="450" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="559" y="452" width="48" height="33">
-			</bounds>
+			<bounds x="559" y="452" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="607" y="342" width="52" height="37">
-			</bounds>
+			<bounds x="607" y="342" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="609" y="344" width="48" height="33">
-			</bounds>
+			<bounds x="609" y="344" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="607" y="234" width="52" height="37">
-			</bounds>
+			<bounds x="607" y="234" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="609" y="236" width="48" height="33">
-			</bounds>
+			<bounds x="609" y="236" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="607" y="272" width="52" height="37">
-			</bounds>
+			<bounds x="607" y="272" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="609" y="274" width="48" height="33">
-			</bounds>
+			<bounds x="609" y="274" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="607" y="307" width="52" height="37">
-			</bounds>
+			<bounds x="607" y="307" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="609" y="309" width="48" height="33">
-			</bounds>
+			<bounds x="609" y="309" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="557" y="234" width="52" height="37">
-			</bounds>
+			<bounds x="557" y="234" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="559" y="236" width="48" height="33">
-			</bounds>
+			<bounds x="559" y="236" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="607" y="198" width="52" height="37">
-			</bounds>
+			<bounds x="607" y="198" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="609" y="200" width="48" height="33">
-			</bounds>
+			<bounds x="609" y="200" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="557" y="198" width="52" height="37">
-			</bounds>
+			<bounds x="557" y="198" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="559" y="200" width="48" height="33">
-			</bounds>
+			<bounds x="559" y="200" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="456" y="198" width="52" height="37">
-			</bounds>
+			<bounds x="456" y="198" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="458" y="200" width="48" height="33">
-			</bounds>
+			<bounds x="458" y="200" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="406" y="198" width="52" height="37">
-			</bounds>
+			<bounds x="406" y="198" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="408" y="200" width="48" height="33">
-			</bounds>
+			<bounds x="408" y="200" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="356" y="198" width="52" height="37">
-			</bounds>
+			<bounds x="356" y="198" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="358" y="200" width="48" height="33">
-			</bounds>
+			<bounds x="358" y="200" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="304" y="233" width="52" height="37">
-			</bounds>
+			<bounds x="304" y="233" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="306" y="235" width="48" height="33">
-			</bounds>
+			<bounds x="306" y="235" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="304" y="199" width="52" height="37">
-			</bounds>
+			<bounds x="304" y="199" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="306" y="201" width="48" height="33">
-			</bounds>
+			<bounds x="306" y="201" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="254" y="199" width="52" height="37">
-			</bounds>
+			<bounds x="254" y="199" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="256" y="201" width="48" height="33">
-			</bounds>
+			<bounds x="256" y="201" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="254" y="233" width="52" height="37">
-			</bounds>
+			<bounds x="254" y="233" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="256" y="235" width="48" height="33">
-			</bounds>
+			<bounds x="256" y="235" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="399" y="389" width="27" height="27">
-			</bounds>
+			<bounds x="399" y="389" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="401" y="391" width="23" height="23">
-			</bounds>
+			<bounds x="401" y="391" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="398" y="259" width="27" height="27">
-			</bounds>
+			<bounds x="398" y="259" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="400" y="261" width="23" height="23">
-			</bounds>
+			<bounds x="400" y="261" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="486" y="247" width="52" height="37">
-			</bounds>
+			<bounds x="486" y="247" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="488" y="249" width="48" height="33">
-			</bounds>
+			<bounds x="488" y="249" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="662" y="529" width="107" height="52">
-			</bounds>
+			<bounds x="662" y="529" width="107" height="52"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="664" y="531" width="103" height="48">
-			</bounds>
+			<bounds x="664" y="531" width="103" height="48"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="787" y="2" width="52" height="35">
-			</bounds>
+			<bounds x="787" y="2" width="52" height="35"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="789" y="4" width="48" height="31">
-			</bounds>
+			<bounds x="789" y="4" width="48" height="31"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="795" y="61" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="61" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="797" y="63" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="63" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="795" y="36" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="36" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="797" y="38" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="38" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="795" y="86" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="86" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="797" y="88" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="88" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="795" y="111" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="111" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="797" y="113" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="113" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="795" y="136" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="136" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="797" y="138" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="138" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="795" y="161" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="161" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="797" y="163" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="163" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="795" y="186" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="186" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="797" y="188" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="188" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="795" y="236" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="236" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="797" y="238" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="238" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="795" y="261" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="261" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="797" y="263" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="263" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="795" y="311" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="311" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="797" y="313" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="313" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="795" y="286" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="286" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="797" y="288" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="288" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="795" y="336" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="336" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="797" y="338" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="338" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="795" y="211" width="37" height="27">
-			</bounds>
+			<bounds x="795" y="211" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="797" y="213" width="33" height="23">
-			</bounds>
+			<bounds x="797" y="213" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="105" y="563" width="52" height="32">
-			</bounds>
+			<bounds x="105" y="563" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="107" y="565" width="48" height="28">
-			</bounds>
+			<bounds x="107" y="565" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="115" y="532" width="32" height="32">
-			</bounds>
+			<bounds x="115" y="532" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="117" y="534" width="28" height="28">
-			</bounds>
+			<bounds x="117" y="534" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="115" y="501" width="32" height="32">
-			</bounds>
+			<bounds x="115" y="501" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="117" y="503" width="28" height="28">
-			</bounds>
+			<bounds x="117" y="503" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="115" y="470" width="32" height="32">
-			</bounds>
+			<bounds x="115" y="470" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="117" y="472" width="28" height="28">
-			</bounds>
+			<bounds x="117" y="472" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="115" y="439" width="32" height="32">
-			</bounds>
+			<bounds x="115" y="439" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="117" y="441" width="28" height="28">
-			</bounds>
+			<bounds x="117" y="441" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="629" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="629" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="631" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="631" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="629" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="629" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="631" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="631" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="599" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="599" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="601" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="601" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="599" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="599" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="601" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="601" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="569" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="569" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="571" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="571" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="569" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="569" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="571" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="571" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="539" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="539" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="541" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="541" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="539" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="539" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="541" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="541" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="509" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="509" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="511" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="511" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="509" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="509" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="511" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="511" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="479" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="479" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="481" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="481" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="479" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="479" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="481" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="481" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="431" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="431" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="433" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="433" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="431" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="431" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="433" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="433" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="659" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="659" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="661" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="661" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="659" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="659" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="661" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="661" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="401" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="401" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="403" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="403" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="401" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="401" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="403" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="403" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="371" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="371" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="373" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="373" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="371" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="371" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="373" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="373" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="341" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="341" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="343" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="343" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="341" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="341" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="343" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="343" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="311" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="311" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="313" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="313" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="311" y="4" width="32" height="32">
-			</bounds>
+			<bounds x="311" y="4" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="313" y="6" width="28" height="28">
-			</bounds>
+			<bounds x="313" y="6" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="223" y="4" width="72" height="32">
-			</bounds>
+			<bounds x="223" y="4" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="225" y="6" width="68" height="28">
-			</bounds>
+			<bounds x="225" y="6" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="223" y="4" width="72" height="32">
-			</bounds>
+			<bounds x="223" y="4" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="225" y="6" width="68" height="28">
-			</bounds>
+			<bounds x="225" y="6" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="782" y="551" width="62" height="32">
-			</bounds>
+			<bounds x="782" y="551" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="784" y="553" width="58" height="28">
-			</bounds>
+			<bounds x="784" y="553" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="782" y="519" width="62" height="32">
-			</bounds>
+			<bounds x="782" y="519" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="784" y="521" width="58" height="28">
-			</bounds>
+			<bounds x="784" y="521" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="782" y="488" width="62" height="32">
-			</bounds>
+			<bounds x="782" y="488" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="784" y="490" width="58" height="28">
-			</bounds>
+			<bounds x="784" y="490" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="782" y="457" width="62" height="32">
-			</bounds>
+			<bounds x="782" y="457" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="784" y="459" width="58" height="28">
-			</bounds>
+			<bounds x="784" y="459" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="782" y="426" width="62" height="32">
-			</bounds>
+			<bounds x="782" y="426" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="784" y="428" width="58" height="28">
-			</bounds>
+			<bounds x="784" y="428" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="colour_button_194_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="144" y="162" width="32" height="32">
-			</bounds>
+			<bounds x="144" y="162" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="colour_button_194" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="146" y="164" width="28" height="28">
-			</bounds>
+			<bounds x="146" y="164" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="colour_button_195_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="144" y="121" width="32" height="32">
-			</bounds>
+			<bounds x="144" y="121" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="colour_button_195" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="146" y="123" width="28" height="28">
-			</bounds>
+			<bounds x="146" y="123" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="colour_button_196_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="144" y="81" width="32" height="32">
-			</bounds>
+			<bounds x="144" y="81" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="colour_button_196" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="146" y="83" width="28" height="28">
-			</bounds>
+			<bounds x="146" y="83" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="colour_button_197_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="145" y="41" width="32" height="32">
-			</bounds>
+			<bounds x="145" y="41" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="colour_button_197" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="147" y="43" width="28" height="28">
-			</bounds>
+			<bounds x="147" y="43" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp90" element="colour_button_198_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="488" y="372" width="52" height="44">
-			</bounds>
+			<bounds x="488" y="372" width="52" height="44"/>
 		</backdrop>
 		<backdrop name="lamp90" element="colour_button_198" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="490" y="374" width="48" height="40">
-			</bounds>
+			<bounds x="490" y="374" width="48" height="40"/>
 		</backdrop>
 		<backdrop name="lamp8" element="colour_button_200_border" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="869" y="641" width="75" height="27">
-			</bounds>
+			<bounds x="869" y="641" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp8" element="colour_button_200" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="871" y="643" width="71" height="23">
-			</bounds>
+			<bounds x="871" y="643" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_201_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="789" y="641" width="75" height="27">
-			</bounds>
+			<bounds x="789" y="641" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_201" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="791" y="643" width="71" height="23">
-			</bounds>
+			<bounds x="791" y="643" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_202_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="709" y="641" width="75" height="27">
-			</bounds>
+			<bounds x="709" y="641" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_202" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="711" y="643" width="71" height="23">
-			</bounds>
+			<bounds x="711" y="643" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_203_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="290" y="641" width="81" height="27">
-			</bounds>
+			<bounds x="290" y="641" width="81" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_203" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="292" y="643" width="77" height="23">
-			</bounds>
+			<bounds x="292" y="643" width="77" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_204_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="375" y="641" width="81" height="27">
-			</bounds>
+			<bounds x="375" y="641" width="81" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_204" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="377" y="643" width="77" height="23">
-			</bounds>
+			<bounds x="377" y="643" width="77" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_205_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="458" y="641" width="81" height="27">
-			</bounds>
+			<bounds x="458" y="641" width="81" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_205" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="460" y="643" width="77" height="23">
-			</bounds>
+			<bounds x="460" y="643" width="77" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_206_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="542" y="641" width="81" height="27">
-			</bounds>
+			<bounds x="542" y="641" width="81" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_206" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="544" y="643" width="77" height="23">
-			</bounds>
+			<bounds x="544" y="643" width="77" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_207_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="188" y="640" width="82" height="27">
-			</bounds>
+			<bounds x="188" y="640" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_207" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="190" y="642" width="78" height="23">
-			</bounds>
+			<bounds x="190" y="642" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_208_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="629" y="641" width="75" height="27">
-			</bounds>
+			<bounds x="629" y="641" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_208" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="631" y="643" width="71" height="23">
-			</bounds>
+			<bounds x="631" y="643" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp75" element="colour_button_209_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="778" y="367" width="75" height="27">
-			</bounds>
+			<bounds x="778" y="367" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp75" element="colour_button_209" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="780" y="369" width="71" height="23">
-			</bounds>
+			<bounds x="780" y="369" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="131" y="251" width="24" height="32">
-			</bounds>
+			<bounds x="131" y="251" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="131" y="251" width="24" height="32">
-			</bounds>
+			<bounds x="131" y="251" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="131" y="251" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="131" y="251" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="107" y="251" width="24" height="32">
-			</bounds>
+			<bounds x="107" y="251" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="107" y="251" width="24" height="32">
-			</bounds>
+			<bounds x="107" y="251" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="107" y="251" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="107" y="251" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="348" y="489" width="227" height="20">
-			</bounds>
+			<bounds x="348" y="489" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="348" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="348" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="362" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="362" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="376" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="376" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="390" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="390" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="404" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="404" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="418" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="418" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="432" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="432" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="446" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="446" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="460" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="460" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="474" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="474" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="488" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="488" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="502" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="502" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="516" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="516" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="530" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="530" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="544" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="544" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="558" y="489" width="14" height="20">
-			</bounds>
+			<bounds x="558" y="489" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="label166" element="label_166">
-			<bounds x="105" y="287" width="51" height="23">
-			</bounds>
+			<bounds x="105" y="287" width="51" height="23"/>
 		</backdrop>
 		<backdrop name="label167" element="label_167">
-			<bounds x="71" y="381" width="102" height="34">
-			</bounds>
+			<bounds x="71" y="381" width="102" height="34"/>
 		</backdrop>
 		<backdrop name="label173" element="label_173">
-			<bounds x="97" y="595" width="67" height="23">
-			</bounds>
+			<bounds x="97" y="595" width="67" height="23"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_button" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_button" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_button" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_button" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_button" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_button" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_button" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4brksp.lay
+++ b/src/mame/layout/sc4brksp.lay
@@ -8,18074 +8,10103 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHERRIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MIXED 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MIXED 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SINGLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SINGLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DOUBLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="DOUBLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRIPLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRIPLE BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="5 SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="5 SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</disk>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</disk>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
+			<color red="0.34" green="0.17" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
+			<color red="0.08" green="0.04" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
+			<color red="0.68" green="0.34" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
+			<color red="0.17" green="0.08" blue="0.00"/>
 		</disk>
 		<text string="6 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
-		</disk>
-		<text string="6 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3 SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3 SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
+			<color red="0.41" green="0.33" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
+			<color red="0.10" green="0.08" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
+			<color red="0.83" green="0.66" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
+			<color red="0.20" green="0.16" blue="0.25"/>
 		</disk>
 		<text string="5 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
-		</disk>
-		<text string="5 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</disk>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</disk>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
+			<color red="0.41" green="0.33" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
+			<color red="0.10" green="0.08" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
+			<color red="0.83" green="0.66" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
+			<color red="0.20" green="0.16" blue="0.25"/>
 		</disk>
 		<text string="3 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
-		</disk>
-		<text string="3 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</disk>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</disk>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="&#xA3;5 + ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="REP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="&#xA3;5 + ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="REP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="VANISH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="VANISH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
+			<color red="0.41" green="0.33" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
+			<color red="0.10" green="0.08" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
+			<color red="0.83" green="0.66" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
+			<color red="0.20" green="0.16" blue="0.25"/>
 		</disk>
 		<text string="4 REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
-		</disk>
-		<text string="4 REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
+			<color red="0.34" green="0.17" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
+			<color red="0.08" green="0.04" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
+			<color red="0.68" green="0.34" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
+			<color red="0.17" green="0.08" blue="0.00"/>
 		</disk>
 		<text string="4 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
-		</disk>
-		<text string="4 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</disk>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</disk>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
+			<color red="0.34" green="0.17" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
+			<color red="0.08" green="0.04" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
+			<color red="0.68" green="0.34" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
+			<color red="0.17" green="0.08" blue="0.00"/>
 		</disk>
 		<text string="2 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
-		</disk>
-		<text string="2 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
+			<color red="0.41" green="0.33" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
+			<color red="0.10" green="0.08" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
+			<color red="0.83" green="0.66" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
+			<color red="0.20" green="0.16" blue="0.25"/>
 		</disk>
 		<text string="2 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
-		</disk>
-		<text string="2 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</disk>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</disk>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</disk>
 		<text string="VANISH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="VANISH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
+			<color red="0.41" green="0.33" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
+			<color red="0.10" green="0.08" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
+			<color red="0.83" green="0.66" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
+			<color red="0.20" green="0.16" blue="0.25"/>
 		</disk>
 		<text string="1 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
-		</disk>
-		<text string="1 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</disk>
 		<text string="2 CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="2 CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</disk>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</disk>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
+			<color red="0.34" green="0.17" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
+			<color red="0.08" green="0.04" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
+			<color red="0.68" green="0.34" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
+			<color red="0.17" green="0.08" blue="0.00"/>
 		</disk>
 		<text string="3 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
-		</disk>
-		<text string="3 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</disk>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</disk>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
+			<color red="0.41" green="0.33" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
+			<color red="0.10" green="0.08" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
+			<color red="0.83" green="0.66" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
+			<color red="0.20" green="0.16" blue="0.25"/>
 		</disk>
 		<text string="6 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
-		</disk>
-		<text string="6 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="JACK ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.27"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="+ R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="JACK ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
-		</text>
-		<text string="+ R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
+			<color red="0.41" green="0.33" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
+			<color red="0.10" green="0.08" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
+			<color red="0.83" green="0.66" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
+			<color red="0.20" green="0.16" blue="0.25"/>
 		</disk>
 		<text string="7 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.41" green="0.33" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.10" green="0.08" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.83" green="0.66" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.20" green="0.16" blue="0.25">
-			</color>
-		</disk>
-		<text string="7 REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="4 SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="4 SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
+			<color red="0.34" green="0.17" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
+			<color red="0.08" green="0.04" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
+			<color red="0.68" green="0.34" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
+			<color red="0.17" green="0.08" blue="0.00"/>
 		</disk>
 		<text string="5 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.34" green="0.17" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.08" green="0.04" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.68" green="0.34" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.17" green="0.08" blue="0.00">
-			</color>
-		</disk>
-		<text string="5 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</disk>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</disk>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</disk>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="2 SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="2 SUP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
+			<color red="0.25" green="0.36" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
+			<color red="0.06" green="0.09" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
+			<color red="0.51" green="0.72" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
+			<color red="0.13" green="0.18" blue="0.20"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.36" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.09" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.51" green="0.72" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.18" blue="0.20">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.41" green="0.00" blue="0.41">
-			</color>
+			<color red="0.41" green="0.00" blue="0.41"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.82" green="0.00" blue="0.82">
-			</color>
+			<color red="0.82" green="0.00" blue="0.82"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="2 MOVES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.41" green="0.00" blue="0.41">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.82" green="0.00" blue="0.82">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="2 MOVES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.40" blue="0.00">
-			</color>
+			<color red="0.40" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.00">
-			</color>
+			<color red="0.10" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.81" green="0.81" blue="0.00">
-			</color>
+			<color red="0.81" green="0.81" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="2 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.81" green="0.81" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="1 MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LEFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="1 MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LEFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.40" blue="0.00">
-			</color>
+			<color red="0.40" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.00">
-			</color>
+			<color red="0.10" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="0.81" green="0.81" blue="0.00">
-			</color>
+			<color red="0.81" green="0.81" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="1 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.81" green="0.81" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.41" green="0.00" blue="0.41">
-			</color>
+			<color red="0.41" green="0.00" blue="0.41"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="0.82" green="0.00" blue="0.82">
-			</color>
+			<color red="0.82" green="0.00" blue="0.82"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="1 MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.41" green="0.00" blue="0.41">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.82" green="0.00" blue="0.82">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="1 MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="VANISH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ACT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="VANISH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ACT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="2 MOVES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LEFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="2 MOVES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LEFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1 STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1 STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="CHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="CHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.40" blue="0.00">
-			</color>
+			<color red="0.40" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.00">
-			</color>
+			<color red="0.10" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.81" green="0.81" blue="0.00">
-			</color>
+			<color red="0.81" green="0.81" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="2 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.81" green="0.81" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MULTI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.40" blue="0.00">
-			</color>
+			<color red="0.40" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.00">
-			</color>
+			<color red="0.10" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.81" green="0.81" blue="0.00">
-			</color>
+			<color red="0.81" green="0.81" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="1 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.81" green="0.81" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI-LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HI-LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FORWA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FORWA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
+			<color red="0.50" green="0.35" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
+			<color red="0.12" green="0.09" blue="0.05"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
+			<color red="1.00" green="0.69" blue="0.39"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
+			<color red="0.25" green="0.17" blue="0.10"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.35" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.05">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.69" blue="0.39">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.17" blue="0.10">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="CHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="CHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
+			<color red="0.50" green="0.33" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
+			<color red="0.12" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.66" blue="1.00">
-			</color>
+			<color red="1.00" green="0.66" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
+			<color red="0.25" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.66" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
+			<color red="0.50" green="0.33" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
+			<color red="0.12" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.66" blue="1.00">
-			</color>
+			<color red="1.00" green="0.66" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
+			<color red="0.25" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.66" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
+			<color red="0.50" green="0.33" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
+			<color red="0.12" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.66" blue="1.00">
-			</color>
+			<color red="1.00" green="0.66" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
+			<color red="0.25" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.66" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WIZARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OF WADS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIZARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OF WADS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MAGIC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="MAGIC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MERLINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MAGIC 777">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="MERLINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MAGIC 777">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="TRICK OR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TREAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRICK OR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TREAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HOCUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POCUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="HOCUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POCUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="IT'S A KIND OF MAGIC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="IT'S A KIND OF MAGIC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HYPNO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="HYPNO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CRYSTAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BALLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CRYSTAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BALLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="NEAREST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="NEAREST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="ABRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CADABRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="ABRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CADABRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MAGIC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CIRCLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="MAGIC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CIRCLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CAST A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPELL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CAST A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPELL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="BR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="BR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="EAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="EAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="SP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="SP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="LL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.42" blue="0.42">
-			</color>
+			<color red="0.00" green="0.42" blue="0.42"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.11" blue="0.11">
-			</color>
+			<color red="0.00" green="0.11" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.85" blue="0.85">
-			</color>
+			<color red="0.00" green="0.85" blue="0.85"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.21" blue="0.21">
-			</color>
+			<color red="0.00" green="0.21" blue="0.21"/>
 		</rect>
 		<text string="LL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
+			<color red="0.40" green="0.00" blue="0.40"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
+			<color red="0.10" green="0.00" blue="0.10"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
+			<color red="0.79" green="0.00" blue="0.79"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
+			<color red="0.20" green="0.00" blue="0.20"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.00" blue="0.40">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.00" blue="0.10">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.79" green="0.00" blue="0.79">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.20">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
+			<color red="0.06" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
+			<color red="0.13" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="FROG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.29">
-			</color>
+			<color red="0.50" green="0.36" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.07">
-			</color>
+			<color red="0.12" green="0.09" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.59">
-			</color>
+			<color red="1.00" green="0.73" blue="0.59"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.15">
-			</color>
+			<color red="0.25" green="0.18" blue="0.15"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.59">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.15">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.29">
-			</color>
+			<color red="0.50" green="0.36" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.07">
-			</color>
+			<color red="0.12" green="0.09" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.59">
-			</color>
+			<color red="1.00" green="0.73" blue="0.59"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.15">
-			</color>
+			<color red="0.25" green="0.18" blue="0.15"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.29">
-			</color>
+			<color red="0.50" green="0.36" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.07">
-			</color>
+			<color red="0.12" green="0.09" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.59">
-			</color>
+			<color red="1.00" green="0.73" blue="0.59"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.15">
-			</color>
+			<color red="0.25" green="0.18" blue="0.15"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.29">
-			</color>
+			<color red="0.50" green="0.36" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.07">
-			</color>
+			<color red="0.12" green="0.09" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.59">
-			</color>
+			<color red="1.00" green="0.73" blue="0.59"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.15">
-			</color>
+			<color red="0.25" green="0.18" blue="0.15"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.59">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.15">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.29">
-			</color>
+			<color red="0.50" green="0.36" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.07">
-			</color>
+			<color red="0.12" green="0.09" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.59">
-			</color>
+			<color red="1.00" green="0.73" blue="0.59"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.15">
-			</color>
+			<color red="0.25" green="0.18" blue="0.15"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.59">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.15">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RED 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BLUE 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BLUE 7's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MELONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_209_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_209">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_210_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_210">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_211_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_211">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_212_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_212">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_213_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_213">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_215_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_215">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_216_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_216">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_217_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_217">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_218_border">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_218">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="RIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_219_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_219">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="LEFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_220_border">
 		<rect state="1">
-			<color red="0.50" green="0.33" blue="0.50">
-			</color>
+			<color red="0.50" green="0.33" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.08" blue="0.12">
-			</color>
+			<color red="0.12" green="0.08" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_220">
 		<rect state="1">
-			<color red="1.00" green="0.66" blue="1.00">
-			</color>
+			<color red="1.00" green="0.66" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.16" blue="0.25">
-			</color>
+			<color red="0.25" green="0.16" blue="0.25"/>
 		</rect>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_221_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_221">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_222_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_222">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="FEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_106">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_107">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_108">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_109">
 		<text string="1-12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_110">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_111">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_112">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_113">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_114">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_115">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_146">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_147">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_148">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_156">
 		<text string="+REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_163">
 		<text string="+REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_208">
 		<text string="WILL AWARD BARCODE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="675">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="675"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="299" y="462" width="80" height="140">
-			</bounds>
+			<bounds x="299" y="462" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="299.0000" y="462.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="299.0000" y="462.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="302.3333" y="463.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="302.3333" y="463.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="305.6667" y="465.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="305.6667" y="465.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="309.0000" y="467.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="309.0000" y="467.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="312.3333" y="469.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="312.3333" y="469.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="315.6667" y="471.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="315.6667" y="471.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="299.0000" y="508.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="299.0000" y="508.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="302.3333" y="510.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="302.3333" y="510.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="305.6667" y="512.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="305.6667" y="512.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="309.0000" y="514.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="309.0000" y="514.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="312.3333" y="516.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="312.3333" y="516.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="315.6667" y="518.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="315.6667" y="518.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="299.0000" y="555.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="299.0000" y="555.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="302.3333" y="557.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="302.3333" y="557.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="305.6667" y="559.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="305.6667" y="559.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="309.0000" y="561.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="309.0000" y="561.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="312.3333" y="563.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="312.3333" y="563.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="315.6667" y="565.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="315.6667" y="565.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="299" y="462" width="80" height="140">
-			</bounds>
+			<bounds x="299" y="462" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="381" y="462" width="80" height="140">
-			</bounds>
+			<bounds x="381" y="462" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="381.0000" y="462.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="381.0000" y="462.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="384.3333" y="463.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="384.3333" y="463.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="387.6667" y="465.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="387.6667" y="465.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="391.0000" y="467.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="391.0000" y="467.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="394.3333" y="469.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="394.3333" y="469.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="397.6667" y="471.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="397.6667" y="471.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="381.0000" y="508.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="381.0000" y="508.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="384.3333" y="510.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="384.3333" y="510.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="387.6667" y="512.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="387.6667" y="512.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="391.0000" y="514.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="391.0000" y="514.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="394.3333" y="516.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="394.3333" y="516.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="397.6667" y="518.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="397.6667" y="518.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="381.0000" y="555.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="381.0000" y="555.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="384.3333" y="557.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="384.3333" y="557.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="387.6667" y="559.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="387.6667" y="559.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="391.0000" y="561.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="391.0000" y="561.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="394.3333" y="563.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="394.3333" y="563.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="397.6667" y="565.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="397.6667" y="565.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="381" y="462" width="80" height="140">
-			</bounds>
+			<bounds x="381" y="462" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="463" y="462" width="80" height="140">
-			</bounds>
+			<bounds x="463" y="462" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="463.0000" y="462.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="463.0000" y="462.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="466.3333" y="463.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="466.3333" y="463.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="469.6667" y="465.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="469.6667" y="465.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="473.0000" y="467.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="473.0000" y="467.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="476.3333" y="469.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="476.3333" y="469.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="479.6667" y="471.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="479.6667" y="471.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="463.0000" y="508.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="463.0000" y="508.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="466.3333" y="510.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="466.3333" y="510.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="469.6667" y="512.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="469.6667" y="512.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="473.0000" y="514.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="473.0000" y="514.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="476.3333" y="516.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="476.3333" y="516.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="479.6667" y="518.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="479.6667" y="518.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="463.0000" y="555.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="463.0000" y="555.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="466.3333" y="557.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="466.3333" y="557.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="469.6667" y="559.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="469.6667" y="559.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="473.0000" y="561.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="473.0000" y="561.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="476.3333" y="563.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="476.3333" y="563.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="479.6667" y="565.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="479.6667" y="565.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="463" y="462" width="80" height="140">
-			</bounds>
+			<bounds x="463" y="462" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="686" y="77" width="80" height="80">
-			</bounds>
+			<bounds x="686" y="77" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="686.0000" y="77.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="686.0000" y="77.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="689.3333" y="80.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="689.3333" y="80.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="692.6667" y="83.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="692.6667" y="83.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="696.0000" y="87.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="696.0000" y="87.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="699.3333" y="90.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="699.3333" y="90.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="702.6667" y="93.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="702.6667" y="93.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="686" y="77" width="80" height="80">
-			</bounds>
+			<bounds x="686" y="77" width="80" height="80"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="730" y="329" width="80" height="80">
-			</bounds>
+			<bounds x="730" y="329" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="730.0000" y="329.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="730.0000" y="329.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="733.3333" y="332.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="733.3333" y="332.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="736.6667" y="335.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="736.6667" y="335.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="740.0000" y="339.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="740.0000" y="339.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="743.3333" y="342.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="743.3333" y="342.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="746.6667" y="345.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="746.6667" y="345.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="730" y="329" width="80" height="80">
-			</bounds>
+			<bounds x="730" y="329" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="9" y="606" width="88" height="30">
-			</bounds>
+			<bounds x="9" y="606" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="11" y="608" width="84" height="26">
-			</bounds>
+			<bounds x="11" y="608" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="135" y="606" width="88" height="30">
-			</bounds>
+			<bounds x="135" y="606" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="137" y="608" width="84" height="26">
-			</bounds>
+			<bounds x="137" y="608" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="261" y="606" width="88" height="30">
-			</bounds>
+			<bounds x="261" y="606" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="263" y="608" width="84" height="26">
-			</bounds>
+			<bounds x="263" y="608" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="425" y="606" width="88" height="30">
-			</bounds>
+			<bounds x="425" y="606" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="427" y="608" width="84" height="26">
-			</bounds>
+			<bounds x="427" y="608" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="551" y="606" width="88" height="30">
-			</bounds>
+			<bounds x="551" y="606" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="553" y="608" width="84" height="26">
-			</bounds>
+			<bounds x="553" y="608" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="677" y="606" width="88" height="30">
-			</bounds>
+			<bounds x="677" y="606" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="679" y="608" width="84" height="26">
-			</bounds>
+			<bounds x="679" y="608" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="803" y="606" width="88" height="30">
-			</bounds>
+			<bounds x="803" y="606" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="805" y="608" width="84" height="26">
-			</bounds>
+			<bounds x="805" y="608" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="307" y="51" width="58" height="58">
-			</bounds>
+			<bounds x="307" y="51" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="309" y="53" width="54" height="54">
-			</bounds>
+			<bounds x="309" y="53" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="277" y="82" width="58" height="58">
-			</bounds>
+			<bounds x="277" y="82" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="279" y="84" width="54" height="54">
-			</bounds>
+			<bounds x="279" y="84" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="247" y="112" width="58" height="58">
-			</bounds>
+			<bounds x="247" y="112" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="249" y="114" width="54" height="54">
-			</bounds>
+			<bounds x="249" y="114" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="337" y="82" width="58" height="58">
-			</bounds>
+			<bounds x="337" y="82" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="339" y="84" width="54" height="54">
-			</bounds>
+			<bounds x="339" y="84" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="307" y="113" width="58" height="58">
-			</bounds>
+			<bounds x="307" y="113" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="309" y="115" width="54" height="54">
-			</bounds>
+			<bounds x="309" y="115" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="277" y="143" width="58" height="58">
-			</bounds>
+			<bounds x="277" y="143" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="279" y="145" width="54" height="54">
-			</bounds>
+			<bounds x="279" y="145" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="246" y="173" width="58" height="58">
-			</bounds>
+			<bounds x="246" y="173" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="248" y="175" width="54" height="54">
-			</bounds>
+			<bounds x="248" y="175" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="216" y="202" width="58" height="58">
-			</bounds>
+			<bounds x="216" y="202" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="218" y="204" width="54" height="54">
-			</bounds>
+			<bounds x="218" y="204" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="185" y="233" width="58" height="58">
-			</bounds>
+			<bounds x="185" y="233" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="187" y="235" width="54" height="54">
-			</bounds>
+			<bounds x="187" y="235" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="155" y="202" width="58" height="58">
-			</bounds>
+			<bounds x="155" y="202" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="157" y="204" width="54" height="54">
-			</bounds>
+			<bounds x="157" y="204" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="186" y="172" width="58" height="58">
-			</bounds>
+			<bounds x="186" y="172" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="188" y="174" width="54" height="54">
-			</bounds>
+			<bounds x="188" y="174" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="217" y="142" width="58" height="58">
-			</bounds>
+			<bounds x="217" y="142" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="219" y="144" width="54" height="54">
-			</bounds>
+			<bounds x="219" y="144" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="397" y="142" width="58" height="58">
-			</bounds>
+			<bounds x="397" y="142" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="399" y="144" width="54" height="54">
-			</bounds>
+			<bounds x="399" y="144" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="428" y="173" width="58" height="58">
-			</bounds>
+			<bounds x="428" y="173" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="430" y="175" width="54" height="54">
-			</bounds>
+			<bounds x="430" y="175" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="397" y="202" width="58" height="58">
-			</bounds>
+			<bounds x="397" y="202" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="399" y="204" width="54" height="54">
-			</bounds>
+			<bounds x="399" y="204" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="367" y="173" width="58" height="58">
-			</bounds>
+			<bounds x="367" y="173" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="369" y="175" width="54" height="54">
-			</bounds>
+			<bounds x="369" y="175" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="337" y="202" width="58" height="58">
-			</bounds>
+			<bounds x="337" y="202" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="339" y="204" width="54" height="54">
-			</bounds>
+			<bounds x="339" y="204" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="367" y="233" width="58" height="58">
-			</bounds>
+			<bounds x="367" y="233" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="369" y="235" width="54" height="54">
-			</bounds>
+			<bounds x="369" y="235" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="337" y="263" width="58" height="58">
-			</bounds>
+			<bounds x="337" y="263" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="339" y="265" width="54" height="54">
-			</bounds>
+			<bounds x="339" y="265" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="307" y="233" width="58" height="58">
-			</bounds>
+			<bounds x="307" y="233" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="309" y="235" width="54" height="54">
-			</bounds>
+			<bounds x="309" y="235" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="307" y="292" width="58" height="58">
-			</bounds>
+			<bounds x="307" y="292" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="309" y="294" width="54" height="54">
-			</bounds>
+			<bounds x="309" y="294" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="216" y="263" width="58" height="58">
-			</bounds>
+			<bounds x="216" y="263" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="218" y="265" width="54" height="54">
-			</bounds>
+			<bounds x="218" y="265" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="246" y="293" width="58" height="58">
-			</bounds>
+			<bounds x="246" y="293" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="248" y="295" width="54" height="54">
-			</bounds>
+			<bounds x="248" y="295" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="277" y="263" width="58" height="58">
-			</bounds>
+			<bounds x="277" y="263" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="279" y="265" width="54" height="54">
-			</bounds>
+			<bounds x="279" y="265" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="246" y="233" width="58" height="58">
-			</bounds>
+			<bounds x="246" y="233" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="248" y="235" width="54" height="54">
-			</bounds>
+			<bounds x="248" y="235" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="277" y="202" width="58" height="58">
-			</bounds>
+			<bounds x="277" y="202" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="279" y="204" width="54" height="54">
-			</bounds>
+			<bounds x="279" y="204" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="307" y="173" width="58" height="58">
-			</bounds>
+			<bounds x="307" y="173" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="309" y="175" width="54" height="54">
-			</bounds>
+			<bounds x="309" y="175" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="337" y="144" width="58" height="58">
-			</bounds>
+			<bounds x="337" y="144" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="339" y="146" width="54" height="54">
-			</bounds>
+			<bounds x="339" y="146" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="367" y="113" width="58" height="58">
-			</bounds>
+			<bounds x="367" y="113" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="369" y="115" width="54" height="54">
-			</bounds>
+			<bounds x="369" y="115" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="277" y="21" width="58" height="58">
-			</bounds>
+			<bounds x="277" y="21" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="279" y="23" width="54" height="54">
-			</bounds>
+			<bounds x="279" y="23" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="246" y="51" width="58" height="58">
-			</bounds>
+			<bounds x="246" y="51" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="248" y="53" width="54" height="54">
-			</bounds>
+			<bounds x="248" y="53" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="216" y="82" width="58" height="58">
-			</bounds>
+			<bounds x="216" y="82" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="218" y="84" width="54" height="54">
-			</bounds>
+			<bounds x="218" y="84" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="186" y="113" width="58" height="58">
-			</bounds>
+			<bounds x="186" y="113" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="188" y="115" width="54" height="54">
-			</bounds>
+			<bounds x="188" y="115" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="155" y="142" width="58" height="58">
-			</bounds>
+			<bounds x="155" y="142" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="157" y="144" width="54" height="54">
-			</bounds>
+			<bounds x="157" y="144" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="123" y="173" width="58" height="58">
-			</bounds>
+			<bounds x="123" y="173" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="125" y="175" width="54" height="54">
-			</bounds>
+			<bounds x="125" y="175" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="277" y="323" width="58" height="58">
-			</bounds>
+			<bounds x="277" y="323" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="279" y="325" width="54" height="54">
-			</bounds>
+			<bounds x="279" y="325" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="439" y="399" width="30" height="30">
-			</bounds>
+			<bounds x="439" y="399" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="441" y="401" width="26" height="26">
-			</bounds>
+			<bounds x="441" y="401" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="409" y="399" width="30" height="30">
-			</bounds>
+			<bounds x="409" y="399" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="411" y="401" width="26" height="26">
-			</bounds>
+			<bounds x="411" y="401" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="379" y="399" width="30" height="30">
-			</bounds>
+			<bounds x="379" y="399" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="381" y="401" width="26" height="26">
-			</bounds>
+			<bounds x="381" y="401" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="469" y="399" width="38" height="30">
-			</bounds>
+			<bounds x="469" y="399" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="471" y="401" width="34" height="26">
-			</bounds>
+			<bounds x="471" y="401" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="507" y="399" width="38" height="30">
-			</bounds>
+			<bounds x="507" y="399" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="509" y="401" width="34" height="26">
-			</bounds>
+			<bounds x="509" y="401" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="545" y="399" width="38" height="30">
-			</bounds>
+			<bounds x="545" y="399" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="547" y="401" width="34" height="26">
-			</bounds>
+			<bounds x="547" y="401" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="583" y="399" width="38" height="30">
-			</bounds>
+			<bounds x="583" y="399" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="585" y="401" width="34" height="26">
-			</bounds>
+			<bounds x="585" y="401" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="795" y="20" width="48" height="22">
-			</bounds>
+			<bounds x="795" y="20" width="48" height="22"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="797" y="22" width="44" height="18">
-			</bounds>
+			<bounds x="797" y="22" width="44" height="18"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="660" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="660" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="662" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="662" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="694" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="694" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="696" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="696" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="728" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="728" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="730" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="730" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="592" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="592" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="594" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="594" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="626" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="626" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="628" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="628" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="558" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="558" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="560" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="560" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="524" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="524" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="526" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="526" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="761" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="761" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="763" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="763" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="490" y="17" width="34" height="26">
-			</bounds>
+			<bounds x="490" y="17" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="492" y="19" width="30" height="22">
-			</bounds>
+			<bounds x="492" y="19" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="442" y="20" width="48" height="22">
-			</bounds>
+			<bounds x="442" y="20" width="48" height="22"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="444" y="22" width="44" height="18">
-			</bounds>
+			<bounds x="444" y="22" width="44" height="18"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="740" y="157" width="26" height="26">
-			</bounds>
+			<bounds x="740" y="157" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="742" y="159" width="22" height="22">
-			</bounds>
+			<bounds x="742" y="159" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="684" y="157" width="26" height="26">
-			</bounds>
+			<bounds x="684" y="157" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="686" y="159" width="22" height="22">
-			</bounds>
+			<bounds x="686" y="159" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="607" y="164" width="58" height="30">
-			</bounds>
+			<bounds x="607" y="164" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="609" y="166" width="54" height="26">
-			</bounds>
+			<bounds x="609" y="166" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="607" y="134" width="58" height="30">
-			</bounds>
+			<bounds x="607" y="134" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="609" y="136" width="54" height="26">
-			</bounds>
+			<bounds x="609" y="136" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="607" y="104" width="58" height="30">
-			</bounds>
+			<bounds x="607" y="104" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="609" y="106" width="54" height="26">
-			</bounds>
+			<bounds x="609" y="106" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="781" y="164" width="58" height="30">
-			</bounds>
+			<bounds x="781" y="164" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="783" y="166" width="54" height="26">
-			</bounds>
+			<bounds x="783" y="166" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="781" y="194" width="58" height="30">
-			</bounds>
+			<bounds x="781" y="194" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="783" y="196" width="54" height="26">
-			</bounds>
+			<bounds x="783" y="196" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="781" y="134" width="58" height="30">
-			</bounds>
+			<bounds x="781" y="134" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="783" y="136" width="54" height="26">
-			</bounds>
+			<bounds x="783" y="136" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="781" y="104" width="58" height="30">
-			</bounds>
+			<bounds x="781" y="104" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="783" y="106" width="54" height="26">
-			</bounds>
+			<bounds x="783" y="106" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="781" y="74" width="58" height="30">
-			</bounds>
+			<bounds x="781" y="74" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="783" y="76" width="54" height="26">
-			</bounds>
+			<bounds x="783" y="76" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="781" y="44" width="58" height="30">
-			</bounds>
+			<bounds x="781" y="44" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="783" y="46" width="54" height="26">
-			</bounds>
+			<bounds x="783" y="46" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="723" y="44" width="58" height="30">
-			</bounds>
+			<bounds x="723" y="44" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="725" y="46" width="54" height="26">
-			</bounds>
+			<bounds x="725" y="46" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="665" y="43" width="58" height="30">
-			</bounds>
+			<bounds x="665" y="43" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="667" y="45" width="54" height="26">
-			</bounds>
+			<bounds x="667" y="45" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="607" y="44" width="58" height="30">
-			</bounds>
+			<bounds x="607" y="44" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="609" y="46" width="54" height="26">
-			</bounds>
+			<bounds x="609" y="46" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="607" y="74" width="58" height="30">
-			</bounds>
+			<bounds x="607" y="74" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="609" y="76" width="54" height="26">
-			</bounds>
+			<bounds x="609" y="76" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="607" y="194" width="58" height="30">
-			</bounds>
+			<bounds x="607" y="194" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="609" y="196" width="54" height="26">
-			</bounds>
+			<bounds x="609" y="196" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="665" y="194" width="58" height="30">
-			</bounds>
+			<bounds x="665" y="194" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="667" y="196" width="54" height="26">
-			</bounds>
+			<bounds x="667" y="196" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="723" y="194" width="58" height="30">
-			</bounds>
+			<bounds x="723" y="194" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="725" y="196" width="54" height="26">
-			</bounds>
+			<bounds x="725" y="196" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="822" y="260" width="58" height="30">
-			</bounds>
+			<bounds x="822" y="260" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="824" y="262" width="54" height="26">
-			</bounds>
+			<bounds x="824" y="262" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="849" y="290" width="58" height="30">
-			</bounds>
+			<bounds x="849" y="290" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="851" y="292" width="54" height="26">
-			</bounds>
+			<bounds x="851" y="292" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="857" y="320" width="58" height="30">
-			</bounds>
+			<bounds x="857" y="320" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="859" y="322" width="54" height="26">
-			</bounds>
+			<bounds x="859" y="322" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="857" y="350" width="58" height="30">
-			</bounds>
+			<bounds x="857" y="350" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="859" y="352" width="54" height="26">
-			</bounds>
+			<bounds x="859" y="352" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="857" y="380" width="58" height="30">
-			</bounds>
+			<bounds x="857" y="380" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="859" y="382" width="54" height="26">
-			</bounds>
+			<bounds x="859" y="382" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="857" y="410" width="58" height="30">
-			</bounds>
+			<bounds x="857" y="410" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="859" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="859" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="799" y="440" width="58" height="30">
-			</bounds>
+			<bounds x="799" y="440" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="801" y="442" width="54" height="26">
-			</bounds>
+			<bounds x="801" y="442" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="741" y="440" width="58" height="30">
-			</bounds>
+			<bounds x="741" y="440" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="743" y="442" width="54" height="26">
-			</bounds>
+			<bounds x="743" y="442" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="683" y="440" width="58" height="30">
-			</bounds>
+			<bounds x="683" y="440" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="685" y="442" width="54" height="26">
-			</bounds>
+			<bounds x="685" y="442" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="857" y="440" width="58" height="30">
-			</bounds>
+			<bounds x="857" y="440" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="859" y="442" width="54" height="26">
-			</bounds>
+			<bounds x="859" y="442" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="671" y="260" width="58" height="30">
-			</bounds>
+			<bounds x="671" y="260" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="673" y="262" width="54" height="26">
-			</bounds>
+			<bounds x="673" y="262" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="716" y="230" width="58" height="30">
-			</bounds>
+			<bounds x="716" y="230" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="718" y="232" width="54" height="26">
-			</bounds>
+			<bounds x="718" y="232" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="774" y="230" width="58" height="30">
-			</bounds>
+			<bounds x="774" y="230" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="776" y="232" width="54" height="26">
-			</bounds>
+			<bounds x="776" y="232" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="646" y="290" width="60" height="30">
-			</bounds>
+			<bounds x="646" y="290" width="60" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="648" y="292" width="56" height="26">
-			</bounds>
+			<bounds x="648" y="292" width="56" height="26"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="625" y="440" width="58" height="30">
-			</bounds>
+			<bounds x="625" y="440" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="627" y="442" width="54" height="26">
-			</bounds>
+			<bounds x="627" y="442" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="625" y="380" width="58" height="30">
-			</bounds>
+			<bounds x="625" y="380" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="627" y="382" width="54" height="26">
-			</bounds>
+			<bounds x="627" y="382" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="625" y="410" width="58" height="30">
-			</bounds>
+			<bounds x="625" y="410" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="627" y="412" width="54" height="26">
-			</bounds>
+			<bounds x="627" y="412" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="625" y="350" width="58" height="30">
-			</bounds>
+			<bounds x="625" y="350" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="627" y="352" width="54" height="26">
-			</bounds>
+			<bounds x="627" y="352" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="625" y="320" width="58" height="30">
-			</bounds>
+			<bounds x="625" y="320" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="627" y="322" width="54" height="26">
-			</bounds>
+			<bounds x="627" y="322" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="552" y="166" width="30" height="30">
-			</bounds>
+			<bounds x="552" y="166" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="554" y="168" width="26" height="26">
-			</bounds>
+			<bounds x="554" y="168" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="552" y="106" width="30" height="30">
-			</bounds>
+			<bounds x="552" y="106" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="554" y="108" width="26" height="26">
-			</bounds>
+			<bounds x="554" y="108" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="552" y="136" width="30" height="30">
-			</bounds>
+			<bounds x="552" y="136" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="554" y="138" width="26" height="26">
-			</bounds>
+			<bounds x="554" y="138" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="15" y="29" width="66" height="26">
-			</bounds>
+			<bounds x="15" y="29" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="17" y="31" width="62" height="22">
-			</bounds>
+			<bounds x="17" y="31" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="15" y="3" width="70" height="26">
-			</bounds>
+			<bounds x="15" y="3" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="17" y="5" width="66" height="22">
-			</bounds>
+			<bounds x="17" y="5" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="75" y="394" width="34" height="22">
-			</bounds>
+			<bounds x="75" y="394" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="77" y="396" width="30" height="18">
-			</bounds>
+			<bounds x="77" y="396" width="30" height="18"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="25" y="56" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="56" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="27" y="58" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="58" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="25" y="86" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="86" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="27" y="88" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="88" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="25" y="116" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="116" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="27" y="118" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="118" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="25" y="146" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="146" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="27" y="148" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="148" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="25" y="176" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="176" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="27" y="178" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="178" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="25" y="206" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="206" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="27" y="208" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="208" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="25" y="236" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="236" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="27" y="238" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="238" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="25" y="266" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="266" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="27" y="268" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="268" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="25" y="296" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="296" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="27" y="298" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="298" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="25" y="326" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="326" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="27" y="328" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="328" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="25" y="356" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="356" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="27" y="358" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="358" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="25" y="386" width="50" height="30">
-			</bounds>
+			<bounds x="25" y="386" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="27" y="388" width="46" height="26">
-			</bounds>
+			<bounds x="27" y="388" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="956" y="416" width="34" height="22">
-			</bounds>
+			<bounds x="956" y="416" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="958" y="418" width="30" height="18">
-			</bounds>
+			<bounds x="958" y="418" width="30" height="18"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="941" y="56" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="56" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="943" y="58" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="58" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="941" y="86" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="86" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="943" y="88" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="88" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="941" y="116" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="116" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="943" y="118" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="118" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="941" y="146" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="146" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="943" y="148" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="148" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="941" y="176" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="176" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="943" y="178" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="178" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="941" y="206" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="206" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="943" y="208" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="208" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="941" y="236" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="236" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="943" y="238" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="238" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="941" y="266" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="266" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="943" y="268" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="268" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="941" y="296" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="296" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="943" y="298" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="298" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="941" y="326" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="326" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="943" y="328" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="328" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="941" y="356" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="356" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="943" y="358" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="358" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="941" y="386" width="62" height="30">
-			</bounds>
+			<bounds x="941" y="386" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="943" y="388" width="58" height="26">
-			</bounds>
+			<bounds x="943" y="388" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="937" y="29" width="66" height="26">
-			</bounds>
+			<bounds x="937" y="29" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="939" y="31" width="62" height="22">
-			</bounds>
+			<bounds x="939" y="31" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="934" y="3" width="70" height="26">
-			</bounds>
+			<bounds x="934" y="3" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="936" y="5" width="66" height="22">
-			</bounds>
+			<bounds x="936" y="5" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="445" y="381" width="19" height="19">
-			</bounds>
+			<bounds x="445" y="381" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="447" y="383" width="15" height="15">
-			</bounds>
+			<bounds x="447" y="383" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="415" y="381" width="19" height="19">
-			</bounds>
+			<bounds x="415" y="381" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="417" y="383" width="15" height="15">
-			</bounds>
+			<bounds x="417" y="383" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="385" y="381" width="19" height="19">
-			</bounds>
+			<bounds x="385" y="381" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="387" y="383" width="15" height="15">
-			</bounds>
+			<bounds x="387" y="383" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="345" y="381" width="19" height="19">
-			</bounds>
+			<bounds x="345" y="381" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="347" y="383" width="15" height="15">
-			</bounds>
+			<bounds x="347" y="383" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="304" y="381" width="19" height="19">
-			</bounds>
+			<bounds x="304" y="381" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="306" y="383" width="15" height="15">
-			</bounds>
+			<bounds x="306" y="383" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="274" y="381" width="19" height="19">
-			</bounds>
+			<bounds x="274" y="381" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="276" y="383" width="15" height="15">
-			</bounds>
+			<bounds x="276" y="383" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="245" y="381" width="19" height="19">
-			</bounds>
+			<bounds x="245" y="381" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="247" y="383" width="15" height="15">
-			</bounds>
+			<bounds x="247" y="383" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="113" y="25" width="38" height="30">
-			</bounds>
+			<bounds x="113" y="25" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="115" y="27" width="34" height="26">
-			</bounds>
+			<bounds x="115" y="27" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="113" y="25" width="38" height="30">
-			</bounds>
+			<bounds x="113" y="25" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="115" y="27" width="34" height="26">
-			</bounds>
+			<bounds x="115" y="27" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="150" y="25" width="50" height="30">
-			</bounds>
+			<bounds x="150" y="25" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="152" y="27" width="46" height="26">
-			</bounds>
+			<bounds x="152" y="27" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="150" y="25" width="50" height="30">
-			</bounds>
+			<bounds x="150" y="25" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="152" y="27" width="46" height="26">
-			</bounds>
+			<bounds x="152" y="27" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="132" y="54" width="50" height="30">
-			</bounds>
+			<bounds x="132" y="54" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="134" y="56" width="46" height="26">
-			</bounds>
+			<bounds x="134" y="56" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="132" y="54" width="50" height="30">
-			</bounds>
+			<bounds x="132" y="54" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="134" y="56" width="46" height="26">
-			</bounds>
+			<bounds x="134" y="56" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="112" y="83" width="36" height="30">
-			</bounds>
+			<bounds x="112" y="83" width="36" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="114" y="85" width="32" height="26">
-			</bounds>
+			<bounds x="114" y="85" width="32" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="112" y="83" width="36" height="30">
-			</bounds>
+			<bounds x="112" y="83" width="36" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="114" y="85" width="32" height="26">
-			</bounds>
+			<bounds x="114" y="85" width="32" height="26"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="147" y="83" width="26" height="30">
-			</bounds>
+			<bounds x="147" y="83" width="26" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="149" y="85" width="22" height="26">
-			</bounds>
+			<bounds x="149" y="85" width="22" height="26"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="147" y="83" width="26" height="30">
-			</bounds>
+			<bounds x="147" y="83" width="26" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="149" y="85" width="22" height="26">
-			</bounds>
+			<bounds x="149" y="85" width="22" height="26"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="172" y="83" width="34" height="30">
-			</bounds>
+			<bounds x="172" y="83" width="34" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="174" y="85" width="30" height="26">
-			</bounds>
+			<bounds x="174" y="85" width="30" height="26"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="172" y="83" width="34" height="30">
-			</bounds>
+			<bounds x="172" y="83" width="34" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="174" y="85" width="30" height="26">
-			</bounds>
+			<bounds x="174" y="85" width="30" height="26"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="842" y="31" width="38" height="26">
-			</bounds>
+			<bounds x="842" y="31" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="844" y="33" width="34" height="22">
-			</bounds>
+			<bounds x="844" y="33" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="842" y="57" width="38" height="26">
-			</bounds>
+			<bounds x="842" y="57" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="844" y="59" width="34" height="22">
-			</bounds>
+			<bounds x="844" y="59" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="842" y="83" width="38" height="26">
-			</bounds>
+			<bounds x="842" y="83" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="844" y="85" width="34" height="22">
-			</bounds>
+			<bounds x="844" y="85" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="842" y="109" width="38" height="26">
-			</bounds>
+			<bounds x="842" y="109" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="844" y="111" width="34" height="22">
-			</bounds>
+			<bounds x="844" y="111" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="842" y="135" width="38" height="26">
-			</bounds>
+			<bounds x="842" y="135" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="844" y="137" width="34" height="22">
-			</bounds>
+			<bounds x="844" y="137" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="329" y="399" width="50" height="30">
-			</bounds>
+			<bounds x="329" y="399" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="331" y="401" width="46" height="26">
-			</bounds>
+			<bounds x="331" y="401" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="299" y="399" width="30" height="30">
-			</bounds>
+			<bounds x="299" y="399" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="301" y="401" width="26" height="26">
-			</bounds>
+			<bounds x="301" y="401" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="269" y="399" width="30" height="30">
-			</bounds>
+			<bounds x="269" y="399" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="271" y="401" width="26" height="26">
-			</bounds>
+			<bounds x="271" y="401" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="189" y="395" width="50" height="34">
-			</bounds>
+			<bounds x="189" y="395" width="50" height="34"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="191" y="397" width="46" height="30">
-			</bounds>
+			<bounds x="191" y="397" width="46" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="239" y="399" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="399" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="241" y="401" width="26" height="26">
-			</bounds>
+			<bounds x="241" y="401" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="532" y="323" width="42" height="26">
-			</bounds>
+			<bounds x="532" y="323" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="534" y="325" width="38" height="22">
-			</bounds>
+			<bounds x="534" y="325" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="490" y="323" width="42" height="26">
-			</bounds>
+			<bounds x="490" y="323" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="492" y="325" width="38" height="22">
-			</bounds>
+			<bounds x="492" y="325" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="448" y="323" width="42" height="26">
-			</bounds>
+			<bounds x="448" y="323" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="450" y="325" width="38" height="22">
-			</bounds>
+			<bounds x="450" y="325" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="448" y="349" width="42" height="26">
-			</bounds>
+			<bounds x="448" y="349" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="450" y="351" width="38" height="22">
-			</bounds>
+			<bounds x="450" y="351" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="490" y="349" width="42" height="26">
-			</bounds>
+			<bounds x="490" y="349" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="492" y="351" width="38" height="22">
-			</bounds>
+			<bounds x="492" y="351" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="532" y="349" width="42" height="26">
-			</bounds>
+			<bounds x="532" y="349" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="534" y="351" width="38" height="22">
-			</bounds>
+			<bounds x="534" y="351" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="574" y="349" width="42" height="26">
-			</bounds>
+			<bounds x="574" y="349" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="576" y="351" width="38" height="22">
-			</bounds>
+			<bounds x="576" y="351" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="574" y="323" width="42" height="26">
-			</bounds>
+			<bounds x="574" y="323" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="576" y="325" width="38" height="22">
-			</bounds>
+			<bounds x="576" y="325" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="406" y="349" width="42" height="26">
-			</bounds>
+			<bounds x="406" y="349" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="408" y="351" width="38" height="22">
-			</bounds>
+			<bounds x="408" y="351" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="406" y="323" width="42" height="26">
-			</bounds>
+			<bounds x="406" y="323" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="408" y="325" width="38" height="22">
-			</bounds>
+			<bounds x="408" y="325" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="253" y="478" width="30" height="30">
-			</bounds>
+			<bounds x="253" y="478" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="255" y="480" width="26" height="26">
-			</bounds>
+			<bounds x="255" y="480" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="253" y="568" width="30" height="30">
-			</bounds>
+			<bounds x="253" y="568" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="255" y="570" width="26" height="26">
-			</bounds>
+			<bounds x="255" y="570" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="253" y="568" width="30" height="30">
-			</bounds>
+			<bounds x="253" y="568" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="255" y="570" width="26" height="26">
-			</bounds>
+			<bounds x="255" y="570" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="253" y="538" width="30" height="30">
-			</bounds>
+			<bounds x="253" y="538" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="255" y="540" width="26" height="26">
-			</bounds>
+			<bounds x="255" y="540" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="253" y="508" width="30" height="30">
-			</bounds>
+			<bounds x="253" y="508" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="255" y="510" width="26" height="26">
-			</bounds>
+			<bounds x="255" y="510" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="215" y="577" width="38" height="22">
-			</bounds>
+			<bounds x="215" y="577" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="217" y="579" width="34" height="18">
-			</bounds>
+			<bounds x="217" y="579" width="34" height="18"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="912" y="481" width="88" height="34">
-			</bounds>
+			<bounds x="912" y="481" width="88" height="34"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="914" y="483" width="84" height="30">
-			</bounds>
+			<bounds x="914" y="483" width="84" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="912" y="514" width="88" height="30">
-			</bounds>
+			<bounds x="912" y="514" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="914" y="516" width="84" height="26">
-			</bounds>
+			<bounds x="914" y="516" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="912" y="544" width="88" height="30">
-			</bounds>
+			<bounds x="912" y="544" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="914" y="546" width="84" height="26">
-			</bounds>
+			<bounds x="914" y="546" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="912" y="574" width="88" height="30">
-			</bounds>
+			<bounds x="912" y="574" width="88" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="914" y="576" width="84" height="26">
-			</bounds>
+			<bounds x="914" y="576" width="84" height="26"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_209_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="241" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="241" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_209" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="243" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="243" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_210_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="541" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="541" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_210" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="543" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="543" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_211_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="616" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="616" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_211" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="618" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="618" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_212_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="691" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="691" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_212" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="693" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="693" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_213_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="890" y="43" width="38" height="38">
-			</bounds>
+			<bounds x="890" y="43" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_213" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="892" y="45" width="34" height="34">
-			</bounds>
+			<bounds x="892" y="45" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_215_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="466" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="466" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_215" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="468" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="468" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_216_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="391" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="391" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_216" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="393" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="393" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_217_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="316" y="642" width="75" height="27">
-			</bounds>
+			<bounds x="316" y="642" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_217" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="318" y="644" width="71" height="23">
-			</bounds>
+			<bounds x="318" y="644" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp151" element="colour_button_218_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="345" y="345" width="50" height="27">
-			</bounds>
+			<bounds x="345" y="345" width="50" height="27"/>
 		</backdrop>
 		<backdrop name="lamp151" element="colour_button_218" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="347" y="347" width="46" height="23">
-			</bounds>
+			<bounds x="347" y="347" width="46" height="23"/>
 		</backdrop>
 		<backdrop name="lamp152" element="colour_button_219_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="221" y="345" width="50" height="27">
-			</bounds>
+			<bounds x="221" y="345" width="50" height="27"/>
 		</backdrop>
 		<backdrop name="lamp152" element="colour_button_219" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="223" y="347" width="46" height="23">
-			</bounds>
+			<bounds x="223" y="347" width="46" height="23"/>
 		</backdrop>
 		<backdrop name="lamp193" element="colour_button_220_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="528" y="197" width="78" height="30">
-			</bounds>
+			<bounds x="528" y="197" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="colour_button_220" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="530" y="199" width="74" height="26">
-			</bounds>
+			<bounds x="530" y="199" width="74" height="26"/>
 		</backdrop>
 		<backdrop name="lamp161" element="colour_button_221_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="29" y="418" width="50" height="27">
-			</bounds>
+			<bounds x="29" y="418" width="50" height="27"/>
 		</backdrop>
 		<backdrop name="lamp161" element="colour_button_221" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="31" y="420" width="46" height="23">
-			</bounds>
+			<bounds x="31" y="420" width="46" height="23"/>
 		</backdrop>
 		<backdrop name="lamp92" element="colour_button_222_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="951" y="438" width="50" height="27">
-			</bounds>
+			<bounds x="951" y="438" width="50" height="27"/>
 		</backdrop>
 		<backdrop name="lamp92" element="colour_button_222" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="953" y="440" width="46" height="23">
-			</bounds>
+			<bounds x="953" y="440" width="46" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="254" y="433" width="323" height="27">
-			</bounds>
+			<bounds x="254" y="433" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="254" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="254" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="274" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="274" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="294" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="294" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="314" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="314" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="334" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="334" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="354" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="354" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="374" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="374" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="394" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="394" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="414" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="414" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="434" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="434" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="454" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="454" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="474" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="474" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="494" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="494" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="514" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="514" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="534" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="534" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="554" y="433" width="20" height="27">
-			</bounds>
+			<bounds x="554" y="433" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label106" element="label_106">
-			<bounds x="668" y="76" width="15" height="13">
-			</bounds>
+			<bounds x="668" y="76" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label107" element="label_107">
-			<bounds x="668" y="105" width="15" height="13">
-			</bounds>
+			<bounds x="668" y="105" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label108" element="label_108">
-			<bounds x="670" y="135" width="15" height="13">
-			</bounds>
+			<bounds x="670" y="135" width="15" height="13"/>
 		</backdrop>
 		<backdrop name="label109" element="label_109">
-			<bounds x="712" y="164" width="26" height="13">
-			</bounds>
+			<bounds x="712" y="164" width="26" height="13"/>
 		</backdrop>
 		<backdrop name="label110" element="label_110">
-			<bounds x="768" y="76" width="8" height="13">
-			</bounds>
+			<bounds x="768" y="76" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label111" element="label_111">
-			<bounds x="768" y="91" width="8" height="13">
-			</bounds>
+			<bounds x="768" y="91" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label112" element="label_112">
-			<bounds x="768" y="105" width="8" height="13">
-			</bounds>
+			<bounds x="768" y="105" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="768" y="120" width="8" height="13">
-			</bounds>
+			<bounds x="768" y="120" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="768" y="135" width="8" height="13">
-			</bounds>
+			<bounds x="768" y="135" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label115" element="label_115">
-			<bounds x="769" y="149" width="8" height="13">
-			</bounds>
+			<bounds x="769" y="149" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label146" element="label_146">
-			<bounds x="671" y="91" width="8" height="13">
-			</bounds>
+			<bounds x="671" y="91" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label147" element="label_147">
-			<bounds x="672" y="120" width="8" height="13">
-			</bounds>
+			<bounds x="672" y="120" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label148" element="label_148">
-			<bounds x="673" y="149" width="8" height="13">
-			</bounds>
+			<bounds x="673" y="149" width="8" height="13"/>
 		</backdrop>
 		<backdrop name="label156" element="label_156">
-			<bounds x="85" y="5" width="81" height="20">
-			</bounds>
+			<bounds x="85" y="5" width="81" height="20"/>
 		</backdrop>
 		<backdrop name="label163" element="label_163">
-			<bounds x="852" y="6" width="81" height="20">
-			</bounds>
+			<bounds x="852" y="6" width="81" height="20"/>
 		</backdrop>
 		<backdrop name="label208" element="label_208">
-			<bounds x="129" y="552" width="52" height="39">
-			</bounds>
+			<bounds x="129" y="552" width="52" height="39"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_button" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_button" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_button" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_button" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_button" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4brollb.lay
+++ b/src/mame/layout/sc4brollb.lay
@@ -8,14874 +8,9347 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
+			<color red="0.50" green="0.28" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
+			<color red="1.00" green="0.57" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
+			<color red="0.25" green="0.14" blue="0.03"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
+			<color red="0.50" green="0.28" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
+			<color red="1.00" green="0.57" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
+			<color red="0.25" green="0.14" blue="0.03"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
+			<color red="0.50" green="0.28" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
+			<color red="1.00" green="0.57" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
+			<color red="0.25" green="0.14" blue="0.03"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
+			<color red="0.50" green="0.28" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
+			<color red="1.00" green="0.57" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
+			<color red="0.25" green="0.14" blue="0.03"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
+			<color red="0.50" green="0.28" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
+			<color red="1.00" green="0.57" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
+			<color red="0.25" green="0.14" blue="0.03"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
+			<color red="0.50" green="0.28" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
+			<color red="1.00" green="0.57" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
+			<color red="0.25" green="0.14" blue="0.03"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
+			<color red="0.50" green="0.28" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
+			<color red="1.00" green="0.57" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
+			<color red="0.25" green="0.14" blue="0.03"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
+			<color red="0.50" green="0.28" blue="0.07"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
+			<color red="0.12" green="0.07" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
+			<color red="1.00" green="0.57" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
+			<color red="0.25" green="0.14" blue="0.03"/>
 		</rect>
 		<text string="4 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.07">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.03">
-			</color>
-		</rect>
-		<text string="4 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
+			<color red="0.72" green="0.72" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.72" green="0.72" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="TAKE NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="TAKE NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="HI-LO ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="HI-LO ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="BREAK THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="BREAK THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="HOT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="HOT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="PAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="PAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="RISE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="NOTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.27"/>
 		</text>
 		<text string="BLAS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="TER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.27"/>
 		</text>
 		<text string="BLAS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="TER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="MAHEM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="MAHEM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="MEGA BUCKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="MEGA BUCKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_207_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_207_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="BIG BANKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="BIG BANKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MULTI STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MULTI STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="10p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="30p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="NOTE CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="NOTE CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;25.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;25.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_63_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_63_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;2.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;2.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BANK ROLL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BANK ROLL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ARROW SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARROW SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.00" blue="0.32">
-			</color>
+			<color red="0.32" green="0.00" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.08">
-			</color>
+			<color red="0.08" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.00" blue="0.64">
-			</color>
+			<color red="0.64" green="0.00" blue="0.64"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.00" blue="0.16">
-			</color>
+			<color red="0.16" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="HIGH 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.32" green="0.00" blue="0.32">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.64" green="0.00" blue="0.64">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="HIGH 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="EXTRA EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="EXTRA EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BONUS ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BONUS ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.32" green="0.00" blue="0.32">
-			</color>
+			<color red="0.32" green="0.00" blue="0.32"/>
 		</rect>
 		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.08">
-			</color>
+			<color red="0.08" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.64" green="0.00" blue="0.64">
-			</color>
+			<color red="0.64" green="0.00" blue="0.64"/>
 		</rect>
 		<rect state="0">
-			<color red="0.16" green="0.00" blue="0.16">
-			</color>
+			<color red="0.16" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="SUPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.32" green="0.00" blue="0.32">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.08" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.64" green="0.00" blue="0.64">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.16" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="SUPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.50">
-			</color>
+			<color red="0.14" green="0.14" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.12">
-			</color>
+			<color red="0.04" green="0.04" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="0.28" green="0.28" blue="1.00">
-			</color>
+			<color red="0.28" green="0.28" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.25">
-			</color>
+			<color red="0.07" green="0.07" blue="0.25"/>
 		</rect>
 		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.14" green="0.14" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.04" green="0.04" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.28" green="0.28" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.25">
-			</color>
-		</rect>
-		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="8 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="8 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="6 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="5 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="4 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="NOTE CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="NOTE CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="12 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="12 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="10 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="10 WINSPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="16 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="16 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NOTE CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NOTE CLIMB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="12 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="12 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_141_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_141">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_142_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_142">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="TAKE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_146_border">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="colour_button_146">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_149_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_149">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.22" blue="0.09">
-			</color>
+			<color red="0.50" green="0.22" blue="0.09"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.05" blue="0.02">
-			</color>
+			<color red="0.12" green="0.05" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="0.45" blue="0.18">
-			</color>
+			<color red="1.00" green="0.45" blue="0.18"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.11" blue="0.04">
-			</color>
+			<color red="0.25" green="0.11" blue="0.04"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="5" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="678">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="678"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="330" y="458" width="80" height="140">
-			</bounds>
+			<bounds x="330" y="458" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="458.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="458.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="459.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="459.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="461.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="461.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="463.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="463.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="465.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="465.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="467.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="467.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="504.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="504.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="506.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="506.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="508.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="508.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="510.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="510.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="512.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="512.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="514.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="514.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="551.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="330.0000" y="551.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="553.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="333.3333" y="553.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="555.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="336.6667" y="555.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="557.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="340.0000" y="557.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="559.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="343.3333" y="559.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="561.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="346.6667" y="561.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="330" y="458" width="80" height="140">
-			</bounds>
+			<bounds x="330" y="458" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="412" y="458" width="80" height="140">
-			</bounds>
+			<bounds x="412" y="458" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="412.0000" y="458.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="412.0000" y="458.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="415.3333" y="459.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="415.3333" y="459.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="418.6667" y="461.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="418.6667" y="461.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="422.0000" y="463.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="422.0000" y="463.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="425.3333" y="465.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="425.3333" y="465.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="428.6667" y="467.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="428.6667" y="467.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="412.0000" y="504.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="412.0000" y="504.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="415.3333" y="506.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="415.3333" y="506.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="418.6667" y="508.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="418.6667" y="508.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="422.0000" y="510.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="422.0000" y="510.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="425.3333" y="512.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="425.3333" y="512.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="428.6667" y="514.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="428.6667" y="514.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="412.0000" y="551.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="412.0000" y="551.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="415.3333" y="553.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="415.3333" y="553.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="418.6667" y="555.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="418.6667" y="555.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="422.0000" y="557.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="422.0000" y="557.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="425.3333" y="559.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="425.3333" y="559.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="428.6667" y="561.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="428.6667" y="561.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="412" y="458" width="80" height="140">
-			</bounds>
+			<bounds x="412" y="458" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="494" y="458" width="80" height="140">
-			</bounds>
+			<bounds x="494" y="458" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="494.0000" y="458.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="494.0000" y="458.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="497.3333" y="459.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="497.3333" y="459.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="500.6667" y="461.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="500.6667" y="461.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="504.0000" y="463.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="504.0000" y="463.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="507.3333" y="465.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="507.3333" y="465.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="510.6667" y="467.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="510.6667" y="467.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="494.0000" y="504.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="494.0000" y="504.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="497.3333" y="506.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="497.3333" y="506.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="500.6667" y="508.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="500.6667" y="508.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="504.0000" y="510.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="504.0000" y="510.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="507.3333" y="512.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="507.3333" y="512.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="510.6667" y="514.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="510.6667" y="514.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="494.0000" y="551.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="494.0000" y="551.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="497.3333" y="553.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="497.3333" y="553.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="500.6667" y="555.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="500.6667" y="555.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="504.0000" y="557.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="504.0000" y="557.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="507.3333" y="559.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="507.3333" y="559.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="510.6667" y="561.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="510.6667" y="561.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="494" y="458" width="80" height="140">
-			</bounds>
+			<bounds x="494" y="458" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="409" y="326" width="200" height="68">
-			</bounds>
+			<bounds x="409" y="326" width="200" height="68"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="409.0000" y="326.0000" width="200.0000" height="13.6000">
-			</bounds>
+			<bounds x="409.0000" y="326.0000" width="200.0000" height="13.6000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="326.5667" width="183.3333" height="12.4667">
-			</bounds>
+			<bounds x="417.3333" y="326.5667" width="183.3333" height="12.4667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="425.6667" y="327.1333" width="166.6667" height="11.3333">
-			</bounds>
+			<bounds x="425.6667" y="327.1333" width="166.6667" height="11.3333"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="327.7000" width="150.0000" height="10.2000">
-			</bounds>
+			<bounds x="434.0000" y="327.7000" width="150.0000" height="10.2000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="442.3333" y="328.2667" width="133.3333" height="9.0667">
-			</bounds>
+			<bounds x="442.3333" y="328.2667" width="133.3333" height="9.0667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="450.6667" y="328.8333" width="116.6667" height="7.9333">
-			</bounds>
+			<bounds x="450.6667" y="328.8333" width="116.6667" height="7.9333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="409.0000" y="339.6000" width="200.0000" height="13.6000">
-			</bounds>
+			<bounds x="409.0000" y="339.6000" width="200.0000" height="13.6000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="340.1667" width="183.3333" height="12.4667">
-			</bounds>
+			<bounds x="417.3333" y="340.1667" width="183.3333" height="12.4667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="425.6667" y="340.7333" width="166.6667" height="11.3333">
-			</bounds>
+			<bounds x="425.6667" y="340.7333" width="166.6667" height="11.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="341.3000" width="150.0000" height="10.2000">
-			</bounds>
+			<bounds x="434.0000" y="341.3000" width="150.0000" height="10.2000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="442.3333" y="341.8667" width="133.3333" height="9.0667">
-			</bounds>
+			<bounds x="442.3333" y="341.8667" width="133.3333" height="9.0667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="450.6667" y="342.4333" width="116.6667" height="7.9333">
-			</bounds>
+			<bounds x="450.6667" y="342.4333" width="116.6667" height="7.9333"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="409.0000" y="353.2000" width="200.0000" height="13.6000">
-			</bounds>
+			<bounds x="409.0000" y="353.2000" width="200.0000" height="13.6000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="353.7667" width="183.3333" height="12.4667">
-			</bounds>
+			<bounds x="417.3333" y="353.7667" width="183.3333" height="12.4667"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="425.6667" y="354.3333" width="166.6667" height="11.3333">
-			</bounds>
+			<bounds x="425.6667" y="354.3333" width="166.6667" height="11.3333"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="354.9000" width="150.0000" height="10.2000">
-			</bounds>
+			<bounds x="434.0000" y="354.9000" width="150.0000" height="10.2000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="442.3333" y="355.4667" width="133.3333" height="9.0667">
-			</bounds>
+			<bounds x="442.3333" y="355.4667" width="133.3333" height="9.0667"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="450.6667" y="356.0334" width="116.6667" height="7.9333">
-			</bounds>
+			<bounds x="450.6667" y="356.0334" width="116.6667" height="7.9333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="409.0000" y="366.8000" width="200.0000" height="13.6000">
-			</bounds>
+			<bounds x="409.0000" y="366.8000" width="200.0000" height="13.6000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="367.3667" width="183.3333" height="12.4667">
-			</bounds>
+			<bounds x="417.3333" y="367.3667" width="183.3333" height="12.4667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="425.6667" y="367.9333" width="166.6667" height="11.3333">
-			</bounds>
+			<bounds x="425.6667" y="367.9333" width="166.6667" height="11.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="368.5000" width="150.0000" height="10.2000">
-			</bounds>
+			<bounds x="434.0000" y="368.5000" width="150.0000" height="10.2000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="442.3333" y="369.0667" width="133.3333" height="9.0667">
-			</bounds>
+			<bounds x="442.3333" y="369.0667" width="133.3333" height="9.0667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="450.6667" y="369.6333" width="116.6667" height="7.9333">
-			</bounds>
+			<bounds x="450.6667" y="369.6333" width="116.6667" height="7.9333"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="409.0000" y="380.4000" width="200.0000" height="13.6000">
-			</bounds>
+			<bounds x="409.0000" y="380.4000" width="200.0000" height="13.6000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="380.9667" width="183.3333" height="12.4667">
-			</bounds>
+			<bounds x="417.3333" y="380.9667" width="183.3333" height="12.4667"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="425.6667" y="381.5333" width="166.6667" height="11.3333">
-			</bounds>
+			<bounds x="425.6667" y="381.5333" width="166.6667" height="11.3333"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="382.1000" width="150.0000" height="10.2000">
-			</bounds>
+			<bounds x="434.0000" y="382.1000" width="150.0000" height="10.2000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="442.3333" y="382.6667" width="133.3333" height="9.0667">
-			</bounds>
+			<bounds x="442.3333" y="382.6667" width="133.3333" height="9.0667"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="450.6667" y="383.2333" width="116.6667" height="7.9333">
-			</bounds>
+			<bounds x="450.6667" y="383.2333" width="116.6667" height="7.9333"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="409" y="326" width="200" height="68">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="409" y="326" width="200" height="68"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="315" y="604" width="38" height="28">
-			</bounds>
+			<bounds x="315" y="604" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="317" y="606" width="34" height="24">
-			</bounds>
+			<bounds x="317" y="606" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="380" y="605" width="26" height="26">
-			</bounds>
+			<bounds x="380" y="605" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="382" y="607" width="22" height="22">
-			</bounds>
+			<bounds x="382" y="607" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="354" y="605" width="26" height="26">
-			</bounds>
+			<bounds x="354" y="605" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="356" y="607" width="22" height="22">
-			</bounds>
+			<bounds x="356" y="607" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="552" y="605" width="26" height="26">
-			</bounds>
+			<bounds x="552" y="605" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="554" y="607" width="22" height="22">
-			</bounds>
+			<bounds x="554" y="607" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="526" y="605" width="26" height="26">
-			</bounds>
+			<bounds x="526" y="605" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="528" y="607" width="22" height="22">
-			</bounds>
+			<bounds x="528" y="607" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="500" y="605" width="26" height="26">
-			</bounds>
+			<bounds x="500" y="605" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="502" y="607" width="22" height="22">
-			</bounds>
+			<bounds x="502" y="607" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="474" y="605" width="26" height="26">
-			</bounds>
+			<bounds x="474" y="605" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="476" y="607" width="22" height="22">
-			</bounds>
+			<bounds x="476" y="607" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="406" y="605" width="26" height="26">
-			</bounds>
+			<bounds x="406" y="605" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="408" y="607" width="22" height="22">
-			</bounds>
+			<bounds x="408" y="607" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="432" y="605" width="42" height="26">
-			</bounds>
+			<bounds x="432" y="605" width="42" height="26"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="434" y="607" width="38" height="22">
-			</bounds>
+			<bounds x="434" y="607" width="38" height="22"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="18" y="12" width="66" height="30">
-			</bounds>
+			<bounds x="18" y="12" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="20" y="14" width="62" height="26">
-			</bounds>
+			<bounds x="20" y="14" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="18" y="102" width="66" height="30">
-			</bounds>
+			<bounds x="18" y="102" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="20" y="104" width="62" height="26">
-			</bounds>
+			<bounds x="20" y="104" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="18" y="42" width="66" height="30">
-			</bounds>
+			<bounds x="18" y="42" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="20" y="44" width="62" height="26">
-			</bounds>
+			<bounds x="20" y="44" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="18" y="72" width="66" height="30">
-			</bounds>
+			<bounds x="18" y="72" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="20" y="74" width="62" height="26">
-			</bounds>
+			<bounds x="20" y="74" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="18" y="132" width="66" height="30">
-			</bounds>
+			<bounds x="18" y="132" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="20" y="134" width="62" height="26">
-			</bounds>
+			<bounds x="20" y="134" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="18" y="162" width="66" height="30">
-			</bounds>
+			<bounds x="18" y="162" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="20" y="164" width="62" height="26">
-			</bounds>
+			<bounds x="20" y="164" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="22" y="192" width="66" height="30">
-			</bounds>
+			<bounds x="22" y="192" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="24" y="194" width="62" height="26">
-			</bounds>
+			<bounds x="24" y="194" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="26" y="222" width="66" height="30">
-			</bounds>
+			<bounds x="26" y="222" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="28" y="224" width="62" height="26">
-			</bounds>
+			<bounds x="28" y="224" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="30" y="252" width="66" height="30">
-			</bounds>
+			<bounds x="30" y="252" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="32" y="254" width="62" height="26">
-			</bounds>
+			<bounds x="32" y="254" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="34" y="282" width="66" height="30">
-			</bounds>
+			<bounds x="34" y="282" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="36" y="284" width="62" height="26">
-			</bounds>
+			<bounds x="36" y="284" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="121" y="19" width="38" height="38">
-			</bounds>
+			<bounds x="121" y="19" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="123" y="21" width="34" height="34">
-			</bounds>
+			<bounds x="123" y="21" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="121" y="19" width="38" height="38">
-			</bounds>
+			<bounds x="121" y="19" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="123" y="21" width="34" height="34">
-			</bounds>
+			<bounds x="123" y="21" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="159" y="11" width="38" height="38">
-			</bounds>
+			<bounds x="159" y="11" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="161" y="13" width="34" height="34">
-			</bounds>
+			<bounds x="161" y="13" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="159" y="11" width="38" height="38">
-			</bounds>
+			<bounds x="159" y="11" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="161" y="13" width="34" height="34">
-			</bounds>
+			<bounds x="161" y="13" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="197" y="11" width="38" height="38">
-			</bounds>
+			<bounds x="197" y="11" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="199" y="13" width="34" height="34">
-			</bounds>
+			<bounds x="199" y="13" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="197" y="11" width="38" height="38">
-			</bounds>
+			<bounds x="197" y="11" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="199" y="13" width="34" height="34">
-			</bounds>
+			<bounds x="199" y="13" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="235" y="19" width="38" height="38">
-			</bounds>
+			<bounds x="235" y="19" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="237" y="21" width="34" height="34">
-			</bounds>
+			<bounds x="237" y="21" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="235" y="19" width="38" height="38">
-			</bounds>
+			<bounds x="235" y="19" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="237" y="21" width="34" height="34">
-			</bounds>
+			<bounds x="237" y="21" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="234" y="58" width="38" height="38">
-			</bounds>
+			<bounds x="234" y="58" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="236" y="60" width="34" height="34">
-			</bounds>
+			<bounds x="236" y="60" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="234" y="58" width="38" height="38">
-			</bounds>
+			<bounds x="234" y="58" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="236" y="60" width="34" height="34">
-			</bounds>
+			<bounds x="236" y="60" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="196" y="50" width="38" height="38">
-			</bounds>
+			<bounds x="196" y="50" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="198" y="52" width="34" height="34">
-			</bounds>
+			<bounds x="198" y="52" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="196" y="50" width="38" height="38">
-			</bounds>
+			<bounds x="196" y="50" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="198" y="52" width="34" height="34">
-			</bounds>
+			<bounds x="198" y="52" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="158" y="50" width="38" height="38">
-			</bounds>
+			<bounds x="158" y="50" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="160" y="52" width="34" height="34">
-			</bounds>
+			<bounds x="160" y="52" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="158" y="50" width="38" height="38">
-			</bounds>
+			<bounds x="158" y="50" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="160" y="52" width="34" height="34">
-			</bounds>
+			<bounds x="160" y="52" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="120" y="58" width="38" height="38">
-			</bounds>
+			<bounds x="120" y="58" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="122" y="60" width="34" height="34">
-			</bounds>
+			<bounds x="122" y="60" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="120" y="58" width="38" height="38">
-			</bounds>
+			<bounds x="120" y="58" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="122" y="60" width="34" height="34">
-			</bounds>
+			<bounds x="122" y="60" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="233" y="100" width="50" height="50">
-			</bounds>
+			<bounds x="233" y="100" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="235" y="102" width="46" height="46">
-			</bounds>
+			<bounds x="235" y="102" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="233" y="100" width="50" height="50">
-			</bounds>
+			<bounds x="233" y="100" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="235" y="102" width="46" height="46">
-			</bounds>
+			<bounds x="235" y="102" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="248" y="149" width="26" height="26">
-			</bounds>
+			<bounds x="248" y="149" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="250" y="151" width="22" height="22">
-			</bounds>
+			<bounds x="250" y="151" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="296" y="157" width="26" height="26">
-			</bounds>
+			<bounds x="296" y="157" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="298" y="159" width="22" height="22">
-			</bounds>
+			<bounds x="298" y="159" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="290" y="112" width="50" height="50">
-			</bounds>
+			<bounds x="290" y="112" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="292" y="114" width="46" height="46">
-			</bounds>
+			<bounds x="292" y="114" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="290" y="112" width="50" height="50">
-			</bounds>
+			<bounds x="290" y="112" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="292" y="114" width="46" height="46">
-			</bounds>
+			<bounds x="292" y="114" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="164" y="256" width="26" height="26">
-			</bounds>
+			<bounds x="164" y="256" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="166" y="258" width="22" height="22">
-			</bounds>
+			<bounds x="166" y="258" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="121" y="256" width="50" height="50">
-			</bounds>
+			<bounds x="121" y="256" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="123" y="258" width="46" height="46">
-			</bounds>
+			<bounds x="123" y="258" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="121" y="256" width="50" height="50">
-			</bounds>
+			<bounds x="121" y="256" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="123" y="258" width="46" height="46">
-			</bounds>
+			<bounds x="123" y="258" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="206" y="162" width="26" height="26">
-			</bounds>
+			<bounds x="206" y="162" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="208" y="164" width="22" height="22">
-			</bounds>
+			<bounds x="208" y="164" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="179" y="112" width="50" height="50">
-			</bounds>
+			<bounds x="179" y="112" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="181" y="114" width="46" height="46">
-			</bounds>
+			<bounds x="181" y="114" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="179" y="112" width="50" height="50">
-			</bounds>
+			<bounds x="179" y="112" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="181" y="114" width="46" height="46">
-			</bounds>
+			<bounds x="181" y="114" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="300" y="271" width="26" height="26">
-			</bounds>
+			<bounds x="300" y="271" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="302" y="273" width="22" height="22">
-			</bounds>
+			<bounds x="302" y="273" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="245" y="303" width="50" height="50">
-			</bounds>
+			<bounds x="245" y="303" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="247" y="305" width="46" height="46">
-			</bounds>
+			<bounds x="247" y="305" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="245" y="303" width="50" height="50">
-			</bounds>
+			<bounds x="245" y="303" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="247" y="305" width="46" height="46">
-			</bounds>
+			<bounds x="247" y="305" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="258" y="280" width="26" height="26">
-			</bounds>
+			<bounds x="258" y="280" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="260" y="282" width="22" height="22">
-			</bounds>
+			<bounds x="260" y="282" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="183" y="294" width="50" height="50">
-			</bounds>
+			<bounds x="183" y="294" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="185" y="296" width="46" height="46">
-			</bounds>
+			<bounds x="185" y="296" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="183" y="294" width="50" height="50">
-			</bounds>
+			<bounds x="183" y="294" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="185" y="296" width="46" height="46">
-			</bounds>
+			<bounds x="185" y="296" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="204" y="275" width="26" height="26">
-			</bounds>
+			<bounds x="204" y="275" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="206" y="277" width="22" height="22">
-			</bounds>
+			<bounds x="206" y="277" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="155" y="219" width="26" height="26">
-			</bounds>
+			<bounds x="155" y="219" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="157" y="221" width="22" height="22">
-			</bounds>
+			<bounds x="157" y="221" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="106" y="203" width="50" height="50">
-			</bounds>
+			<bounds x="106" y="203" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="108" y="205" width="46" height="46">
-			</bounds>
+			<bounds x="108" y="205" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="106" y="203" width="50" height="50">
-			</bounds>
+			<bounds x="106" y="203" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="108" y="205" width="46" height="46">
-			</bounds>
+			<bounds x="108" y="205" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="173" y="182" width="26" height="26">
-			</bounds>
+			<bounds x="173" y="182" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="175" y="184" width="22" height="22">
-			</bounds>
+			<bounds x="175" y="184" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="126" y="147" width="50" height="50">
-			</bounds>
+			<bounds x="126" y="147" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="128" y="149" width="46" height="46">
-			</bounds>
+			<bounds x="128" y="149" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="126" y="147" width="50" height="50">
-			</bounds>
+			<bounds x="126" y="147" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="128" y="149" width="46" height="46">
-			</bounds>
+			<bounds x="128" y="149" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="309" y="291" width="50" height="50">
-			</bounds>
+			<bounds x="309" y="291" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="311" y="293" width="46" height="46">
-			</bounds>
+			<bounds x="311" y="293" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="309" y="291" width="50" height="50">
-			</bounds>
+			<bounds x="309" y="291" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="311" y="293" width="46" height="46">
-			</bounds>
+			<bounds x="311" y="293" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="355" y="252" width="50" height="50">
-			</bounds>
+			<bounds x="355" y="252" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="357" y="254" width="46" height="46">
-			</bounds>
+			<bounds x="357" y="254" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="355" y="252" width="50" height="50">
-			</bounds>
+			<bounds x="355" y="252" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="357" y="254" width="46" height="46">
-			</bounds>
+			<bounds x="357" y="254" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="331" y="250" width="26" height="26">
-			</bounds>
+			<bounds x="331" y="250" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="333" y="252" width="22" height="22">
-			</bounds>
+			<bounds x="333" y="252" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="338" y="142" width="50" height="50">
-			</bounds>
+			<bounds x="338" y="142" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="340" y="144" width="46" height="46">
-			</bounds>
+			<bounds x="340" y="144" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="338" y="142" width="50" height="50">
-			</bounds>
+			<bounds x="338" y="142" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="340" y="144" width="46" height="46">
-			</bounds>
+			<bounds x="340" y="144" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="332" y="179" width="26" height="26">
-			</bounds>
+			<bounds x="332" y="179" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="334" y="181" width="22" height="22">
-			</bounds>
+			<bounds x="334" y="181" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1_border" state="0">
-			<bounds x="344" y="214" width="26" height="26">
-			</bounds>
+			<bounds x="344" y="214" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp207" element="lamp_207_1" state="0">
-			<bounds x="346" y="216" width="22" height="22">
-			</bounds>
+			<bounds x="346" y="216" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="367" y="195" width="50" height="50">
-			</bounds>
+			<bounds x="367" y="195" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="369" y="197" width="46" height="46">
-			</bounds>
+			<bounds x="369" y="197" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="367" y="195" width="50" height="50">
-			</bounds>
+			<bounds x="367" y="195" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="369" y="197" width="46" height="46">
-			</bounds>
+			<bounds x="369" y="197" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="159" y="413" width="58" height="30">
-			</bounds>
+			<bounds x="159" y="413" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="161" y="415" width="54" height="26">
-			</bounds>
+			<bounds x="161" y="415" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="179" y="446" width="58" height="30">
-			</bounds>
+			<bounds x="179" y="446" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="181" y="448" width="54" height="26">
-			</bounds>
+			<bounds x="181" y="448" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="141" y="446" width="38" height="30">
-			</bounds>
+			<bounds x="141" y="446" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="143" y="448" width="34" height="26">
-			</bounds>
+			<bounds x="143" y="448" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1_border" state="0">
-			<bounds x="141" y="476" width="38" height="30">
-			</bounds>
+			<bounds x="141" y="476" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1" state="0">
-			<bounds x="143" y="478" width="34" height="26">
-			</bounds>
+			<bounds x="143" y="478" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0">
-			<bounds x="179" y="476" width="58" height="30">
-			</bounds>
+			<bounds x="179" y="476" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0">
-			<bounds x="181" y="478" width="54" height="26">
-			</bounds>
+			<bounds x="181" y="478" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="179" y="506" width="58" height="30">
-			</bounds>
+			<bounds x="179" y="506" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="181" y="508" width="54" height="26">
-			</bounds>
+			<bounds x="181" y="508" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="141" y="506" width="38" height="30">
-			</bounds>
+			<bounds x="141" y="506" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="143" y="508" width="34" height="26">
-			</bounds>
+			<bounds x="143" y="508" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="719" y="445" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="445" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="721" y="447" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="447" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="719" y="445" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="445" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="721" y="447" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="447" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="719" y="475" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="475" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="721" y="477" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="477" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="719" y="475" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="475" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="721" y="477" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="477" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="719" y="505" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="505" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="721" y="507" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="507" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="719" y="505" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="505" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="721" y="507" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="507" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="719" y="535" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="535" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="721" y="537" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="537" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="719" y="535" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="535" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="721" y="537" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="537" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="719" y="205" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="205" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="721" y="207" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="207" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="719" y="205" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="205" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="721" y="207" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="207" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="719" y="235" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="235" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="721" y="237" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="237" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="719" y="235" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="235" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="721" y="237" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="237" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="719" y="265" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="265" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="721" y="267" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="267" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="719" y="265" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="265" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="721" y="267" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="267" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="719" y="295" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="295" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="721" y="297" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="297" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="719" y="295" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="295" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="721" y="297" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="297" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="719" y="325" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="325" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="721" y="327" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="327" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="719" y="325" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="325" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="721" y="327" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="327" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="719" y="355" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="355" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="721" y="357" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="357" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="719" y="355" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="355" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="721" y="357" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="357" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="719" y="385" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="385" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="721" y="387" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="387" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="719" y="385" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="385" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="721" y="387" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="387" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="719" y="415" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="415" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="721" y="417" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="417" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="719" y="415" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="415" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="721" y="417" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="417" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="719" y="175" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="175" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="721" y="177" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="177" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="719" y="175" width="66" height="22">
-			</bounds>
+			<bounds x="719" y="175" width="66" height="22"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="721" y="177" width="62" height="18">
-			</bounds>
+			<bounds x="721" y="177" width="62" height="18"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="779" y="136" width="86" height="38">
-			</bounds>
+			<bounds x="779" y="136" width="86" height="38"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="781" y="138" width="82" height="34">
-			</bounds>
+			<bounds x="781" y="138" width="82" height="34"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="787" y="175" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="175" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="789" y="177" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="177" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="787" y="205" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="205" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="789" y="207" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="207" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="787" y="235" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="235" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="789" y="237" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="237" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="787" y="265" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="265" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="789" y="267" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="267" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="787" y="295" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="295" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="789" y="297" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="297" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="787" y="325" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="325" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="789" y="327" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="327" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="787" y="565" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="565" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="789" y="567" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="567" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="787" y="535" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="535" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="789" y="537" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="537" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="787" y="505" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="505" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="789" y="507" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="507" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1_border" state="0">
-			<bounds x="787" y="475" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="475" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="lamp_63_1" state="0">
-			<bounds x="789" y="477" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="477" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="787" y="445" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="445" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="789" y="447" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="447" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="787" y="415" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="415" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="789" y="417" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="417" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="787" y="385" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="385" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="789" y="387" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="387" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="787" y="355" width="66" height="30">
-			</bounds>
+			<bounds x="787" y="355" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="789" y="357" width="62" height="26">
-			</bounds>
+			<bounds x="789" y="357" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="308" y="581" width="19" height="19">
-			</bounds>
+			<bounds x="308" y="581" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="310" y="583" width="15" height="15">
-			</bounds>
+			<bounds x="310" y="583" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="309" y="457" width="19" height="19">
-			</bounds>
+			<bounds x="309" y="457" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="311" y="459" width="15" height="15">
-			</bounds>
+			<bounds x="311" y="459" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="578" y="456" width="19" height="19">
-			</bounds>
+			<bounds x="578" y="456" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="580" y="458" width="15" height="15">
-			</bounds>
+			<bounds x="580" y="458" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="578" y="581" width="19" height="19">
-			</bounds>
+			<bounds x="578" y="581" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="580" y="583" width="15" height="15">
-			</bounds>
+			<bounds x="580" y="583" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="578" y="562" width="19" height="19">
-			</bounds>
+			<bounds x="578" y="562" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="580" y="564" width="15" height="15">
-			</bounds>
+			<bounds x="580" y="564" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="578" y="478" width="19" height="19">
-			</bounds>
+			<bounds x="578" y="478" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="580" y="480" width="15" height="15">
-			</bounds>
+			<bounds x="580" y="480" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="308" y="562" width="19" height="19">
-			</bounds>
+			<bounds x="308" y="562" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="310" y="564" width="15" height="15">
-			</bounds>
+			<bounds x="310" y="564" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="308" y="478" width="19" height="19">
-			</bounds>
+			<bounds x="308" y="478" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="310" y="480" width="15" height="15">
-			</bounds>
+			<bounds x="310" y="480" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="578" y="518" width="19" height="19">
-			</bounds>
+			<bounds x="578" y="518" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="580" y="520" width="15" height="15">
-			</bounds>
+			<bounds x="580" y="520" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="308" y="518" width="19" height="19">
-			</bounds>
+			<bounds x="308" y="518" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="310" y="520" width="15" height="15">
-			</bounds>
+			<bounds x="310" y="520" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="625" y="162" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="162" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="627" y="164" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="164" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="625" y="188" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="188" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="627" y="190" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="190" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="625" y="214" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="214" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="627" y="216" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="216" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="625" y="396" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="396" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="627" y="398" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="398" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="625" y="370" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="370" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="627" y="372" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="372" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="625" y="344" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="344" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="627" y="346" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="346" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="625" y="318" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="318" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="627" y="320" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="320" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="625" y="292" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="292" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="627" y="294" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="294" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="625" y="266" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="266" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="627" y="268" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="268" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="625" y="240" width="66" height="26">
-			</bounds>
+			<bounds x="625" y="240" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="627" y="242" width="62" height="22">
-			</bounds>
+			<bounds x="627" y="242" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="496" y="273" width="58" height="26">
-			</bounds>
+			<bounds x="496" y="273" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="498" y="275" width="54" height="22">
-			</bounds>
+			<bounds x="498" y="275" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="538" y="117" width="58" height="26">
-			</bounds>
+			<bounds x="538" y="117" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="540" y="119" width="54" height="22">
-			</bounds>
+			<bounds x="540" y="119" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="550" y="143" width="58" height="26">
-			</bounds>
+			<bounds x="550" y="143" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="552" y="145" width="54" height="22">
-			</bounds>
+			<bounds x="552" y="145" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="550" y="169" width="58" height="26">
-			</bounds>
+			<bounds x="550" y="169" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="552" y="171" width="54" height="22">
-			</bounds>
+			<bounds x="552" y="171" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="538" y="195" width="58" height="26">
-			</bounds>
+			<bounds x="538" y="195" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="540" y="197" width="54" height="22">
-			</bounds>
+			<bounds x="540" y="197" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="526" y="221" width="58" height="26">
-			</bounds>
+			<bounds x="526" y="221" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="528" y="223" width="54" height="22">
-			</bounds>
+			<bounds x="528" y="223" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="514" y="247" width="58" height="26">
-			</bounds>
+			<bounds x="514" y="247" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="516" y="249" width="54" height="22">
-			</bounds>
+			<bounds x="516" y="249" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="496" y="36" width="66" height="30">
-			</bounds>
+			<bounds x="496" y="36" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="498" y="38" width="62" height="26">
-			</bounds>
+			<bounds x="498" y="38" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="514" y="65" width="58" height="26">
-			</bounds>
+			<bounds x="514" y="65" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="516" y="67" width="54" height="22">
-			</bounds>
+			<bounds x="516" y="67" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="526" y="91" width="58" height="26">
-			</bounds>
+			<bounds x="526" y="91" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="528" y="93" width="54" height="22">
-			</bounds>
+			<bounds x="528" y="93" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="408" y="273" width="58" height="26">
-			</bounds>
+			<bounds x="408" y="273" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="410" y="275" width="54" height="22">
-			</bounds>
+			<bounds x="410" y="275" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="420" y="247" width="58" height="26">
-			</bounds>
+			<bounds x="420" y="247" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="422" y="249" width="54" height="22">
-			</bounds>
+			<bounds x="422" y="249" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="432" y="221" width="58" height="26">
-			</bounds>
+			<bounds x="432" y="221" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="434" y="223" width="54" height="22">
-			</bounds>
+			<bounds x="434" y="223" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="444" y="195" width="58" height="26">
-			</bounds>
+			<bounds x="444" y="195" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="446" y="197" width="54" height="22">
-			</bounds>
+			<bounds x="446" y="197" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="456" y="169" width="58" height="26">
-			</bounds>
+			<bounds x="456" y="169" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="458" y="171" width="54" height="22">
-			</bounds>
+			<bounds x="458" y="171" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="456" y="143" width="58" height="26">
-			</bounds>
+			<bounds x="456" y="143" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="458" y="145" width="54" height="22">
-			</bounds>
+			<bounds x="458" y="145" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="444" y="117" width="58" height="26">
-			</bounds>
+			<bounds x="444" y="117" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="446" y="119" width="54" height="22">
-			</bounds>
+			<bounds x="446" y="119" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="420" y="65" width="58" height="26">
-			</bounds>
+			<bounds x="420" y="65" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="422" y="67" width="54" height="22">
-			</bounds>
+			<bounds x="422" y="67" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="408" y="36" width="66" height="30">
-			</bounds>
+			<bounds x="408" y="36" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="410" y="38" width="62" height="26">
-			</bounds>
+			<bounds x="410" y="38" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="432" y="91" width="58" height="26">
-			</bounds>
+			<bounds x="432" y="91" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="434" y="93" width="54" height="22">
-			</bounds>
+			<bounds x="434" y="93" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_136_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="933" y="11" width="46" height="36">
-			</bounds>
+			<bounds x="933" y="11" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_136" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="935" y="13" width="42" height="32">
-			</bounds>
+			<bounds x="935" y="13" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_138_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="656" y="635" width="75" height="27">
-			</bounds>
+			<bounds x="656" y="635" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_138" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="658" y="637" width="71" height="23">
-			</bounds>
+			<bounds x="658" y="637" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_139_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="356" y="635" width="75" height="27">
-			</bounds>
+			<bounds x="356" y="635" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_139" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="358" y="637" width="71" height="23">
-			</bounds>
+			<bounds x="358" y="637" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_140_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="431" y="635" width="75" height="27">
-			</bounds>
+			<bounds x="431" y="635" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_140" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="433" y="637" width="71" height="23">
-			</bounds>
+			<bounds x="433" y="637" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_141_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="506" y="635" width="75" height="27">
-			</bounds>
+			<bounds x="506" y="635" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_141" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="508" y="637" width="71" height="23">
-			</bounds>
+			<bounds x="508" y="637" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_142_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="581" y="635" width="75" height="27">
-			</bounds>
+			<bounds x="581" y="635" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_142" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="583" y="637" width="71" height="23">
-			</bounds>
+			<bounds x="583" y="637" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_143_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="206" y="635" width="75" height="27">
-			</bounds>
+			<bounds x="206" y="635" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_143" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="208" y="637" width="71" height="23">
-			</bounds>
+			<bounds x="208" y="637" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_144_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="281" y="635" width="75" height="27">
-			</bounds>
+			<bounds x="281" y="635" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_144" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="283" y="637" width="71" height="23">
-			</bounds>
+			<bounds x="283" y="637" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_145_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="229" y="223" width="78" height="26">
-			</bounds>
+			<bounds x="229" y="223" width="78" height="26"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_145" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="231" y="225" width="74" height="22">
-			</bounds>
+			<bounds x="231" y="225" width="74" height="22"/>
 		</backdrop>
 		<backdrop name="lamp75" element="colour_button_146_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="575" y="300" width="36" height="26">
-			</bounds>
+			<bounds x="575" y="300" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp75" element="colour_button_146" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="577" y="302" width="32" height="22">
-			</bounds>
+			<bounds x="577" y="302" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp74" element="colour_button_147_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="496" y="300" width="36" height="26">
-			</bounds>
+			<bounds x="496" y="300" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp74" element="colour_button_147" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="498" y="302" width="32" height="22">
-			</bounds>
+			<bounds x="498" y="302" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp73" element="colour_button_148_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="408" y="300" width="36" height="26">
-			</bounds>
+			<bounds x="408" y="300" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp73" element="colour_button_148" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="410" y="302" width="32" height="22">
-			</bounds>
+			<bounds x="410" y="302" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp71" element="colour_button_149_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="497" y="395" width="36" height="26">
-			</bounds>
+			<bounds x="497" y="395" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp71" element="colour_button_149" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="499" y="397" width="32" height="22">
-			</bounds>
+			<bounds x="499" y="397" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp70" element="colour_button_150_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="576" y="395" width="36" height="26">
-			</bounds>
+			<bounds x="576" y="395" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="colour_button_150" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="578" y="397" width="32" height="22">
-			</bounds>
+			<bounds x="578" y="397" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp72" element="colour_button_151_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="408" y="395" width="36" height="26">
-			</bounds>
+			<bounds x="408" y="395" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp72" element="colour_button_151" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="410" y="397" width="32" height="22">
-			</bounds>
+			<bounds x="410" y="397" width="32" height="22"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="292" y="426" width="323" height="27">
-			</bounds>
+			<bounds x="292" y="426" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="292" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="292" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="312" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="312" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="332" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="332" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="352" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="352" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="372" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="372" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="392" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="392" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="412" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="412" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="432" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="432" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="452" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="452" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="472" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="472" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="492" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="492" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="512" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="512" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="532" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="532" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="552" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="552" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="572" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="572" y="426" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="592" y="426" width="20" height="27">
-			</bounds>
+			<bounds x="592" y="426" width="20" height="27"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_button" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_button" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_button" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_button" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_button" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_button" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cabin.lay
+++ b/src/mame/layout/sc4cabin.lay
@@ -8,13620 +8,8967 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WILD THING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WILD THING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HOE DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HOE DOWN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MISSING LINK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MISSING LINK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="FAST CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="FAST CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MONEY MAYHEM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MONEY MAYHEM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HI LO YEHA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HI LO YEHA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="DELIVERANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="DELIVERANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="DUELING BANJOS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="DUELING BANJOS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPERHOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPERHOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXTRA SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXTRA SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="SKILL STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BONUS SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="BONUS SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BONUS RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="BONUS RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="HIGH 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="HIGH 5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Bonus Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Bonus Step">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="SWAP NUMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="SWAP NUMBER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BONUS SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BONUS SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MEGA STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MEGA STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXTRA SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXTRA SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MEGA STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MEGA STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CRAZY PAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CRAZY PAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="EXTRA SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CASH ODDITY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CASH ODDITY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="RICH PICKINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="RICH PICKINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="30p PLAY 5 LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="30p PLAY 5 LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LIGHT ALL SPITS TO ACTIVATE SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIGHT ALL SPITS TO ACTIVATE SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SPIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10p PLAY 1 LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10p PLAY 1 LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20p PLAY 3 LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p PLAY 3 LINES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="HIGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HIGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HIGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_170_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_170">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_171_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_171">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_172_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_172">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_173_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_173">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_174_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_174">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TRANSFER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_175_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_175">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_176_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_176">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_177_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_177">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_178_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_178">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_179_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_179">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_180_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_180">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COL/CAN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="5" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_163">
 		<text string="CREDIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_164">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="996" height="672">
-			</bounds>
+			<bounds x="0" y="0" width="996" height="672"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="254" y="411" width="90" height="140">
-			</bounds>
+			<bounds x="254" y="411" width="90" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="411.0000" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="254.0000" y="411.0000" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="257.7500" y="412.9445" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="257.7500" y="412.9445" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.5000" y="414.8889" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="261.5000" y="414.8889" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.2500" y="416.8333" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="265.2500" y="416.8333" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="269.0000" y="418.7778" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="269.0000" y="418.7778" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="272.7500" y="420.7222" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="272.7500" y="420.7222" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="457.6667" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="254.0000" y="457.6667" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="257.7500" y="459.6111" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="257.7500" y="459.6111" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.5000" y="461.5555" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="261.5000" y="461.5555" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.2500" y="463.5000" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="265.2500" y="463.5000" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="269.0000" y="465.4444" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="269.0000" y="465.4444" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="272.7500" y="467.3889" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="272.7500" y="467.3889" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="504.3333" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="254.0000" y="504.3333" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="257.7500" y="506.2778" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="257.7500" y="506.2778" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="261.5000" y="508.2222" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="261.5000" y="508.2222" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="265.2500" y="510.1667" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="265.2500" y="510.1667" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="269.0000" y="512.1111" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="269.0000" y="512.1111" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="272.7500" y="514.0555" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="272.7500" y="514.0555" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="254" y="411" width="90" height="140">
-			</bounds>
+			<bounds x="254" y="411" width="90" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="361" y="411" width="90" height="140">
-			</bounds>
+			<bounds x="361" y="411" width="90" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="361.0000" y="411.0000" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="361.0000" y="411.0000" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="364.7500" y="412.9445" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="364.7500" y="412.9445" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="368.5000" y="414.8889" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="368.5000" y="414.8889" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="372.2500" y="416.8333" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="372.2500" y="416.8333" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="376.0000" y="418.7778" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="376.0000" y="418.7778" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="379.7500" y="420.7222" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="379.7500" y="420.7222" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="361.0000" y="457.6667" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="361.0000" y="457.6667" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="364.7500" y="459.6111" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="364.7500" y="459.6111" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="368.5000" y="461.5555" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="368.5000" y="461.5555" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="372.2500" y="463.5000" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="372.2500" y="463.5000" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="376.0000" y="465.4444" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="376.0000" y="465.4444" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="379.7500" y="467.3889" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="379.7500" y="467.3889" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="361.0000" y="504.3333" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="361.0000" y="504.3333" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="364.7500" y="506.2778" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="364.7500" y="506.2778" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="368.5000" y="508.2222" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="368.5000" y="508.2222" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="372.2500" y="510.1667" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="372.2500" y="510.1667" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="376.0000" y="512.1111" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="376.0000" y="512.1111" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="379.7500" y="514.0555" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="379.7500" y="514.0555" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="361" y="411" width="90" height="140">
-			</bounds>
+			<bounds x="361" y="411" width="90" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="469" y="411" width="90" height="140">
-			</bounds>
+			<bounds x="469" y="411" width="90" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="469.0000" y="411.0000" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="469.0000" y="411.0000" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="472.7500" y="412.9445" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="472.7500" y="412.9445" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="476.5000" y="414.8889" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="476.5000" y="414.8889" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="480.2500" y="416.8333" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="480.2500" y="416.8333" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="484.0000" y="418.7778" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="484.0000" y="418.7778" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="487.7500" y="420.7222" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="487.7500" y="420.7222" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="469.0000" y="457.6667" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="469.0000" y="457.6667" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="472.7500" y="459.6111" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="472.7500" y="459.6111" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="476.5000" y="461.5555" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="476.5000" y="461.5555" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="480.2500" y="463.5000" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="480.2500" y="463.5000" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="484.0000" y="465.4444" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="484.0000" y="465.4444" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="487.7500" y="467.3889" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="487.7500" y="467.3889" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="469.0000" y="504.3333" width="90.0000" height="46.6667">
-			</bounds>
+			<bounds x="469.0000" y="504.3333" width="90.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="472.7500" y="506.2778" width="82.5000" height="42.7778">
-			</bounds>
+			<bounds x="472.7500" y="506.2778" width="82.5000" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="476.5000" y="508.2222" width="75.0000" height="38.8889">
-			</bounds>
+			<bounds x="476.5000" y="508.2222" width="75.0000" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="480.2500" y="510.1667" width="67.5000" height="35.0000">
-			</bounds>
+			<bounds x="480.2500" y="510.1667" width="67.5000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="484.0000" y="512.1111" width="60.0000" height="31.1111">
-			</bounds>
+			<bounds x="484.0000" y="512.1111" width="60.0000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="487.7500" y="514.0555" width="52.5000" height="27.2222">
-			</bounds>
+			<bounds x="487.7500" y="514.0555" width="52.5000" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="469" y="411" width="90" height="140">
-			</bounds>
+			<bounds x="469" y="411" width="90" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="254" y="331" width="305" height="45">
-			</bounds>
+			<bounds x="254" y="331" width="305" height="45"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="331.0000" width="305.0000" height="9.0000">
-			</bounds>
+			<bounds x="254.0000" y="331.0000" width="305.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_1" state="0">
-			<bounds x="266.7083" y="331.3750" width="279.5833" height="8.2500">
-			</bounds>
+			<bounds x="266.7083" y="331.3750" width="279.5833" height="8.2500"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.4167" y="331.7500" width="254.1667" height="7.5000">
-			</bounds>
+			<bounds x="279.4167" y="331.7500" width="254.1667" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_3" state="0">
-			<bounds x="292.1250" y="332.1250" width="228.7500" height="6.7500">
-			</bounds>
+			<bounds x="292.1250" y="332.1250" width="228.7500" height="6.7500"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_4" state="0">
-			<bounds x="304.8333" y="332.5000" width="203.3333" height="6.0000">
-			</bounds>
+			<bounds x="304.8333" y="332.5000" width="203.3333" height="6.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_5" state="0">
-			<bounds x="317.5417" y="332.8750" width="177.9167" height="5.2500">
-			</bounds>
+			<bounds x="317.5417" y="332.8750" width="177.9167" height="5.2500"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="340.0000" width="305.0000" height="9.0000">
-			</bounds>
+			<bounds x="254.0000" y="340.0000" width="305.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="266.7083" y="340.3750" width="279.5833" height="8.2500">
-			</bounds>
+			<bounds x="266.7083" y="340.3750" width="279.5833" height="8.2500"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.4167" y="340.7500" width="254.1667" height="7.5000">
-			</bounds>
+			<bounds x="279.4167" y="340.7500" width="254.1667" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="292.1250" y="341.1250" width="228.7500" height="6.7500">
-			</bounds>
+			<bounds x="292.1250" y="341.1250" width="228.7500" height="6.7500"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="304.8333" y="341.5000" width="203.3333" height="6.0000">
-			</bounds>
+			<bounds x="304.8333" y="341.5000" width="203.3333" height="6.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="317.5417" y="341.8750" width="177.9167" height="5.2500">
-			</bounds>
+			<bounds x="317.5417" y="341.8750" width="177.9167" height="5.2500"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="349.0000" width="305.0000" height="9.0000">
-			</bounds>
+			<bounds x="254.0000" y="349.0000" width="305.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_1" state="0">
-			<bounds x="266.7083" y="349.3750" width="279.5833" height="8.2500">
-			</bounds>
+			<bounds x="266.7083" y="349.3750" width="279.5833" height="8.2500"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.4167" y="349.7500" width="254.1667" height="7.5000">
-			</bounds>
+			<bounds x="279.4167" y="349.7500" width="254.1667" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_3" state="0">
-			<bounds x="292.1250" y="350.1250" width="228.7500" height="6.7500">
-			</bounds>
+			<bounds x="292.1250" y="350.1250" width="228.7500" height="6.7500"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_4" state="0">
-			<bounds x="304.8333" y="350.5000" width="203.3333" height="6.0000">
-			</bounds>
+			<bounds x="304.8333" y="350.5000" width="203.3333" height="6.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_5" state="0">
-			<bounds x="317.5417" y="350.8750" width="177.9167" height="5.2500">
-			</bounds>
+			<bounds x="317.5417" y="350.8750" width="177.9167" height="5.2500"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="358.0000" width="305.0000" height="9.0000">
-			</bounds>
+			<bounds x="254.0000" y="358.0000" width="305.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="266.7083" y="358.3750" width="279.5833" height="8.2500">
-			</bounds>
+			<bounds x="266.7083" y="358.3750" width="279.5833" height="8.2500"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.4167" y="358.7500" width="254.1667" height="7.5000">
-			</bounds>
+			<bounds x="279.4167" y="358.7500" width="254.1667" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="292.1250" y="359.1250" width="228.7500" height="6.7500">
-			</bounds>
+			<bounds x="292.1250" y="359.1250" width="228.7500" height="6.7500"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="304.8333" y="359.5000" width="203.3333" height="6.0000">
-			</bounds>
+			<bounds x="304.8333" y="359.5000" width="203.3333" height="6.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="317.5417" y="359.8750" width="177.9167" height="5.2500">
-			</bounds>
+			<bounds x="317.5417" y="359.8750" width="177.9167" height="5.2500"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="367.0000" width="305.0000" height="9.0000">
-			</bounds>
+			<bounds x="254.0000" y="367.0000" width="305.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_1" state="0">
-			<bounds x="266.7083" y="367.3750" width="279.5833" height="8.2500">
-			</bounds>
+			<bounds x="266.7083" y="367.3750" width="279.5833" height="8.2500"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_2" state="0">
-			<bounds x="279.4167" y="367.7500" width="254.1667" height="7.5000">
-			</bounds>
+			<bounds x="279.4167" y="367.7500" width="254.1667" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_3" state="0">
-			<bounds x="292.1250" y="368.1250" width="228.7500" height="6.7500">
-			</bounds>
+			<bounds x="292.1250" y="368.1250" width="228.7500" height="6.7500"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_4" state="0">
-			<bounds x="304.8333" y="368.5000" width="203.3333" height="6.0000">
-			</bounds>
+			<bounds x="304.8333" y="368.5000" width="203.3333" height="6.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_5" state="0">
-			<bounds x="317.5417" y="368.8750" width="177.9167" height="5.2500">
-			</bounds>
+			<bounds x="317.5417" y="368.8750" width="177.9167" height="5.2500"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="254" y="331" width="305" height="45">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="254" y="331" width="305" height="45"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="23" y="151" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="151" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="25" y="153" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="153" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="23" y="151" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="151" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="25" y="153" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="153" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="23" y="178" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="178" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="25" y="180" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="180" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="23" y="178" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="178" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="25" y="180" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="180" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="23" y="205" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="205" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="25" y="207" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="207" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="23" y="205" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="205" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="25" y="207" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="207" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="667" y="72" width="37" height="19">
-			</bounds>
+			<bounds x="667" y="72" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="669" y="74" width="33" height="15">
-			</bounds>
+			<bounds x="669" y="74" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="667" y="72" width="37" height="19">
-			</bounds>
+			<bounds x="667" y="72" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="669" y="74" width="33" height="15">
-			</bounds>
+			<bounds x="669" y="74" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="23" y="232" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="232" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="25" y="234" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="234" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="23" y="232" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="232" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="25" y="234" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="234" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="23" y="259" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="259" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="25" y="261" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="261" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="23" y="259" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="259" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="25" y="261" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="261" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="710" y="72" width="37" height="19">
-			</bounds>
+			<bounds x="710" y="72" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="712" y="74" width="33" height="15">
-			</bounds>
+			<bounds x="712" y="74" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="710" y="72" width="37" height="19">
-			</bounds>
+			<bounds x="710" y="72" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="712" y="74" width="33" height="15">
-			</bounds>
+			<bounds x="712" y="74" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="23" y="286" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="286" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="25" y="288" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="288" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="23" y="286" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="286" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="25" y="288" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="288" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="23" y="313" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="313" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="25" y="315" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="315" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="23" y="313" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="313" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="25" y="315" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="315" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="23" y="340" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="340" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="25" y="342" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="342" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="23" y="340" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="340" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="25" y="342" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="342" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="23" y="367" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="367" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="25" y="369" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="369" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="23" y="367" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="367" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="25" y="369" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="369" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="45" y="485" width="37" height="47">
-			</bounds>
+			<bounds x="45" y="485" width="37" height="47"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="47" y="487" width="33" height="43">
-			</bounds>
+			<bounds x="47" y="487" width="33" height="43"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="86" y="485" width="37" height="47">
-			</bounds>
+			<bounds x="86" y="485" width="37" height="47"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="88" y="487" width="33" height="43">
-			</bounds>
+			<bounds x="88" y="487" width="33" height="43"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="127" y="485" width="37" height="47">
-			</bounds>
+			<bounds x="127" y="485" width="37" height="47"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="129" y="487" width="33" height="43">
-			</bounds>
+			<bounds x="129" y="487" width="33" height="43"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="377" y="244" width="57" height="57">
-			</bounds>
+			<bounds x="377" y="244" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="379" y="246" width="53" height="53">
-			</bounds>
+			<bounds x="379" y="246" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="377" y="244" width="57" height="57">
-			</bounds>
+			<bounds x="377" y="244" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="379" y="246" width="53" height="53">
-			</bounds>
+			<bounds x="379" y="246" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="289" y="228" width="57" height="57">
-			</bounds>
+			<bounds x="289" y="228" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="291" y="230" width="53" height="53">
-			</bounds>
+			<bounds x="291" y="230" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="289" y="228" width="57" height="57">
-			</bounds>
+			<bounds x="289" y="228" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="291" y="230" width="53" height="53">
-			</bounds>
+			<bounds x="291" y="230" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="207" y="207" width="57" height="57">
-			</bounds>
+			<bounds x="207" y="207" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="209" y="209" width="53" height="53">
-			</bounds>
+			<bounds x="209" y="209" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="542" y="207" width="57" height="57">
-			</bounds>
+			<bounds x="542" y="207" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="544" y="209" width="53" height="53">
-			</bounds>
+			<bounds x="544" y="209" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="289" y="26" width="57" height="57">
-			</bounds>
+			<bounds x="289" y="26" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="291" y="28" width="53" height="53">
-			</bounds>
+			<bounds x="291" y="28" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="207" y="66" width="57" height="57">
-			</bounds>
+			<bounds x="207" y="66" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="209" y="68" width="53" height="53">
-			</bounds>
+			<bounds x="209" y="68" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="185" y="137" width="57" height="57">
-			</bounds>
+			<bounds x="185" y="137" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="187" y="139" width="53" height="53">
-			</bounds>
+			<bounds x="187" y="139" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="464" y="175" width="32" height="32">
-			</bounds>
+			<bounds x="464" y="175" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="466" y="177" width="28" height="28">
-			</bounds>
+			<bounds x="466" y="177" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="418" y="175" width="32" height="32">
-			</bounds>
+			<bounds x="418" y="175" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="420" y="177" width="28" height="28">
-			</bounds>
+			<bounds x="420" y="177" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="345" y="144" width="32" height="32">
-			</bounds>
+			<bounds x="345" y="144" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="347" y="146" width="28" height="28">
-			</bounds>
+			<bounds x="347" y="146" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="294" y="144" width="32" height="32">
-			</bounds>
+			<bounds x="294" y="144" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="296" y="146" width="28" height="28">
-			</bounds>
+			<bounds x="296" y="146" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="915" y="499" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="499" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="917" y="501" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="501" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="915" y="499" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="499" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="917" y="501" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="501" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="915" y="465" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="465" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="917" y="467" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="467" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="915" y="465" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="465" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="917" y="467" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="467" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="562" y="438" width="19" height="19">
-			</bounds>
+			<bounds x="562" y="438" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="564" y="440" width="15" height="15">
-			</bounds>
+			<bounds x="564" y="440" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="562" y="411" width="19" height="19">
-			</bounds>
+			<bounds x="562" y="411" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="564" y="413" width="15" height="15">
-			</bounds>
+			<bounds x="564" y="413" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="915" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="917" y="433" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="433" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="915" y="431" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="431" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="917" y="433" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="433" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="915" y="397" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="397" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="917" y="399" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="399" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="915" y="397" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="397" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="917" y="399" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="399" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="915" y="363" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="363" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="917" y="365" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="365" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="915" y="363" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="363" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="917" y="365" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="365" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="757" y="482" width="47" height="27">
-			</bounds>
+			<bounds x="757" y="482" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="759" y="484" width="43" height="23">
-			</bounds>
+			<bounds x="759" y="484" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="707" y="482" width="47" height="27">
-			</bounds>
+			<bounds x="707" y="482" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="709" y="484" width="43" height="23">
-			</bounds>
+			<bounds x="709" y="484" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="657" y="482" width="47" height="27">
-			</bounds>
+			<bounds x="657" y="482" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="659" y="484" width="43" height="23">
-			</bounds>
+			<bounds x="659" y="484" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="657" y="447" width="47" height="27">
-			</bounds>
+			<bounds x="657" y="447" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="659" y="449" width="43" height="23">
-			</bounds>
+			<bounds x="659" y="449" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="707" y="447" width="47" height="27">
-			</bounds>
+			<bounds x="707" y="447" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="709" y="449" width="43" height="23">
-			</bounds>
+			<bounds x="709" y="449" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="757" y="447" width="47" height="27">
-			</bounds>
+			<bounds x="757" y="447" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="759" y="449" width="43" height="23">
-			</bounds>
+			<bounds x="759" y="449" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="915" y="329" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="329" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="917" y="331" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="331" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="915" y="329" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="329" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="917" y="331" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="331" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="726" y="369" width="57" height="37">
-			</bounds>
+			<bounds x="726" y="369" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="728" y="371" width="53" height="33">
-			</bounds>
+			<bounds x="728" y="371" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="666" y="369" width="57" height="37">
-			</bounds>
+			<bounds x="666" y="369" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="668" y="371" width="53" height="33">
-			</bounds>
+			<bounds x="668" y="371" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="915" y="295" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="295" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="917" y="297" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="297" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="915" y="295" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="295" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="917" y="297" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="297" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="915" y="261" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="261" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="917" y="263" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="263" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="915" y="261" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="261" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="917" y="263" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="263" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="726" y="333" width="57" height="37">
-			</bounds>
+			<bounds x="726" y="333" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="728" y="335" width="53" height="33">
-			</bounds>
+			<bounds x="728" y="335" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="666" y="333" width="57" height="37">
-			</bounds>
+			<bounds x="666" y="333" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="668" y="335" width="53" height="33">
-			</bounds>
+			<bounds x="668" y="335" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="726" y="297" width="57" height="37">
-			</bounds>
+			<bounds x="726" y="297" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="728" y="299" width="53" height="33">
-			</bounds>
+			<bounds x="728" y="299" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="915" y="227" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="227" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="917" y="229" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="229" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="915" y="227" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="227" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="917" y="229" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="229" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="915" y="193" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="193" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="917" y="195" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="195" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="915" y="193" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="193" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="917" y="195" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="195" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="666" y="297" width="57" height="37">
-			</bounds>
+			<bounds x="666" y="297" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="668" y="299" width="53" height="33">
-			</bounds>
+			<bounds x="668" y="299" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="726" y="261" width="57" height="37">
-			</bounds>
+			<bounds x="726" y="261" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="728" y="263" width="53" height="33">
-			</bounds>
+			<bounds x="728" y="263" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="666" y="261" width="57" height="37">
-			</bounds>
+			<bounds x="666" y="261" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="668" y="263" width="53" height="33">
-			</bounds>
+			<bounds x="668" y="263" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="694" y="225" width="57" height="37">
-			</bounds>
+			<bounds x="694" y="225" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="696" y="227" width="53" height="33">
-			</bounds>
+			<bounds x="696" y="227" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="694" y="225" width="57" height="37">
-			</bounds>
+			<bounds x="694" y="225" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="696" y="227" width="53" height="33">
-			</bounds>
+			<bounds x="696" y="227" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="915" y="159" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="159" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="917" y="161" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="161" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="915" y="159" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="159" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="917" y="161" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="161" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="915" y="125" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="125" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="917" y="127" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="127" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="915" y="125" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="125" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="917" y="127" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="127" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="915" y="91" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="91" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="917" y="93" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="93" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="915" y="91" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="91" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="917" y="93" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="93" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="915" y="57" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="57" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="917" y="59" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="59" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="915" y="57" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="57" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="917" y="59" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="59" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="840" y="11" width="107" height="47">
-			</bounds>
+			<bounds x="840" y="11" width="107" height="47"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="842" y="13" width="103" height="43">
-			</bounds>
+			<bounds x="842" y="13" width="103" height="43"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="840" y="11" width="107" height="47">
-			</bounds>
+			<bounds x="840" y="11" width="107" height="47"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="842" y="13" width="103" height="43">
-			</bounds>
+			<bounds x="842" y="13" width="103" height="43"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="542" y="67" width="57" height="57">
-			</bounds>
+			<bounds x="542" y="67" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="544" y="69" width="53" height="53">
-			</bounds>
+			<bounds x="544" y="69" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="447" y="144" width="32" height="32">
-			</bounds>
+			<bounds x="447" y="144" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="449" y="146" width="28" height="28">
-			</bounds>
+			<bounds x="449" y="146" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="374" y="175" width="32" height="32">
-			</bounds>
+			<bounds x="374" y="175" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="376" y="177" width="28" height="28">
-			</bounds>
+			<bounds x="376" y="177" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="499" y="144" width="32" height="32">
-			</bounds>
+			<bounds x="499" y="144" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="501" y="146" width="28" height="28">
-			</bounds>
+			<bounds x="501" y="146" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="465" y="26" width="57" height="57">
-			</bounds>
+			<bounds x="465" y="26" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="467" y="28" width="53" height="53">
-			</bounds>
+			<bounds x="467" y="28" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="465" y="26" width="57" height="57">
-			</bounds>
+			<bounds x="465" y="26" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="467" y="28" width="53" height="53">
-			</bounds>
+			<bounds x="467" y="28" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="377" y="7" width="57" height="57">
-			</bounds>
+			<bounds x="377" y="7" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="379" y="9" width="53" height="53">
-			</bounds>
+			<bounds x="379" y="9" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="377" y="7" width="57" height="57">
-			</bounds>
+			<bounds x="377" y="7" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="379" y="9" width="53" height="53">
-			</bounds>
+			<bounds x="379" y="9" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="267" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="267" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="269" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="269" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="249" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="249" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="251" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="251" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="229" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="229" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="231" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="231" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="213" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="213" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="215" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="215" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="193" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="193" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="195" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="195" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="173" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="173" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="175" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="175" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="153" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="153" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="155" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="155" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="132" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="132" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="134" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="134" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="111" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="111" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="113" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="113" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="23" y="23" width="107" height="47">
-			</bounds>
+			<bounds x="23" y="23" width="107" height="47"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="25" y="25" width="103" height="43">
-			</bounds>
+			<bounds x="25" y="25" width="103" height="43"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="23" y="23" width="107" height="47">
-			</bounds>
+			<bounds x="23" y="23" width="107" height="47"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="25" y="25" width="103" height="43">
-			</bounds>
+			<bounds x="25" y="25" width="103" height="43"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="23" y="70" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="70" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="25" y="72" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="72" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="23" y="70" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="70" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="25" y="72" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="72" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="285" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="285" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="287" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="287" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="304" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="304" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="306" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="306" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="320" y="1" width="19" height="19">
-			</bounds>
+			<bounds x="320" y="1" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="322" y="3" width="15" height="15">
-			</bounds>
+			<bounds x="322" y="3" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="576" y="137" width="57" height="57">
-			</bounds>
+			<bounds x="576" y="137" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="578" y="139" width="53" height="53">
-			</bounds>
+			<bounds x="578" y="139" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="329" y="175" width="32" height="32">
-			</bounds>
+			<bounds x="329" y="175" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="331" y="177" width="28" height="28">
-			</bounds>
+			<bounds x="331" y="177" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="395" y="144" width="32" height="32">
-			</bounds>
+			<bounds x="395" y="144" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="397" y="146" width="28" height="28">
-			</bounds>
+			<bounds x="397" y="146" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="465" y="229" width="57" height="57">
-			</bounds>
+			<bounds x="465" y="229" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="467" y="231" width="53" height="53">
-			</bounds>
+			<bounds x="467" y="231" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="23" y="124" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="124" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="25" y="126" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="126" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="23" y="124" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="124" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="25" y="126" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="126" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="23" y="97" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="97" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="25" y="99" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="99" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="23" y="97" width="107" height="27">
-			</bounds>
+			<bounds x="23" y="97" width="107" height="27"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="25" y="99" width="103" height="23">
-			</bounds>
+			<bounds x="25" y="99" width="103" height="23"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="915" y="533" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="533" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="917" y="535" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="535" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="915" y="533" width="32" height="32">
-			</bounds>
+			<bounds x="915" y="533" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="917" y="535" width="28" height="28">
-			</bounds>
+			<bounds x="917" y="535" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="180" y="570" width="57" height="47">
-			</bounds>
+			<bounds x="180" y="570" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="182" y="572" width="53" height="43">
-			</bounds>
+			<bounds x="182" y="572" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="259" y="588" width="87" height="42">
-			</bounds>
+			<bounds x="259" y="588" width="87" height="42"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="261" y="590" width="83" height="38">
-			</bounds>
+			<bounds x="261" y="590" width="83" height="38"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="489" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="489" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="491" y="590" width="28" height="28">
-			</bounds>
+			<bounds x="491" y="590" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="545" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="545" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="547" y="590" width="28" height="28">
-			</bounds>
+			<bounds x="547" y="590" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="659" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="659" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="661" y="590" width="28" height="28">
-			</bounds>
+			<bounds x="661" y="590" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="714" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="714" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="716" y="590" width="28" height="28">
-			</bounds>
+			<bounds x="716" y="590" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="678" y="26" width="102" height="47">
-			</bounds>
+			<bounds x="678" y="26" width="102" height="47"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="680" y="28" width="98" height="43">
-			</bounds>
+			<bounds x="680" y="28" width="98" height="43"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="753" y="72" width="37" height="19">
-			</bounds>
+			<bounds x="753" y="72" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="755" y="74" width="33" height="15">
-			</bounds>
+			<bounds x="755" y="74" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="753" y="72" width="37" height="19">
-			</bounds>
+			<bounds x="753" y="72" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="755" y="74" width="33" height="15">
-			</bounds>
+			<bounds x="755" y="74" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="232" y="411" width="19" height="19">
-			</bounds>
+			<bounds x="232" y="411" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="234" y="413" width="15" height="15">
-			</bounds>
+			<bounds x="234" y="413" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="232" y="438" width="19" height="19">
-			</bounds>
+			<bounds x="232" y="438" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="234" y="440" width="15" height="15">
-			</bounds>
+			<bounds x="234" y="440" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="232" y="473" width="19" height="19">
-			</bounds>
+			<bounds x="232" y="473" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="234" y="475" width="15" height="15">
-			</bounds>
+			<bounds x="234" y="475" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="66" y="570" width="57" height="47">
-			</bounds>
+			<bounds x="66" y="570" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="68" y="572" width="53" height="43">
-			</bounds>
+			<bounds x="68" y="572" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="123" y="570" width="57" height="47">
-			</bounds>
+			<bounds x="123" y="570" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="125" y="572" width="53" height="43">
-			</bounds>
+			<bounds x="125" y="572" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="232" y="507" width="19" height="19">
-			</bounds>
+			<bounds x="232" y="507" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="234" y="509" width="15" height="15">
-			</bounds>
+			<bounds x="234" y="509" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="232" y="532" width="19" height="19">
-			</bounds>
+			<bounds x="232" y="532" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="234" y="534" width="15" height="15">
-			</bounds>
+			<bounds x="234" y="534" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="432" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="432" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="434" y="590" width="28" height="28">
-			</bounds>
+			<bounds x="434" y="590" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="374" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="374" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="376" y="590" width="28" height="28">
-			</bounds>
+			<bounds x="376" y="590" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="602" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="602" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="604" y="590" width="28" height="28">
-			</bounds>
+			<bounds x="604" y="590" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="770" y="588" width="32" height="32">
-			</bounds>
+			<bounds x="770" y="588" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="772" y="590" width="28" height="28">
-			</bounds>
+			<bounds x="772" y="590" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="562" y="532" width="19" height="19">
-			</bounds>
+			<bounds x="562" y="532" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="564" y="534" width="15" height="15">
-			</bounds>
+			<bounds x="564" y="534" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="562" y="507" width="19" height="19">
-			</bounds>
+			<bounds x="562" y="507" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="564" y="509" width="15" height="15">
-			</bounds>
+			<bounds x="564" y="509" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="562" y="473" width="19" height="19">
-			</bounds>
+			<bounds x="562" y="473" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="564" y="475" width="15" height="15">
-			</bounds>
+			<bounds x="564" y="475" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp229" element="colour_button_165_border" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="176" y="485" width="47" height="47">
-			</bounds>
+			<bounds x="176" y="485" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp229" element="colour_button_165" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="178" y="487" width="43" height="43">
-			</bounds>
+			<bounds x="178" y="487" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp230" element="colour_button_166_border" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="253" y="299" width="92" height="27">
-			</bounds>
+			<bounds x="253" y="299" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp230" element="colour_button_166" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="255" y="301" width="88" height="23">
-			</bounds>
+			<bounds x="255" y="301" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp231" element="colour_button_167_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="360" y="300" width="92" height="27">
-			</bounds>
+			<bounds x="360" y="300" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp231" element="colour_button_167" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="362" y="302" width="88" height="23">
-			</bounds>
+			<bounds x="362" y="302" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp232" element="colour_button_168_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="468" y="300" width="92" height="27">
-			</bounds>
+			<bounds x="468" y="300" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp232" element="colour_button_168" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="470" y="302" width="88" height="23">
-			</bounds>
+			<bounds x="470" y="302" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="colour_button_169_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="746" y="110" width="57" height="57">
-			</bounds>
+			<bounds x="746" y="110" width="57" height="57"/>
 		</backdrop>
 		<backdrop name="lamp133" element="colour_button_169" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="748" y="112" width="53" height="53">
-			</bounds>
+			<bounds x="748" y="112" width="53" height="53"/>
 		</backdrop>
 		<backdrop name="lamp84" element="colour_button_170_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="468" y="379" width="92" height="27">
-			</bounds>
+			<bounds x="468" y="379" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp84" element="colour_button_170" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="470" y="381" width="88" height="23">
-			</bounds>
+			<bounds x="470" y="381" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp85" element="colour_button_171_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="360" y="379" width="92" height="27">
-			</bounds>
+			<bounds x="360" y="379" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp85" element="colour_button_171" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="362" y="381" width="88" height="23">
-			</bounds>
+			<bounds x="362" y="381" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp86" element="colour_button_172_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="253" y="379" width="92" height="27">
-			</bounds>
+			<bounds x="253" y="379" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp86" element="colour_button_172" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="255" y="381" width="88" height="23">
-			</bounds>
+			<bounds x="255" y="381" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_173_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="877" y="634" width="92" height="27">
-			</bounds>
+			<bounds x="877" y="634" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_173" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="879" y="636" width="88" height="23">
-			</bounds>
+			<bounds x="879" y="636" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_174_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="770" y="634" width="92" height="27">
-			</bounds>
+			<bounds x="770" y="634" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_174" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="772" y="636" width="88" height="23">
-			</bounds>
+			<bounds x="772" y="636" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_175_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="661" y="634" width="92" height="27">
-			</bounds>
+			<bounds x="661" y="634" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_175" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="663" y="636" width="88" height="23">
-			</bounds>
+			<bounds x="663" y="636" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_176_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="468" y="634" width="92" height="27">
-			</bounds>
+			<bounds x="468" y="634" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_176" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="470" y="636" width="88" height="23">
-			</bounds>
+			<bounds x="470" y="636" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_177_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="360" y="634" width="92" height="27">
-			</bounds>
+			<bounds x="360" y="634" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_177" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="362" y="636" width="88" height="23">
-			</bounds>
+			<bounds x="362" y="636" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_178_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="253" y="634" width="92" height="27">
-			</bounds>
+			<bounds x="253" y="634" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_178" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="255" y="636" width="88" height="23">
-			</bounds>
+			<bounds x="255" y="636" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_179_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="142" y="634" width="92" height="27">
-			</bounds>
+			<bounds x="142" y="634" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_179" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="144" y="636" width="88" height="23">
-			</bounds>
+			<bounds x="144" y="636" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_180_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="44" y="634" width="92" height="27">
-			</bounds>
+			<bounds x="44" y="634" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_180" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="46" y="636" width="88" height="23">
-			</bounds>
+			<bounds x="46" y="636" width="88" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="336" y="83" width="35" height="50">
-			</bounds>
+			<bounds x="336" y="83" width="35" height="50"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="336" y="83" width="35" height="50">
-			</bounds>
+			<bounds x="336" y="83" width="35" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="336" y="83" width="35" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="336" y="83" width="35" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="370" y="83" width="35" height="50">
-			</bounds>
+			<bounds x="370" y="83" width="35" height="50"/>
 		</backdrop>
 		<backdrop name="digit4" element="led_digit_red">
-			<bounds x="370" y="83" width="35" height="50">
-			</bounds>
+			<bounds x="370" y="83" width="35" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="370" y="83" width="35" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="370" y="83" width="35" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="405" y="83" width="35" height="50">
-			</bounds>
+			<bounds x="405" y="83" width="35" height="50"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="405" y="83" width="35" height="50">
-			</bounds>
+			<bounds x="405" y="83" width="35" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="405" y="83" width="35" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="405" y="83" width="35" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="440" y="83" width="35" height="50">
-			</bounds>
+			<bounds x="440" y="83" width="35" height="50"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="440" y="83" width="35" height="50">
-			</bounds>
+			<bounds x="440" y="83" width="35" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="440" y="83" width="35" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="440" y="83" width="35" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="697" y="117" width="35" height="50">
-			</bounds>
+			<bounds x="697" y="117" width="35" height="50"/>
 		</backdrop>
 		<backdrop name="digit8" element="led_digit_red">
-			<bounds x="697" y="117" width="35" height="50">
-			</bounds>
+			<bounds x="697" y="117" width="35" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="697" y="117" width="35" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="697" y="117" width="35" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="662" y="117" width="35" height="50">
-			</bounds>
+			<bounds x="662" y="117" width="35" height="50"/>
 		</backdrop>
 		<backdrop name="digit10" element="led_digit_red">
-			<bounds x="662" y="117" width="35" height="50">
-			</bounds>
+			<bounds x="662" y="117" width="35" height="50"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="662" y="117" width="35" height="50">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="662" y="117" width="35" height="50"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="299" y="568" width="227" height="20">
-			</bounds>
+			<bounds x="299" y="568" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="299" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="299" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="313" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="313" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="327" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="327" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="341" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="341" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="355" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="355" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="369" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="369" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="383" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="383" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="397" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="397" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="411" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="411" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="425" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="425" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="439" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="439" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="453" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="453" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="467" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="467" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="481" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="481" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="495" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="495" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="509" y="568" width="14" height="20">
-			</bounds>
+			<bounds x="509" y="568" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="label163" element="label_163">
-			<bounds x="481" y="555" width="38" height="14">
-			</bounds>
+			<bounds x="481" y="555" width="38" height="14"/>
 		</backdrop>
 		<backdrop name="label164" element="label_164">
-			<bounds x="299" y="555" width="52" height="14">
-			</bounds>
+			<bounds x="299" y="555" width="52" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_button" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_button" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_button" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_button" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_button" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_button" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_button" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_button" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp221" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4canca.lay
+++ b/src/mame/layout/sc4canca.lay
@@ -8,7682 +8,5380 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_53_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_53">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_54_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_54">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="AUTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_55_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_55">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_56_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_56">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_57_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_57">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_58_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_58">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_11">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_13">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_14">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_25">
 		<text string="27 WAYS TO ENTER FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_26">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_33">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_34">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_35">
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="788" height="593">
-			</bounds>
+			<bounds x="0" y="0" width="788" height="593"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="254" y="342" width="100" height="160">
-			</bounds>
+			<bounds x="254" y="342" width="100" height="160"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="342.0000" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="254.0000" y="342.0000" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.1667" y="344.2222" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="258.1667" y="344.2222" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="262.3333" y="346.4445" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="262.3333" y="346.4445" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="266.5000" y="348.6667" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="266.5000" y="348.6667" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.6667" y="350.8889" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="270.6667" y="350.8889" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.8333" y="353.1111" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="274.8333" y="353.1111" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="395.3333" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="254.0000" y="395.3333" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.1667" y="397.5556" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="258.1667" y="397.5556" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="262.3333" y="399.7778" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="262.3333" y="399.7778" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="266.5000" y="402.0000" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="266.5000" y="402.0000" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.6667" y="404.2222" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="270.6667" y="404.2222" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.8333" y="406.4445" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="274.8333" y="406.4445" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="448.6667" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="254.0000" y="448.6667" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="258.1667" y="450.8889" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="258.1667" y="450.8889" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="262.3333" y="453.1111" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="262.3333" y="453.1111" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="266.5000" y="455.3333" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="266.5000" y="455.3333" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="270.6667" y="457.5555" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="270.6667" y="457.5555" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.8333" y="459.7778" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="274.8333" y="459.7778" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="254" y="342" width="100" height="160">
-			</bounds>
+			<bounds x="254" y="342" width="100" height="160"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="352" y="342" width="100" height="160">
-			</bounds>
+			<bounds x="352" y="342" width="100" height="160"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="352.0000" y="342.0000" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="352.0000" y="342.0000" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="356.1667" y="344.2222" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="356.1667" y="344.2222" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="360.3333" y="346.4445" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="360.3333" y="346.4445" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="364.5000" y="348.6667" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="364.5000" y="348.6667" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.6667" y="350.8889" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="368.6667" y="350.8889" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.8333" y="353.1111" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="372.8333" y="353.1111" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="352.0000" y="395.3333" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="352.0000" y="395.3333" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="356.1667" y="397.5556" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="356.1667" y="397.5556" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="360.3333" y="399.7778" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="360.3333" y="399.7778" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="364.5000" y="402.0000" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="364.5000" y="402.0000" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.6667" y="404.2222" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="368.6667" y="404.2222" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.8333" y="406.4445" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="372.8333" y="406.4445" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="352.0000" y="448.6667" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="352.0000" y="448.6667" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="356.1667" y="450.8889" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="356.1667" y="450.8889" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="360.3333" y="453.1111" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="360.3333" y="453.1111" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="364.5000" y="455.3333" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="364.5000" y="455.3333" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="368.6667" y="457.5555" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="368.6667" y="457.5555" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.8333" y="459.7778" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="372.8333" y="459.7778" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="352" y="342" width="100" height="160">
-			</bounds>
+			<bounds x="352" y="342" width="100" height="160"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="451" y="342" width="100" height="160">
-			</bounds>
+			<bounds x="451" y="342" width="100" height="160"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="451.0000" y="342.0000" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="451.0000" y="342.0000" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="455.1667" y="344.2222" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="455.1667" y="344.2222" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="459.3333" y="346.4445" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="459.3333" y="346.4445" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="463.5000" y="348.6667" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="463.5000" y="348.6667" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="467.6667" y="350.8889" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="467.6667" y="350.8889" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="471.8333" y="353.1111" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="471.8333" y="353.1111" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="451.0000" y="395.3333" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="451.0000" y="395.3333" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="455.1667" y="397.5556" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="455.1667" y="397.5556" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="459.3333" y="399.7778" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="459.3333" y="399.7778" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="463.5000" y="402.0000" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="463.5000" y="402.0000" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="467.6667" y="404.2222" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="467.6667" y="404.2222" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="471.8333" y="406.4445" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="471.8333" y="406.4445" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="451.0000" y="448.6667" width="100.0000" height="53.3333">
-			</bounds>
+			<bounds x="451.0000" y="448.6667" width="100.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="455.1667" y="450.8889" width="91.6667" height="48.8889">
-			</bounds>
+			<bounds x="455.1667" y="450.8889" width="91.6667" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="459.3333" y="453.1111" width="83.3333" height="44.4444">
-			</bounds>
+			<bounds x="459.3333" y="453.1111" width="83.3333" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="463.5000" y="455.3333" width="75.0000" height="40.0000">
-			</bounds>
+			<bounds x="463.5000" y="455.3333" width="75.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="467.6667" y="457.5555" width="66.6667" height="35.5556">
-			</bounds>
+			<bounds x="467.6667" y="457.5555" width="66.6667" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="471.8333" y="459.7778" width="58.3333" height="31.1111">
-			</bounds>
+			<bounds x="471.8333" y="459.7778" width="58.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="451" y="342" width="100" height="160">
-			</bounds>
+			<bounds x="451" y="342" width="100" height="160"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="356" y="65" width="100" height="80">
-			</bounds>
+			<bounds x="356" y="65" width="100" height="80"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="356" y="65" width="100" height="80">
-			</bounds>
+			<bounds x="356" y="65" width="100" height="80"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="639" y="1" width="46" height="46">
-			</bounds>
+			<bounds x="639" y="1" width="46" height="46"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="641" y="3" width="42" height="42">
-			</bounds>
+			<bounds x="641" y="3" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="710" y="421" width="67" height="47">
-			</bounds>
+			<bounds x="710" y="421" width="67" height="47"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="712" y="423" width="63" height="43">
-			</bounds>
+			<bounds x="712" y="423" width="63" height="43"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="630" y="459" width="79" height="35">
-			</bounds>
+			<bounds x="630" y="459" width="79" height="35"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="632" y="461" width="75" height="31">
-			</bounds>
+			<bounds x="632" y="461" width="75" height="31"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="644" y="421" width="35" height="35">
-			</bounds>
+			<bounds x="644" y="421" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="646" y="423" width="31" height="31">
-			</bounds>
+			<bounds x="646" y="423" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="679" y="386" width="34" height="34">
-			</bounds>
+			<bounds x="679" y="386" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="681" y="388" width="30" height="30">
-			</bounds>
+			<bounds x="681" y="388" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="649" y="349" width="34" height="34">
-			</bounds>
+			<bounds x="649" y="349" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="651" y="351" width="30" height="30">
-			</bounds>
+			<bounds x="651" y="351" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="74" y="123" width="58" height="58">
-			</bounds>
+			<bounds x="74" y="123" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="76" y="125" width="54" height="54">
-			</bounds>
+			<bounds x="76" y="125" width="54" height="54"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="73" y="186" width="48" height="48">
-			</bounds>
+			<bounds x="73" y="186" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="75" y="188" width="44" height="44">
-			</bounds>
+			<bounds x="75" y="188" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="73" y="236" width="48" height="48">
-			</bounds>
+			<bounds x="73" y="236" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="75" y="238" width="44" height="44">
-			</bounds>
+			<bounds x="75" y="238" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="73" y="333" width="48" height="48">
-			</bounds>
+			<bounds x="73" y="333" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="75" y="335" width="44" height="44">
-			</bounds>
+			<bounds x="75" y="335" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="73" y="284" width="48" height="48">
-			</bounds>
+			<bounds x="73" y="284" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="75" y="286" width="44" height="44">
-			</bounds>
+			<bounds x="75" y="286" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="227" y="1" width="47" height="47">
-			</bounds>
+			<bounds x="227" y="1" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="229" y="3" width="43" height="43">
-			</bounds>
+			<bounds x="229" y="3" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="270" y="8" width="34" height="34">
-			</bounds>
+			<bounds x="270" y="8" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="272" y="10" width="30" height="30">
-			</bounds>
+			<bounds x="272" y="10" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="303" y="8" width="34" height="34">
-			</bounds>
+			<bounds x="303" y="8" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="305" y="10" width="30" height="30">
-			</bounds>
+			<bounds x="305" y="10" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="334" y="1" width="47" height="47">
-			</bounds>
+			<bounds x="334" y="1" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="336" y="3" width="43" height="43">
-			</bounds>
+			<bounds x="336" y="3" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="546" y="3" width="47" height="47">
-			</bounds>
+			<bounds x="546" y="3" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="548" y="5" width="43" height="43">
-			</bounds>
+			<bounds x="548" y="5" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="438" y="3" width="47" height="47">
-			</bounds>
+			<bounds x="438" y="3" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="440" y="5" width="43" height="43">
-			</bounds>
+			<bounds x="440" y="5" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="483" y="11" width="34" height="34">
-			</bounds>
+			<bounds x="483" y="11" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="485" y="13" width="30" height="30">
-			</bounds>
+			<bounds x="485" y="13" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="409" y="11" width="34" height="34">
-			</bounds>
+			<bounds x="409" y="11" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="411" y="13" width="30" height="30">
-			</bounds>
+			<bounds x="411" y="13" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="380" y="11" width="34" height="34">
-			</bounds>
+			<bounds x="380" y="11" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="382" y="13" width="30" height="30">
-			</bounds>
+			<bounds x="382" y="13" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="515" y="11" width="34" height="34">
-			</bounds>
+			<bounds x="515" y="11" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="517" y="13" width="30" height="30">
-			</bounds>
+			<bounds x="517" y="13" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_53_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="649" y="517" width="75" height="47">
-			</bounds>
+			<bounds x="649" y="517" width="75" height="47"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_53" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="651" y="519" width="71" height="43">
-			</bounds>
+			<bounds x="651" y="519" width="71" height="43"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_54_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="561" y="517" width="75" height="47">
-			</bounds>
+			<bounds x="561" y="517" width="75" height="47"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_54" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="563" y="519" width="71" height="43">
-			</bounds>
+			<bounds x="563" y="519" width="71" height="43"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_55_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="176" y="517" width="75" height="47">
-			</bounds>
+			<bounds x="176" y="517" width="75" height="47"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_55" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="178" y="519" width="71" height="43">
-			</bounds>
+			<bounds x="178" y="519" width="71" height="43"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_56_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="466" y="517" width="75" height="47">
-			</bounds>
+			<bounds x="466" y="517" width="75" height="47"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_56" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="468" y="519" width="71" height="43">
-			</bounds>
+			<bounds x="468" y="519" width="71" height="43"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_57_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="370" y="517" width="75" height="47">
-			</bounds>
+			<bounds x="370" y="517" width="75" height="47"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_57" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="372" y="519" width="71" height="43">
-			</bounds>
+			<bounds x="372" y="519" width="71" height="43"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_58_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="265" y="517" width="75" height="47">
-			</bounds>
+			<bounds x="265" y="517" width="75" height="47"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_58" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="267" y="519" width="71" height="43">
-			</bounds>
+			<bounds x="267" y="519" width="71" height="43"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="249" y="299" width="323" height="27">
-			</bounds>
+			<bounds x="249" y="299" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="249" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="249" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="269" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="269" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="289" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="289" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="309" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="309" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="329" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="329" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="349" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="349" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="369" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="369" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="389" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="389" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="409" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="409" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="429" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="429" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="449" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="449" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="469" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="469" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="489" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="489" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="509" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="509" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="529" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="529" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="549" y="299" width="20" height="27">
-			</bounds>
+			<bounds x="549" y="299" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="219" y="415" width="30" height="16">
-			</bounds>
+			<bounds x="219" y="415" width="30" height="16"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="556" y="414" width="34" height="16">
-			</bounds>
+			<bounds x="556" y="414" width="34" height="16"/>
 		</backdrop>
 		<backdrop name="label13" element="label_13">
-			<bounds x="272" y="273" width="50" height="19">
-			</bounds>
+			<bounds x="272" y="273" width="50" height="19"/>
 		</backdrop>
 		<backdrop name="label14" element="label_14">
-			<bounds x="515" y="273" width="56" height="19">
-			</bounds>
+			<bounds x="515" y="273" width="56" height="19"/>
 		</backdrop>
 		<backdrop name="label25" element="label_25">
-			<bounds x="660" y="268" width="72" height="64">
-			</bounds>
+			<bounds x="660" y="268" width="72" height="64"/>
 		</backdrop>
 		<backdrop name="label26" element="label_26">
-			<bounds x="710" y="190" width="16" height="24">
-			</bounds>
+			<bounds x="710" y="190" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label33" element="label_33">
-			<bounds x="658" y="118" width="16" height="24">
-			</bounds>
+			<bounds x="658" y="118" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label34" element="label_34">
-			<bounds x="707" y="118" width="16" height="24">
-			</bounds>
+			<bounds x="707" y="118" width="16" height="24"/>
 		</backdrop>
 		<backdrop name="label35" element="label_35">
-			<bounds x="658" y="190" width="16" height="24">
-			</bounds>
+			<bounds x="658" y="190" width="16" height="24"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4captn.lay
+++ b/src/mame/layout/sc4captn.lay
@@ -8,15236 +8,8946 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="IN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="IN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="+rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="+rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+rpt chanc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+rpt chanc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="EQUAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="EQUAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="FAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="FAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="FOLLOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" ME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="FOLLOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" ME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MIX N MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="MIX N MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+rpt chanc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+rpt chanc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.oo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.oo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+ rpt chan">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+ rpt chan">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RPT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="HI LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="HI LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" K O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" K O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="K O ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="K O ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="strike">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="strike">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="   super money belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="   super money belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 2  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="K O S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 2  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="K O S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="???">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROULETT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROULETT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="quick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="knockout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="quick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="knockout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+2 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2 FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="COIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ALL LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ALL LIT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STARTS SUPER BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STARTS SUPER BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="K O S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="K O S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BOARD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" K O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" K O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_215_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_215">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_220_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_220">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_221_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_221">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_222_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_222">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="K O;S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_223_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_223">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_224_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_224">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_225_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_225">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_226_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_226">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_227_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_227">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_228_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_228">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_229_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_229">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_146">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_147">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_148">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_149">
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_150">
 		<text string="&#xA3;1.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_151">
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_152">
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_153">
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_154">
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_187">
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_188">
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_189">
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_190">
 		<text string="&#xA3;8.00+rpt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="957" height="725">
-			</bounds>
+			<bounds x="0" y="0" width="957" height="725"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="303" y="483" width="80" height="140">
-			</bounds>
+			<bounds x="303" y="483" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="483.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="483.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="484.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="484.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="486.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="486.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="488.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="488.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="490.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="490.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="492.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="492.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="529.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="529.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="531.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="531.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="533.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="533.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="535.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="535.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="537.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="537.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="539.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="539.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="303.0000" y="576.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="303.0000" y="576.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="306.3333" y="578.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="306.3333" y="578.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="309.6667" y="580.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="309.6667" y="580.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="313.0000" y="582.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="313.0000" y="582.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="316.3333" y="584.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="316.3333" y="584.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="319.6667" y="586.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="319.6667" y="586.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="303" y="483" width="80" height="140">
-			</bounds>
+			<bounds x="303" y="483" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="386" y="483" width="80" height="140">
-			</bounds>
+			<bounds x="386" y="483" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="483.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="386.0000" y="483.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="484.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="389.3333" y="484.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="486.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="392.6667" y="486.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="488.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="396.0000" y="488.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="490.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="399.3333" y="490.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="492.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="402.6667" y="492.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="529.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="386.0000" y="529.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="531.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="389.3333" y="531.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="533.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="392.6667" y="533.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="535.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="396.0000" y="535.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="537.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="399.3333" y="537.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="539.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="402.6667" y="539.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="576.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="386.0000" y="576.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="578.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="389.3333" y="578.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="580.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="392.6667" y="580.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="582.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="396.0000" y="582.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="584.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="399.3333" y="584.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="586.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="402.6667" y="586.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="386" y="483" width="80" height="140">
-			</bounds>
+			<bounds x="386" y="483" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="470" y="483" width="80" height="140">
-			</bounds>
+			<bounds x="470" y="483" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="470.0000" y="483.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="470.0000" y="483.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="473.3333" y="484.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="473.3333" y="484.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="476.6667" y="486.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="476.6667" y="486.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="480.0000" y="488.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="480.0000" y="488.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="483.3333" y="490.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="483.3333" y="490.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="486.6667" y="492.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="486.6667" y="492.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="470.0000" y="529.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="470.0000" y="529.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="473.3333" y="531.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="473.3333" y="531.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="476.6667" y="533.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="476.6667" y="533.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="480.0000" y="535.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="480.0000" y="535.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="483.3333" y="537.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="483.3333" y="537.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="486.6667" y="539.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="486.6667" y="539.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="470.0000" y="576.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="470.0000" y="576.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="473.3333" y="578.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="473.3333" y="578.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="476.6667" y="580.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="476.6667" y="580.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="480.0000" y="582.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="480.0000" y="582.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="483.3333" y="584.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="483.3333" y="584.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="486.6667" y="586.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="486.6667" y="586.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="470" y="483" width="80" height="140">
-			</bounds>
+			<bounds x="470" y="483" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="403" y="251" width="80" height="60">
-			</bounds>
+			<bounds x="403" y="251" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="403.0000" y="251.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="403.0000" y="251.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="406.3333" y="253.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="406.3333" y="253.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="409.6667" y="256.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="409.6667" y="256.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="413.0000" y="258.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="413.0000" y="258.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="416.3333" y="261.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="416.3333" y="261.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="419.6667" y="263.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="419.6667" y="263.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="403" y="251" width="80" height="60">
-			</bounds>
+			<bounds x="403" y="251" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="177" y="567" width="46" height="34">
-			</bounds>
+			<bounds x="177" y="567" width="46" height="34"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="179" y="569" width="42" height="30">
-			</bounds>
+			<bounds x="179" y="569" width="42" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="771" y="1" width="36" height="36">
-			</bounds>
+			<bounds x="771" y="1" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="773" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="773" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="304" y="1" width="34" height="42">
-			</bounds>
+			<bounds x="304" y="1" width="34" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="306" y="3" width="30" height="38">
-			</bounds>
+			<bounds x="306" y="3" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="304" y="1" width="34" height="42">
-			</bounds>
+			<bounds x="304" y="1" width="34" height="42"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="306" y="3" width="30" height="38">
-			</bounds>
+			<bounds x="306" y="3" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="336" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="336" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="338" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="338" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="336" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="336" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="338" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="338" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="368" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="368" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="370" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="370" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="368" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="368" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="370" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="370" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="466" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="466" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="468" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="468" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="466" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="466" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="468" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="468" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="433" y="1" width="34" height="42">
-			</bounds>
+			<bounds x="433" y="1" width="34" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="435" y="3" width="30" height="38">
-			</bounds>
+			<bounds x="435" y="3" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="433" y="1" width="34" height="42">
-			</bounds>
+			<bounds x="433" y="1" width="34" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="435" y="3" width="30" height="38">
-			</bounds>
+			<bounds x="435" y="3" width="30" height="38"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="497" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="497" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="499" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="499" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="497" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="497" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="499" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="499" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="400" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="400" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="402" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="402" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="400" y="6" width="34" height="34">
-			</bounds>
+			<bounds x="400" y="6" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="402" y="8" width="30" height="30">
-			</bounds>
+			<bounds x="402" y="8" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="780" y="349" width="58" height="28">
-			</bounds>
+			<bounds x="780" y="349" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="782" y="351" width="54" height="24">
-			</bounds>
+			<bounds x="782" y="351" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="780" y="376" width="58" height="28">
-			</bounds>
+			<bounds x="780" y="376" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="782" y="378" width="54" height="24">
-			</bounds>
+			<bounds x="782" y="378" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="781" y="403" width="58" height="28">
-			</bounds>
+			<bounds x="781" y="403" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="783" y="405" width="54" height="24">
-			</bounds>
+			<bounds x="783" y="405" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="781" y="430" width="58" height="28">
-			</bounds>
+			<bounds x="781" y="430" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="783" y="432" width="54" height="24">
-			</bounds>
+			<bounds x="783" y="432" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="800" y="456" width="24" height="24">
-			</bounds>
+			<bounds x="800" y="456" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="802" y="458" width="20" height="20">
-			</bounds>
+			<bounds x="802" y="458" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="800" y="479" width="24" height="24">
-			</bounds>
+			<bounds x="800" y="479" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="802" y="481" width="20" height="20">
-			</bounds>
+			<bounds x="802" y="481" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="800" y="525" width="24" height="24">
-			</bounds>
+			<bounds x="800" y="525" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="802" y="527" width="20" height="20">
-			</bounds>
+			<bounds x="802" y="527" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="800" y="500" width="24" height="24">
-			</bounds>
+			<bounds x="800" y="500" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="802" y="502" width="20" height="20">
-			</bounds>
+			<bounds x="802" y="502" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="787" y="549" width="46" height="38">
-			</bounds>
+			<bounds x="787" y="549" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="789" y="551" width="42" height="34">
-			</bounds>
+			<bounds x="789" y="551" width="42" height="34"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="800" y="606" width="24" height="24">
-			</bounds>
+			<bounds x="800" y="606" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="802" y="608" width="20" height="20">
-			</bounds>
+			<bounds x="802" y="608" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="800" y="630" width="24" height="24">
-			</bounds>
+			<bounds x="800" y="630" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="802" y="632" width="20" height="20">
-			</bounds>
+			<bounds x="802" y="632" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="789" y="654" width="46" height="38">
-			</bounds>
+			<bounds x="789" y="654" width="46" height="38"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="791" y="656" width="42" height="34">
-			</bounds>
+			<bounds x="791" y="656" width="42" height="34"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="800" y="584" width="24" height="24">
-			</bounds>
+			<bounds x="800" y="584" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="802" y="586" width="20" height="20">
-			</bounds>
+			<bounds x="802" y="586" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="196" y="294" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="294" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="198" y="296" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="296" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="196" y="271" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="271" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="198" y="273" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="273" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="196" y="247" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="247" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="198" y="249" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="249" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="196" y="224" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="224" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="198" y="226" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="226" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="196" y="201" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="201" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="198" y="203" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="203" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="196" y="178" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="178" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="198" y="180" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="180" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="196" y="154" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="154" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="198" y="156" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="156" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="196" y="130" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="130" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="198" y="132" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="132" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="196" y="106" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="106" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="198" y="108" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="108" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="196" y="82" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="82" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="198" y="84" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="84" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="196" y="317" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="317" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="198" y="319" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="319" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="196" y="339" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="339" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="198" y="341" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="341" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="196" y="362" width="34" height="24">
-			</bounds>
+			<bounds x="196" y="362" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="198" y="364" width="30" height="20">
-			</bounds>
+			<bounds x="198" y="364" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="176" y="38" width="70" height="48">
-			</bounds>
+			<bounds x="176" y="38" width="70" height="48"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="178" y="40" width="66" height="44">
-			</bounds>
+			<bounds x="178" y="40" width="66" height="44"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="176" y="38" width="70" height="48">
-			</bounds>
+			<bounds x="176" y="38" width="70" height="48"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="178" y="40" width="66" height="44">
-			</bounds>
+			<bounds x="178" y="40" width="66" height="44"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="657" y="12" width="70" height="46">
-			</bounds>
+			<bounds x="657" y="12" width="70" height="46"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="659" y="14" width="66" height="42">
-			</bounds>
+			<bounds x="659" y="14" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="657" y="12" width="70" height="46">
-			</bounds>
+			<bounds x="657" y="12" width="70" height="46"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="659" y="14" width="66" height="42">
-			</bounds>
+			<bounds x="659" y="14" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="659" y="153" width="66" height="34">
-			</bounds>
+			<bounds x="659" y="153" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="661" y="155" width="62" height="30">
-			</bounds>
+			<bounds x="661" y="155" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="659" y="121" width="66" height="34">
-			</bounds>
+			<bounds x="659" y="121" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="661" y="123" width="62" height="30">
-			</bounds>
+			<bounds x="661" y="123" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="659" y="89" width="66" height="34">
-			</bounds>
+			<bounds x="659" y="89" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="661" y="91" width="62" height="30">
-			</bounds>
+			<bounds x="661" y="91" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="659" y="290" width="64" height="36">
-			</bounds>
+			<bounds x="659" y="290" width="64" height="36"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="661" y="292" width="60" height="32">
-			</bounds>
+			<bounds x="661" y="292" width="60" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="659" y="255" width="64" height="36">
-			</bounds>
+			<bounds x="659" y="255" width="64" height="36"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="661" y="257" width="60" height="32">
-			</bounds>
+			<bounds x="661" y="257" width="60" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="659" y="220" width="64" height="36">
-			</bounds>
+			<bounds x="659" y="220" width="64" height="36"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="661" y="222" width="60" height="32">
-			</bounds>
+			<bounds x="661" y="222" width="60" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="659" y="185" width="64" height="36">
-			</bounds>
+			<bounds x="659" y="185" width="64" height="36"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="661" y="187" width="60" height="32">
-			</bounds>
+			<bounds x="661" y="187" width="60" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="888" y="159" width="58" height="28">
-			</bounds>
+			<bounds x="888" y="159" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="890" y="161" width="54" height="24">
-			</bounds>
+			<bounds x="890" y="161" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="888" y="132" width="58" height="28">
-			</bounds>
+			<bounds x="888" y="132" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="890" y="134" width="54" height="24">
-			</bounds>
+			<bounds x="890" y="134" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="888" y="106" width="58" height="28">
-			</bounds>
+			<bounds x="888" y="106" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="890" y="108" width="54" height="24">
-			</bounds>
+			<bounds x="890" y="108" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="882" y="59" width="70" height="46">
-			</bounds>
+			<bounds x="882" y="59" width="70" height="46"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="884" y="61" width="66" height="42">
-			</bounds>
+			<bounds x="884" y="61" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="882" y="59" width="70" height="46">
-			</bounds>
+			<bounds x="882" y="59" width="70" height="46"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="884" y="61" width="66" height="42">
-			</bounds>
+			<bounds x="884" y="61" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="888" y="241" width="58" height="24">
-			</bounds>
+			<bounds x="888" y="241" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="890" y="243" width="54" height="20">
-			</bounds>
+			<bounds x="890" y="243" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="888" y="264" width="58" height="26">
-			</bounds>
+			<bounds x="888" y="264" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="890" y="266" width="54" height="22">
-			</bounds>
+			<bounds x="890" y="266" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="888" y="288" width="58" height="28">
-			</bounds>
+			<bounds x="888" y="288" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="890" y="290" width="54" height="24">
-			</bounds>
+			<bounds x="890" y="290" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="888" y="316" width="58" height="28">
-			</bounds>
+			<bounds x="888" y="316" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="890" y="318" width="54" height="24">
-			</bounds>
+			<bounds x="890" y="318" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="888" y="343" width="58" height="26">
-			</bounds>
+			<bounds x="888" y="343" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="890" y="345" width="54" height="22">
-			</bounds>
+			<bounds x="890" y="345" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="888" y="368" width="58" height="24">
-			</bounds>
+			<bounds x="888" y="368" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="890" y="370" width="54" height="20">
-			</bounds>
+			<bounds x="890" y="370" width="54" height="20"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="888" y="390" width="58" height="26">
-			</bounds>
+			<bounds x="888" y="390" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="890" y="392" width="54" height="22">
-			</bounds>
+			<bounds x="890" y="392" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="888" y="186" width="58" height="28">
-			</bounds>
+			<bounds x="888" y="186" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="890" y="188" width="54" height="24">
-			</bounds>
+			<bounds x="890" y="188" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="888" y="213" width="58" height="28">
-			</bounds>
+			<bounds x="888" y="213" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="890" y="215" width="54" height="24">
-			</bounds>
+			<bounds x="890" y="215" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="128" y="539" width="28" height="24">
-			</bounds>
+			<bounds x="128" y="539" width="28" height="24"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="130" y="541" width="24" height="20">
-			</bounds>
+			<bounds x="130" y="541" width="24" height="20"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="128" y="516" width="28" height="24">
-			</bounds>
+			<bounds x="128" y="516" width="28" height="24"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="130" y="518" width="24" height="20">
-			</bounds>
+			<bounds x="130" y="518" width="24" height="20"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="128" y="493" width="28" height="24">
-			</bounds>
+			<bounds x="128" y="493" width="28" height="24"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="130" y="495" width="24" height="20">
-			</bounds>
+			<bounds x="130" y="495" width="24" height="20"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="128" y="471" width="28" height="24">
-			</bounds>
+			<bounds x="128" y="471" width="28" height="24"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="130" y="473" width="24" height="20">
-			</bounds>
+			<bounds x="130" y="473" width="24" height="20"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="114" y="563" width="58" height="46">
-			</bounds>
+			<bounds x="114" y="563" width="58" height="46"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="116" y="565" width="54" height="42">
-			</bounds>
+			<bounds x="116" y="565" width="54" height="42"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="66" y="289" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="289" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="68" y="291" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="291" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="66" y="266" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="266" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="68" y="268" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="268" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="66" y="244" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="244" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="68" y="246" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="246" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="66" y="221" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="221" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="68" y="223" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="223" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="66" y="198" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="198" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="68" y="200" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="200" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="66" y="177" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="177" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="68" y="179" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="179" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="66" y="153" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="153" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="68" y="155" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="155" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="66" y="129" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="129" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="68" y="131" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="131" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="66" y="107" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="107" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="68" y="109" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="109" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="66" y="82" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="82" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="68" y="84" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="84" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="49" y="38" width="70" height="46">
-			</bounds>
+			<bounds x="49" y="38" width="70" height="46"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="51" y="40" width="66" height="42">
-			</bounds>
+			<bounds x="51" y="40" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="49" y="38" width="70" height="46">
-			</bounds>
+			<bounds x="49" y="38" width="70" height="46"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="51" y="40" width="66" height="42">
-			</bounds>
+			<bounds x="51" y="40" width="66" height="42"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="66" y="354" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="354" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="68" y="356" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="356" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="66" y="332" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="332" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="68" y="334" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="334" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="66" y="310" width="34" height="24">
-			</bounds>
+			<bounds x="66" y="310" width="34" height="24"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="68" y="312" width="30" height="20">
-			</bounds>
+			<bounds x="68" y="312" width="30" height="20"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="464" y="315" width="82" height="34">
-			</bounds>
+			<bounds x="464" y="315" width="82" height="34"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="466" y="317" width="78" height="30">
-			</bounds>
+			<bounds x="466" y="317" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="464" y="348" width="82" height="34">
-			</bounds>
+			<bounds x="464" y="348" width="82" height="34"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="466" y="350" width="78" height="30">
-			</bounds>
+			<bounds x="466" y="350" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="326" y="349" width="82" height="34">
-			</bounds>
+			<bounds x="326" y="349" width="82" height="34"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="328" y="351" width="78" height="30">
-			</bounds>
+			<bounds x="328" y="351" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="326" y="315" width="82" height="34">
-			</bounds>
+			<bounds x="326" y="315" width="82" height="34"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="328" y="317" width="78" height="30">
-			</bounds>
+			<bounds x="328" y="317" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="268" y="334" width="58" height="28">
-			</bounds>
+			<bounds x="268" y="334" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="270" y="336" width="54" height="24">
-			</bounds>
+			<bounds x="270" y="336" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="268" y="361" width="58" height="28">
-			</bounds>
+			<bounds x="268" y="361" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="270" y="363" width="54" height="24">
-			</bounds>
+			<bounds x="270" y="363" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="268" y="306" width="58" height="28">
-			</bounds>
+			<bounds x="268" y="306" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="270" y="308" width="54" height="24">
-			</bounds>
+			<bounds x="270" y="308" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="268" y="248" width="58" height="28">
-			</bounds>
+			<bounds x="268" y="248" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="270" y="250" width="54" height="24">
-			</bounds>
+			<bounds x="270" y="250" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="268" y="278" width="58" height="28">
-			</bounds>
+			<bounds x="268" y="278" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="270" y="280" width="54" height="24">
-			</bounds>
+			<bounds x="270" y="280" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="554" y="248" width="58" height="28">
-			</bounds>
+			<bounds x="554" y="248" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="556" y="250" width="54" height="24">
-			</bounds>
+			<bounds x="556" y="250" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="554" y="388" width="58" height="28">
-			</bounds>
+			<bounds x="554" y="388" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="556" y="390" width="54" height="24">
-			</bounds>
+			<bounds x="556" y="390" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="554" y="361" width="58" height="28">
-			</bounds>
+			<bounds x="554" y="361" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="556" y="363" width="54" height="24">
-			</bounds>
+			<bounds x="556" y="363" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="554" y="334" width="58" height="28">
-			</bounds>
+			<bounds x="554" y="334" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="556" y="336" width="54" height="24">
-			</bounds>
+			<bounds x="556" y="336" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="553" y="306" width="58" height="28">
-			</bounds>
+			<bounds x="553" y="306" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="555" y="308" width="54" height="24">
-			</bounds>
+			<bounds x="555" y="308" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="554" y="278" width="58" height="28">
-			</bounds>
+			<bounds x="554" y="278" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="556" y="280" width="54" height="24">
-			</bounds>
+			<bounds x="556" y="280" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="554" y="416" width="58" height="28">
-			</bounds>
+			<bounds x="554" y="416" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="556" y="418" width="54" height="24">
-			</bounds>
+			<bounds x="556" y="418" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="439" y="416" width="58" height="28">
-			</bounds>
+			<bounds x="439" y="416" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="441" y="418" width="54" height="24">
-			</bounds>
+			<bounds x="441" y="418" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="382" y="416" width="58" height="28">
-			</bounds>
+			<bounds x="382" y="416" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="384" y="418" width="54" height="24">
-			</bounds>
+			<bounds x="384" y="418" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="326" y="416" width="58" height="28">
-			</bounds>
+			<bounds x="326" y="416" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="328" y="418" width="54" height="24">
-			</bounds>
+			<bounds x="328" y="418" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="268" y="416" width="58" height="28">
-			</bounds>
+			<bounds x="268" y="416" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="270" y="418" width="54" height="24">
-			</bounds>
+			<bounds x="270" y="418" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="268" y="388" width="58" height="28">
-			</bounds>
+			<bounds x="268" y="388" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="270" y="390" width="54" height="24">
-			</bounds>
+			<bounds x="270" y="390" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="326" y="381" width="82" height="34">
-			</bounds>
+			<bounds x="326" y="381" width="82" height="34"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="328" y="383" width="78" height="30">
-			</bounds>
+			<bounds x="328" y="383" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="464" y="381" width="82" height="34">
-			</bounds>
+			<bounds x="464" y="381" width="82" height="34"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="466" y="383" width="78" height="30">
-			</bounds>
+			<bounds x="466" y="383" width="78" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="496" y="416" width="58" height="28">
-			</bounds>
+			<bounds x="496" y="416" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="498" y="418" width="54" height="24">
-			</bounds>
+			<bounds x="498" y="418" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="368" y="263" width="35" height="35">
-			</bounds>
+			<bounds x="368" y="263" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="370" y="265" width="31" height="31">
-			</bounds>
+			<bounds x="370" y="265" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="482" y="264" width="35" height="35">
-			</bounds>
+			<bounds x="482" y="264" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="484" y="266" width="31" height="31">
-			</bounds>
+			<bounds x="484" y="266" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="268" y="221" width="58" height="28">
-			</bounds>
+			<bounds x="268" y="221" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="270" y="223" width="54" height="24">
-			</bounds>
+			<bounds x="270" y="223" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="382" y="222" width="58" height="28">
-			</bounds>
+			<bounds x="382" y="222" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="384" y="224" width="54" height="24">
-			</bounds>
+			<bounds x="384" y="224" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="326" y="222" width="58" height="28">
-			</bounds>
+			<bounds x="326" y="222" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="328" y="224" width="54" height="24">
-			</bounds>
+			<bounds x="328" y="224" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="439" y="222" width="58" height="28">
-			</bounds>
+			<bounds x="439" y="222" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="441" y="224" width="54" height="24">
-			</bounds>
+			<bounds x="441" y="224" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="496" y="222" width="58" height="28">
-			</bounds>
+			<bounds x="496" y="222" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="498" y="224" width="54" height="24">
-			</bounds>
+			<bounds x="498" y="224" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="554" y="222" width="58" height="28">
-			</bounds>
+			<bounds x="554" y="222" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="556" y="224" width="54" height="24">
-			</bounds>
+			<bounds x="556" y="224" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="659" y="325" width="64" height="36">
-			</bounds>
+			<bounds x="659" y="325" width="64" height="36"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="661" y="327" width="60" height="32">
-			</bounds>
+			<bounds x="661" y="327" width="60" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="659" y="360" width="64" height="36">
-			</bounds>
+			<bounds x="659" y="360" width="64" height="36"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="661" y="362" width="60" height="32">
-			</bounds>
+			<bounds x="661" y="362" width="60" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="659" y="395" width="64" height="36">
-			</bounds>
+			<bounds x="659" y="395" width="64" height="36"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="661" y="397" width="60" height="32">
-			</bounds>
+			<bounds x="661" y="397" width="60" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="659" y="429" width="64" height="36">
-			</bounds>
+			<bounds x="659" y="429" width="64" height="36"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="661" y="431" width="60" height="32">
-			</bounds>
+			<bounds x="661" y="431" width="60" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="659" y="57" width="66" height="34">
-			</bounds>
+			<bounds x="659" y="57" width="66" height="34"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="661" y="59" width="62" height="30">
-			</bounds>
+			<bounds x="661" y="59" width="62" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="472" y="129" width="58" height="28">
-			</bounds>
+			<bounds x="472" y="129" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="474" y="131" width="54" height="24">
-			</bounds>
+			<bounds x="474" y="131" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="472" y="101" width="58" height="28">
-			</bounds>
+			<bounds x="472" y="101" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="474" y="103" width="54" height="24">
-			</bounds>
+			<bounds x="474" y="103" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="472" y="74" width="58" height="28">
-			</bounds>
+			<bounds x="472" y="74" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="474" y="76" width="54" height="24">
-			</bounds>
+			<bounds x="474" y="76" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="531" y="105" width="38" height="38">
-			</bounds>
+			<bounds x="531" y="105" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="533" y="107" width="34" height="34">
-			</bounds>
+			<bounds x="533" y="107" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="568" y="105" width="38" height="38">
-			</bounds>
+			<bounds x="568" y="105" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="570" y="107" width="34" height="34">
-			</bounds>
+			<bounds x="570" y="107" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="605" y="106" width="38" height="38">
-			</bounds>
+			<bounds x="605" y="106" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="607" y="108" width="34" height="34">
-			</bounds>
+			<bounds x="607" y="108" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="535" y="140" width="34" height="44">
-			</bounds>
+			<bounds x="535" y="140" width="34" height="44"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="537" y="142" width="30" height="40">
-			</bounds>
+			<bounds x="537" y="142" width="30" height="40"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="566" y="140" width="78" height="44">
-			</bounds>
+			<bounds x="566" y="140" width="78" height="44"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="568" y="142" width="74" height="40">
-			</bounds>
+			<bounds x="568" y="142" width="74" height="40"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="358" y="74" width="58" height="28">
-			</bounds>
+			<bounds x="358" y="74" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="360" y="76" width="54" height="24">
-			</bounds>
+			<bounds x="360" y="76" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="301" y="74" width="58" height="28">
-			</bounds>
+			<bounds x="301" y="74" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="303" y="76" width="54" height="24">
-			</bounds>
+			<bounds x="303" y="76" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="302" y="102" width="58" height="28">
-			</bounds>
+			<bounds x="302" y="102" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="304" y="104" width="54" height="24">
-			</bounds>
+			<bounds x="304" y="104" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="416" y="74" width="58" height="28">
-			</bounds>
+			<bounds x="416" y="74" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="418" y="76" width="54" height="24">
-			</bounds>
+			<bounds x="418" y="76" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="472" y="157" width="58" height="28">
-			</bounds>
+			<bounds x="472" y="157" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="474" y="159" width="54" height="24">
-			</bounds>
+			<bounds x="474" y="159" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="415" y="157" width="58" height="28">
-			</bounds>
+			<bounds x="415" y="157" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="417" y="159" width="54" height="24">
-			</bounds>
+			<bounds x="417" y="159" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="358" y="157" width="58" height="28">
-			</bounds>
+			<bounds x="358" y="157" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="360" y="159" width="54" height="24">
-			</bounds>
+			<bounds x="360" y="159" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="302" y="130" width="58" height="28">
-			</bounds>
+			<bounds x="302" y="130" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="304" y="132" width="54" height="24">
-			</bounds>
+			<bounds x="304" y="132" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="301" y="157" width="58" height="28">
-			</bounds>
+			<bounds x="301" y="157" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="303" y="159" width="54" height="24">
-			</bounds>
+			<bounds x="303" y="159" width="54" height="24"/>
 		</backdrop>
 		<backdrop name="lamp237" element="colour_button_215_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="175" y="386" width="78" height="42">
-			</bounds>
+			<bounds x="175" y="386" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp237" element="colour_button_215" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="177" y="388" width="74" height="38">
-			</bounds>
+			<bounds x="177" y="388" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp107" element="colour_button_220_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="652" y="469" width="78" height="42">
-			</bounds>
+			<bounds x="652" y="469" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp107" element="colour_button_220" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="654" y="471" width="74" height="38">
-			</bounds>
+			<bounds x="654" y="471" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp88" element="colour_button_221_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="879" y="419" width="78" height="42">
-			</bounds>
+			<bounds x="879" y="419" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp88" element="colour_button_221" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="881" y="421" width="74" height="38">
-			</bounds>
+			<bounds x="881" y="421" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp238" element="colour_button_222_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="46" y="378" width="78" height="42">
-			</bounds>
+			<bounds x="46" y="378" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp238" element="colour_button_222" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="48" y="380" width="74" height="38">
-			</bounds>
+			<bounds x="48" y="380" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_223_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="699" y="677" width="75" height="37">
-			</bounds>
+			<bounds x="699" y="677" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_223" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="701" y="679" width="71" height="33">
-			</bounds>
+			<bounds x="701" y="679" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_224_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="622" y="677" width="75" height="37">
-			</bounds>
+			<bounds x="622" y="677" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_224" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="624" y="679" width="71" height="33">
-			</bounds>
+			<bounds x="624" y="679" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_225_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="543" y="677" width="75" height="37">
-			</bounds>
+			<bounds x="543" y="677" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_225" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="545" y="679" width="71" height="33">
-			</bounds>
+			<bounds x="545" y="679" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_226_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="466" y="677" width="75" height="37">
-			</bounds>
+			<bounds x="466" y="677" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_226" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="468" y="679" width="71" height="33">
-			</bounds>
+			<bounds x="468" y="679" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_227_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="384" y="677" width="75" height="37">
-			</bounds>
+			<bounds x="384" y="677" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_227" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="386" y="679" width="71" height="33">
-			</bounds>
+			<bounds x="386" y="679" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_228_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="300" y="677" width="75" height="37">
-			</bounds>
+			<bounds x="300" y="677" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_228" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="302" y="679" width="71" height="33">
-			</bounds>
+			<bounds x="302" y="679" width="71" height="33"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_229_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="214" y="677" width="75" height="37">
-			</bounds>
+			<bounds x="214" y="677" width="75" height="37"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_229" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="216" y="679" width="71" height="33">
-			</bounds>
+			<bounds x="216" y="679" width="71" height="33"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="293" y="448" width="272" height="30">
-			</bounds>
+			<bounds x="293" y="448" width="272" height="30"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="293" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="293" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="310" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="310" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="327" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="327" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="344" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="344" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="361" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="361" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="378" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="378" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="395" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="395" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="412" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="412" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="429" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="429" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="446" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="446" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="463" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="463" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="480" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="480" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="497" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="497" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="514" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="514" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="531" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="531" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="548" y="448" width="17" height="30">
-			</bounds>
+			<bounds x="548" y="448" width="17" height="30"/>
 		</backdrop>
 		<backdrop name="label146" element="label_146">
-			<bounds x="256" y="543" width="35" height="22">
-			</bounds>
+			<bounds x="256" y="543" width="35" height="22"/>
 		</backdrop>
 		<backdrop name="label147" element="label_147">
-			<bounds x="551" y="543" width="43" height="22">
-			</bounds>
+			<bounds x="551" y="543" width="43" height="22"/>
 		</backdrop>
 		<backdrop name="label148" element="label_148">
-			<bounds x="147" y="655" width="22" height="22">
-			</bounds>
+			<bounds x="147" y="655" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="label149" element="label_149">
-			<bounds x="217" y="655" width="40" height="19">
-			</bounds>
+			<bounds x="217" y="655" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label150" element="label_150">
-			<bounds x="302" y="655" width="40" height="19">
-			</bounds>
+			<bounds x="302" y="655" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label151" element="label_151">
-			<bounds x="385" y="655" width="40" height="19">
-			</bounds>
+			<bounds x="385" y="655" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label152" element="label_152">
-			<bounds x="629" y="655" width="40" height="19">
-			</bounds>
+			<bounds x="629" y="655" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label153" element="label_153">
-			<bounds x="462" y="655" width="40" height="19">
-			</bounds>
+			<bounds x="462" y="655" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label154" element="label_154">
-			<bounds x="545" y="655" width="40" height="19">
-			</bounds>
+			<bounds x="545" y="655" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label187" element="label_187">
-			<bounds x="709" y="655" width="40" height="19">
-			</bounds>
+			<bounds x="709" y="655" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label188" element="label_188">
-			<bounds x="709" y="582" width="40" height="19">
-			</bounds>
+			<bounds x="709" y="582" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label189" element="label_189">
-			<bounds x="709" y="618" width="40" height="19">
-			</bounds>
+			<bounds x="709" y="618" width="40" height="19"/>
 		</backdrop>
 		<backdrop name="label190" element="label_190">
-			<bounds x="680" y="542" width="70" height="19">
-			</bounds>
+			<bounds x="680" y="542" width="70" height="19"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_button" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_button" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_button" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_button" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cariqd.lay
+++ b/src/mame/layout/sc4cariqd.lay
@@ -8,13708 +8,8021 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;8.00 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SMASH AND GRAB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SMASH AND GRAB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ODDS ON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ODDS ON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EASY MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EASY MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="REEL MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CASH RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER MONEY BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER MONEY BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FAST CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FAST CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE BUSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE BUSTER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LIMBO DANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIMBO DANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REPEATER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="ELIMINATOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SKILLSTOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SKILLSTOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5 SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5 SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="CaribbeaN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MADNESS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="CaribbeaN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MADNESS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="TROPICAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="TROPICAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEATU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CASH LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH LOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RIB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RIB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="AN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="AS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_226_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_226">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_227_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_227">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_228_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_228">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_229_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_229">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_230_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_230">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_231_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_231">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_232_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_232">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_233_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_233">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_234_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_234">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_235_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_235">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_236_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_236">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_238_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_238">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SHOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_239_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_239">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="QPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_240_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_240">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_223">
 		<text string="With thanks to Bugs!!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_224">
 		<text string="Thanks to DAD for the reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="769" height="819">
-			</bounds>
+			<bounds x="0" y="0" width="769" height="819"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="203" y="580" width="80" height="140">
-			</bounds>
+			<bounds x="203" y="580" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="580.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="580.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="581.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="581.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="583.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="583.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="585.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="585.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="587.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="587.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="589.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="589.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="626.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="626.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="628.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="628.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="630.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="630.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="632.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="632.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="634.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="634.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="636.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="636.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="203.0000" y="673.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="203.0000" y="673.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="206.3333" y="675.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="206.3333" y="675.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="209.6667" y="677.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="209.6667" y="677.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="213.0000" y="679.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="213.0000" y="679.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="216.3333" y="681.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="216.3333" y="681.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="219.6667" y="683.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="219.6667" y="683.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="203" y="580" width="80" height="140">
-			</bounds>
+			<bounds x="203" y="580" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="287" y="580" width="80" height="140">
-			</bounds>
+			<bounds x="287" y="580" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="287.0000" y="580.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="287.0000" y="580.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="290.3333" y="581.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="290.3333" y="581.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="293.6667" y="583.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="293.6667" y="583.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="297.0000" y="585.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="297.0000" y="585.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="300.3333" y="587.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="300.3333" y="587.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.6667" y="589.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="303.6667" y="589.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="287.0000" y="626.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="287.0000" y="626.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="290.3333" y="628.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="290.3333" y="628.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="293.6667" y="630.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="293.6667" y="630.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="297.0000" y="632.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="297.0000" y="632.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="300.3333" y="634.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="300.3333" y="634.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.6667" y="636.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="303.6667" y="636.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="287.0000" y="673.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="287.0000" y="673.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="290.3333" y="675.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="290.3333" y="675.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="293.6667" y="677.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="293.6667" y="677.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="297.0000" y="679.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="297.0000" y="679.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="300.3333" y="681.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="300.3333" y="681.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.6667" y="683.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="303.6667" y="683.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="287" y="580" width="80" height="140">
-			</bounds>
+			<bounds x="287" y="580" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="371" y="580" width="80" height="140">
-			</bounds>
+			<bounds x="371" y="580" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="371.0000" y="580.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="371.0000" y="580.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="374.3333" y="581.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="374.3333" y="581.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="377.6667" y="583.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="377.6667" y="583.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="381.0000" y="585.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="381.0000" y="585.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="384.3333" y="587.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="384.3333" y="587.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="387.6667" y="589.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="387.6667" y="589.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="371.0000" y="626.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="371.0000" y="626.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="374.3333" y="628.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="374.3333" y="628.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="377.6667" y="630.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="377.6667" y="630.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="381.0000" y="632.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="381.0000" y="632.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="384.3333" y="634.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="384.3333" y="634.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="387.6667" y="636.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="387.6667" y="636.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="371.0000" y="673.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="371.0000" y="673.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="374.3333" y="675.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="374.3333" y="675.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="377.6667" y="677.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="377.6667" y="677.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="381.0000" y="679.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="381.0000" y="679.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="384.3333" y="681.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="384.3333" y="681.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="387.6667" y="683.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="387.6667" y="683.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="371" y="580" width="80" height="140">
-			</bounds>
+			<bounds x="371" y="580" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="330" y="358" width="80" height="60">
-			</bounds>
+			<bounds x="330" y="358" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="330.0000" y="358.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="330.0000" y="358.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="333.3333" y="360.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="333.3333" y="360.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="336.6667" y="363.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="336.6667" y="363.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="340.0000" y="365.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="340.0000" y="365.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="343.3333" y="368.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="343.3333" y="368.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="346.6667" y="370.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="346.6667" y="370.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="330" y="358" width="80" height="60">
-			</bounds>
+			<bounds x="330" y="358" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="623" y="146" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="146" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="625" y="148" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="148" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="219" y="220" width="52" height="32">
-			</bounds>
+			<bounds x="219" y="220" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="221" y="222" width="48" height="28">
-			</bounds>
+			<bounds x="221" y="222" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="478" y="205" width="52" height="32">
-			</bounds>
+			<bounds x="478" y="205" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="480" y="207" width="48" height="28">
-			</bounds>
+			<bounds x="480" y="207" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="284" y="255" width="52" height="32">
-			</bounds>
+			<bounds x="284" y="255" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="286" y="257" width="48" height="28">
-			</bounds>
+			<bounds x="286" y="257" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="345" y="321" width="52" height="32">
-			</bounds>
+			<bounds x="345" y="321" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="347" y="323" width="48" height="28">
-			</bounds>
+			<bounds x="347" y="323" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="478" y="282" width="52" height="32">
-			</bounds>
+			<bounds x="478" y="282" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="480" y="284" width="48" height="28">
-			</bounds>
+			<bounds x="480" y="284" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="457" y="322" width="52" height="32">
-			</bounds>
+			<bounds x="457" y="322" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="459" y="324" width="48" height="28">
-			</bounds>
+			<bounds x="459" y="324" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="279" y="317" width="52" height="32">
-			</bounds>
+			<bounds x="279" y="317" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="281" y="319" width="48" height="28">
-			</bounds>
+			<bounds x="281" y="319" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="348" y="287" width="52" height="32">
-			</bounds>
+			<bounds x="348" y="287" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="350" y="289" width="48" height="28">
-			</bounds>
+			<bounds x="350" y="289" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="455" y="241" width="52" height="32">
-			</bounds>
+			<bounds x="455" y="241" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="457" y="243" width="48" height="28">
-			</bounds>
+			<bounds x="457" y="243" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="391" y="165" width="52" height="32">
-			</bounds>
+			<bounds x="391" y="165" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="393" y="167" width="48" height="28">
-			</bounds>
+			<bounds x="393" y="167" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="410" y="206" width="52" height="32">
-			</bounds>
+			<bounds x="410" y="206" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="412" y="208" width="48" height="28">
-			</bounds>
+			<bounds x="412" y="208" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="292" y="167" width="52" height="32">
-			</bounds>
+			<bounds x="292" y="167" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="294" y="169" width="48" height="28">
-			</bounds>
+			<bounds x="294" y="169" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="216" y="169" width="52" height="32">
-			</bounds>
+			<bounds x="216" y="169" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="218" y="171" width="48" height="28">
-			</bounds>
+			<bounds x="218" y="171" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="292" y="206" width="52" height="32">
-			</bounds>
+			<bounds x="292" y="206" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="294" y="208" width="48" height="28">
-			</bounds>
+			<bounds x="294" y="208" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="481" y="167" width="52" height="32">
-			</bounds>
+			<bounds x="481" y="167" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="483" y="169" width="48" height="28">
-			</bounds>
+			<bounds x="483" y="169" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="402" y="314" width="52" height="32">
-			</bounds>
+			<bounds x="402" y="314" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="404" y="316" width="48" height="28">
-			</bounds>
+			<bounds x="404" y="316" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="216" y="273" width="52" height="32">
-			</bounds>
+			<bounds x="216" y="273" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="218" y="275" width="48" height="28">
-			</bounds>
+			<bounds x="218" y="275" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="216" y="317" width="52" height="32">
-			</bounds>
+			<bounds x="216" y="317" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="218" y="319" width="48" height="28">
-			</bounds>
+			<bounds x="218" y="319" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="623" y="291" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="291" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="625" y="293" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="293" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="623" y="407" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="407" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="625" y="409" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="409" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="623" y="378" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="378" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="625" y="380" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="380" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="623" y="349" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="349" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="625" y="351" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="351" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="623" y="320" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="320" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="625" y="322" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="322" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="623" y="233" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="233" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="625" y="235" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="235" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="623" y="204" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="204" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="625" y="206" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="206" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="623" y="175" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="175" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="625" y="177" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="177" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="623" y="262" width="92" height="32">
-			</bounds>
+			<bounds x="623" y="262" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="625" y="264" width="88" height="28">
-			</bounds>
+			<bounds x="625" y="264" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="33" y="609" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="609" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="35" y="611" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="611" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="33" y="348" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="348" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="35" y="350" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="350" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="33" y="377" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="377" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="35" y="379" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="379" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="33" y="406" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="406" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="35" y="408" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="408" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="33" y="435" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="435" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="35" y="437" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="437" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="33" y="464" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="464" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="35" y="466" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="466" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="33" y="493" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="493" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="35" y="495" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="495" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="33" y="522" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="522" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="35" y="524" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="524" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="33" y="551" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="551" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="35" y="553" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="553" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="33" y="580" width="32" height="32">
-			</bounds>
+			<bounds x="33" y="580" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="35" y="582" width="28" height="28">
-			</bounds>
+			<bounds x="35" y="582" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="3" y="319" width="92" height="32">
-			</bounds>
+			<bounds x="3" y="319" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="5" y="321" width="88" height="28">
-			</bounds>
+			<bounds x="5" y="321" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="3" y="222" width="92" height="32">
-			</bounds>
+			<bounds x="3" y="222" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="5" y="224" width="88" height="28">
-			</bounds>
+			<bounds x="5" y="224" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="3" y="193" width="92" height="32">
-			</bounds>
+			<bounds x="3" y="193" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="5" y="195" width="88" height="28">
-			</bounds>
+			<bounds x="5" y="195" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="3" y="106" width="92" height="32">
-			</bounds>
+			<bounds x="3" y="106" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="5" y="108" width="88" height="28">
-			</bounds>
+			<bounds x="5" y="108" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="3" y="164" width="92" height="32">
-			</bounds>
+			<bounds x="3" y="164" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="5" y="166" width="88" height="28">
-			</bounds>
+			<bounds x="5" y="166" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="3" y="135" width="92" height="32">
-			</bounds>
+			<bounds x="3" y="135" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="5" y="137" width="88" height="28">
-			</bounds>
+			<bounds x="5" y="137" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="547" y="106" width="62" height="52">
-			</bounds>
+			<bounds x="547" y="106" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="549" y="108" width="58" height="48">
-			</bounds>
+			<bounds x="549" y="108" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="547" y="400" width="62" height="52">
-			</bounds>
+			<bounds x="547" y="400" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="549" y="402" width="58" height="48">
-			</bounds>
+			<bounds x="549" y="402" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="547" y="204" width="62" height="52">
-			</bounds>
+			<bounds x="547" y="204" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="549" y="206" width="58" height="48">
-			</bounds>
+			<bounds x="549" y="206" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="547" y="253" width="62" height="52">
-			</bounds>
+			<bounds x="547" y="253" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="549" y="255" width="58" height="48">
-			</bounds>
+			<bounds x="549" y="255" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="547" y="302" width="62" height="52">
-			</bounds>
+			<bounds x="547" y="302" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="549" y="304" width="58" height="48">
-			</bounds>
+			<bounds x="549" y="304" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="547" y="351" width="62" height="52">
-			</bounds>
+			<bounds x="547" y="351" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="549" y="353" width="58" height="48">
-			</bounds>
+			<bounds x="549" y="353" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="488" y="106" width="62" height="52">
-			</bounds>
+			<bounds x="488" y="106" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="490" y="108" width="58" height="48">
-			</bounds>
+			<bounds x="490" y="108" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="429" y="106" width="62" height="52">
-			</bounds>
+			<bounds x="429" y="106" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="431" y="108" width="58" height="48">
-			</bounds>
+			<bounds x="431" y="108" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="370" y="106" width="62" height="52">
-			</bounds>
+			<bounds x="370" y="106" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="372" y="108" width="58" height="48">
-			</bounds>
+			<bounds x="372" y="108" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="311" y="106" width="62" height="52">
-			</bounds>
+			<bounds x="311" y="106" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="313" y="108" width="58" height="48">
-			</bounds>
+			<bounds x="313" y="108" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="252" y="106" width="62" height="52">
-			</bounds>
+			<bounds x="252" y="106" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="254" y="108" width="58" height="48">
-			</bounds>
+			<bounds x="254" y="108" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="193" y="106" width="62" height="52">
-			</bounds>
+			<bounds x="193" y="106" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="195" y="108" width="58" height="48">
-			</bounds>
+			<bounds x="195" y="108" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="547" y="155" width="62" height="52">
-			</bounds>
+			<bounds x="547" y="155" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="549" y="157" width="58" height="48">
-			</bounds>
+			<bounds x="549" y="157" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="134" y="106" width="62" height="52">
-			</bounds>
+			<bounds x="134" y="106" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="136" y="108" width="58" height="48">
-			</bounds>
+			<bounds x="136" y="108" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="134" y="204" width="62" height="52">
-			</bounds>
+			<bounds x="134" y="204" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="136" y="206" width="58" height="48">
-			</bounds>
+			<bounds x="136" y="206" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="547" y="449" width="62" height="52">
-			</bounds>
+			<bounds x="547" y="449" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="549" y="451" width="58" height="48">
-			</bounds>
+			<bounds x="549" y="451" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="488" y="449" width="62" height="52">
-			</bounds>
+			<bounds x="488" y="449" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="490" y="451" width="58" height="48">
-			</bounds>
+			<bounds x="490" y="451" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="429" y="449" width="62" height="52">
-			</bounds>
+			<bounds x="429" y="449" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="431" y="451" width="58" height="48">
-			</bounds>
+			<bounds x="431" y="451" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="370" y="449" width="62" height="52">
-			</bounds>
+			<bounds x="370" y="449" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="372" y="451" width="58" height="48">
-			</bounds>
+			<bounds x="372" y="451" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="311" y="449" width="62" height="52">
-			</bounds>
+			<bounds x="311" y="449" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="313" y="451" width="58" height="48">
-			</bounds>
+			<bounds x="313" y="451" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="134" y="253" width="62" height="52">
-			</bounds>
+			<bounds x="134" y="253" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="136" y="255" width="58" height="48">
-			</bounds>
+			<bounds x="136" y="255" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="134" y="302" width="62" height="52">
-			</bounds>
+			<bounds x="134" y="302" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="136" y="304" width="58" height="48">
-			</bounds>
+			<bounds x="136" y="304" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="134" y="351" width="62" height="52">
-			</bounds>
+			<bounds x="134" y="351" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="136" y="353" width="58" height="48">
-			</bounds>
+			<bounds x="136" y="353" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="134" y="400" width="62" height="52">
-			</bounds>
+			<bounds x="134" y="400" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="136" y="402" width="58" height="48">
-			</bounds>
+			<bounds x="136" y="402" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="134" y="449" width="62" height="52">
-			</bounds>
+			<bounds x="134" y="449" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="136" y="451" width="58" height="48">
-			</bounds>
+			<bounds x="136" y="451" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="193" y="449" width="62" height="52">
-			</bounds>
+			<bounds x="193" y="449" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="195" y="451" width="58" height="48">
-			</bounds>
+			<bounds x="195" y="451" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="252" y="449" width="62" height="52">
-			</bounds>
+			<bounds x="252" y="449" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="254" y="451" width="58" height="48">
-			</bounds>
+			<bounds x="254" y="451" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="267" y="391" width="62" height="52">
-			</bounds>
+			<bounds x="267" y="391" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="269" y="393" width="58" height="48">
-			</bounds>
+			<bounds x="269" y="393" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="411" y="391" width="62" height="52">
-			</bounds>
+			<bounds x="411" y="391" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="413" y="393" width="58" height="48">
-			</bounds>
+			<bounds x="413" y="393" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="134" y="155" width="62" height="52">
-			</bounds>
+			<bounds x="134" y="155" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="136" y="157" width="58" height="48">
-			</bounds>
+			<bounds x="136" y="157" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="149" y="44" width="62" height="52">
-			</bounds>
+			<bounds x="149" y="44" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="151" y="46" width="58" height="48">
-			</bounds>
+			<bounds x="151" y="46" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="639" y="46" width="52" height="32">
-			</bounds>
+			<bounds x="639" y="46" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="641" y="48" width="48" height="28">
-			</bounds>
+			<bounds x="641" y="48" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="20" y="18" width="27" height="27">
-			</bounds>
+			<bounds x="20" y="18" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="22" y="20" width="23" height="23">
-			</bounds>
+			<bounds x="22" y="20" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="44" y="18" width="27" height="27">
-			</bounds>
+			<bounds x="44" y="18" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="46" y="20" width="23" height="23">
-			</bounds>
+			<bounds x="46" y="20" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="68" y="18" width="27" height="27">
-			</bounds>
+			<bounds x="68" y="18" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="70" y="20" width="23" height="23">
-			</bounds>
+			<bounds x="70" y="20" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="92" y="18" width="27" height="27">
-			</bounds>
+			<bounds x="92" y="18" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="94" y="20" width="23" height="23">
-			</bounds>
+			<bounds x="94" y="20" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="32" y="42" width="27" height="27">
-			</bounds>
+			<bounds x="32" y="42" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="34" y="44" width="23" height="23">
-			</bounds>
+			<bounds x="34" y="44" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="56" y="42" width="27" height="27">
-			</bounds>
+			<bounds x="56" y="42" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="58" y="44" width="23" height="23">
-			</bounds>
+			<bounds x="58" y="44" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="80" y="42" width="27" height="27">
-			</bounds>
+			<bounds x="80" y="42" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="82" y="44" width="23" height="23">
-			</bounds>
+			<bounds x="82" y="44" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="312" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="312" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="314" y="5" width="28" height="28">
-			</bounds>
+			<bounds x="314" y="5" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="341" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="341" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="343" y="5" width="28" height="28">
-			</bounds>
+			<bounds x="343" y="5" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="283" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="283" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="285" y="5" width="28" height="28">
-			</bounds>
+			<bounds x="285" y="5" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="370" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="370" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="372" y="5" width="28" height="28">
-			</bounds>
+			<bounds x="372" y="5" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="428" y="32" width="32" height="32">
-			</bounds>
+			<bounds x="428" y="32" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="430" y="34" width="28" height="28">
-			</bounds>
+			<bounds x="430" y="34" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="428" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="428" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="430" y="5" width="28" height="28">
-			</bounds>
+			<bounds x="430" y="5" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="399" y="3" width="32" height="32">
-			</bounds>
+			<bounds x="399" y="3" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="401" y="5" width="28" height="28">
-			</bounds>
+			<bounds x="401" y="5" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="283" y="32" width="32" height="32">
-			</bounds>
+			<bounds x="283" y="32" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="285" y="34" width="28" height="28">
-			</bounds>
+			<bounds x="285" y="34" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="283" y="61" width="32" height="32">
-			</bounds>
+			<bounds x="283" y="61" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="285" y="63" width="28" height="28">
-			</bounds>
+			<bounds x="285" y="63" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="312" y="61" width="32" height="32">
-			</bounds>
+			<bounds x="312" y="61" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="314" y="63" width="28" height="28">
-			</bounds>
+			<bounds x="314" y="63" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="341" y="61" width="32" height="32">
-			</bounds>
+			<bounds x="341" y="61" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="343" y="63" width="28" height="28">
-			</bounds>
+			<bounds x="343" y="63" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="428" y="61" width="32" height="32">
-			</bounds>
+			<bounds x="428" y="61" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="430" y="63" width="28" height="28">
-			</bounds>
+			<bounds x="430" y="63" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="399" y="61" width="32" height="32">
-			</bounds>
+			<bounds x="399" y="61" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="401" y="63" width="28" height="28">
-			</bounds>
+			<bounds x="401" y="63" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="370" y="61" width="32" height="32">
-			</bounds>
+			<bounds x="370" y="61" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="372" y="63" width="28" height="28">
-			</bounds>
+			<bounds x="372" y="63" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="399" y="35" width="27" height="27">
-			</bounds>
+			<bounds x="399" y="35" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="401" y="37" width="23" height="23">
-			</bounds>
+			<bounds x="401" y="37" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="372" y="35" width="27" height="27">
-			</bounds>
+			<bounds x="372" y="35" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="374" y="37" width="23" height="23">
-			</bounds>
+			<bounds x="374" y="37" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="345" y="35" width="27" height="27">
-			</bounds>
+			<bounds x="345" y="35" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="347" y="37" width="23" height="23">
-			</bounds>
+			<bounds x="347" y="37" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="318" y="35" width="27" height="27">
-			</bounds>
+			<bounds x="318" y="35" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="320" y="37" width="23" height="23">
-			</bounds>
+			<bounds x="320" y="37" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="368" y="545" width="42" height="19">
-			</bounds>
+			<bounds x="368" y="545" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="370" y="547" width="38" height="15">
-			</bounds>
+			<bounds x="370" y="547" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="409" y="545" width="42" height="19">
-			</bounds>
+			<bounds x="409" y="545" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="411" y="547" width="38" height="15">
-			</bounds>
+			<bounds x="411" y="547" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="204" y="545" width="42" height="19">
-			</bounds>
+			<bounds x="204" y="545" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="206" y="547" width="38" height="15">
-			</bounds>
+			<bounds x="206" y="547" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="286" y="545" width="42" height="19">
-			</bounds>
+			<bounds x="286" y="545" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="288" y="547" width="38" height="15">
-			</bounds>
+			<bounds x="288" y="547" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="245" y="545" width="42" height="19">
-			</bounds>
+			<bounds x="245" y="545" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="247" y="547" width="38" height="15">
-			</bounds>
+			<bounds x="247" y="547" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="146" y="663" width="32" height="32">
-			</bounds>
+			<bounds x="146" y="663" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="148" y="665" width="28" height="28">
-			</bounds>
+			<bounds x="148" y="665" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="146" y="634" width="32" height="32">
-			</bounds>
+			<bounds x="146" y="634" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="148" y="636" width="28" height="28">
-			</bounds>
+			<bounds x="148" y="636" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="146" y="605" width="32" height="32">
-			</bounds>
+			<bounds x="146" y="605" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="148" y="607" width="28" height="28">
-			</bounds>
+			<bounds x="148" y="607" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="146" y="576" width="32" height="32">
-			</bounds>
+			<bounds x="146" y="576" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="148" y="578" width="28" height="28">
-			</bounds>
+			<bounds x="148" y="578" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="141" y="692" width="42" height="19">
-			</bounds>
+			<bounds x="141" y="692" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="143" y="694" width="38" height="15">
-			</bounds>
+			<bounds x="143" y="694" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_226_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="375" y="780" width="75" height="27">
-			</bounds>
+			<bounds x="375" y="780" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_226" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="377" y="782" width="71" height="23">
-			</bounds>
+			<bounds x="377" y="782" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_227_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="290" y="780" width="75" height="27">
-			</bounds>
+			<bounds x="290" y="780" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_227" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="292" y="782" width="71" height="23">
-			</bounds>
+			<bounds x="292" y="782" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_228_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="207" y="780" width="75" height="27">
-			</bounds>
+			<bounds x="207" y="780" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_228" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="209" y="782" width="71" height="23">
-			</bounds>
+			<bounds x="209" y="782" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_229_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="111" y="780" width="75" height="27">
-			</bounds>
+			<bounds x="111" y="780" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_229" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="113" y="782" width="71" height="23">
-			</bounds>
+			<bounds x="113" y="782" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_230_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="453" y="780" width="75" height="27">
-			</bounds>
+			<bounds x="453" y="780" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_230" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="455" y="782" width="71" height="23">
-			</bounds>
+			<bounds x="455" y="782" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_231_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="687" y="780" width="75" height="27">
-			</bounds>
+			<bounds x="687" y="780" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_231" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="689" y="782" width="71" height="23">
-			</bounds>
+			<bounds x="689" y="782" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_232_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="609" y="780" width="75" height="27">
-			</bounds>
+			<bounds x="609" y="780" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_232" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="611" y="782" width="71" height="23">
-			</bounds>
+			<bounds x="611" y="782" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_233_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="531" y="780" width="75" height="27">
-			</bounds>
+			<bounds x="531" y="780" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_233" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="533" y="782" width="71" height="23">
-			</bounds>
+			<bounds x="533" y="782" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp144" element="colour_button_234_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="639" y="438" width="62" height="62">
-			</bounds>
+			<bounds x="639" y="438" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp144" element="colour_button_234" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="641" y="440" width="58" height="58">
-			</bounds>
+			<bounds x="641" y="440" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp204" element="colour_button_235_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="20" y="642" width="62" height="62">
-			</bounds>
+			<bounds x="20" y="642" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp204" element="colour_button_235" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="22" y="644" width="58" height="58">
-			</bounds>
+			<bounds x="22" y="644" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp220" element="colour_button_236_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="18" y="255" width="62" height="62">
-			</bounds>
+			<bounds x="18" y="255" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp220" element="colour_button_236" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="20" y="257" width="58" height="58">
-			</bounds>
+			<bounds x="20" y="257" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp179" element="colour_button_238_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="345" y="225" width="62" height="62">
-			</bounds>
+			<bounds x="345" y="225" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp179" element="colour_button_238" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="347" y="227" width="58" height="58">
-			</bounds>
+			<bounds x="347" y="227" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp60" element="colour_button_239_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="103" y="510" width="62" height="62">
-			</bounds>
+			<bounds x="103" y="510" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp60" element="colour_button_239" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="105" y="512" width="58" height="58">
-			</bounds>
+			<bounds x="105" y="512" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_240_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="625" y="14" width="75" height="27">
-			</bounds>
+			<bounds x="625" y="14" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp255" element="colour_button_240" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="627" y="16" width="71" height="23">
-			</bounds>
+			<bounds x="627" y="16" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="173" y="506" width="323" height="27">
-			</bounds>
+			<bounds x="173" y="506" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="173" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="173" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="193" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="193" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="213" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="213" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="233" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="233" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="253" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="253" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="273" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="273" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="293" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="293" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="313" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="313" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="333" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="333" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="353" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="353" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="373" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="373" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="393" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="393" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="413" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="413" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="433" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="433" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="453" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="453" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="473" y="506" width="20" height="27">
-			</bounds>
+			<bounds x="473" y="506" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label223" element="label_223">
-			<bounds x="595" y="513" width="68" height="28">
-			</bounds>
+			<bounds x="595" y="513" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="label224" element="label_224">
-			<bounds x="92" y="718" width="41" height="56">
-			</bounds>
+			<bounds x="92" y="718" width="41" height="56"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_button" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_button" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_button" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_button" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_button" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_button" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4carrya.lay
+++ b/src/mame/layout/sc4carrya.lay
@@ -8,10052 +8,6410 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="g">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="g">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Step To Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Step To Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Fruit Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Unlock Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Unlock Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Carry On">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Carry On">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Fruit Lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit Lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Skill Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skill Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_174_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_174">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_175_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_175">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_176_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_176">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_177_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_177">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_178_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_178">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_179_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_179">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_180_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_180">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Meter??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="colour_button_182_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_182">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_72">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_115">
 		<text string="Win line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_116">
 		<text string="Win line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="968" height="641">
-			</bounds>
+			<bounds x="0" y="0" width="968" height="641"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="275" y="403" width="90" height="160">
-			</bounds>
+			<bounds x="275" y="403" width="90" height="160"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="275.0000" y="403.0000" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="275.0000" y="403.0000" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="278.7500" y="405.2222" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="278.7500" y="405.2222" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.5000" y="407.4445" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="282.5000" y="407.4445" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="286.2500" y="409.6667" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="286.2500" y="409.6667" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="290.0000" y="411.8889" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="290.0000" y="411.8889" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="293.7500" y="414.1111" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="293.7500" y="414.1111" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="275.0000" y="456.3333" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="275.0000" y="456.3333" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="278.7500" y="458.5556" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="278.7500" y="458.5556" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.5000" y="460.7778" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="282.5000" y="460.7778" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="286.2500" y="463.0000" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="286.2500" y="463.0000" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="290.0000" y="465.2222" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="290.0000" y="465.2222" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="293.7500" y="467.4445" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="293.7500" y="467.4445" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="275.0000" y="509.6667" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="275.0000" y="509.6667" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="278.7500" y="511.8889" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="278.7500" y="511.8889" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="282.5000" y="514.1111" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="282.5000" y="514.1111" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="286.2500" y="516.3333" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="286.2500" y="516.3333" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="290.0000" y="518.5555" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="290.0000" y="518.5555" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="293.7500" y="520.7778" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="293.7500" y="520.7778" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="275" y="403" width="90" height="160">
-			</bounds>
+			<bounds x="275" y="403" width="90" height="160"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="376" y="403" width="90" height="160">
-			</bounds>
+			<bounds x="376" y="403" width="90" height="160"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="376.0000" y="403.0000" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="376.0000" y="403.0000" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="379.7500" y="405.2222" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="379.7500" y="405.2222" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="383.5000" y="407.4445" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="383.5000" y="407.4445" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="387.2500" y="409.6667" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="387.2500" y="409.6667" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="391.0000" y="411.8889" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="391.0000" y="411.8889" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="394.7500" y="414.1111" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="394.7500" y="414.1111" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="376.0000" y="456.3333" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="376.0000" y="456.3333" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="379.7500" y="458.5556" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="379.7500" y="458.5556" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="383.5000" y="460.7778" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="383.5000" y="460.7778" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="387.2500" y="463.0000" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="387.2500" y="463.0000" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="391.0000" y="465.2222" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="391.0000" y="465.2222" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="394.7500" y="467.4445" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="394.7500" y="467.4445" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="376.0000" y="509.6667" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="376.0000" y="509.6667" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="379.7500" y="511.8889" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="379.7500" y="511.8889" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="383.5000" y="514.1111" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="383.5000" y="514.1111" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="387.2500" y="516.3333" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="387.2500" y="516.3333" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="391.0000" y="518.5555" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="391.0000" y="518.5555" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="394.7500" y="520.7778" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="394.7500" y="520.7778" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="376" y="403" width="90" height="160">
-			</bounds>
+			<bounds x="376" y="403" width="90" height="160"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="479" y="403" width="90" height="160">
-			</bounds>
+			<bounds x="479" y="403" width="90" height="160"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="479.0000" y="403.0000" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="479.0000" y="403.0000" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="482.7500" y="405.2222" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="482.7500" y="405.2222" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="486.5000" y="407.4445" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="486.5000" y="407.4445" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="490.2500" y="409.6667" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="490.2500" y="409.6667" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="494.0000" y="411.8889" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="494.0000" y="411.8889" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="497.7500" y="414.1111" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="497.7500" y="414.1111" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="479.0000" y="456.3333" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="479.0000" y="456.3333" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="482.7500" y="458.5556" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="482.7500" y="458.5556" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="486.5000" y="460.7778" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="486.5000" y="460.7778" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="490.2500" y="463.0000" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="490.2500" y="463.0000" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="494.0000" y="465.2222" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="494.0000" y="465.2222" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="497.7500" y="467.4445" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="497.7500" y="467.4445" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="479.0000" y="509.6667" width="90.0000" height="53.3333">
-			</bounds>
+			<bounds x="479.0000" y="509.6667" width="90.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="482.7500" y="511.8889" width="82.5000" height="48.8889">
-			</bounds>
+			<bounds x="482.7500" y="511.8889" width="82.5000" height="48.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="486.5000" y="514.1111" width="75.0000" height="44.4444">
-			</bounds>
+			<bounds x="486.5000" y="514.1111" width="75.0000" height="44.4444"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="490.2500" y="516.3333" width="67.5000" height="40.0000">
-			</bounds>
+			<bounds x="490.2500" y="516.3333" width="67.5000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="494.0000" y="518.5555" width="60.0000" height="35.5556">
-			</bounds>
+			<bounds x="494.0000" y="518.5555" width="60.0000" height="35.5556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="497.7500" y="520.7778" width="52.5000" height="31.1111">
-			</bounds>
+			<bounds x="497.7500" y="520.7778" width="52.5000" height="31.1111"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="479" y="403" width="90" height="160">
-			</bounds>
+			<bounds x="479" y="403" width="90" height="160"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="412" y="179" width="50" height="50">
-			</bounds>
+			<bounds x="412" y="179" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="412.0000" y="179.0000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="412.0000" y="179.0000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="414.0833" y="181.0833" width="45.8333" height="45.8333">
-			</bounds>
+			<bounds x="414.0833" y="181.0833" width="45.8333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="416.1667" y="183.1667" width="41.6667" height="41.6667">
-			</bounds>
+			<bounds x="416.1667" y="183.1667" width="41.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="418.2500" y="185.2500" width="37.5000" height="37.5000">
-			</bounds>
+			<bounds x="418.2500" y="185.2500" width="37.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="420.3333" y="187.3333" width="33.3333" height="33.3333">
-			</bounds>
+			<bounds x="420.3333" y="187.3333" width="33.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="422.4167" y="189.4167" width="29.1667" height="29.1667">
-			</bounds>
+			<bounds x="422.4167" y="189.4167" width="29.1667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="412" y="179" width="50" height="50">
-			</bounds>
+			<bounds x="412" y="179" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="880" y="6" width="42" height="52">
-			</bounds>
+			<bounds x="880" y="6" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="882" y="8" width="38" height="48">
-			</bounds>
+			<bounds x="882" y="8" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="72" y="535" width="82" height="27">
-			</bounds>
+			<bounds x="72" y="535" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="74" y="537" width="78" height="23">
-			</bounds>
+			<bounds x="74" y="537" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="81" y="488" width="62" height="28">
-			</bounds>
+			<bounds x="81" y="488" width="62" height="28"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="83" y="490" width="58" height="24">
-			</bounds>
+			<bounds x="83" y="490" width="58" height="24"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="846" y="123" width="102" height="42">
-			</bounds>
+			<bounds x="846" y="123" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="848" y="125" width="98" height="38">
-			</bounds>
+			<bounds x="848" y="125" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="846" y="165" width="102" height="42">
-			</bounds>
+			<bounds x="846" y="165" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="848" y="167" width="98" height="38">
-			</bounds>
+			<bounds x="848" y="167" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="846" y="207" width="102" height="42">
-			</bounds>
+			<bounds x="846" y="207" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="848" y="209" width="98" height="38">
-			</bounds>
+			<bounds x="848" y="209" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="797" y="88" width="42" height="32">
-			</bounds>
+			<bounds x="797" y="88" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="799" y="90" width="38" height="28">
-			</bounds>
+			<bounds x="799" y="90" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="846" y="81" width="102" height="42">
-			</bounds>
+			<bounds x="846" y="81" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="848" y="83" width="98" height="38">
-			</bounds>
+			<bounds x="848" y="83" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="732" y="79" width="62" height="42">
-			</bounds>
+			<bounds x="732" y="79" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="734" y="81" width="58" height="38">
-			</bounds>
+			<bounds x="734" y="81" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="846" y="333" width="102" height="42">
-			</bounds>
+			<bounds x="846" y="333" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="848" y="335" width="98" height="38">
-			</bounds>
+			<bounds x="848" y="335" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="846" y="249" width="102" height="42">
-			</bounds>
+			<bounds x="846" y="249" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="848" y="251" width="98" height="38">
-			</bounds>
+			<bounds x="848" y="251" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="846" y="291" width="102" height="42">
-			</bounds>
+			<bounds x="846" y="291" width="102" height="42"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="848" y="293" width="98" height="38">
-			</bounds>
+			<bounds x="848" y="293" width="98" height="38"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="798" y="293" width="42" height="32">
-			</bounds>
+			<bounds x="798" y="293" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="800" y="295" width="38" height="28">
-			</bounds>
+			<bounds x="800" y="295" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="732" y="289" width="62" height="42">
-			</bounds>
+			<bounds x="732" y="289" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="734" y="291" width="58" height="38">
-			</bounds>
+			<bounds x="734" y="291" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="798" y="255" width="42" height="32">
-			</bounds>
+			<bounds x="798" y="255" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="800" y="257" width="38" height="28">
-			</bounds>
+			<bounds x="800" y="257" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="732" y="247" width="62" height="42">
-			</bounds>
+			<bounds x="732" y="247" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="734" y="249" width="58" height="38">
-			</bounds>
+			<bounds x="734" y="249" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="798" y="337" width="42" height="32">
-			</bounds>
+			<bounds x="798" y="337" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="800" y="339" width="38" height="28">
-			</bounds>
+			<bounds x="800" y="339" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="732" y="331" width="62" height="42">
-			</bounds>
+			<bounds x="732" y="331" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="734" y="333" width="58" height="38">
-			</bounds>
+			<bounds x="734" y="333" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="732" y="121" width="62" height="42">
-			</bounds>
+			<bounds x="732" y="121" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="734" y="123" width="58" height="38">
-			</bounds>
+			<bounds x="734" y="123" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="732" y="205" width="62" height="42">
-			</bounds>
+			<bounds x="732" y="205" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="734" y="207" width="58" height="38">
-			</bounds>
+			<bounds x="734" y="207" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="797" y="213" width="42" height="32">
-			</bounds>
+			<bounds x="797" y="213" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="799" y="215" width="38" height="28">
-			</bounds>
+			<bounds x="799" y="215" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="796" y="171" width="42" height="32">
-			</bounds>
+			<bounds x="796" y="171" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="798" y="173" width="38" height="28">
-			</bounds>
+			<bounds x="798" y="173" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="732" y="163" width="62" height="42">
-			</bounds>
+			<bounds x="732" y="163" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="734" y="165" width="58" height="38">
-			</bounds>
+			<bounds x="734" y="165" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="796" y="124" width="42" height="32">
-			</bounds>
+			<bounds x="796" y="124" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="798" y="126" width="38" height="28">
-			</bounds>
+			<bounds x="798" y="126" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="196" y="165" width="32" height="42">
-			</bounds>
+			<bounds x="196" y="165" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="198" y="167" width="28" height="38">
-			</bounds>
+			<bounds x="198" y="167" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="165" y="165" width="32" height="42">
-			</bounds>
+			<bounds x="165" y="165" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="167" y="167" width="28" height="38">
-			</bounds>
+			<bounds x="167" y="167" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="134" y="165" width="32" height="42">
-			</bounds>
+			<bounds x="134" y="165" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="136" y="167" width="28" height="38">
-			</bounds>
+			<bounds x="136" y="167" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="103" y="165" width="32" height="42">
-			</bounds>
+			<bounds x="103" y="165" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="105" y="167" width="28" height="38">
-			</bounds>
+			<bounds x="105" y="167" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="72" y="165" width="32" height="42">
-			</bounds>
+			<bounds x="72" y="165" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="74" y="167" width="28" height="38">
-			</bounds>
+			<bounds x="74" y="167" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="41" y="165" width="32" height="42">
-			</bounds>
+			<bounds x="41" y="165" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="43" y="167" width="28" height="38">
-			</bounds>
+			<bounds x="43" y="167" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="7" y="165" width="35" height="42">
-			</bounds>
+			<bounds x="7" y="165" width="35" height="42"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="9" y="167" width="31" height="38">
-			</bounds>
+			<bounds x="9" y="167" width="31" height="38"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="9" y="82" width="35" height="42">
-			</bounds>
+			<bounds x="9" y="82" width="35" height="42"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="11" y="84" width="31" height="38">
-			</bounds>
+			<bounds x="11" y="84" width="31" height="38"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="43" y="82" width="32" height="42">
-			</bounds>
+			<bounds x="43" y="82" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="45" y="84" width="28" height="38">
-			</bounds>
+			<bounds x="45" y="84" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="74" y="82" width="32" height="42">
-			</bounds>
+			<bounds x="74" y="82" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="76" y="84" width="28" height="38">
-			</bounds>
+			<bounds x="76" y="84" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="105" y="82" width="42" height="42">
-			</bounds>
+			<bounds x="105" y="82" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="107" y="84" width="38" height="38">
-			</bounds>
+			<bounds x="107" y="84" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="153" y="82" width="32" height="42">
-			</bounds>
+			<bounds x="153" y="82" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="155" y="84" width="28" height="38">
-			</bounds>
+			<bounds x="155" y="84" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="184" y="82" width="32" height="42">
-			</bounds>
+			<bounds x="184" y="82" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="186" y="84" width="28" height="38">
-			</bounds>
+			<bounds x="186" y="84" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="485" y="236" width="22" height="22">
-			</bounds>
+			<bounds x="485" y="236" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="487" y="238" width="18" height="18">
-			</bounds>
+			<bounds x="487" y="238" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="485" y="153" width="22" height="22">
-			</bounds>
+			<bounds x="485" y="153" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="487" y="155" width="18" height="18">
-			</bounds>
+			<bounds x="487" y="155" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="475" y="188" width="42" height="32">
-			</bounds>
+			<bounds x="475" y="188" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="477" y="190" width="38" height="28">
-			</bounds>
+			<bounds x="477" y="190" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="543" y="152" width="42" height="42">
-			</bounds>
+			<bounds x="543" y="152" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="545" y="154" width="38" height="38">
-			</bounds>
+			<bounds x="545" y="154" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="495" y="104" width="42" height="42">
-			</bounds>
+			<bounds x="495" y="104" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="497" y="106" width="38" height="38">
-			</bounds>
+			<bounds x="497" y="106" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="399" y="104" width="42" height="42">
-			</bounds>
+			<bounds x="399" y="104" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="401" y="106" width="38" height="38">
-			</bounds>
+			<bounds x="401" y="106" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="447" y="296" width="42" height="42">
-			</bounds>
+			<bounds x="447" y="296" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="449" y="298" width="38" height="38">
-			</bounds>
+			<bounds x="449" y="298" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="255" y="296" width="42" height="42">
-			</bounds>
+			<bounds x="255" y="296" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="257" y="298" width="38" height="38">
-			</bounds>
+			<bounds x="257" y="298" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="543" y="296" width="42" height="42">
-			</bounds>
+			<bounds x="543" y="296" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="545" y="298" width="38" height="38">
-			</bounds>
+			<bounds x="545" y="298" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="255" y="104" width="42" height="42">
-			</bounds>
+			<bounds x="255" y="104" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="257" y="106" width="38" height="38">
-			</bounds>
+			<bounds x="257" y="106" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="305" y="152" width="92" height="19">
-			</bounds>
+			<bounds x="305" y="152" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="307" y="154" width="88" height="15">
-			</bounds>
+			<bounds x="307" y="154" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="304" y="176" width="92" height="19">
-			</bounds>
+			<bounds x="304" y="176" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="306" y="178" width="88" height="15">
-			</bounds>
+			<bounds x="306" y="178" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="305" y="200" width="92" height="19">
-			</bounds>
+			<bounds x="305" y="200" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="307" y="202" width="88" height="15">
-			</bounds>
+			<bounds x="307" y="202" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="305" y="224" width="92" height="19">
-			</bounds>
+			<bounds x="305" y="224" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="307" y="226" width="88" height="15">
-			</bounds>
+			<bounds x="307" y="226" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="304" y="248" width="92" height="19">
-			</bounds>
+			<bounds x="304" y="248" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="306" y="250" width="88" height="15">
-			</bounds>
+			<bounds x="306" y="250" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="305" y="272" width="92" height="19">
-			</bounds>
+			<bounds x="305" y="272" width="92" height="19"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="307" y="274" width="88" height="15">
-			</bounds>
+			<bounds x="307" y="274" width="88" height="15"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="116" y="296" width="32" height="42">
-			</bounds>
+			<bounds x="116" y="296" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="118" y="298" width="28" height="38">
-			</bounds>
+			<bounds x="118" y="298" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="76" y="336" width="32" height="42">
-			</bounds>
+			<bounds x="76" y="336" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="78" y="338" width="28" height="38">
-			</bounds>
+			<bounds x="78" y="338" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="74" y="416" width="32" height="42">
-			</bounds>
+			<bounds x="74" y="416" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="76" y="418" width="28" height="38">
-			</bounds>
+			<bounds x="76" y="418" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="116" y="380" width="32" height="42">
-			</bounds>
+			<bounds x="116" y="380" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="118" y="382" width="28" height="38">
-			</bounds>
+			<bounds x="118" y="382" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_174_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="482" y="589" width="75" height="32">
-			</bounds>
+			<bounds x="482" y="589" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_174" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="484" y="591" width="71" height="28">
-			</bounds>
+			<bounds x="484" y="591" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_175_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="382" y="589" width="75" height="32">
-			</bounds>
+			<bounds x="382" y="589" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_175" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="384" y="591" width="71" height="28">
-			</bounds>
+			<bounds x="384" y="591" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_176_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="278" y="589" width="75" height="32">
-			</bounds>
+			<bounds x="278" y="589" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_176" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="280" y="591" width="71" height="28">
-			</bounds>
+			<bounds x="280" y="591" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_177_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="600" y="589" width="75" height="32">
-			</bounds>
+			<bounds x="600" y="589" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_177" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="602" y="591" width="71" height="28">
-			</bounds>
+			<bounds x="602" y="591" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_178_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="80" y="589" width="75" height="32">
-			</bounds>
+			<bounds x="80" y="589" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_178" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="82" y="591" width="71" height="28">
-			</bounds>
+			<bounds x="82" y="591" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_179_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="180" y="589" width="75" height="32">
-			</bounds>
+			<bounds x="180" y="589" width="75" height="32"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_179" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="182" y="591" width="71" height="28">
-			</bounds>
+			<bounds x="182" y="591" width="71" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="colour_button_180_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="290" y="28" width="52" height="46">
-			</bounds>
+			<bounds x="290" y="28" width="52" height="46"/>
 		</backdrop>
 		<backdrop name="lamp112" element="colour_button_180" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="292" y="30" width="48" height="42">
-			</bounds>
+			<bounds x="292" y="30" width="48" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_182_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="405" y="236" width="62" height="27">
-			</bounds>
+			<bounds x="405" y="236" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_182" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="407" y="238" width="58" height="23">
-			</bounds>
+			<bounds x="407" y="238" width="58" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="385" y="31" width="28" height="40">
-			</bounds>
+			<bounds x="385" y="31" width="28" height="40"/>
 		</backdrop>
 		<backdrop name="digit23" element="led_digit_red">
-			<bounds x="385" y="31" width="28" height="40">
-			</bounds>
+			<bounds x="385" y="31" width="28" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="385" y="31" width="28" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="385" y="31" width="28" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="413" y="31" width="28" height="40">
-			</bounds>
+			<bounds x="413" y="31" width="28" height="40"/>
 		</backdrop>
 		<backdrop name="digit21" element="led_digit_red">
-			<bounds x="413" y="31" width="28" height="40">
-			</bounds>
+			<bounds x="413" y="31" width="28" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="413" y="31" width="28" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="413" y="31" width="28" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="441" y="31" width="28" height="40">
-			</bounds>
+			<bounds x="441" y="31" width="28" height="40"/>
 		</backdrop>
 		<backdrop name="digit19" element="led_digit_red">
-			<bounds x="441" y="31" width="28" height="40">
-			</bounds>
+			<bounds x="441" y="31" width="28" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="441" y="31" width="28" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="441" y="31" width="28" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="469" y="31" width="28" height="40">
-			</bounds>
+			<bounds x="469" y="31" width="28" height="40"/>
 		</backdrop>
 		<backdrop name="digit17" element="led_digit_red">
-			<bounds x="469" y="31" width="28" height="40">
-			</bounds>
+			<bounds x="469" y="31" width="28" height="40"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="469" y="31" width="28" height="40">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="469" y="31" width="28" height="40"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="305" y="360" width="227" height="20">
-			</bounds>
+			<bounds x="305" y="360" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="305" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="305" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="319" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="319" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="333" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="333" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="347" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="347" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="361" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="361" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="375" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="375" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="389" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="389" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="403" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="403" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="417" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="417" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="431" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="431" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="445" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="445" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="459" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="459" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="473" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="473" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="487" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="487" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="501" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="501" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="515" y="360" width="14" height="20">
-			</bounds>
+			<bounds x="515" y="360" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="label72" element="label_72">
-			<bounds x="351" y="25" width="28" height="49">
-			</bounds>
+			<bounds x="351" y="25" width="28" height="49"/>
 		</backdrop>
 		<backdrop name="label115" element="label_115">
-			<bounds x="578" y="465" width="53" height="19">
-			</bounds>
+			<bounds x="578" y="465" width="53" height="19"/>
 		</backdrop>
 		<backdrop name="label116" element="label_116">
-			<bounds x="211" y="464" width="53" height="19">
-			</bounds>
+			<bounds x="211" y="464" width="53" height="19"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_button" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cashm.lay
+++ b/src/mame/layout/sc4cashm.lay
@@ -8,14116 +8,8309 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Wink">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Wink">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Sexy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Sevens">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Sexy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Sevens">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stand">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Lost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Lost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cherry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Heart">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Heart">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cupids">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Arrow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cupids">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Arrow">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="All Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Long">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="All Night">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Long">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Madness">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Melon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Madness">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="8 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="8 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="7 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="7 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="6 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="6 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="5 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="5 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="4 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="3 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="2 Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="1 Blast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="1 Blast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.60+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.80+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.80+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1+Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="9 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="9 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="3 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="1 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="1 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1Win Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1Win Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="6 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="7 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="7 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</disk>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cashanova">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cashanova">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="5 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="5 Ko">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="1Blast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="1Blast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Heart">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Heart">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="2Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="2Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Heart">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Heart">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="2Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="3Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="3Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="1Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="1Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="MultiFill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="MultiFill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Enters">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Enters">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="All Lit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="All Lit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Take">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_28">
 		<text string="Light All Three Arrows ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="Light To Enter Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="543" height="689">
-			</bounds>
+			<bounds x="0" y="0" width="543" height="689"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="68" y="510" width="55" height="90">
-			</bounds>
+			<bounds x="68" y="510" width="55" height="90"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="68.0000" y="510.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="68.0000" y="510.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="70.2917" y="511.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="70.2917" y="511.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="72.5833" y="512.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="72.5833" y="512.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="74.8750" y="513.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="74.8750" y="513.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="77.1667" y="515.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="77.1667" y="515.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="79.4583" y="516.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="79.4583" y="516.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="68.0000" y="540.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="68.0000" y="540.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="70.2917" y="541.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="70.2917" y="541.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="72.5833" y="542.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="72.5833" y="542.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="74.8750" y="543.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="74.8750" y="543.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="77.1667" y="545.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="77.1667" y="545.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="79.4583" y="546.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="79.4583" y="546.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="68.0000" y="570.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="68.0000" y="570.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="70.2917" y="571.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="70.2917" y="571.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="72.5833" y="572.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="72.5833" y="572.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="74.8750" y="573.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="74.8750" y="573.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="77.1667" y="575.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="77.1667" y="575.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="79.4583" y="576.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="79.4583" y="576.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="68" y="510" width="55" height="90">
-			</bounds>
+			<bounds x="68" y="510" width="55" height="90"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="147" y="511" width="55" height="90">
-			</bounds>
+			<bounds x="147" y="511" width="55" height="90"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="147.0000" y="511.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="147.0000" y="511.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="149.2917" y="512.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="149.2917" y="512.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="151.5833" y="513.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="151.5833" y="513.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="153.8750" y="514.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="153.8750" y="514.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="156.1667" y="516.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="156.1667" y="516.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="158.4583" y="517.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="158.4583" y="517.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="147.0000" y="541.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="147.0000" y="541.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="149.2917" y="542.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="149.2917" y="542.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="151.5833" y="543.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="151.5833" y="543.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="153.8750" y="544.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="153.8750" y="544.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="156.1667" y="546.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="156.1667" y="546.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="158.4583" y="547.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="158.4583" y="547.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="147.0000" y="571.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="147.0000" y="571.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="149.2917" y="572.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="149.2917" y="572.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="151.5833" y="573.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="151.5833" y="573.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="153.8750" y="574.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="153.8750" y="574.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="156.1667" y="576.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="156.1667" y="576.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="158.4583" y="577.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="158.4583" y="577.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="147" y="511" width="55" height="90">
-			</bounds>
+			<bounds x="147" y="511" width="55" height="90"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="226" y="511" width="55" height="90">
-			</bounds>
+			<bounds x="226" y="511" width="55" height="90"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="226.0000" y="511.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="226.0000" y="511.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.2917" y="512.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="228.2917" y="512.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="230.5833" y="513.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="230.5833" y="513.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="232.8750" y="514.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="232.8750" y="514.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="235.1667" y="516.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="235.1667" y="516.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.4583" y="517.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="237.4583" y="517.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="226.0000" y="541.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="226.0000" y="541.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.2917" y="542.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="228.2917" y="542.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="230.5833" y="543.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="230.5833" y="543.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="232.8750" y="544.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="232.8750" y="544.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="235.1667" y="546.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="235.1667" y="546.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.4583" y="547.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="237.4583" y="547.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="226.0000" y="571.0000" width="55.0000" height="30.0000">
-			</bounds>
+			<bounds x="226.0000" y="571.0000" width="55.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="228.2917" y="572.2500" width="50.4167" height="27.5000">
-			</bounds>
+			<bounds x="228.2917" y="572.2500" width="50.4167" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="230.5833" y="573.5000" width="45.8333" height="25.0000">
-			</bounds>
+			<bounds x="230.5833" y="573.5000" width="45.8333" height="25.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="232.8750" y="574.7500" width="41.2500" height="22.5000">
-			</bounds>
+			<bounds x="232.8750" y="574.7500" width="41.2500" height="22.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="235.1667" y="576.0000" width="36.6667" height="20.0000">
-			</bounds>
+			<bounds x="235.1667" y="576.0000" width="36.6667" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="237.4583" y="577.2500" width="32.0833" height="17.5000">
-			</bounds>
+			<bounds x="237.4583" y="577.2500" width="32.0833" height="17.5000"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="226" y="511" width="55" height="90">
-			</bounds>
+			<bounds x="226" y="511" width="55" height="90"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="79" y="416" width="45" height="45">
-			</bounds>
+			<bounds x="79" y="416" width="45" height="45"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="79.0000" y="416.0000" width="45.0000" height="45.0000">
-			</bounds>
+			<bounds x="79.0000" y="416.0000" width="45.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="80.8750" y="417.8750" width="41.2500" height="41.2500">
-			</bounds>
+			<bounds x="80.8750" y="417.8750" width="41.2500" height="41.2500"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="82.7500" y="419.7500" width="37.5000" height="37.5000">
-			</bounds>
+			<bounds x="82.7500" y="419.7500" width="37.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="84.6250" y="421.6250" width="33.7500" height="33.7500">
-			</bounds>
+			<bounds x="84.6250" y="421.6250" width="33.7500" height="33.7500"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="86.5000" y="423.5000" width="30.0000" height="30.0000">
-			</bounds>
+			<bounds x="86.5000" y="423.5000" width="30.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="88.3750" y="425.3750" width="26.2500" height="26.2500">
-			</bounds>
+			<bounds x="88.3750" y="425.3750" width="26.2500" height="26.2500"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="79" y="416" width="45" height="45">
-			</bounds>
+			<bounds x="79" y="416" width="45" height="45"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="1" y="584" width="16" height="57">
-			</bounds>
+			<bounds x="1" y="584" width="16" height="57"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="3" y="586" width="12" height="53">
-			</bounds>
+			<bounds x="3" y="586" width="12" height="53"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="1" y="454" width="67" height="39">
-			</bounds>
+			<bounds x="1" y="454" width="67" height="39"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="3" y="456" width="63" height="35">
-			</bounds>
+			<bounds x="3" y="456" width="63" height="35"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="1" y="154" width="62" height="32">
-			</bounds>
+			<bounds x="1" y="154" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="3" y="156" width="58" height="28">
-			</bounds>
+			<bounds x="3" y="156" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="87" y="461" width="29" height="24">
-			</bounds>
+			<bounds x="87" y="461" width="29" height="24"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="89" y="463" width="25" height="20">
-			</bounds>
+			<bounds x="89" y="463" width="25" height="20"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="87" y="393" width="29" height="24">
-			</bounds>
+			<bounds x="87" y="393" width="29" height="24"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="89" y="395" width="25" height="20">
-			</bounds>
+			<bounds x="89" y="395" width="25" height="20"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="326" y="52" width="32" height="22">
-			</bounds>
+			<bounds x="326" y="52" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="328" y="54" width="28" height="18">
-			</bounds>
+			<bounds x="328" y="54" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="332" y="73" width="19" height="19">
-			</bounds>
+			<bounds x="332" y="73" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="334" y="75" width="15" height="15">
-			</bounds>
+			<bounds x="334" y="75" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="332" y="91" width="19" height="19">
-			</bounds>
+			<bounds x="332" y="91" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="334" y="93" width="15" height="15">
-			</bounds>
+			<bounds x="334" y="93" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="332" y="109" width="19" height="19">
-			</bounds>
+			<bounds x="332" y="109" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="334" y="111" width="15" height="15">
-			</bounds>
+			<bounds x="334" y="111" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="300" y="91" width="19" height="19">
-			</bounds>
+			<bounds x="300" y="91" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="302" y="93" width="15" height="15">
-			</bounds>
+			<bounds x="302" y="93" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="300" y="109" width="19" height="19">
-			</bounds>
+			<bounds x="300" y="109" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="302" y="111" width="15" height="15">
-			</bounds>
+			<bounds x="302" y="111" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="293" y="52" width="32" height="22">
-			</bounds>
+			<bounds x="293" y="52" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="295" y="54" width="28" height="18">
-			</bounds>
+			<bounds x="295" y="54" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="300" y="73" width="19" height="19">
-			</bounds>
+			<bounds x="300" y="73" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="302" y="75" width="15" height="15">
-			</bounds>
+			<bounds x="302" y="75" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="17" y="491" width="38" height="38">
-			</bounds>
+			<bounds x="17" y="491" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="19" y="493" width="34" height="34">
-			</bounds>
+			<bounds x="19" y="493" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="17" y="604" width="38" height="38">
-			</bounds>
+			<bounds x="17" y="604" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="19" y="606" width="34" height="34">
-			</bounds>
+			<bounds x="19" y="606" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="17" y="604" width="38" height="38">
-			</bounds>
+			<bounds x="17" y="604" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="19" y="606" width="34" height="34">
-			</bounds>
+			<bounds x="19" y="606" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="17" y="566" width="38" height="38">
-			</bounds>
+			<bounds x="17" y="566" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="19" y="568" width="34" height="34">
-			</bounds>
+			<bounds x="19" y="568" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="17" y="528" width="38" height="38">
-			</bounds>
+			<bounds x="17" y="528" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="19" y="530" width="34" height="34">
-			</bounds>
+			<bounds x="19" y="530" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="206" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="206" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="208" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="208" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="206" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="206" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="208" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="208" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="3" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="3" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="5" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="5" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="3" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="3" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="5" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="5" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="235" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="235" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="237" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="237" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="235" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="235" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="237" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="237" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="177" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="177" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="179" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="179" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="177" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="177" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="179" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="179" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="148" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="148" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="150" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="150" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="148" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="148" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="150" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="150" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="119" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="119" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="121" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="121" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="119" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="119" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="121" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="121" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="90" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="90" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="92" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="92" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="90" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="90" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="92" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="92" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="61" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="61" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="63" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="63" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="61" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="61" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="63" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="63" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="32" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="32" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="34" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="34" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="32" y="3" width="32" height="61">
-			</bounds>
+			<bounds x="32" y="3" width="32" height="61"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="34" y="5" width="28" height="57">
-			</bounds>
+			<bounds x="34" y="5" width="28" height="57"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="5" y="183" width="50" height="25">
-			</bounds>
+			<bounds x="5" y="183" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="7" y="185" width="46" height="21">
-			</bounds>
+			<bounds x="7" y="185" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="127" y="233" width="44" height="28">
-			</bounds>
+			<bounds x="127" y="233" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="129" y="235" width="40" height="24">
-			</bounds>
+			<bounds x="129" y="235" width="40" height="24"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="127" y="258" width="44" height="28">
-			</bounds>
+			<bounds x="127" y="258" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="129" y="260" width="40" height="24">
-			</bounds>
+			<bounds x="129" y="260" width="40" height="24"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="127" y="283" width="44" height="28">
-			</bounds>
+			<bounds x="127" y="283" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="129" y="285" width="40" height="24">
-			</bounds>
+			<bounds x="129" y="285" width="40" height="24"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="127" y="358" width="44" height="28">
-			</bounds>
+			<bounds x="127" y="358" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="129" y="360" width="40" height="24">
-			</bounds>
+			<bounds x="129" y="360" width="40" height="24"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="127" y="333" width="44" height="28">
-			</bounds>
+			<bounds x="127" y="333" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="129" y="335" width="40" height="24">
-			</bounds>
+			<bounds x="129" y="335" width="40" height="24"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="127" y="308" width="44" height="28">
-			</bounds>
+			<bounds x="127" y="308" width="44" height="28"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="129" y="310" width="40" height="24">
-			</bounds>
+			<bounds x="129" y="310" width="40" height="24"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="123" y="183" width="52" height="28">
-			</bounds>
+			<bounds x="123" y="183" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="125" y="185" width="48" height="24">
-			</bounds>
+			<bounds x="125" y="185" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="123" y="208" width="52" height="28">
-			</bounds>
+			<bounds x="123" y="208" width="52" height="28"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="125" y="210" width="48" height="24">
-			</bounds>
+			<bounds x="125" y="210" width="48" height="24"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="64" y="183" width="50" height="25">
-			</bounds>
+			<bounds x="64" y="183" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="66" y="185" width="46" height="21">
-			</bounds>
+			<bounds x="66" y="185" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="64" y="204" width="50" height="25">
-			</bounds>
+			<bounds x="64" y="204" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="66" y="206" width="46" height="21">
-			</bounds>
+			<bounds x="66" y="206" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="64" y="226" width="50" height="25">
-			</bounds>
+			<bounds x="64" y="226" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="66" y="228" width="46" height="21">
-			</bounds>
+			<bounds x="66" y="228" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="64" y="248" width="50" height="25">
-			</bounds>
+			<bounds x="64" y="248" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="66" y="250" width="46" height="21">
-			</bounds>
+			<bounds x="66" y="250" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="64" y="270" width="50" height="25">
-			</bounds>
+			<bounds x="64" y="270" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="66" y="272" width="46" height="21">
-			</bounds>
+			<bounds x="66" y="272" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="64" y="292" width="50" height="25">
-			</bounds>
+			<bounds x="64" y="292" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="66" y="294" width="46" height="21">
-			</bounds>
+			<bounds x="66" y="294" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="64" y="314" width="50" height="25">
-			</bounds>
+			<bounds x="64" y="314" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="66" y="316" width="46" height="21">
-			</bounds>
+			<bounds x="66" y="316" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="64" y="336" width="50" height="25">
-			</bounds>
+			<bounds x="64" y="336" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="66" y="338" width="46" height="21">
-			</bounds>
+			<bounds x="66" y="338" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="1" y="205" width="64" height="25">
-			</bounds>
+			<bounds x="1" y="205" width="64" height="25"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="3" y="207" width="60" height="21">
-			</bounds>
+			<bounds x="3" y="207" width="60" height="21"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="6" y="227" width="50" height="25">
-			</bounds>
+			<bounds x="6" y="227" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="8" y="229" width="46" height="21">
-			</bounds>
+			<bounds x="8" y="229" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="1" y="249" width="64" height="25">
-			</bounds>
+			<bounds x="1" y="249" width="64" height="25"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="3" y="251" width="60" height="21">
-			</bounds>
+			<bounds x="3" y="251" width="60" height="21"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="6" y="271" width="50" height="25">
-			</bounds>
+			<bounds x="6" y="271" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="8" y="273" width="46" height="21">
-			</bounds>
+			<bounds x="8" y="273" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="1" y="293" width="64" height="25">
-			</bounds>
+			<bounds x="1" y="293" width="64" height="25"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="3" y="295" width="60" height="21">
-			</bounds>
+			<bounds x="3" y="295" width="60" height="21"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="1" y="315" width="64" height="25">
-			</bounds>
+			<bounds x="1" y="315" width="64" height="25"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="3" y="317" width="60" height="21">
-			</bounds>
+			<bounds x="3" y="317" width="60" height="21"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="6" y="337" width="50" height="25">
-			</bounds>
+			<bounds x="6" y="337" width="50" height="25"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="8" y="339" width="46" height="21">
-			</bounds>
+			<bounds x="8" y="339" width="46" height="21"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="60" y="154" width="62" height="32">
-			</bounds>
+			<bounds x="60" y="154" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="62" y="156" width="58" height="28">
-			</bounds>
+			<bounds x="62" y="156" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="119" y="154" width="62" height="32">
-			</bounds>
+			<bounds x="119" y="154" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="121" y="156" width="58" height="28">
-			</bounds>
+			<bounds x="121" y="156" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="297" y="149" width="19" height="19">
-			</bounds>
+			<bounds x="297" y="149" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="299" y="151" width="15" height="15">
-			</bounds>
+			<bounds x="299" y="151" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="316" y="144" width="40" height="29">
-			</bounds>
+			<bounds x="316" y="144" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="318" y="146" width="36" height="25">
-			</bounds>
+			<bounds x="318" y="146" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="353" y="148" width="19" height="19">
-			</bounds>
+			<bounds x="353" y="148" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="355" y="150" width="15" height="15">
-			</bounds>
+			<bounds x="355" y="150" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="370" y="144" width="33" height="29">
-			</bounds>
+			<bounds x="370" y="144" width="33" height="29"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="372" y="146" width="29" height="25">
-			</bounds>
+			<bounds x="372" y="146" width="29" height="25"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="402" y="150" width="19" height="19">
-			</bounds>
+			<bounds x="402" y="150" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="404" y="152" width="15" height="15">
-			</bounds>
+			<bounds x="404" y="152" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="420" y="143" width="44" height="33">
-			</bounds>
+			<bounds x="420" y="143" width="44" height="33"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="422" y="145" width="40" height="29">
-			</bounds>
+			<bounds x="422" y="145" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="463" y="149" width="19" height="19">
-			</bounds>
+			<bounds x="463" y="149" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="465" y="151" width="15" height="15">
-			</bounds>
+			<bounds x="465" y="151" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="481" y="144" width="40" height="29">
-			</bounds>
+			<bounds x="481" y="144" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="483" y="146" width="36" height="25">
-			</bounds>
+			<bounds x="483" y="146" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="493" y="172" width="19" height="19">
-			</bounds>
+			<bounds x="493" y="172" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="495" y="174" width="15" height="15">
-			</bounds>
+			<bounds x="495" y="174" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="432" y="273" width="44" height="33">
-			</bounds>
+			<bounds x="432" y="273" width="44" height="33"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="434" y="275" width="40" height="29">
-			</bounds>
+			<bounds x="434" y="275" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="497" y="231" width="33" height="29">
-			</bounds>
+			<bounds x="497" y="231" width="33" height="29"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="499" y="233" width="29" height="25">
-			</bounds>
+			<bounds x="499" y="233" width="29" height="25"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="480" y="234" width="19" height="19">
-			</bounds>
+			<bounds x="480" y="234" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="482" y="236" width="15" height="15">
-			</bounds>
+			<bounds x="482" y="236" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="448" y="231" width="36" height="29">
-			</bounds>
+			<bounds x="448" y="231" width="36" height="29"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="450" y="233" width="32" height="25">
-			</bounds>
+			<bounds x="450" y="233" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="431" y="236" width="19" height="19">
-			</bounds>
+			<bounds x="431" y="236" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="433" y="238" width="15" height="15">
-			</bounds>
+			<bounds x="433" y="238" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="394" y="230" width="40" height="29">
-			</bounds>
+			<bounds x="394" y="230" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="396" y="232" width="36" height="25">
-			</bounds>
+			<bounds x="396" y="232" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="325" y="234" width="19" height="19">
-			</bounds>
+			<bounds x="325" y="234" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="327" y="236" width="15" height="15">
-			</bounds>
+			<bounds x="327" y="236" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="342" y="230" width="36" height="29">
-			</bounds>
+			<bounds x="342" y="230" width="36" height="29"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="344" y="232" width="32" height="25">
-			</bounds>
+			<bounds x="344" y="232" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="377" y="234" width="19" height="19">
-			</bounds>
+			<bounds x="377" y="234" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="379" y="236" width="15" height="15">
-			</bounds>
+			<bounds x="379" y="236" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="265" y="236" width="19" height="19">
-			</bounds>
+			<bounds x="265" y="236" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="267" y="238" width="15" height="15">
-			</bounds>
+			<bounds x="267" y="238" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="228" y="230" width="40" height="29">
-			</bounds>
+			<bounds x="228" y="230" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="230" y="232" width="36" height="25">
-			</bounds>
+			<bounds x="230" y="232" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="211" y="235" width="19" height="19">
-			</bounds>
+			<bounds x="211" y="235" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="213" y="237" width="15" height="15">
-			</bounds>
+			<bounds x="213" y="237" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="283" y="230" width="44" height="33">
-			</bounds>
+			<bounds x="283" y="230" width="44" height="33"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="285" y="232" width="40" height="29">
-			</bounds>
+			<bounds x="285" y="232" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="187" y="214" width="19" height="19">
-			</bounds>
+			<bounds x="187" y="214" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="189" y="216" width="15" height="15">
-			</bounds>
+			<bounds x="189" y="216" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="506" y="259" width="19" height="19">
-			</bounds>
+			<bounds x="506" y="259" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="508" y="261" width="15" height="15">
-			</bounds>
+			<bounds x="508" y="261" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="493" y="276" width="40" height="29">
-			</bounds>
+			<bounds x="493" y="276" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="495" y="278" width="36" height="25">
-			</bounds>
+			<bounds x="495" y="278" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="475" y="279" width="19" height="19">
-			</bounds>
+			<bounds x="475" y="279" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="477" y="281" width="15" height="15">
-			</bounds>
+			<bounds x="477" y="281" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="416" y="277" width="19" height="19">
-			</bounds>
+			<bounds x="416" y="277" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="418" y="279" width="15" height="15">
-			</bounds>
+			<bounds x="418" y="279" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="385" y="273" width="33" height="29">
-			</bounds>
+			<bounds x="385" y="273" width="33" height="29"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="387" y="275" width="29" height="25">
-			</bounds>
+			<bounds x="387" y="275" width="29" height="25"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="369" y="278" width="19" height="19">
-			</bounds>
+			<bounds x="369" y="278" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="371" y="280" width="15" height="15">
-			</bounds>
+			<bounds x="371" y="280" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="226" y="271" width="33" height="29">
-			</bounds>
+			<bounds x="226" y="271" width="33" height="29"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="228" y="273" width="29" height="25">
-			</bounds>
+			<bounds x="228" y="273" width="29" height="25"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="273" y="273" width="40" height="29">
-			</bounds>
+			<bounds x="273" y="273" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="275" y="275" width="36" height="25">
-			</bounds>
+			<bounds x="275" y="275" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="257" y="276" width="19" height="19">
-			</bounds>
+			<bounds x="257" y="276" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="259" y="278" width="15" height="15">
-			</bounds>
+			<bounds x="259" y="278" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="311" y="278" width="19" height="19">
-			</bounds>
+			<bounds x="311" y="278" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="313" y="280" width="15" height="15">
-			</bounds>
+			<bounds x="313" y="280" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="326" y="272" width="44" height="33">
-			</bounds>
+			<bounds x="326" y="272" width="44" height="33"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="328" y="274" width="40" height="29">
-			</bounds>
+			<bounds x="328" y="274" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="482" y="190" width="36" height="29">
-			</bounds>
+			<bounds x="482" y="190" width="36" height="29"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="484" y="192" width="32" height="25">
-			</bounds>
+			<bounds x="484" y="192" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="284" y="193" width="19" height="19">
-			</bounds>
+			<bounds x="284" y="193" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="286" y="195" width="15" height="15">
-			</bounds>
+			<bounds x="286" y="195" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="461" y="195" width="19" height="19">
-			</bounds>
+			<bounds x="461" y="195" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="463" y="197" width="15" height="15">
-			</bounds>
+			<bounds x="463" y="197" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="396" y="193" width="19" height="19">
-			</bounds>
+			<bounds x="396" y="193" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="398" y="195" width="15" height="15">
-			</bounds>
+			<bounds x="398" y="195" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="356" y="189" width="40" height="29">
-			</bounds>
+			<bounds x="356" y="189" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="358" y="191" width="36" height="25">
-			</bounds>
+			<bounds x="358" y="191" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="337" y="193" width="19" height="19">
-			</bounds>
+			<bounds x="337" y="193" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="339" y="195" width="15" height="15">
-			</bounds>
+			<bounds x="339" y="195" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="304" y="189" width="33" height="29">
-			</bounds>
+			<bounds x="304" y="189" width="33" height="29"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="306" y="191" width="29" height="25">
-			</bounds>
+			<bounds x="306" y="191" width="29" height="25"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="243" y="188" width="40" height="29">
-			</bounds>
+			<bounds x="243" y="188" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="245" y="190" width="36" height="25">
-			</bounds>
+			<bounds x="245" y="190" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="223" y="192" width="19" height="19">
-			</bounds>
+			<bounds x="223" y="192" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="225" y="194" width="15" height="15">
-			</bounds>
+			<bounds x="225" y="194" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="184" y="188" width="36" height="29">
-			</bounds>
+			<bounds x="184" y="188" width="36" height="29"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="186" y="190" width="32" height="25">
-			</bounds>
+			<bounds x="186" y="190" width="32" height="25"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="416" y="188" width="44" height="33">
-			</bounds>
+			<bounds x="416" y="188" width="44" height="33"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="418" y="190" width="40" height="29">
-			</bounds>
+			<bounds x="418" y="190" width="40" height="29"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="181" y="143" width="112" height="32">
-			</bounds>
+			<bounds x="181" y="143" width="112" height="32"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="183" y="145" width="108" height="28">
-			</bounds>
+			<bounds x="183" y="145" width="108" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="180" y="237" width="33" height="29">
-			</bounds>
+			<bounds x="180" y="237" width="33" height="29"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="182" y="239" width="29" height="25">
-			</bounds>
+			<bounds x="182" y="239" width="29" height="25"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="225" y="342" width="40" height="27">
-			</bounds>
+			<bounds x="225" y="342" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="227" y="344" width="36" height="23">
-			</bounds>
+			<bounds x="227" y="344" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="265" y="342" width="27" height="27">
-			</bounds>
+			<bounds x="265" y="342" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="267" y="344" width="23" height="23">
-			</bounds>
+			<bounds x="267" y="344" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="328" y="342" width="39" height="27">
-			</bounds>
+			<bounds x="328" y="342" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="330" y="344" width="35" height="23">
-			</bounds>
+			<bounds x="330" y="344" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="367" y="332" width="44" height="37">
-			</bounds>
+			<bounds x="367" y="332" width="44" height="37"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="369" y="334" width="40" height="33">
-			</bounds>
+			<bounds x="369" y="334" width="40" height="33"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="411" y="341" width="31" height="27">
-			</bounds>
+			<bounds x="411" y="341" width="31" height="27"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="413" y="343" width="27" height="23">
-			</bounds>
+			<bounds x="413" y="343" width="27" height="23"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="480" y="341" width="39" height="27">
-			</bounds>
+			<bounds x="480" y="341" width="39" height="27"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="482" y="343" width="35" height="23">
-			</bounds>
+			<bounds x="482" y="343" width="35" height="23"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="443" y="341" width="36" height="27">
-			</bounds>
+			<bounds x="443" y="341" width="36" height="27"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="445" y="343" width="32" height="23">
-			</bounds>
+			<bounds x="445" y="343" width="32" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="292" y="342" width="36" height="27">
-			</bounds>
+			<bounds x="292" y="342" width="36" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="294" y="344" width="32" height="23">
-			</bounds>
+			<bounds x="294" y="344" width="32" height="23"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="201" y="419" width="38" height="27">
-			</bounds>
+			<bounds x="201" y="419" width="38" height="27"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="203" y="421" width="34" height="23">
-			</bounds>
+			<bounds x="203" y="421" width="34" height="23"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="358" y="419" width="37" height="27">
-			</bounds>
+			<bounds x="358" y="419" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="360" y="421" width="33" height="23">
-			</bounds>
+			<bounds x="360" y="421" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="310" y="419" width="45" height="27">
-			</bounds>
+			<bounds x="310" y="419" width="45" height="27"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="312" y="421" width="41" height="23">
-			</bounds>
+			<bounds x="312" y="421" width="41" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="240" y="418" width="37" height="27">
-			</bounds>
+			<bounds x="240" y="418" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="242" y="420" width="33" height="23">
-			</bounds>
+			<bounds x="242" y="420" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="280" y="419" width="27" height="27">
-			</bounds>
+			<bounds x="280" y="419" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="282" y="421" width="23" height="23">
-			</bounds>
+			<bounds x="282" y="421" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="502" y="370" width="27" height="27">
-			</bounds>
+			<bounds x="502" y="370" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="504" y="372" width="23" height="23">
-			</bounds>
+			<bounds x="504" y="372" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="500" y="400" width="35" height="27">
-			</bounds>
+			<bounds x="500" y="400" width="35" height="27"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="502" y="402" width="31" height="23">
-			</bounds>
+			<bounds x="502" y="402" width="31" height="23"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="450" y="419" width="46" height="27">
-			</bounds>
+			<bounds x="450" y="419" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="452" y="421" width="42" height="23">
-			</bounds>
+			<bounds x="452" y="421" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="399" y="419" width="47" height="27">
-			</bounds>
+			<bounds x="399" y="419" width="47" height="27"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="401" y="421" width="43" height="23">
-			</bounds>
+			<bounds x="401" y="421" width="43" height="23"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="174" y="354" width="52" height="37">
-			</bounds>
+			<bounds x="174" y="354" width="52" height="37"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="176" y="356" width="48" height="33">
-			</bounds>
+			<bounds x="176" y="356" width="48" height="33"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="187" y="390" width="40" height="27">
-			</bounds>
+			<bounds x="187" y="390" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="189" y="392" width="36" height="23">
-			</bounds>
+			<bounds x="189" y="392" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="389" y="528" width="49" height="26">
-			</bounds>
+			<bounds x="389" y="528" width="49" height="26"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="391" y="530" width="45" height="22">
-			</bounds>
+			<bounds x="391" y="530" width="45" height="22"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="348" y="528" width="45" height="26">
-			</bounds>
+			<bounds x="348" y="528" width="45" height="26"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="350" y="530" width="41" height="22">
-			</bounds>
+			<bounds x="350" y="530" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="307" y="528" width="45" height="26">
-			</bounds>
+			<bounds x="307" y="528" width="45" height="26"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="309" y="530" width="41" height="22">
-			</bounds>
+			<bounds x="309" y="530" width="41" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_155_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="429" y="13" width="75" height="27">
-			</bounds>
+			<bounds x="429" y="13" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_155" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="431" y="15" width="71" height="23">
-			</bounds>
+			<bounds x="431" y="15" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_156_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="6" y="645" width="52" height="38">
-			</bounds>
+			<bounds x="6" y="645" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_156" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="8" y="647" width="48" height="34">
-			</bounds>
+			<bounds x="8" y="647" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_157_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="495" y="645" width="45" height="38">
-			</bounds>
+			<bounds x="495" y="645" width="45" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_157" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="497" y="647" width="41" height="34">
-			</bounds>
+			<bounds x="497" y="647" width="41" height="34"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_158_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="70" y="645" width="52" height="38">
-			</bounds>
+			<bounds x="70" y="645" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_158" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="72" y="647" width="48" height="34">
-			</bounds>
+			<bounds x="72" y="647" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_159_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="152" y="644" width="52" height="38">
-			</bounds>
+			<bounds x="152" y="644" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_159" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="154" y="646" width="48" height="34">
-			</bounds>
+			<bounds x="154" y="646" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_160_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="231" y="644" width="52" height="38">
-			</bounds>
+			<bounds x="231" y="644" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_160" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="233" y="646" width="48" height="34">
-			</bounds>
+			<bounds x="233" y="646" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_161_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="317" y="644" width="52" height="38">
-			</bounds>
+			<bounds x="317" y="644" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_161" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="319" y="646" width="48" height="34">
-			</bounds>
+			<bounds x="319" y="646" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_162_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="403" y="644" width="67" height="38">
-			</bounds>
+			<bounds x="403" y="644" width="67" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_162" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="405" y="646" width="63" height="34">
-			</bounds>
+			<bounds x="405" y="646" width="63" height="34"/>
 		</backdrop>
 		<backdrop name="lamp93" element="colour_button_163_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="66" y="365" width="45" height="27">
-			</bounds>
+			<bounds x="66" y="365" width="45" height="27"/>
 		</backdrop>
 		<backdrop name="lamp93" element="colour_button_163" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="68" y="367" width="41" height="23">
-			</bounds>
+			<bounds x="68" y="367" width="41" height="23"/>
 		</backdrop>
 		<backdrop name="lamp94" element="colour_button_164_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="8" y="364" width="45" height="27">
-			</bounds>
+			<bounds x="8" y="364" width="45" height="27"/>
 		</backdrop>
 		<backdrop name="lamp94" element="colour_button_164" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="10" y="366" width="41" height="23">
-			</bounds>
+			<bounds x="10" y="366" width="41" height="23"/>
 		</backdrop>
 		<backdrop name="lamp92" element="colour_button_165_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="126" y="389" width="45" height="27">
-			</bounds>
+			<bounds x="126" y="389" width="45" height="27"/>
 		</backdrop>
 		<backdrop name="lamp92" element="colour_button_165" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="128" y="391" width="41" height="23">
-			</bounds>
+			<bounds x="128" y="391" width="41" height="23"/>
 		</backdrop>
 		<backdrop name="lamp91" element="colour_button_166_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="177" y="273" width="40" height="27">
-			</bounds>
+			<bounds x="177" y="273" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp91" element="colour_button_166" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="179" y="275" width="36" height="23">
-			</bounds>
+			<bounds x="179" y="275" width="36" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="247" y="381" width="227" height="20">
-			</bounds>
+			<bounds x="247" y="381" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="247" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="247" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="261" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="261" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="275" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="275" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="289" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="289" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="303" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="303" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="317" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="317" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="331" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="331" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="345" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="345" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="359" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="359" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="373" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="373" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="387" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="387" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="401" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="401" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="415" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="415" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="429" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="429" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="443" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="443" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="457" y="381" width="14" height="20">
-			</bounds>
+			<bounds x="457" y="381" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="label28" element="label_28">
-			<bounds x="300" y="6" width="60" height="48">
-			</bounds>
+			<bounds x="300" y="6" width="60" height="48"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="173" y="327" width="111" height="13">
-			</bounds>
+			<bounds x="173" y="327" width="111" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_button" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_button" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_button" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_button" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_button" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cclasd.lay
+++ b/src/mame/layout/sc4cclasd.lay
@@ -8,10944 +8,7023 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="PRESS CANCEL FOR WINNING SHUFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="PRESS CANCEL FOR WINNING SHUFFLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="AUTOPLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="AUTOPLAY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="LEMONS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="ORANGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="ORANGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="pears">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="pears">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_159_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
+			<color red="0.06" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_159_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
+			<color red="0.13" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STRAWBERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STRAWBERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
+			<color red="0.00" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
+			<color red="0.00" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="PLUMS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="PLUMS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_175_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_175_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="GRAPES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1000">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1000">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BELLS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.10" blue="0.27">
-			</color>
+			<color red="0.13" green="0.10" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.02" blue="0.07">
-			</color>
+			<color red="0.03" green="0.02" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.20" blue="0.53">
-			</color>
+			<color red="0.25" green="0.20" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.05" blue="0.13">
-			</color>
+			<color red="0.06" green="0.05" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.10" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.02" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.20" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.05" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.10" blue="0.27">
-			</color>
+			<color red="0.13" green="0.10" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.02" blue="0.07">
-			</color>
+			<color red="0.03" green="0.02" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.20" blue="0.53">
-			</color>
+			<color red="0.25" green="0.20" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.05" blue="0.13">
-			</color>
+			<color red="0.06" green="0.05" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.10" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.02" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.20" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.05" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.10" blue="0.27">
-			</color>
+			<color red="0.13" green="0.10" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.02" blue="0.07">
-			</color>
+			<color red="0.03" green="0.02" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.20" blue="0.53">
-			</color>
+			<color red="0.25" green="0.20" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.05" blue="0.13">
-			</color>
+			<color red="0.06" green="0.05" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.13" green="0.10" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.03" green="0.02" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.20" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.05" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_191_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_191_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_223_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_223_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_173_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_173">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="0" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="0" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="0" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="0" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="0" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel5" defstate="0">
 		<reel reelreversed="0" stateoffset="0" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_114">
 		<text string="SUPERMETER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_115">
 		<text string="WINNINGS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_116">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_117">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_148">
 		<text string="x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_149">
 		<text string="x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_150">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_151">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_152">
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_153">
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_154">
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_155">
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_156">
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_157">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_158">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_159">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_5">
 		<text string="24">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1005" height="680">
-			</bounds>
+			<bounds x="0" y="0" width="1005" height="680"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="205" y="408" width="80" height="140">
-			</bounds>
+			<bounds x="205" y="408" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="408.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="408.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="409.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="409.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="411.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="411.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="413.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="413.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="415.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="415.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="417.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="417.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="454.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="454.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="456.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="456.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="458.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="458.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="460.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="460.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="462.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="462.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="464.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="464.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="501.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="501.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="503.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="503.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="505.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="505.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="507.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="507.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="509.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="509.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="511.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="511.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="205" y="408" width="80" height="140">
-			</bounds>
+			<bounds x="205" y="408" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="315" y="408" width="80" height="140">
-			</bounds>
+			<bounds x="315" y="408" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="408.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="315.0000" y="408.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="318.3333" y="409.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="318.3333" y="409.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="321.6667" y="411.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="321.6667" y="411.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="325.0000" y="413.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="325.0000" y="413.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="328.3333" y="415.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="328.3333" y="415.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="331.6667" y="417.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="331.6667" y="417.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="454.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="315.0000" y="454.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="318.3333" y="456.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="318.3333" y="456.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="321.6667" y="458.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="321.6667" y="458.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="325.0000" y="460.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="325.0000" y="460.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="328.3333" y="462.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="328.3333" y="462.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="331.6667" y="464.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="331.6667" y="464.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="501.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="315.0000" y="501.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="318.3333" y="503.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="318.3333" y="503.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="321.6667" y="505.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="321.6667" y="505.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="325.0000" y="507.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="325.0000" y="507.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="328.3333" y="509.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="328.3333" y="509.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="331.6667" y="511.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="331.6667" y="511.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="315" y="408" width="80" height="140">
-			</bounds>
+			<bounds x="315" y="408" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="424" y="408" width="80" height="140">
-			</bounds>
+			<bounds x="424" y="408" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="424.0000" y="408.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="424.0000" y="408.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.3333" y="409.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="427.3333" y="409.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.6667" y="411.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="430.6667" y="411.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="413.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="434.0000" y="413.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="437.3333" y="415.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="437.3333" y="415.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="440.6667" y="417.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="440.6667" y="417.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="424.0000" y="454.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="424.0000" y="454.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.3333" y="456.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="427.3333" y="456.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.6667" y="458.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="430.6667" y="458.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="460.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="434.0000" y="460.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="437.3333" y="462.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="437.3333" y="462.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="440.6667" y="464.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="440.6667" y="464.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="424.0000" y="501.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="424.0000" y="501.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.3333" y="503.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="427.3333" y="503.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.6667" y="505.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="430.6667" y="505.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="507.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="434.0000" y="507.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="437.3333" y="509.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="437.3333" y="509.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="440.6667" y="511.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="440.6667" y="511.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="424" y="408" width="80" height="140">
-			</bounds>
+			<bounds x="424" y="408" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="205" y="139" width="80" height="140">
-			</bounds>
+			<bounds x="205" y="139" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="139.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="139.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="140.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="140.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="142.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="142.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="144.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="144.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="146.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="146.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="148.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="148.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="185.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="185.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="187.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="187.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="189.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="189.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="191.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="191.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="193.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="193.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="195.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="195.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="232.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="205.0000" y="232.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="208.3333" y="234.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="208.3333" y="234.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="211.6667" y="236.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="211.6667" y="236.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="215.0000" y="238.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="215.0000" y="238.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="218.3333" y="240.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="218.3333" y="240.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="221.6667" y="242.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="221.6667" y="242.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="205" y="139" width="80" height="140">
-			</bounds>
+			<bounds x="205" y="139" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="315" y="139" width="80" height="140">
-			</bounds>
+			<bounds x="315" y="139" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="139.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="315.0000" y="139.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_1" state="0">
-			<bounds x="318.3333" y="140.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="318.3333" y="140.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_2" state="0">
-			<bounds x="321.6667" y="142.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="321.6667" y="142.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_3" state="0">
-			<bounds x="325.0000" y="144.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="325.0000" y="144.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_4" state="0">
-			<bounds x="328.3333" y="146.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="328.3333" y="146.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_5" state="0">
-			<bounds x="331.6667" y="148.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="331.6667" y="148.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="185.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="315.0000" y="185.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_1" state="0">
-			<bounds x="318.3333" y="187.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="318.3333" y="187.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_2" state="0">
-			<bounds x="321.6667" y="189.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="321.6667" y="189.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_3" state="0">
-			<bounds x="325.0000" y="191.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="325.0000" y="191.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_4" state="0">
-			<bounds x="328.3333" y="193.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="328.3333" y="193.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_5" state="0">
-			<bounds x="331.6667" y="195.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="331.6667" y="195.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="232.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="315.0000" y="232.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_1" state="0">
-			<bounds x="318.3333" y="234.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="318.3333" y="234.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_2" state="0">
-			<bounds x="321.6667" y="236.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="321.6667" y="236.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_3" state="0">
-			<bounds x="325.0000" y="238.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="325.0000" y="238.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_4" state="0">
-			<bounds x="328.3333" y="240.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="328.3333" y="240.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_5" state="0">
-			<bounds x="331.6667" y="242.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="331.6667" y="242.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="315" y="139" width="80" height="140">
-			</bounds>
+			<bounds x="315" y="139" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="424" y="139" width="80" height="140">
-			</bounds>
+			<bounds x="424" y="139" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_0" state="0">
-			<bounds x="424.0000" y="139.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="424.0000" y="139.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.3333" y="140.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="427.3333" y="140.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.6667" y="142.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="430.6667" y="142.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="144.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="434.0000" y="144.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_4" state="0">
-			<bounds x="437.3333" y="146.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="437.3333" y="146.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_5" state="0">
-			<bounds x="440.6667" y="148.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="440.6667" y="148.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_0" state="0">
-			<bounds x="424.0000" y="185.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="424.0000" y="185.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.3333" y="187.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="427.3333" y="187.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.6667" y="189.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="430.6667" y="189.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="191.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="434.0000" y="191.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_4" state="0">
-			<bounds x="437.3333" y="193.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="437.3333" y="193.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_5" state="0">
-			<bounds x="440.6667" y="195.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="440.6667" y="195.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_0" state="0">
-			<bounds x="424.0000" y="232.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="424.0000" y="232.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_1" state="0">
-			<bounds x="427.3333" y="234.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="427.3333" y="234.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_2" state="0">
-			<bounds x="430.6667" y="236.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="430.6667" y="236.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_3" state="0">
-			<bounds x="434.0000" y="238.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="434.0000" y="238.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_4" state="0">
-			<bounds x="437.3333" y="240.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="437.3333" y="240.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_5" state="0">
-			<bounds x="440.6667" y="242.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="440.6667" y="242.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<bounds x="424" y="139" width="80" height="140">
-			</bounds>
+			<bounds x="424" y="139" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="620" y="557" width="82" height="62">
-			</bounds>
+			<bounds x="620" y="557" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="622" y="559" width="78" height="58">
-			</bounds>
+			<bounds x="622" y="559" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="557" y="401" width="42" height="42">
-			</bounds>
+			<bounds x="557" y="401" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="559" y="403" width="38" height="38">
-			</bounds>
+			<bounds x="559" y="403" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="557" y="449" width="42" height="42">
-			</bounds>
+			<bounds x="557" y="449" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="559" y="451" width="38" height="38">
-			</bounds>
+			<bounds x="559" y="451" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="557" y="497" width="42" height="42">
-			</bounds>
+			<bounds x="557" y="497" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="559" y="499" width="38" height="38">
-			</bounds>
+			<bounds x="559" y="499" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="704" y="557" width="82" height="62">
-			</bounds>
+			<bounds x="704" y="557" width="82" height="62"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="706" y="559" width="78" height="58">
-			</bounds>
+			<bounds x="706" y="559" width="78" height="58"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="824" y="326" width="42" height="32">
-			</bounds>
+			<bounds x="824" y="326" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="826" y="328" width="38" height="28">
-			</bounds>
+			<bounds x="826" y="328" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="772" y="326" width="42" height="32">
-			</bounds>
+			<bounds x="772" y="326" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="774" y="328" width="38" height="28">
-			</bounds>
+			<bounds x="774" y="328" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="719" y="326" width="42" height="32">
-			</bounds>
+			<bounds x="719" y="326" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="721" y="328" width="38" height="28">
-			</bounds>
+			<bounds x="721" y="328" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="628" y="326" width="92" height="32">
-			</bounds>
+			<bounds x="628" y="326" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="630" y="328" width="88" height="28">
-			</bounds>
+			<bounds x="630" y="328" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="824" y="290" width="42" height="32">
-			</bounds>
+			<bounds x="824" y="290" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="826" y="292" width="38" height="28">
-			</bounds>
+			<bounds x="826" y="292" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="772" y="290" width="42" height="32">
-			</bounds>
+			<bounds x="772" y="290" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="774" y="292" width="38" height="28">
-			</bounds>
+			<bounds x="774" y="292" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="719" y="290" width="42" height="32">
-			</bounds>
+			<bounds x="719" y="290" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="721" y="292" width="38" height="28">
-			</bounds>
+			<bounds x="721" y="292" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="628" y="290" width="92" height="32">
-			</bounds>
+			<bounds x="628" y="290" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="630" y="292" width="88" height="28">
-			</bounds>
+			<bounds x="630" y="292" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="824" y="254" width="42" height="32">
-			</bounds>
+			<bounds x="824" y="254" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="826" y="256" width="38" height="28">
-			</bounds>
+			<bounds x="826" y="256" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="772" y="254" width="42" height="32">
-			</bounds>
+			<bounds x="772" y="254" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="774" y="256" width="38" height="28">
-			</bounds>
+			<bounds x="774" y="256" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="719" y="254" width="42" height="32">
-			</bounds>
+			<bounds x="719" y="254" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="721" y="256" width="38" height="28">
-			</bounds>
+			<bounds x="721" y="256" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="628" y="254" width="92" height="32">
-			</bounds>
+			<bounds x="628" y="254" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="630" y="256" width="88" height="28">
-			</bounds>
+			<bounds x="630" y="256" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="824" y="218" width="42" height="32">
-			</bounds>
+			<bounds x="824" y="218" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="826" y="220" width="38" height="28">
-			</bounds>
+			<bounds x="826" y="220" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="772" y="218" width="42" height="32">
-			</bounds>
+			<bounds x="772" y="218" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="774" y="220" width="38" height="28">
-			</bounds>
+			<bounds x="774" y="220" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="719" y="218" width="42" height="32">
-			</bounds>
+			<bounds x="719" y="218" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="721" y="220" width="38" height="28">
-			</bounds>
+			<bounds x="721" y="220" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1_border" state="0">
-			<bounds x="628" y="218" width="92" height="32">
-			</bounds>
+			<bounds x="628" y="218" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp159" element="lamp_159_1" state="0">
-			<bounds x="630" y="220" width="88" height="28">
-			</bounds>
+			<bounds x="630" y="220" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="824" y="182" width="42" height="32">
-			</bounds>
+			<bounds x="824" y="182" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="826" y="184" width="38" height="28">
-			</bounds>
+			<bounds x="826" y="184" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="772" y="182" width="42" height="32">
-			</bounds>
+			<bounds x="772" y="182" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="774" y="184" width="38" height="28">
-			</bounds>
+			<bounds x="774" y="184" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="719" y="182" width="42" height="32">
-			</bounds>
+			<bounds x="719" y="182" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="721" y="184" width="38" height="28">
-			</bounds>
+			<bounds x="721" y="184" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="628" y="182" width="92" height="32">
-			</bounds>
+			<bounds x="628" y="182" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="630" y="184" width="88" height="28">
-			</bounds>
+			<bounds x="630" y="184" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="824" y="146" width="42" height="32">
-			</bounds>
+			<bounds x="824" y="146" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="826" y="148" width="38" height="28">
-			</bounds>
+			<bounds x="826" y="148" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="772" y="146" width="42" height="32">
-			</bounds>
+			<bounds x="772" y="146" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="774" y="148" width="38" height="28">
-			</bounds>
+			<bounds x="774" y="148" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="719" y="146" width="42" height="32">
-			</bounds>
+			<bounds x="719" y="146" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="721" y="148" width="38" height="28">
-			</bounds>
+			<bounds x="721" y="148" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1_border" state="0">
-			<bounds x="628" y="146" width="92" height="32">
-			</bounds>
+			<bounds x="628" y="146" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp175" element="lamp_175_1" state="0">
-			<bounds x="630" y="148" width="88" height="28">
-			</bounds>
+			<bounds x="630" y="148" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="824" y="111" width="42" height="32">
-			</bounds>
+			<bounds x="824" y="111" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="826" y="113" width="38" height="28">
-			</bounds>
+			<bounds x="826" y="113" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="772" y="111" width="42" height="32">
-			</bounds>
+			<bounds x="772" y="111" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="774" y="113" width="38" height="28">
-			</bounds>
+			<bounds x="774" y="113" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="719" y="111" width="42" height="32">
-			</bounds>
+			<bounds x="719" y="111" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="721" y="113" width="38" height="28">
-			</bounds>
+			<bounds x="721" y="113" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="628" y="111" width="92" height="32">
-			</bounds>
+			<bounds x="628" y="111" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="630" y="113" width="88" height="28">
-			</bounds>
+			<bounds x="630" y="113" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="824" y="80" width="42" height="32">
-			</bounds>
+			<bounds x="824" y="80" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="826" y="82" width="38" height="28">
-			</bounds>
+			<bounds x="826" y="82" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="772" y="80" width="42" height="32">
-			</bounds>
+			<bounds x="772" y="80" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="774" y="82" width="38" height="28">
-			</bounds>
+			<bounds x="774" y="82" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="719" y="80" width="42" height="32">
-			</bounds>
+			<bounds x="719" y="80" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="721" y="82" width="38" height="28">
-			</bounds>
+			<bounds x="721" y="82" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1_border" state="0">
-			<bounds x="628" y="80" width="92" height="32">
-			</bounds>
+			<bounds x="628" y="80" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp191" element="lamp_191_1" state="0">
-			<bounds x="630" y="82" width="88" height="28">
-			</bounds>
+			<bounds x="630" y="82" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="509" y="261" width="42" height="32">
-			</bounds>
+			<bounds x="509" y="261" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="511" y="263" width="38" height="28">
-			</bounds>
+			<bounds x="511" y="263" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="509" y="227" width="42" height="32">
-			</bounds>
+			<bounds x="509" y="227" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="511" y="229" width="38" height="28">
-			</bounds>
+			<bounds x="511" y="229" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="509" y="193" width="42" height="32">
-			</bounds>
+			<bounds x="509" y="193" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="511" y="195" width="38" height="28">
-			</bounds>
+			<bounds x="511" y="195" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="509" y="159" width="42" height="32">
-			</bounds>
+			<bounds x="509" y="159" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="511" y="161" width="38" height="28">
-			</bounds>
+			<bounds x="511" y="161" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="509" y="125" width="42" height="32">
-			</bounds>
+			<bounds x="509" y="125" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="511" y="127" width="38" height="28">
-			</bounds>
+			<bounds x="511" y="127" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="402" y="59" width="32" height="32">
-			</bounds>
+			<bounds x="402" y="59" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="404" y="61" width="28" height="28">
-			</bounds>
+			<bounds x="404" y="61" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="158" y="125" width="42" height="32">
-			</bounds>
+			<bounds x="158" y="125" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="160" y="127" width="38" height="28">
-			</bounds>
+			<bounds x="160" y="127" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="158" y="159" width="42" height="32">
-			</bounds>
+			<bounds x="158" y="159" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="160" y="161" width="38" height="28">
-			</bounds>
+			<bounds x="160" y="161" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="158" y="193" width="42" height="32">
-			</bounds>
+			<bounds x="158" y="193" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="160" y="195" width="38" height="28">
-			</bounds>
+			<bounds x="160" y="195" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="158" y="227" width="42" height="32">
-			</bounds>
+			<bounds x="158" y="227" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="160" y="229" width="38" height="28">
-			</bounds>
+			<bounds x="160" y="229" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1_border" state="0">
-			<bounds x="158" y="261" width="42" height="32">
-			</bounds>
+			<bounds x="158" y="261" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp223" element="lamp_223_1" state="0">
-			<bounds x="160" y="263" width="38" height="28">
-			</bounds>
+			<bounds x="160" y="263" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="216" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="216" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="218" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="218" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="247" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="247" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="249" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="249" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="278" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="278" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="280" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="280" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="309" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="309" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="311" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="311" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="340" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="340" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="342" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="342" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="371" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="371" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="373" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="373" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0">
-			<bounds x="402" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="402" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0">
-			<bounds x="404" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="404" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="433" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="433" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="435" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="435" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="464" y="28" width="32" height="32">
-			</bounds>
+			<bounds x="464" y="28" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="466" y="30" width="28" height="28">
-			</bounds>
+			<bounds x="466" y="30" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="278" y="59" width="32" height="32">
-			</bounds>
+			<bounds x="278" y="59" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="280" y="61" width="28" height="28">
-			</bounds>
+			<bounds x="280" y="61" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="309" y="59" width="32" height="32">
-			</bounds>
+			<bounds x="309" y="59" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="311" y="61" width="28" height="28">
-			</bounds>
+			<bounds x="311" y="61" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="340" y="59" width="32" height="32">
-			</bounds>
+			<bounds x="340" y="59" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="342" y="61" width="28" height="28">
-			</bounds>
+			<bounds x="342" y="61" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="371" y="59" width="32" height="32">
-			</bounds>
+			<bounds x="371" y="59" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="373" y="61" width="28" height="28">
-			</bounds>
+			<bounds x="373" y="61" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_160_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="62" y="629" width="77" height="42">
-			</bounds>
+			<bounds x="62" y="629" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_160" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="64" y="631" width="73" height="38">
-			</bounds>
+			<bounds x="64" y="631" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_161_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="206" y="629" width="77" height="42">
-			</bounds>
+			<bounds x="206" y="629" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_161" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="208" y="631" width="73" height="38">
-			</bounds>
+			<bounds x="208" y="631" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_162_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="317" y="628" width="77" height="42">
-			</bounds>
+			<bounds x="317" y="628" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_162" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="319" y="630" width="73" height="38">
-			</bounds>
+			<bounds x="319" y="630" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_163_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="426" y="628" width="77" height="42">
-			</bounds>
+			<bounds x="426" y="628" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_163" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="428" y="630" width="73" height="38">
-			</bounds>
+			<bounds x="428" y="630" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_164_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="546" y="628" width="77" height="42">
-			</bounds>
+			<bounds x="546" y="628" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_164" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="548" y="630" width="73" height="38">
-			</bounds>
+			<bounds x="548" y="630" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_166_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="632" y="627" width="77" height="42">
-			</bounds>
+			<bounds x="632" y="627" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_166" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="634" y="629" width="73" height="38">
-			</bounds>
+			<bounds x="634" y="629" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_167_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="718" y="627" width="77" height="42">
-			</bounds>
+			<bounds x="718" y="627" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_167" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="720" y="629" width="73" height="38">
-			</bounds>
+			<bounds x="720" y="629" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_168_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="821" y="626" width="77" height="42">
-			</bounds>
+			<bounds x="821" y="626" width="77" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_168" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="823" y="628" width="73" height="38">
-			</bounds>
+			<bounds x="823" y="628" width="73" height="38"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_173_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="770" y="22" width="27" height="27">
-			</bounds>
+			<bounds x="770" y="22" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_173" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="772" y="24" width="23" height="23">
-			</bounds>
+			<bounds x="772" y="24" width="23" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="411" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="411" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop name="digit17" element="led_digit_red">
-			<bounds x="411" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="411" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="411" y="303" width="40" height="60">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="411" y="303" width="40" height="60"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="371" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="371" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop name="digit19" element="led_digit_red">
-			<bounds x="371" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="371" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="371" y="303" width="40" height="60">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="371" y="303" width="40" height="60"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="331" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="331" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop name="digit21" element="led_digit_red">
-			<bounds x="331" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="331" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="331" y="303" width="40" height="60">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="331" y="303" width="40" height="60"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="291" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="291" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop name="digit23" element="led_digit_red">
-			<bounds x="291" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="291" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="291" y="303" width="40" height="60">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="291" y="303" width="40" height="60"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="251" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="251" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop name="digit25" element="led_digit_red">
-			<bounds x="251" y="303" width="40" height="60">
-			</bounds>
+			<bounds x="251" y="303" width="40" height="60"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="251" y="303" width="40" height="60">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="251" y="303" width="40" height="60"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="193" y="378" width="323" height="27">
-			</bounds>
+			<bounds x="193" y="378" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="193" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="193" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="213" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="213" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="233" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="233" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="253" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="253" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="273" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="273" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="293" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="293" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="313" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="313" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="333" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="333" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="353" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="353" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="373" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="373" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="393" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="393" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="413" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="413" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="433" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="433" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="453" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="453" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="473" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="473" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="493" y="378" width="20" height="27">
-			</bounds>
+			<bounds x="493" y="378" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="277" y="280" width="144" height="24">
-			</bounds>
+			<bounds x="277" y="280" width="144" height="24"/>
 		</backdrop>
 		<backdrop name="label115" element="label_115">
-			<bounds x="198" y="364" width="52" height="14">
-			</bounds>
+			<bounds x="198" y="364" width="52" height="14"/>
 		</backdrop>
 		<backdrop name="label116" element="label_116">
-			<bounds x="449" y="365" width="45" height="14">
-			</bounds>
+			<bounds x="449" y="365" width="45" height="14"/>
 		</backdrop>
 		<backdrop name="label117" element="label_117">
-			<bounds x="229" y="314" width="18" height="37">
-			</bounds>
+			<bounds x="229" y="314" width="18" height="37"/>
 		</backdrop>
 		<backdrop name="label148" element="label_148">
-			<bounds x="427" y="606" width="5" height="13">
-			</bounds>
+			<bounds x="427" y="606" width="5" height="13"/>
 		</backdrop>
 		<backdrop name="label149" element="label_149">
-			<bounds x="460" y="606" width="5" height="13">
-			</bounds>
+			<bounds x="460" y="606" width="5" height="13"/>
 		</backdrop>
 		<backdrop name="label150" element="label_150">
-			<bounds x="353" y="606" width="12" height="14">
-			</bounds>
+			<bounds x="353" y="606" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label151" element="label_151">
-			<bounds x="353" y="582" width="12" height="14">
-			</bounds>
+			<bounds x="353" y="582" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label152" element="label_152">
-			<bounds x="353" y="557" width="12" height="14">
-			</bounds>
+			<bounds x="353" y="557" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label153" element="label_153">
-			<bounds x="495" y="606" width="12" height="14">
-			</bounds>
+			<bounds x="495" y="606" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label154" element="label_154">
-			<bounds x="488" y="582" width="18" height="14">
-			</bounds>
+			<bounds x="488" y="582" width="18" height="14"/>
 		</backdrop>
 		<backdrop name="label155" element="label_155">
-			<bounds x="488" y="557" width="18" height="14">
-			</bounds>
+			<bounds x="488" y="557" width="18" height="14"/>
 		</backdrop>
 		<backdrop name="label156" element="label_156">
-			<bounds x="540" y="577" width="33" height="22">
-			</bounds>
+			<bounds x="540" y="577" width="33" height="22"/>
 		</backdrop>
 		<backdrop name="label157" element="label_157">
-			<bounds x="232" y="557" width="12" height="14">
-			</bounds>
+			<bounds x="232" y="557" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label158" element="label_158">
-			<bounds x="232" y="582" width="12" height="14">
-			</bounds>
+			<bounds x="232" y="582" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label159" element="label_159">
-			<bounds x="232" y="606" width="12" height="14">
-			</bounds>
+			<bounds x="232" y="606" width="12" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp69" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp67" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp82" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp81" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp80" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="312.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="312.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="315.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="315.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="318.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="318.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="322.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="322.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="325.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="325.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp85" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="328.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="328.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="392.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="392.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="395.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="395.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="398.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="398.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="402.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="402.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="405.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="405.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp84" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="408.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="408.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="472.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="472.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="475.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="475.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="478.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="478.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="482.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="482.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="485.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="485.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp83" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="488.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="488.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel6" element="debug_stepper_value">
-			<bounds x="1100" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="552" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_5">
-			<bounds x="1180" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="552" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cclim.lay
+++ b/src/mame/layout/sc4cclim.lay
@@ -6,6942 +6,5043 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png">
-		</image>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="27 ways to start feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="27 ways to start feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
+			<color red="0.00" green="0.80" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
+			<color red="0.00" green="0.80" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
+			<color red="0.00" green="0.80" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
+			<color red="0.00" green="0.80" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
+			<color red="0.00" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
+			<color red="0.00" green="0.10" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
+			<color red="0.00" green="0.80" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.10" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.80" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_63_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_63">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_64_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_64">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_65_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_65">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_66_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_66">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_67_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_67">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_68_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_68">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_71_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_71">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AUTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_7">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_8">
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_9">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_20">
 		<text string="Crazy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_21">
 		<text string="climber">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_23">
 		<text string="MFME 9.4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
-			<bounds x="0" y="0" width="736" height="762">
-			</bounds>
+		<backdrop element="backdrop_colour">
+			<bounds x="0" y="0" width="736" height="762"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="205" y="499" width="100" height="180">
-			</bounds>
+			<bounds x="205" y="499" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="499.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="205.0000" y="499.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="209.1667" y="501.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="209.1667" y="501.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="213.3333" y="504.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="213.3333" y="504.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="217.5000" y="506.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="217.5000" y="506.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="221.6667" y="509.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="221.6667" y="509.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="225.8333" y="511.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="225.8333" y="511.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="559.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="205.0000" y="559.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="209.1667" y="561.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="209.1667" y="561.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="213.3333" y="564.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="213.3333" y="564.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="217.5000" y="566.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="217.5000" y="566.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="221.6667" y="569.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="221.6667" y="569.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="225.8333" y="571.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="225.8333" y="571.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="205.0000" y="619.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="205.0000" y="619.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="209.1667" y="621.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="209.1667" y="621.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="213.3333" y="624.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="213.3333" y="624.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="217.5000" y="626.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="217.5000" y="626.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="221.6667" y="629.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="221.6667" y="629.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="225.8333" y="631.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="225.8333" y="631.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="205" y="499" width="100" height="180">
-			</bounds>
+			<bounds x="205" y="499" width="100" height="180"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="315" y="499" width="100" height="180">
-			</bounds>
+			<bounds x="315" y="499" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="499.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="315.0000" y="499.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="319.1667" y="501.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="319.1667" y="501.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="323.3333" y="504.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="323.3333" y="504.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.5000" y="506.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="327.5000" y="506.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.6667" y="509.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="331.6667" y="509.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="335.8333" y="511.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="335.8333" y="511.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="559.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="315.0000" y="559.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="319.1667" y="561.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="319.1667" y="561.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="323.3333" y="564.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="323.3333" y="564.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.5000" y="566.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="327.5000" y="566.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.6667" y="569.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="331.6667" y="569.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="335.8333" y="571.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="335.8333" y="571.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="619.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="315.0000" y="619.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="319.1667" y="621.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="319.1667" y="621.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="323.3333" y="624.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="323.3333" y="624.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="327.5000" y="626.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="327.5000" y="626.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.6667" y="629.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="331.6667" y="629.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="335.8333" y="631.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="335.8333" y="631.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="315" y="499" width="100" height="180">
-			</bounds>
+			<bounds x="315" y="499" width="100" height="180"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="425" y="498" width="100" height="180">
-			</bounds>
+			<bounds x="425" y="498" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="498.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="425.0000" y="498.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="429.1667" y="500.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="429.1667" y="500.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="433.3333" y="503.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="433.3333" y="503.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="437.5000" y="505.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="437.5000" y="505.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="441.6667" y="508.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="441.6667" y="508.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="445.8333" y="510.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="445.8333" y="510.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="558.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="425.0000" y="558.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="429.1667" y="560.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="429.1667" y="560.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="433.3333" y="563.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="433.3333" y="563.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="437.5000" y="565.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="437.5000" y="565.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="441.6667" y="568.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="441.6667" y="568.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="445.8333" y="570.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="445.8333" y="570.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="618.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="425.0000" y="618.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="429.1667" y="620.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="429.1667" y="620.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="433.3333" y="623.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="433.3333" y="623.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="437.5000" y="625.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="437.5000" y="625.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="441.6667" y="628.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="441.6667" y="628.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="445.8333" y="630.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="445.8333" y="630.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="425" y="498" width="100" height="180">
-			</bounds>
+			<bounds x="425" y="498" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="65" y="575" width="32" height="52">
-			</bounds>
+			<bounds x="65" y="575" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="67" y="577" width="28" height="48">
-			</bounds>
+			<bounds x="67" y="577" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="93" y="551" width="32" height="52">
-			</bounds>
+			<bounds x="93" y="551" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="95" y="553" width="28" height="48">
-			</bounds>
+			<bounds x="95" y="553" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="648" y="4" width="52" height="52">
-			</bounds>
+			<bounds x="648" y="4" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="650" y="6" width="48" height="48">
-			</bounds>
+			<bounds x="650" y="6" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="122" y="528" width="32" height="52">
-			</bounds>
+			<bounds x="122" y="528" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="124" y="530" width="28" height="48">
-			</bounds>
+			<bounds x="124" y="530" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="553" y="519" width="152" height="32">
-			</bounds>
+			<bounds x="553" y="519" width="152" height="32"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="555" y="521" width="148" height="28">
-			</bounds>
+			<bounds x="555" y="521" width="148" height="28"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="310" y="154" width="48" height="48">
-			</bounds>
+			<bounds x="310" y="154" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="312" y="156" width="44" height="44">
-			</bounds>
+			<bounds x="312" y="156" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="310" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="310" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="312" y="201" width="44" height="44">
-			</bounds>
+			<bounds x="312" y="201" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="310" y="243" width="48" height="48">
-			</bounds>
+			<bounds x="310" y="243" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="312" y="245" width="44" height="44">
-			</bounds>
+			<bounds x="312" y="245" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="310" y="288" width="48" height="48">
-			</bounds>
+			<bounds x="310" y="288" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="312" y="290" width="44" height="44">
-			</bounds>
+			<bounds x="312" y="290" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="310" y="334" width="48" height="48">
-			</bounds>
+			<bounds x="310" y="334" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="312" y="336" width="44" height="44">
-			</bounds>
+			<bounds x="312" y="336" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_63_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="14" y="711" width="75" height="42">
-			</bounds>
+			<bounds x="14" y="711" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_63" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="16" y="713" width="71" height="38">
-			</bounds>
+			<bounds x="16" y="713" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_64_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="114" y="709" width="75" height="42">
-			</bounds>
+			<bounds x="114" y="709" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_64" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="116" y="711" width="71" height="38">
-			</bounds>
+			<bounds x="116" y="711" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_65_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="326" y="709" width="75" height="42">
-			</bounds>
+			<bounds x="326" y="709" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_65" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="328" y="711" width="71" height="38">
-			</bounds>
+			<bounds x="328" y="711" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_66_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="208" y="709" width="75" height="42">
-			</bounds>
+			<bounds x="208" y="709" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_66" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="210" y="711" width="71" height="38">
-			</bounds>
+			<bounds x="210" y="711" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_67_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="645" y="709" width="75" height="42">
-			</bounds>
+			<bounds x="645" y="709" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_67" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="647" y="711" width="71" height="38">
-			</bounds>
+			<bounds x="647" y="711" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_68_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="443" y="710" width="75" height="42">
-			</bounds>
+			<bounds x="443" y="710" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_68" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="445" y="712" width="71" height="38">
-			</bounds>
+			<bounds x="445" y="712" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_71_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="541" y="709" width="75" height="42">
-			</bounds>
+			<bounds x="541" y="709" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_71" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="543" y="711" width="71" height="38">
-			</bounds>
+			<bounds x="543" y="711" width="71" height="38"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="202" y="455" width="323" height="27">
-			</bounds>
+			<bounds x="202" y="455" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="202" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="202" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="222" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="222" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="242" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="242" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="262" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="262" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="282" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="282" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="302" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="302" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="322" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="322" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="342" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="342" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="362" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="362" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="382" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="382" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="402" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="402" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="422" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="422" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="442" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="442" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="462" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="462" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="482" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="482" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="502" y="455" width="20" height="27">
-			</bounds>
+			<bounds x="502" y="455" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label7" element="label_7">
-			<bounds x="335" y="3" width="70" height="29">
-			</bounds>
+			<bounds x="335" y="3" width="70" height="29"/>
 		</backdrop>
 		<backdrop name="label8" element="label_8">
-			<bounds x="55" y="635" width="109" height="29">
-			</bounds>
+			<bounds x="55" y="635" width="109" height="29"/>
 		</backdrop>
 		<backdrop name="label9" element="label_9">
-			<bounds x="175" y="2" width="76" height="135">
-			</bounds>
+			<bounds x="175" y="2" width="76" height="135"/>
 		</backdrop>
 		<backdrop name="label20" element="label_20">
-			<bounds x="536" y="155" width="176" height="90">
-			</bounds>
+			<bounds x="536" y="155" width="176" height="90"/>
 		</backdrop>
 		<backdrop name="label21" element="label_21">
-			<bounds x="543" y="274" width="166" height="67">
-			</bounds>
+			<bounds x="543" y="274" width="166" height="67"/>
 		</backdrop>
 		<backdrop name="label23" element="label_23">
-			<bounds x="6" y="4" width="36" height="26">
-			</bounds>
+			<bounds x="6" y="4" width="36" height="26"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cfcas.lay
+++ b/src/mame/layout/sc4cfcas.lay
@@ -8,7570 +8,5206 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_2_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_2_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_1_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_1_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_0_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_0_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_3_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_3_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_4_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_4_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_6_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_6_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BELL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BELL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BELL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BELL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BELL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BELL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MELON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MELON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MELON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MELON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MELON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MELON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="PLUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="PLUM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LEMON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LEMON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LEMON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LEMON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LEMON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LEMON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHERRY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Casino">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_11">
 		<text string="By Cardie">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Laptop Frien">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_33">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_47">
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="463" height="595">
-			</bounds>
+			<bounds x="0" y="0" width="463" height="595"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="90" y="403" width="80" height="105">
-			</bounds>
+			<bounds x="90" y="403" width="80" height="105"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="90.0000" y="403.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="403.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="93.3333" y="404.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="93.3333" y="404.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="96.6667" y="405.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="96.6667" y="405.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="100.0000" y="407.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="100.0000" y="407.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="103.3333" y="408.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="103.3333" y="408.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="106.6667" y="410.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="106.6667" y="410.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="90.0000" y="438.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="438.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="93.3333" y="439.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="93.3333" y="439.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="96.6667" y="440.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="96.6667" y="440.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="100.0000" y="442.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="100.0000" y="442.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="103.3333" y="443.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="103.3333" y="443.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="106.6667" y="445.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="106.6667" y="445.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="90.0000" y="473.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="90.0000" y="473.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="93.3333" y="474.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="93.3333" y="474.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="96.6667" y="475.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="96.6667" y="475.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="100.0000" y="477.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="100.0000" y="477.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="103.3333" y="478.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="103.3333" y="478.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="106.6667" y="480.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="106.6667" y="480.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="90" y="403" width="80" height="105">
-			</bounds>
+			<bounds x="90" y="403" width="80" height="105"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="174" y="403" width="80" height="105">
-			</bounds>
+			<bounds x="174" y="403" width="80" height="105"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="174.0000" y="403.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="174.0000" y="403.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="177.3333" y="404.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="177.3333" y="404.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="180.6667" y="405.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="180.6667" y="405.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="184.0000" y="407.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="184.0000" y="407.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="187.3333" y="408.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="187.3333" y="408.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="190.6667" y="410.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="190.6667" y="410.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="174.0000" y="438.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="174.0000" y="438.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="177.3333" y="439.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="177.3333" y="439.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="180.6667" y="440.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="180.6667" y="440.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="184.0000" y="442.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="184.0000" y="442.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="187.3333" y="443.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="187.3333" y="443.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="190.6667" y="445.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="190.6667" y="445.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="174.0000" y="473.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="174.0000" y="473.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="177.3333" y="474.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="177.3333" y="474.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="180.6667" y="475.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="180.6667" y="475.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="184.0000" y="477.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="184.0000" y="477.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="187.3333" y="478.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="187.3333" y="478.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="190.6667" y="480.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="190.6667" y="480.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="174" y="403" width="80" height="105">
-			</bounds>
+			<bounds x="174" y="403" width="80" height="105"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="258" y="403" width="80" height="105">
-			</bounds>
+			<bounds x="258" y="403" width="80" height="105"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="258.0000" y="403.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="258.0000" y="403.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.3333" y="404.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="261.3333" y="404.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="264.6667" y="405.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="264.6667" y="405.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="268.0000" y="407.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="268.0000" y="407.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="271.3333" y="408.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="271.3333" y="408.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.6667" y="410.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="274.6667" y="410.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="258.0000" y="438.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="258.0000" y="438.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.3333" y="439.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="261.3333" y="439.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="264.6667" y="440.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="264.6667" y="440.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="268.0000" y="442.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="268.0000" y="442.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="271.3333" y="443.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="271.3333" y="443.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.6667" y="445.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="274.6667" y="445.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="258.0000" y="473.0000" width="80.0000" height="35.0000">
-			</bounds>
+			<bounds x="258.0000" y="473.0000" width="80.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.3333" y="474.4583" width="73.3333" height="32.0833">
-			</bounds>
+			<bounds x="261.3333" y="474.4583" width="73.3333" height="32.0833"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="264.6667" y="475.9167" width="66.6667" height="29.1667">
-			</bounds>
+			<bounds x="264.6667" y="475.9167" width="66.6667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="268.0000" y="477.3750" width="60.0000" height="26.2500">
-			</bounds>
+			<bounds x="268.0000" y="477.3750" width="60.0000" height="26.2500"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="271.3333" y="478.8333" width="53.3333" height="23.3333">
-			</bounds>
+			<bounds x="271.3333" y="478.8333" width="53.3333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.6667" y="480.2917" width="46.6667" height="20.4167">
-			</bounds>
+			<bounds x="274.6667" y="480.2917" width="46.6667" height="20.4167"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="258" y="403" width="80" height="105">
-			</bounds>
+			<bounds x="258" y="403" width="80" height="105"/>
 		</backdrop>
 		<backdrop name="lamp2" element="lamp_2_1_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="265" y="530" width="54" height="50">
-			</bounds>
+			<bounds x="265" y="530" width="54" height="50"/>
 		</backdrop>
 		<backdrop name="lamp2" element="lamp_2_1" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="267" y="532" width="50" height="46">
-			</bounds>
+			<bounds x="267" y="532" width="50" height="46"/>
 		</backdrop>
 		<backdrop name="lamp1" element="lamp_1_1_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="180" y="530" width="54" height="50">
-			</bounds>
+			<bounds x="180" y="530" width="54" height="50"/>
 		</backdrop>
 		<backdrop name="lamp1" element="lamp_1_1" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="182" y="532" width="50" height="46">
-			</bounds>
+			<bounds x="182" y="532" width="50" height="46"/>
 		</backdrop>
 		<backdrop name="lamp0" element="lamp_0_1_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="95" y="529" width="54" height="50">
-			</bounds>
+			<bounds x="95" y="529" width="54" height="50"/>
 		</backdrop>
 		<backdrop name="lamp0" element="lamp_0_1" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="97" y="531" width="50" height="46">
-			</bounds>
+			<bounds x="97" y="531" width="50" height="46"/>
 		</backdrop>
 		<backdrop name="lamp3" element="lamp_3_1_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="332" y="530" width="54" height="50">
-			</bounds>
+			<bounds x="332" y="530" width="54" height="50"/>
 		</backdrop>
 		<backdrop name="lamp3" element="lamp_3_1" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="334" y="532" width="50" height="46">
-			</bounds>
+			<bounds x="334" y="532" width="50" height="46"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="11" y="529" width="54" height="50">
-			</bounds>
+			<bounds x="11" y="529" width="54" height="50"/>
 		</backdrop>
 		<backdrop name="lamp4" element="lamp_4_1" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="13" y="531" width="50" height="46">
-			</bounds>
+			<bounds x="13" y="531" width="50" height="46"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="400" y="530" width="54" height="50">
-			</bounds>
+			<bounds x="400" y="530" width="54" height="50"/>
 		</backdrop>
 		<backdrop name="lamp6" element="lamp_6_1" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="402" y="532" width="50" height="46">
-			</bounds>
+			<bounds x="402" y="532" width="50" height="46"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="98" y="118" width="43" height="45">
-			</bounds>
+			<bounds x="98" y="118" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="100" y="120" width="39" height="41">
-			</bounds>
+			<bounds x="100" y="120" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="139" y="118" width="43" height="45">
-			</bounds>
+			<bounds x="139" y="118" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="141" y="120" width="39" height="41">
-			</bounds>
+			<bounds x="141" y="120" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="180" y="118" width="43" height="45">
-			</bounds>
+			<bounds x="180" y="118" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="182" y="120" width="39" height="41">
-			</bounds>
+			<bounds x="182" y="120" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="25" y="189" width="43" height="45">
-			</bounds>
+			<bounds x="25" y="189" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="27" y="191" width="39" height="41">
-			</bounds>
+			<bounds x="27" y="191" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="295" y="271" width="43" height="45">
-			</bounds>
+			<bounds x="295" y="271" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="297" y="273" width="39" height="41">
-			</bounds>
+			<bounds x="297" y="273" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="107" y="189" width="43" height="45">
-			</bounds>
+			<bounds x="107" y="189" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="109" y="191" width="39" height="41">
-			</bounds>
+			<bounds x="109" y="191" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="66" y="189" width="43" height="45">
-			</bounds>
+			<bounds x="66" y="189" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="68" y="191" width="39" height="41">
-			</bounds>
+			<bounds x="68" y="191" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="212" y="189" width="43" height="45">
-			</bounds>
+			<bounds x="212" y="189" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="214" y="191" width="39" height="41">
-			</bounds>
+			<bounds x="214" y="191" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="253" y="189" width="43" height="45">
-			</bounds>
+			<bounds x="253" y="189" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="255" y="191" width="39" height="41">
-			</bounds>
+			<bounds x="255" y="191" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="294" y="189" width="43" height="45">
-			</bounds>
+			<bounds x="294" y="189" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="296" y="191" width="39" height="41">
-			</bounds>
+			<bounds x="296" y="191" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="25" y="272" width="43" height="45">
-			</bounds>
+			<bounds x="25" y="272" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="27" y="274" width="39" height="41">
-			</bounds>
+			<bounds x="27" y="274" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="66" y="272" width="43" height="45">
-			</bounds>
+			<bounds x="66" y="272" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="68" y="274" width="39" height="41">
-			</bounds>
+			<bounds x="68" y="274" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="107" y="272" width="43" height="45">
-			</bounds>
+			<bounds x="107" y="272" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="109" y="274" width="39" height="41">
-			</bounds>
+			<bounds x="109" y="274" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="254" y="271" width="43" height="45">
-			</bounds>
+			<bounds x="254" y="271" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="256" y="273" width="39" height="41">
-			</bounds>
+			<bounds x="256" y="273" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="213" y="271" width="43" height="45">
-			</bounds>
+			<bounds x="213" y="271" width="43" height="45"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="215" y="273" width="39" height="41">
-			</bounds>
+			<bounds x="215" y="273" width="39" height="41"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="42" y="327" width="91" height="19">
-			</bounds>
+			<bounds x="42" y="327" width="91" height="19"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="44" y="329" width="87" height="15">
-			</bounds>
+			<bounds x="44" y="329" width="87" height="15"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="27" y="396" width="42" height="36">
-			</bounds>
+			<bounds x="27" y="396" width="42" height="36"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="29" y="398" width="38" height="32">
-			</bounds>
+			<bounds x="29" y="398" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="27" y="429" width="42" height="36">
-			</bounds>
+			<bounds x="27" y="429" width="42" height="36"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="29" y="431" width="38" height="32">
-			</bounds>
+			<bounds x="29" y="431" width="38" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="27" y="462" width="42" height="36">
-			</bounds>
+			<bounds x="27" y="462" width="42" height="36"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="29" y="464" width="38" height="32">
-			</bounds>
+			<bounds x="29" y="464" width="38" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="398" y="396" width="19" height="24">
-			</bounds>
+			<bounds x="398" y="396" width="19" height="24"/>
 		</backdrop>
 		<backdrop name="digit22" element="led_digit_red">
-			<bounds x="398" y="396" width="19" height="24">
-			</bounds>
+			<bounds x="398" y="396" width="19" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="398" y="396" width="19" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="398" y="396" width="19" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="379" y="396" width="19" height="24">
-			</bounds>
+			<bounds x="379" y="396" width="19" height="24"/>
 		</backdrop>
 		<backdrop name="digit20" element="led_digit_red">
-			<bounds x="379" y="396" width="19" height="24">
-			</bounds>
+			<bounds x="379" y="396" width="19" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="379" y="396" width="19" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="379" y="396" width="19" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="382" y="459" width="36" height="52">
-			</bounds>
+			<bounds x="382" y="459" width="36" height="52"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="207" y="92" width="29" height="13">
-			</bounds>
+			<bounds x="207" y="92" width="29" height="13"/>
 		</backdrop>
 		<backdrop name="label33" element="label_33">
-			<bounds x="375" y="426" width="47" height="13">
-			</bounds>
+			<bounds x="375" y="426" width="47" height="13"/>
 		</backdrop>
 		<backdrop name="label47" element="label_47">
-			<bounds x="27" y="505" width="46" height="13">
-			</bounds>
+			<bounds x="27" y="505" width="46" height="13"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4chainb.lay
+++ b/src/mame/layout/sc4chainb.lay
@@ -8,13548 +8,8067 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LOOK OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOOK OUT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="FOR HIDDEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="FOR HIDDEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="50p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string=" LIFE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string=" LIFE ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTI-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="VATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RESPI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RESPI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="EM UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="EM UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RIGHT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LEFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LEFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LUCKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LUCKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 STEPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 STEPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 STEPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 STEPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="It's a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="It's a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Mystery">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Knockout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Knockout">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Choose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Choose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Gambler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Gambler">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Link">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Link">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Spin And">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Spin And">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Turbo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Turbo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Weakest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Link">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Weakest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Link">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ACTIVATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="IN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="IN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="ON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="ON">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="TI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="AC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="AC">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="RE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="RE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="50P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="50P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROULETT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROULETT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="FOLLOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="FOLLOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="THE TOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="OVER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="THE TOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="TREK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="TREK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="WINNING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="DOUBLE GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="ADVANCES CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="REPEATER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="WINNING">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="DOUBLE GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="ADVANCES CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="REPEATER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="colour_button_131_border">
 		<rect state="1">
-			<color red="0.26" green="0.41" blue="0.24">
-			</color>
+			<color red="0.26" green="0.41" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.10" blue="0.06">
-			</color>
+			<color red="0.06" green="0.10" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_131">
 		<rect state="1">
-			<color red="0.52" green="0.82" blue="0.47">
-			</color>
+			<color red="0.52" green="0.82" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.20" blue="0.12">
-			</color>
+			<color red="0.13" green="0.20" blue="0.12"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REPEATE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_132_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_132">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DOUBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_134_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_134">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_135_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_135">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_136_border">
 		<rect state="1">
-			<color red="0.26" green="0.41" blue="0.24">
-			</color>
+			<color red="0.26" green="0.41" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.10" blue="0.06">
-			</color>
+			<color red="0.06" green="0.10" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_136">
 		<rect state="1">
-			<color red="0.52" green="0.82" blue="0.47">
-			</color>
+			<color red="0.52" green="0.82" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.20" blue="0.12">
-			</color>
+			<color red="0.13" green="0.20" blue="0.12"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_137_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_137">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_138_border">
 		<rect state="1">
-			<color red="0.26" green="0.41" blue="0.24">
-			</color>
+			<color red="0.26" green="0.41" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.10" blue="0.06">
-			</color>
+			<color red="0.06" green="0.10" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_138">
 		<rect state="1">
-			<color red="0.52" green="0.82" blue="0.47">
-			</color>
+			<color red="0.52" green="0.82" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.20" blue="0.12">
-			</color>
+			<color red="0.13" green="0.20" blue="0.12"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_139_border">
 		<rect state="1">
-			<color red="0.26" green="0.41" blue="0.24">
-			</color>
+			<color red="0.26" green="0.41" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.10" blue="0.06">
-			</color>
+			<color red="0.06" green="0.10" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_139">
 		<rect state="1">
-			<color red="0.52" green="0.82" blue="0.47">
-			</color>
+			<color red="0.52" green="0.82" blue="0.47"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.20" blue="0.12">
-			</color>
+			<color red="0.13" green="0.20" blue="0.12"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_140_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_140">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_141_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_141">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEATURE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_143_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_143">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_144_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_144">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_146_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_146">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel5" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_5">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="966" height="743">
-			</bounds>
+			<bounds x="0" y="0" width="966" height="743"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="351" y="541" width="80" height="140">
-			</bounds>
+			<bounds x="351" y="541" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="351.0000" y="541.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="351.0000" y="541.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="354.3333" y="542.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="354.3333" y="542.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="357.6667" y="544.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="357.6667" y="544.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="361.0000" y="546.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="361.0000" y="546.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="364.3333" y="548.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="364.3333" y="548.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="367.6667" y="550.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="367.6667" y="550.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="351.0000" y="587.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="351.0000" y="587.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="354.3333" y="589.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="354.3333" y="589.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="357.6667" y="591.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="357.6667" y="591.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="361.0000" y="593.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="361.0000" y="593.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="364.3333" y="595.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="364.3333" y="595.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="367.6667" y="597.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="367.6667" y="597.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="351.0000" y="634.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="351.0000" y="634.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="354.3333" y="636.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="354.3333" y="636.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="357.6667" y="638.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="357.6667" y="638.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="361.0000" y="640.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="361.0000" y="640.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="364.3333" y="642.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="364.3333" y="642.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="367.6667" y="644.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="367.6667" y="644.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="351" y="541" width="80" height="140">
-			</bounds>
+			<bounds x="351" y="541" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="445" y="542" width="80" height="140">
-			</bounds>
+			<bounds x="445" y="542" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="445.0000" y="542.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="445.0000" y="542.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="448.3333" y="543.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="448.3333" y="543.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="451.6667" y="545.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="451.6667" y="545.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="455.0000" y="547.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="455.0000" y="547.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="458.3333" y="549.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="458.3333" y="549.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="461.6667" y="551.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="461.6667" y="551.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="445.0000" y="588.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="445.0000" y="588.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="448.3333" y="590.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="448.3333" y="590.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="451.6667" y="592.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="451.6667" y="592.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="455.0000" y="594.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="455.0000" y="594.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="458.3333" y="596.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="458.3333" y="596.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="461.6667" y="598.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="461.6667" y="598.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="445.0000" y="635.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="445.0000" y="635.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="448.3333" y="637.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="448.3333" y="637.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="451.6667" y="639.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="451.6667" y="639.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="455.0000" y="641.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="455.0000" y="641.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="458.3333" y="643.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="458.3333" y="643.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="461.6667" y="645.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="461.6667" y="645.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="445" y="542" width="80" height="140">
-			</bounds>
+			<bounds x="445" y="542" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="540" y="542" width="80" height="140">
-			</bounds>
+			<bounds x="540" y="542" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="540.0000" y="542.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="540.0000" y="542.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="543.3333" y="543.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="543.3333" y="543.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="546.6667" y="545.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="546.6667" y="545.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="550.0000" y="547.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="550.0000" y="547.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="553.3333" y="549.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="553.3333" y="549.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="556.6667" y="551.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="556.6667" y="551.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="540.0000" y="588.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="540.0000" y="588.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="543.3333" y="590.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="543.3333" y="590.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="546.6667" y="592.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="546.6667" y="592.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="550.0000" y="594.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="550.0000" y="594.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="553.3333" y="596.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="553.3333" y="596.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="556.6667" y="598.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="556.6667" y="598.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="540.0000" y="635.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="540.0000" y="635.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="543.3333" y="637.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="543.3333" y="637.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="546.6667" y="639.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="546.6667" y="639.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="550.0000" y="641.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="550.0000" y="641.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="553.3333" y="643.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="553.3333" y="643.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="556.6667" y="645.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="556.6667" y="645.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="540" y="542" width="80" height="140">
-			</bounds>
+			<bounds x="540" y="542" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="365" y="103" width="80" height="140">
-			</bounds>
+			<bounds x="365" y="103" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="365.0000" y="103.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="365.0000" y="103.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="368.3333" y="104.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="368.3333" y="104.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="371.6667" y="106.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="371.6667" y="106.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="375.0000" y="108.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="375.0000" y="108.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="378.3333" y="110.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="378.3333" y="110.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="381.6667" y="112.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="381.6667" y="112.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="365.0000" y="149.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="365.0000" y="149.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="368.3333" y="151.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="368.3333" y="151.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="371.6667" y="153.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="371.6667" y="153.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="375.0000" y="155.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="375.0000" y="155.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="378.3333" y="157.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="378.3333" y="157.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="381.6667" y="159.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="381.6667" y="159.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="365.0000" y="196.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="365.0000" y="196.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="368.3333" y="198.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="368.3333" y="198.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="371.6667" y="200.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="371.6667" y="200.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="375.0000" y="202.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="375.0000" y="202.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="378.3333" y="204.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="378.3333" y="204.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="381.6667" y="206.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="381.6667" y="206.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="365" y="103" width="80" height="140">
-			</bounds>
+			<bounds x="365" y="103" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="501" y="103" width="80" height="140">
-			</bounds>
+			<bounds x="501" y="103" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="501.0000" y="103.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="501.0000" y="103.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="504.3333" y="104.9444" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="504.3333" y="104.9444" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="507.6667" y="106.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="507.6667" y="106.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="511.0000" y="108.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="511.0000" y="108.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="514.3333" y="110.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="514.3333" y="110.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="517.6667" y="112.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="517.6667" y="112.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="501.0000" y="149.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="501.0000" y="149.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="504.3333" y="151.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="504.3333" y="151.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="507.6667" y="153.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="507.6667" y="153.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="511.0000" y="155.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="511.0000" y="155.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="514.3333" y="157.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="514.3333" y="157.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="517.6667" y="159.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="517.6667" y="159.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="501.0000" y="196.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="501.0000" y="196.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="504.3333" y="198.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="504.3333" y="198.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="507.6667" y="200.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="507.6667" y="200.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="511.0000" y="202.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="511.0000" y="202.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="514.3333" y="204.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="514.3333" y="204.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="517.6667" y="206.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="517.6667" y="206.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<bounds x="501" y="103" width="80" height="140">
-			</bounds>
+			<bounds x="501" y="103" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="828" y="9" width="42" height="52">
-			</bounds>
+			<bounds x="828" y="9" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="830" y="11" width="38" height="48">
-			</bounds>
+			<bounds x="830" y="11" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="710" y="621" width="77" height="27">
-			</bounds>
+			<bounds x="710" y="621" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="712" y="623" width="73" height="23">
-			</bounds>
+			<bounds x="712" y="623" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="787" y="621" width="84" height="27">
-			</bounds>
+			<bounds x="787" y="621" width="84" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="789" y="623" width="80" height="23">
-			</bounds>
+			<bounds x="789" y="623" width="80" height="23"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="871" y="621" width="77" height="27">
-			</bounds>
+			<bounds x="871" y="621" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="873" y="623" width="73" height="23">
-			</bounds>
+			<bounds x="873" y="623" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="87" y="227" width="62" height="37">
-			</bounds>
+			<bounds x="87" y="227" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="89" y="229" width="58" height="33">
-			</bounds>
+			<bounds x="89" y="229" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="87" y="263" width="62" height="37">
-			</bounds>
+			<bounds x="87" y="263" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="89" y="265" width="58" height="33">
-			</bounds>
+			<bounds x="89" y="265" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="87" y="299" width="62" height="37">
-			</bounds>
+			<bounds x="87" y="299" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="89" y="301" width="58" height="33">
-			</bounds>
+			<bounds x="89" y="301" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="87" y="191" width="62" height="37">
-			</bounds>
+			<bounds x="87" y="191" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="89" y="193" width="58" height="33">
-			</bounds>
+			<bounds x="89" y="193" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="74" y="149" width="92" height="42">
-			</bounds>
+			<bounds x="74" y="149" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="76" y="151" width="88" height="38">
-			</bounds>
+			<bounds x="76" y="151" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="676" y="93" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="93" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="678" y="95" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="95" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="676" y="125" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="125" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="678" y="127" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="127" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="676" y="189" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="189" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="678" y="191" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="191" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="676" y="221" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="221" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="678" y="223" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="223" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="676" y="253" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="253" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="678" y="255" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="255" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="676" y="285" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="285" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="678" y="287" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="287" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="676" y="317" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="317" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="678" y="319" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="319" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="676" y="349" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="349" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="678" y="351" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="351" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="676" y="381" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="381" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="678" y="383" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="383" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="676" y="413" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="413" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="678" y="415" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="415" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="676" y="157" width="62" height="19">
-			</bounds>
+			<bounds x="676" y="157" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="678" y="159" width="58" height="15">
-			</bounds>
+			<bounds x="678" y="159" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="612" y="437" width="62" height="22">
-			</bounds>
+			<bounds x="612" y="437" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="614" y="439" width="58" height="18">
-			</bounds>
+			<bounds x="614" y="439" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="612" y="85" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="85" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="614" y="87" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="87" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="612" y="117" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="117" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="614" y="119" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="119" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="612" y="149" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="149" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="614" y="151" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="151" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="612" y="181" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="181" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="614" y="183" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="183" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="612" y="213" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="213" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="614" y="215" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="215" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="612" y="245" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="245" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="614" y="247" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="247" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="612" y="277" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="277" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="614" y="279" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="279" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="612" y="309" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="309" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="614" y="311" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="311" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="612" y="341" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="341" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="614" y="343" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="343" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="612" y="373" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="373" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="614" y="375" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="375" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="612" y="405" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="405" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="614" y="407" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="407" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="412" y="460" width="62" height="42">
-			</bounds>
+			<bounds x="412" y="460" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="414" y="462" width="58" height="38">
-			</bounds>
+			<bounds x="414" y="462" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="474" y="419" width="62" height="42">
-			</bounds>
+			<bounds x="474" y="419" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="476" y="421" width="58" height="38">
-			</bounds>
+			<bounds x="476" y="421" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="474" y="460" width="62" height="42">
-			</bounds>
+			<bounds x="474" y="460" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="476" y="462" width="58" height="38">
-			</bounds>
+			<bounds x="476" y="462" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="350" y="378" width="62" height="42">
-			</bounds>
+			<bounds x="350" y="378" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="352" y="380" width="58" height="38">
-			</bounds>
+			<bounds x="352" y="380" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="412" y="419" width="62" height="42">
-			</bounds>
+			<bounds x="412" y="419" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="414" y="421" width="58" height="38">
-			</bounds>
+			<bounds x="414" y="421" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="351" y="419" width="62" height="42">
-			</bounds>
+			<bounds x="351" y="419" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="353" y="421" width="58" height="38">
-			</bounds>
+			<bounds x="353" y="421" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="351" y="460" width="62" height="42">
-			</bounds>
+			<bounds x="351" y="460" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="353" y="462" width="58" height="38">
-			</bounds>
+			<bounds x="353" y="462" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="536" y="418" width="62" height="42">
-			</bounds>
+			<bounds x="536" y="418" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="538" y="420" width="58" height="38">
-			</bounds>
+			<bounds x="538" y="420" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="536" y="377" width="62" height="42">
-			</bounds>
+			<bounds x="536" y="377" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="538" y="379" width="58" height="38">
-			</bounds>
+			<bounds x="538" y="379" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="536" y="459" width="62" height="42">
-			</bounds>
+			<bounds x="536" y="459" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="538" y="461" width="58" height="38">
-			</bounds>
+			<bounds x="538" y="461" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="376" y="286" width="62" height="32">
-			</bounds>
+			<bounds x="376" y="286" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="378" y="288" width="58" height="28">
-			</bounds>
+			<bounds x="378" y="288" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="444" y="286" width="62" height="32">
-			</bounds>
+			<bounds x="444" y="286" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="446" y="288" width="58" height="28">
-			</bounds>
+			<bounds x="446" y="288" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="512" y="286" width="62" height="32">
-			</bounds>
+			<bounds x="512" y="286" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="514" y="288" width="58" height="28">
-			</bounds>
+			<bounds x="514" y="288" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="676" y="54" width="62" height="32">
-			</bounds>
+			<bounds x="676" y="54" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="678" y="56" width="58" height="28">
-			</bounds>
+			<bounds x="678" y="56" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="427" y="382" width="92" height="32">
-			</bounds>
+			<bounds x="427" y="382" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="429" y="384" width="88" height="28">
-			</bounds>
+			<bounds x="429" y="384" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="612" y="54" width="62" height="32">
-			</bounds>
+			<bounds x="612" y="54" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="614" y="56" width="58" height="28">
-			</bounds>
+			<bounds x="614" y="56" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="213" y="54" width="62" height="32">
-			</bounds>
+			<bounds x="213" y="54" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="215" y="56" width="58" height="28">
-			</bounds>
+			<bounds x="215" y="56" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="278" y="55" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="55" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="280" y="57" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="57" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="278" y="438" width="62" height="22">
-			</bounds>
+			<bounds x="278" y="438" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="280" y="440" width="58" height="18">
-			</bounds>
+			<bounds x="280" y="440" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="278" y="406" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="406" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="280" y="408" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="408" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="278" y="150" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="150" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="280" y="152" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="152" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="278" y="182" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="182" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="280" y="184" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="184" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="278" y="214" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="214" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="280" y="216" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="216" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="278" y="246" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="246" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="280" y="248" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="248" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="278" y="278" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="278" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="280" y="280" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="280" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="278" y="310" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="310" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="280" y="312" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="312" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="278" y="374" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="374" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="280" y="376" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="376" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="278" y="342" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="342" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="280" y="344" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="344" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="278" y="118" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="118" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="280" y="120" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="120" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="278" y="86" width="62" height="32">
-			</bounds>
+			<bounds x="278" y="86" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="280" y="88" width="58" height="28">
-			</bounds>
+			<bounds x="280" y="88" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="213" y="382" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="382" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="215" y="384" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="384" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="213" y="350" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="350" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="215" y="352" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="352" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="213" y="318" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="318" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="215" y="320" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="320" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="213" y="286" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="286" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="215" y="288" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="288" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="213" y="254" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="254" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="215" y="256" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="256" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="213" y="222" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="222" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="215" y="224" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="224" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="213" y="190" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="190" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="215" y="192" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="192" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="213" y="158" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="158" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="215" y="160" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="160" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="213" y="126" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="126" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="215" y="128" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="128" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="213" y="94" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="94" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="215" y="96" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="96" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="213" y="414" width="62" height="19">
-			</bounds>
+			<bounds x="213" y="414" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="215" y="416" width="58" height="15">
-			</bounds>
+			<bounds x="215" y="416" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="280" y="3" width="62" height="52">
-			</bounds>
+			<bounds x="280" y="3" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="282" y="5" width="58" height="48">
-			</bounds>
+			<bounds x="282" y="5" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="341" y="3" width="42" height="52">
-			</bounds>
+			<bounds x="341" y="3" width="42" height="52"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="343" y="5" width="38" height="48">
-			</bounds>
+			<bounds x="343" y="5" width="38" height="48"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="382" y="3" width="52" height="52">
-			</bounds>
+			<bounds x="382" y="3" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="384" y="5" width="48" height="48">
-			</bounds>
+			<bounds x="384" y="5" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="610" y="3" width="64" height="52">
-			</bounds>
+			<bounds x="610" y="3" width="64" height="52"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="612" y="5" width="60" height="48">
-			</bounds>
+			<bounds x="612" y="5" width="60" height="48"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="559" y="3" width="52" height="52">
-			</bounds>
+			<bounds x="559" y="3" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="561" y="5" width="48" height="48">
-			</bounds>
+			<bounds x="561" y="5" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="496" y="3" width="64" height="52">
-			</bounds>
+			<bounds x="496" y="3" width="64" height="52"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="498" y="5" width="60" height="48">
-			</bounds>
+			<bounds x="498" y="5" width="60" height="48"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="436" y="3" width="62" height="52">
-			</bounds>
+			<bounds x="436" y="3" width="62" height="52"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="438" y="5" width="58" height="48">
-			</bounds>
+			<bounds x="438" y="5" width="58" height="48"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="303" y="673" width="22" height="22">
-			</bounds>
+			<bounds x="303" y="673" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="305" y="675" width="18" height="18">
-			</bounds>
+			<bounds x="305" y="675" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="304" y="637" width="22" height="22">
-			</bounds>
+			<bounds x="304" y="637" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="306" y="639" width="18" height="18">
-			</bounds>
+			<bounds x="306" y="639" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="303" y="599" width="22" height="22">
-			</bounds>
+			<bounds x="303" y="599" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="305" y="601" width="18" height="18">
-			</bounds>
+			<bounds x="305" y="601" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1_border" state="0">
-			<bounds x="304" y="527" width="22" height="22">
-			</bounds>
+			<bounds x="304" y="527" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1" state="0">
-			<bounds x="306" y="529" width="18" height="18">
-			</bounds>
+			<bounds x="306" y="529" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="304" y="565" width="22" height="22">
-			</bounds>
+			<bounds x="304" y="565" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="306" y="567" width="18" height="18">
-			</bounds>
+			<bounds x="306" y="567" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="639" y="642" width="22" height="22">
-			</bounds>
+			<bounds x="639" y="642" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="641" y="644" width="18" height="18">
-			</bounds>
+			<bounds x="641" y="644" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="638" y="677" width="22" height="22">
-			</bounds>
+			<bounds x="638" y="677" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="640" y="679" width="18" height="18">
-			</bounds>
+			<bounds x="640" y="679" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="639" y="526" width="22" height="22">
-			</bounds>
+			<bounds x="639" y="526" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="641" y="528" width="18" height="18">
-			</bounds>
+			<bounds x="641" y="528" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="638" y="565" width="22" height="22">
-			</bounds>
+			<bounds x="638" y="565" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="640" y="567" width="18" height="18">
-			</bounds>
+			<bounds x="640" y="567" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="639" y="605" width="22" height="22">
-			</bounds>
+			<bounds x="639" y="605" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="641" y="607" width="18" height="18">
-			</bounds>
+			<bounds x="641" y="607" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="886" y="204" width="42" height="32">
-			</bounds>
+			<bounds x="886" y="204" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="888" y="206" width="38" height="28">
-			</bounds>
+			<bounds x="888" y="206" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="886" y="244" width="42" height="32">
-			</bounds>
+			<bounds x="886" y="244" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="888" y="246" width="38" height="28">
-			</bounds>
+			<bounds x="888" y="246" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="886" y="286" width="42" height="32">
-			</bounds>
+			<bounds x="886" y="286" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="888" y="288" width="38" height="28">
-			</bounds>
+			<bounds x="888" y="288" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="886" y="328" width="42" height="32">
-			</bounds>
+			<bounds x="886" y="328" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="888" y="330" width="38" height="28">
-			</bounds>
+			<bounds x="888" y="330" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="886" y="370" width="42" height="32">
-			</bounds>
+			<bounds x="886" y="370" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="888" y="372" width="38" height="28">
-			</bounds>
+			<bounds x="888" y="372" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="886" y="160" width="42" height="32">
-			</bounds>
+			<bounds x="886" y="160" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="888" y="162" width="38" height="28">
-			</bounds>
+			<bounds x="888" y="162" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="862" y="545" width="72" height="32">
-			</bounds>
+			<bounds x="862" y="545" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="864" y="547" width="68" height="28">
-			</bounds>
+			<bounds x="864" y="547" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="862" y="575" width="72" height="32">
-			</bounds>
+			<bounds x="862" y="575" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="864" y="577" width="68" height="28">
-			</bounds>
+			<bounds x="864" y="577" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="722" y="575" width="72" height="32">
-			</bounds>
+			<bounds x="722" y="575" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="724" y="577" width="68" height="28">
-			</bounds>
+			<bounds x="724" y="577" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="722" y="545" width="72" height="32">
-			</bounds>
+			<bounds x="722" y="545" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="724" y="547" width="68" height="28">
-			</bounds>
+			<bounds x="724" y="547" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="792" y="575" width="72" height="32">
-			</bounds>
+			<bounds x="792" y="575" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="794" y="577" width="68" height="28">
-			</bounds>
+			<bounds x="794" y="577" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="792" y="545" width="72" height="32">
-			</bounds>
+			<bounds x="792" y="545" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="794" y="547" width="68" height="28">
-			</bounds>
+			<bounds x="794" y="547" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="76" y="394" width="82" height="102">
-			</bounds>
+			<bounds x="76" y="394" width="82" height="102"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="78" y="396" width="78" height="98">
-			</bounds>
+			<bounds x="78" y="396" width="78" height="98"/>
 		</backdrop>
 		<backdrop name="lamp148" element="colour_button_131_border" state="0" inputtag="IN-9" inputmask="0x08">
-			<bounds x="79" y="339" width="78" height="42">
-			</bounds>
+			<bounds x="79" y="339" width="78" height="42"/>
 		</backdrop>
 		<backdrop name="lamp148" element="colour_button_131" state="0" inputtag="IN-9" inputmask="0x08">
-			<bounds x="81" y="341" width="74" height="38">
-			</bounds>
+			<bounds x="81" y="341" width="74" height="38"/>
 		</backdrop>
 		<backdrop name="lamp133" element="colour_button_132_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="437" y="332" width="75" height="40">
-			</bounds>
+			<bounds x="437" y="332" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp133" element="colour_button_132" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="439" y="334" width="71" height="36">
-			</bounds>
+			<bounds x="439" y="334" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp106" element="colour_button_134_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="607" y="460" width="75" height="40">
-			</bounds>
+			<bounds x="607" y="460" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp106" element="colour_button_134" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="609" y="462" width="71" height="36">
-			</bounds>
+			<bounds x="609" y="462" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp97" element="colour_button_135_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="368" y="246" width="75" height="27">
-			</bounds>
+			<bounds x="368" y="246" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="colour_button_135" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="370" y="248" width="71" height="23">
-			</bounds>
+			<bounds x="370" y="248" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp149" element="colour_button_136_border" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="504" y="74" width="75" height="27">
-			</bounds>
+			<bounds x="504" y="74" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp149" element="colour_button_136" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="506" y="76" width="71" height="23">
-			</bounds>
+			<bounds x="506" y="76" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp147" element="colour_button_137_border" state="0" inputtag="IN-9" inputmask="0x10">
-			<bounds x="368" y="74" width="75" height="27">
-			</bounds>
+			<bounds x="368" y="74" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp147" element="colour_button_137" state="0" inputtag="IN-9" inputmask="0x10">
-			<bounds x="370" y="76" width="71" height="23">
-			</bounds>
+			<bounds x="370" y="76" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="colour_button_138_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="503" y="246" width="75" height="27">
-			</bounds>
+			<bounds x="503" y="246" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="colour_button_138" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="505" y="248" width="71" height="23">
-			</bounds>
+			<bounds x="505" y="248" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="colour_button_139_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="523" y="331" width="75" height="40">
-			</bounds>
+			<bounds x="523" y="331" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp100" element="colour_button_139" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="525" y="333" width="71" height="36">
-			</bounds>
+			<bounds x="525" y="333" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp98" element="colour_button_140_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="350" y="331" width="75" height="40">
-			</bounds>
+			<bounds x="350" y="331" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp98" element="colour_button_140" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="352" y="333" width="71" height="36">
-			</bounds>
+			<bounds x="352" y="333" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp96" element="colour_button_141_border" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="269" y="463" width="75" height="40">
-			</bounds>
+			<bounds x="269" y="463" width="75" height="40"/>
 		</backdrop>
 		<backdrop name="lamp96" element="colour_button_141" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="271" y="465" width="71" height="36">
-			</bounds>
+			<bounds x="271" y="465" width="71" height="36"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_143_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="207" y="696" width="75" height="27">
-			</bounds>
+			<bounds x="207" y="696" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_143" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="209" y="698" width="71" height="23">
-			</bounds>
+			<bounds x="209" y="698" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_144_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="694" y="696" width="75" height="27">
-			</bounds>
+			<bounds x="694" y="696" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_144" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="696" y="698" width="71" height="23">
-			</bounds>
+			<bounds x="696" y="698" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_145_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="117" y="696" width="75" height="27">
-			</bounds>
+			<bounds x="117" y="696" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_145" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="119" y="698" width="71" height="23">
-			</bounds>
+			<bounds x="119" y="698" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_146_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="354" y="697" width="75" height="27">
-			</bounds>
+			<bounds x="354" y="697" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_146" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="356" y="699" width="71" height="23">
-			</bounds>
+			<bounds x="356" y="699" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_147_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="448" y="696" width="75" height="27">
-			</bounds>
+			<bounds x="448" y="696" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_147" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="450" y="698" width="71" height="23">
-			</bounds>
+			<bounds x="450" y="698" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_148_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="544" y="697" width="75" height="27">
-			</bounds>
+			<bounds x="544" y="697" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_148" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="546" y="699" width="71" height="23">
-			</bounds>
+			<bounds x="546" y="699" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="372" y="507" width="227" height="20">
-			</bounds>
+			<bounds x="372" y="507" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="372" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="372" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="386" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="386" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="400" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="400" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="414" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="414" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="428" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="428" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="442" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="442" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="456" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="456" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="470" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="470" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="484" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="484" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="498" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="498" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="512" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="512" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="526" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="526" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="540" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="540" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="554" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="554" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="568" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="568" y="507" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="582" y="507" width="14" height="20">
-			</bounds>
+			<bounds x="582" y="507" width="14" height="20"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_button" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_button" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_button" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_button" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_button" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_button" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_button" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_button" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_button" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_button" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1660.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1665.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1670.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1675.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1680.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1685.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="312.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="312.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="315.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="315.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="318.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="318.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="322.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="322.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="325.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="325.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="328.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="328.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="392.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="392.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="395.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="395.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="398.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="398.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="402.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="402.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="405.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="405.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="408.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="408.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="472.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="472.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="475.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="475.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="478.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="478.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="482.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="482.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="485.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="485.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="488.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="488.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel6" element="debug_stepper_value">
-			<bounds x="1100" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="552" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_5">
-			<bounds x="1180" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="552" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4chavy.lay
+++ b/src/mame/layout/sc4chavy.lay
@@ -8,15484 +8,9664 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash Pots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Pots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Wheel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Wheel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Boy Racer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Boy Racer">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SHUT IT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SHUT IT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Go Back">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go Back">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Burberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Burberry">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Special Brew">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Special Brew">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Wheel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Wheel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Yeah But No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Yeah But No">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CASH POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Max Power">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Max Power">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Wheel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Wheel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Go Back">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go Back">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="King of Bling">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="King of Bling">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 Shots Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 Shots Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Stella">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Stella">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Go Back">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go Back">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5 Cash Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Streets">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Streets">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Wheel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Wheel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Chav It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Chav It">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Cash Pot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Go Back">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Go Back">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Am I Bovverd ??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Am I Bovverd ??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5 Win Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bling Bling">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bling Bling">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="V">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_3_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_3" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="By">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cardi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_4_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_4" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="By">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cardi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
 		<text string="STA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="STA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Multi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Multi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TAKE CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TAKE CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="SKILL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
+			<color red="0.25" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
+			<color red="0.06" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
+			<color red="0.50" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
+			<color red="0.13" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="WHEEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="WHEEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="WHEEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="WHEEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="RESPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRAIL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LUCKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LUCKY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Credi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Credi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.27">
-			</bounds>
-		</text>
 		<text string="Take Cash Meter">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.37" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.37" width="0.80" height="0.27"/>
 		</text>
 		<text string="or Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.63" width="0.80" height="0.27">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.63" width="0.80" height="0.27"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGE LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGE HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_171_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_171">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist=",,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel5" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist=",,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_125">
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_130">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_154">
 		<text string="Light All 3 For BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_5">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="790" height="738">
-			</bounds>
+			<bounds x="0" y="0" width="790" height="738"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="112" y="497" width="80" height="140">
-			</bounds>
+			<bounds x="112" y="497" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="112.0000" y="497.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="112.0000" y="497.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="115.3333" y="498.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="115.3333" y="498.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="118.6667" y="500.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="118.6667" y="500.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="122.0000" y="502.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="122.0000" y="502.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="125.3333" y="504.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="125.3333" y="504.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="128.6667" y="506.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="128.6667" y="506.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="112.0000" y="543.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="112.0000" y="543.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="115.3333" y="545.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="115.3333" y="545.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="118.6667" y="547.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="118.6667" y="547.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="122.0000" y="549.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="122.0000" y="549.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="125.3333" y="551.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="125.3333" y="551.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="128.6667" y="553.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="128.6667" y="553.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="112.0000" y="590.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="112.0000" y="590.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="115.3333" y="592.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="115.3333" y="592.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="118.6667" y="594.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="118.6667" y="594.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="122.0000" y="596.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="122.0000" y="596.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="125.3333" y="598.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="125.3333" y="598.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="128.6667" y="600.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="128.6667" y="600.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="112" y="497" width="80" height="140">
-			</bounds>
+			<bounds x="112" y="497" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="199" y="497" width="80" height="140">
-			</bounds>
+			<bounds x="199" y="497" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="199.0000" y="497.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="199.0000" y="497.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="202.3333" y="498.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="202.3333" y="498.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="205.6667" y="500.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="205.6667" y="500.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="209.0000" y="502.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="209.0000" y="502.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="212.3333" y="504.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="212.3333" y="504.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="215.6667" y="506.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="215.6667" y="506.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="199.0000" y="543.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="199.0000" y="543.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="202.3333" y="545.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="202.3333" y="545.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="205.6667" y="547.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="205.6667" y="547.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="209.0000" y="549.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="209.0000" y="549.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="212.3333" y="551.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="212.3333" y="551.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="215.6667" y="553.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="215.6667" y="553.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="199.0000" y="590.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="199.0000" y="590.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="202.3333" y="592.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="202.3333" y="592.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="205.6667" y="594.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="205.6667" y="594.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="209.0000" y="596.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="209.0000" y="596.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="212.3333" y="598.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="212.3333" y="598.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="215.6667" y="600.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="215.6667" y="600.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="199" y="497" width="80" height="140">
-			</bounds>
+			<bounds x="199" y="497" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="286" y="497" width="80" height="140">
-			</bounds>
+			<bounds x="286" y="497" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="286.0000" y="497.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="286.0000" y="497.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="289.3333" y="498.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="289.3333" y="498.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="292.6667" y="500.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="292.6667" y="500.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="296.0000" y="502.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="296.0000" y="502.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="299.3333" y="504.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="299.3333" y="504.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="302.6667" y="506.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="302.6667" y="506.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="286.0000" y="543.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="286.0000" y="543.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="289.3333" y="545.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="289.3333" y="545.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="292.6667" y="547.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="292.6667" y="547.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="296.0000" y="549.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="296.0000" y="549.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="299.3333" y="551.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="299.3333" y="551.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="302.6667" y="553.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="302.6667" y="553.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="286.0000" y="590.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="286.0000" y="590.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="289.3333" y="592.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="289.3333" y="592.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="292.6667" y="594.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="292.6667" y="594.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="296.0000" y="596.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="296.0000" y="596.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="299.3333" y="598.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="299.3333" y="598.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="302.6667" y="600.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="302.6667" y="600.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="286" y="497" width="80" height="140">
-			</bounds>
+			<bounds x="286" y="497" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="150" y="357" width="46" height="53">
-			</bounds>
+			<bounds x="150" y="357" width="46" height="53"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="150.0000" y="357.0000" width="46.0000" height="53.0000">
-			</bounds>
+			<bounds x="150.0000" y="357.0000" width="46.0000" height="53.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="151.9167" y="359.2083" width="42.1667" height="48.5833">
-			</bounds>
+			<bounds x="151.9167" y="359.2083" width="42.1667" height="48.5833"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="153.8333" y="361.4167" width="38.3333" height="44.1667">
-			</bounds>
+			<bounds x="153.8333" y="361.4167" width="38.3333" height="44.1667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="155.7500" y="363.6250" width="34.5000" height="39.7500">
-			</bounds>
+			<bounds x="155.7500" y="363.6250" width="34.5000" height="39.7500"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="157.6667" y="365.8333" width="30.6667" height="35.3333">
-			</bounds>
+			<bounds x="157.6667" y="365.8333" width="30.6667" height="35.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="159.5833" y="368.0417" width="26.8333" height="30.9167">
-			</bounds>
+			<bounds x="159.5833" y="368.0417" width="26.8333" height="30.9167"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="150" y="357" width="46" height="53">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="150" y="357" width="46" height="53"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="254" y="148" width="46" height="53">
-			</bounds>
+			<bounds x="254" y="148" width="46" height="53"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="254.0000" y="148.0000" width="46.0000" height="53.0000">
-			</bounds>
+			<bounds x="254.0000" y="148.0000" width="46.0000" height="53.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="255.9167" y="150.2083" width="42.1667" height="48.5833">
-			</bounds>
+			<bounds x="255.9167" y="150.2083" width="42.1667" height="48.5833"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="257.8333" y="152.4167" width="38.3333" height="44.1667">
-			</bounds>
+			<bounds x="257.8333" y="152.4167" width="38.3333" height="44.1667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="259.7500" y="154.6250" width="34.5000" height="39.7500">
-			</bounds>
+			<bounds x="259.7500" y="154.6250" width="34.5000" height="39.7500"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="261.6667" y="156.8333" width="30.6667" height="35.3333">
-			</bounds>
+			<bounds x="261.6667" y="156.8333" width="30.6667" height="35.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="263.5833" y="159.0417" width="26.8333" height="30.9167">
-			</bounds>
+			<bounds x="263.5833" y="159.0417" width="26.8333" height="30.9167"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="254" y="148" width="46" height="53">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="254" y="148" width="46" height="53"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="70" y="142" width="57" height="24">
-			</bounds>
+			<bounds x="70" y="142" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="72" y="144" width="53" height="20">
-			</bounds>
+			<bounds x="72" y="144" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="46" y="167" width="79" height="24">
-			</bounds>
+			<bounds x="46" y="167" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="48" y="169" width="75" height="20">
-			</bounds>
+			<bounds x="48" y="169" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="21" y="217" width="79" height="24">
-			</bounds>
+			<bounds x="21" y="217" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="23" y="219" width="75" height="20">
-			</bounds>
+			<bounds x="23" y="219" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="21" y="217" width="79" height="24">
-			</bounds>
+			<bounds x="21" y="217" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="23" y="219" width="75" height="20">
-			</bounds>
+			<bounds x="23" y="219" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="189" y="242" width="57" height="24">
-			</bounds>
+			<bounds x="189" y="242" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="191" y="244" width="53" height="20">
-			</bounds>
+			<bounds x="191" y="244" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="245" y="242" width="57" height="24">
-			</bounds>
+			<bounds x="245" y="242" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="247" y="244" width="53" height="20">
-			</bounds>
+			<bounds x="247" y="244" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="301" y="242" width="79" height="24">
-			</bounds>
+			<bounds x="301" y="242" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="303" y="244" width="75" height="20">
-			</bounds>
+			<bounds x="303" y="244" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="301" y="242" width="79" height="24">
-			</bounds>
+			<bounds x="301" y="242" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="303" y="244" width="75" height="20">
-			</bounds>
+			<bounds x="303" y="244" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="379" y="242" width="79" height="24">
-			</bounds>
+			<bounds x="379" y="242" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="381" y="244" width="75" height="20">
-			</bounds>
+			<bounds x="381" y="244" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="387" y="265" width="79" height="24">
-			</bounds>
+			<bounds x="387" y="265" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="389" y="267" width="75" height="20">
-			</bounds>
+			<bounds x="389" y="267" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="387" y="288" width="79" height="24">
-			</bounds>
+			<bounds x="387" y="288" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="389" y="290" width="75" height="20">
-			</bounds>
+			<bounds x="389" y="290" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="387" y="288" width="79" height="24">
-			</bounds>
+			<bounds x="387" y="288" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="389" y="290" width="75" height="20">
-			</bounds>
+			<bounds x="389" y="290" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="387" y="311" width="79" height="24">
-			</bounds>
+			<bounds x="387" y="311" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="389" y="313" width="75" height="20">
-			</bounds>
+			<bounds x="389" y="313" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="387" y="311" width="79" height="24">
-			</bounds>
+			<bounds x="387" y="311" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="389" y="313" width="75" height="20">
-			</bounds>
+			<bounds x="389" y="313" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="228" y="12" width="57" height="24">
-			</bounds>
+			<bounds x="228" y="12" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="230" y="14" width="53" height="20">
-			</bounds>
+			<bounds x="230" y="14" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="429" y="119" width="79" height="24">
-			</bounds>
+			<bounds x="429" y="119" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="431" y="121" width="75" height="20">
-			</bounds>
+			<bounds x="431" y="121" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="429" y="119" width="79" height="24">
-			</bounds>
+			<bounds x="429" y="119" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="431" y="121" width="75" height="20">
-			</bounds>
+			<bounds x="431" y="121" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="491" y="92" width="57" height="24">
-			</bounds>
+			<bounds x="491" y="92" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="493" y="94" width="53" height="20">
-			</bounds>
+			<bounds x="493" y="94" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="486" y="61" width="79" height="24">
-			</bounds>
+			<bounds x="486" y="61" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="488" y="63" width="75" height="20">
-			</bounds>
+			<bounds x="488" y="63" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="486" y="61" width="79" height="24">
-			</bounds>
+			<bounds x="486" y="61" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="488" y="63" width="75" height="20">
-			</bounds>
+			<bounds x="488" y="63" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="466" y="27" width="79" height="24">
-			</bounds>
+			<bounds x="466" y="27" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="468" y="29" width="75" height="20">
-			</bounds>
+			<bounds x="468" y="29" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="466" y="27" width="79" height="24">
-			</bounds>
+			<bounds x="466" y="27" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="468" y="29" width="75" height="20">
-			</bounds>
+			<bounds x="468" y="29" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="375" y="15" width="79" height="24">
-			</bounds>
+			<bounds x="375" y="15" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="377" y="17" width="75" height="20">
-			</bounds>
+			<bounds x="377" y="17" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="375" y="15" width="79" height="24">
-			</bounds>
+			<bounds x="375" y="15" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="377" y="17" width="75" height="20">
-			</bounds>
+			<bounds x="377" y="17" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="299" y="13" width="57" height="24">
-			</bounds>
+			<bounds x="299" y="13" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="301" y="15" width="53" height="20">
-			</bounds>
+			<bounds x="301" y="15" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="375" y="209" width="79" height="24">
-			</bounds>
+			<bounds x="375" y="209" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="377" y="211" width="75" height="20">
-			</bounds>
+			<bounds x="377" y="211" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="375" y="209" width="79" height="24">
-			</bounds>
+			<bounds x="375" y="209" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="377" y="211" width="75" height="20">
-			</bounds>
+			<bounds x="377" y="211" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="456" y="216" width="79" height="24">
-			</bounds>
+			<bounds x="456" y="216" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="458" y="218" width="75" height="20">
-			</bounds>
+			<bounds x="458" y="218" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="456" y="216" width="79" height="24">
-			</bounds>
+			<bounds x="456" y="216" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="458" y="218" width="75" height="20">
-			</bounds>
+			<bounds x="458" y="218" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="463" y="240" width="79" height="24">
-			</bounds>
+			<bounds x="463" y="240" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="465" y="242" width="75" height="20">
-			</bounds>
+			<bounds x="465" y="242" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="463" y="240" width="79" height="24">
-			</bounds>
+			<bounds x="463" y="240" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="465" y="242" width="75" height="20">
-			</bounds>
+			<bounds x="465" y="242" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="466" y="265" width="79" height="24">
-			</bounds>
+			<bounds x="466" y="265" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="468" y="267" width="75" height="20">
-			</bounds>
+			<bounds x="468" y="267" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="466" y="265" width="79" height="24">
-			</bounds>
+			<bounds x="466" y="265" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="468" y="267" width="75" height="20">
-			</bounds>
+			<bounds x="468" y="267" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="466" y="288" width="79" height="24">
-			</bounds>
+			<bounds x="466" y="288" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="468" y="290" width="75" height="20">
-			</bounds>
+			<bounds x="468" y="290" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="466" y="311" width="79" height="24">
-			</bounds>
+			<bounds x="466" y="311" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="468" y="313" width="75" height="20">
-			</bounds>
+			<bounds x="468" y="313" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="393" y="92" width="79" height="24">
-			</bounds>
+			<bounds x="393" y="92" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="395" y="94" width="75" height="20">
-			</bounds>
+			<bounds x="395" y="94" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="393" y="92" width="79" height="24">
-			</bounds>
+			<bounds x="393" y="92" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="395" y="94" width="75" height="20">
-			</bounds>
+			<bounds x="395" y="94" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="422" y="62" width="57" height="24">
-			</bounds>
+			<bounds x="422" y="62" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="424" y="64" width="53" height="20">
-			</bounds>
+			<bounds x="424" y="64" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="362" y="44" width="57" height="24">
-			</bounds>
+			<bounds x="362" y="44" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="364" y="46" width="53" height="20">
-			</bounds>
+			<bounds x="364" y="46" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="305" y="42" width="57" height="24">
-			</bounds>
+			<bounds x="305" y="42" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="307" y="44" width="53" height="20">
-			</bounds>
+			<bounds x="307" y="44" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="225" y="39" width="79" height="24">
-			</bounds>
+			<bounds x="225" y="39" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="227" y="41" width="75" height="20">
-			</bounds>
+			<bounds x="227" y="41" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="225" y="39" width="79" height="24">
-			</bounds>
+			<bounds x="225" y="39" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="227" y="41" width="75" height="20">
-			</bounds>
+			<bounds x="227" y="41" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="312" y="92" width="79" height="24">
-			</bounds>
+			<bounds x="312" y="92" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="314" y="94" width="75" height="20">
-			</bounds>
+			<bounds x="314" y="94" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="312" y="92" width="79" height="24">
-			</bounds>
+			<bounds x="312" y="92" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="314" y="94" width="75" height="20">
-			</bounds>
+			<bounds x="314" y="94" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="231" y="92" width="79" height="24">
-			</bounds>
+			<bounds x="231" y="92" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="233" y="94" width="75" height="20">
-			</bounds>
+			<bounds x="233" y="94" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="231" y="92" width="79" height="24">
-			</bounds>
+			<bounds x="231" y="92" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="233" y="94" width="75" height="20">
-			</bounds>
+			<bounds x="233" y="94" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="172" y="92" width="57" height="24">
-			</bounds>
+			<bounds x="172" y="92" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="174" y="94" width="53" height="20">
-			</bounds>
+			<bounds x="174" y="94" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="91" y="92" width="79" height="24">
-			</bounds>
+			<bounds x="91" y="92" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="93" y="94" width="75" height="20">
-			</bounds>
+			<bounds x="93" y="94" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="91" y="92" width="79" height="24">
-			</bounds>
+			<bounds x="91" y="92" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="93" y="94" width="75" height="20">
-			</bounds>
+			<bounds x="93" y="94" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="68" y="117" width="79" height="24">
-			</bounds>
+			<bounds x="68" y="117" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="70" y="119" width="75" height="20">
-			</bounds>
+			<bounds x="70" y="119" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="68" y="117" width="79" height="24">
-			</bounds>
+			<bounds x="68" y="117" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="70" y="119" width="75" height="20">
-			</bounds>
+			<bounds x="70" y="119" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="31" y="192" width="79" height="24">
-			</bounds>
+			<bounds x="31" y="192" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="33" y="194" width="75" height="20">
-			</bounds>
+			<bounds x="33" y="194" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="350" y="119" width="79" height="24">
-			</bounds>
+			<bounds x="350" y="119" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="352" y="121" width="75" height="20">
-			</bounds>
+			<bounds x="352" y="121" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="350" y="119" width="79" height="24">
-			</bounds>
+			<bounds x="350" y="119" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="352" y="121" width="75" height="20">
-			</bounds>
+			<bounds x="352" y="121" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="293" y="119" width="57" height="24">
-			</bounds>
+			<bounds x="293" y="119" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="295" y="121" width="53" height="20">
-			</bounds>
+			<bounds x="295" y="121" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="236" y="119" width="57" height="24">
-			</bounds>
+			<bounds x="236" y="119" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="238" y="121" width="53" height="20">
-			</bounds>
+			<bounds x="238" y="121" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="236" y="119" width="57" height="24">
-			</bounds>
+			<bounds x="236" y="119" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="238" y="121" width="53" height="20">
-			</bounds>
+			<bounds x="238" y="121" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="157" y="136" width="79" height="24">
-			</bounds>
+			<bounds x="157" y="136" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="159" y="138" width="75" height="20">
-			</bounds>
+			<bounds x="159" y="138" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="157" y="136" width="79" height="24">
-			</bounds>
+			<bounds x="157" y="136" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="159" y="138" width="75" height="20">
-			</bounds>
+			<bounds x="159" y="138" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="149" y="161" width="57" height="24">
-			</bounds>
+			<bounds x="149" y="161" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="151" y="163" width="53" height="20">
-			</bounds>
+			<bounds x="151" y="163" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="136" y="185" width="79" height="24">
-			</bounds>
+			<bounds x="136" y="185" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="138" y="187" width="75" height="20">
-			</bounds>
+			<bounds x="138" y="187" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="136" y="185" width="79" height="24">
-			</bounds>
+			<bounds x="136" y="185" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="138" y="187" width="75" height="20">
-			</bounds>
+			<bounds x="138" y="187" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="129" y="209" width="57" height="24">
-			</bounds>
+			<bounds x="129" y="209" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="131" y="211" width="53" height="20">
-			</bounds>
+			<bounds x="131" y="211" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="185" y="209" width="57" height="24">
-			</bounds>
+			<bounds x="185" y="209" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="187" y="211" width="53" height="20">
-			</bounds>
+			<bounds x="187" y="211" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="241" y="209" width="57" height="24">
-			</bounds>
+			<bounds x="241" y="209" width="57" height="24"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="243" y="211" width="53" height="20">
-			</bounds>
+			<bounds x="243" y="211" width="53" height="20"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="297" y="209" width="79" height="24">
-			</bounds>
+			<bounds x="297" y="209" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="299" y="211" width="75" height="20">
-			</bounds>
+			<bounds x="299" y="211" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="297" y="209" width="79" height="24">
-			</bounds>
+			<bounds x="297" y="209" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="299" y="211" width="75" height="20">
-			</bounds>
+			<bounds x="299" y="211" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="111" y="242" width="79" height="24">
-			</bounds>
+			<bounds x="111" y="242" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="113" y="244" width="75" height="20">
-			</bounds>
+			<bounds x="113" y="244" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="111" y="242" width="79" height="24">
-			</bounds>
+			<bounds x="111" y="242" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="113" y="244" width="75" height="20">
-			</bounds>
+			<bounds x="113" y="244" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="33" y="242" width="79" height="24">
-			</bounds>
+			<bounds x="33" y="242" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="35" y="244" width="75" height="20">
-			</bounds>
+			<bounds x="35" y="244" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="33" y="242" width="79" height="24">
-			</bounds>
+			<bounds x="33" y="242" width="79" height="24"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="35" y="244" width="75" height="20">
-			</bounds>
+			<bounds x="35" y="244" width="75" height="20"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="152" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="152" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="154" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="154" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="152" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="152" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="154" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="154" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="117" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="117" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="119" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="119" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="117" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="117" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="119" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="119" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="82" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="82" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="84" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="84" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="82" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="82" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="84" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="84" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="47" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="47" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="49" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="49" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="47" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="47" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="49" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="49" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="12" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="12" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="14" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="14" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="12" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="12" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="14" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="14" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="187" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="187" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="189" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="189" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2_border" state="0">
-			<bounds x="187" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="187" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_2" state="0">
-			<bounds x="189" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="189" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_2_border" state="0">
-			<bounds x="152" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="152" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_2" state="0">
-			<bounds x="154" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="154" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_2_border" state="0">
-			<bounds x="152" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="152" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_2" state="0">
-			<bounds x="154" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="154" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_2_border" state="0">
-			<bounds x="117" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="117" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_2" state="0">
-			<bounds x="119" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="119" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_2_border" state="0">
-			<bounds x="117" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="117" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_2" state="0">
-			<bounds x="119" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="119" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_2_border" state="0">
-			<bounds x="12" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="12" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_2" state="0">
-			<bounds x="14" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="14" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_3_border" state="0">
-			<bounds x="12" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="12" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_3" state="0">
-			<bounds x="14" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="14" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_2_border" state="0">
-			<bounds x="47" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="47" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_2" state="0">
-			<bounds x="49" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="49" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_2_border" state="0">
-			<bounds x="47" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="47" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_2" state="0">
-			<bounds x="49" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="49" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_2_border" state="0">
-			<bounds x="82" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="82" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_2" state="0">
-			<bounds x="84" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="84" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_2_border" state="0">
-			<bounds x="82" y="8" width="38" height="29">
-			</bounds>
+			<bounds x="82" y="8" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_2" state="0">
-			<bounds x="84" y="10" width="34" height="25">
-			</bounds>
+			<bounds x="84" y="10" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_2_border" state="0">
-			<bounds x="187" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="187" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_2" state="0">
-			<bounds x="189" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="189" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_4_border" state="0">
-			<bounds x="187" y="34" width="38" height="29">
-			</bounds>
+			<bounds x="187" y="34" width="38" height="29"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_4" state="0">
-			<bounds x="189" y="36" width="34" height="25">
-			</bounds>
+			<bounds x="189" y="36" width="34" height="25"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="479" y="375" width="19" height="19">
-			</bounds>
+			<bounds x="479" y="375" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="481" y="377" width="15" height="15">
-			</bounds>
+			<bounds x="481" y="377" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="479" y="356" width="19" height="19">
-			</bounds>
+			<bounds x="479" y="356" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="481" y="358" width="15" height="15">
-			</bounds>
+			<bounds x="481" y="358" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="479" y="337" width="19" height="19">
-			</bounds>
+			<bounds x="479" y="337" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="481" y="339" width="15" height="15">
-			</bounds>
+			<bounds x="481" y="339" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="417" y="375" width="19" height="19">
-			</bounds>
+			<bounds x="417" y="375" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="419" y="377" width="15" height="15">
-			</bounds>
+			<bounds x="419" y="377" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="417" y="356" width="19" height="19">
-			</bounds>
+			<bounds x="417" y="356" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="419" y="358" width="15" height="15">
-			</bounds>
+			<bounds x="419" y="358" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="417" y="337" width="19" height="19">
-			</bounds>
+			<bounds x="417" y="337" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="419" y="339" width="15" height="15">
-			</bounds>
+			<bounds x="419" y="339" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="99" y="642" width="30" height="30">
-			</bounds>
+			<bounds x="99" y="642" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="101" y="644" width="26" height="26">
-			</bounds>
+			<bounds x="101" y="644" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="127" y="642" width="30" height="30">
-			</bounds>
+			<bounds x="127" y="642" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="129" y="644" width="26" height="26">
-			</bounds>
+			<bounds x="129" y="644" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="155" y="642" width="30" height="30">
-			</bounds>
+			<bounds x="155" y="642" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="157" y="644" width="26" height="26">
-			</bounds>
+			<bounds x="157" y="644" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="183" y="642" width="50" height="30">
-			</bounds>
+			<bounds x="183" y="642" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="185" y="644" width="46" height="26">
-			</bounds>
+			<bounds x="185" y="644" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="231" y="642" width="30" height="30">
-			</bounds>
+			<bounds x="231" y="642" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="233" y="644" width="26" height="26">
-			</bounds>
+			<bounds x="233" y="644" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="259" y="642" width="30" height="30">
-			</bounds>
+			<bounds x="259" y="642" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="261" y="644" width="26" height="26">
-			</bounds>
+			<bounds x="261" y="644" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="287" y="642" width="30" height="30">
-			</bounds>
+			<bounds x="287" y="642" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="289" y="644" width="26" height="26">
-			</bounds>
+			<bounds x="289" y="644" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="319" y="642" width="40" height="42">
-			</bounds>
+			<bounds x="319" y="642" width="40" height="42"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="321" y="644" width="36" height="38">
-			</bounds>
+			<bounds x="321" y="644" width="36" height="38"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="358" y="642" width="37" height="47">
-			</bounds>
+			<bounds x="358" y="642" width="37" height="47"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="360" y="644" width="33" height="43">
-			</bounds>
+			<bounds x="360" y="644" width="33" height="43"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="394" y="642" width="37" height="47">
-			</bounds>
+			<bounds x="394" y="642" width="37" height="47"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="396" y="644" width="33" height="43">
-			</bounds>
+			<bounds x="396" y="644" width="33" height="43"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="430" y="642" width="37" height="47">
-			</bounds>
+			<bounds x="430" y="642" width="37" height="47"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="432" y="644" width="33" height="43">
-			</bounds>
+			<bounds x="432" y="644" width="33" height="43"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="466" y="642" width="52" height="47">
-			</bounds>
+			<bounds x="466" y="642" width="52" height="47"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="468" y="644" width="48" height="43">
-			</bounds>
+			<bounds x="468" y="644" width="48" height="43"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="28" y="649" width="68" height="19">
-			</bounds>
+			<bounds x="28" y="649" width="68" height="19"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="30" y="651" width="64" height="15">
-			</bounds>
+			<bounds x="30" y="651" width="64" height="15"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="392" y="541" width="40" height="31">
-			</bounds>
+			<bounds x="392" y="541" width="40" height="31"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="394" y="543" width="36" height="27">
-			</bounds>
+			<bounds x="394" y="543" width="36" height="27"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="244" y="408" width="40" height="30">
-			</bounds>
+			<bounds x="244" y="408" width="40" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="246" y="410" width="36" height="26">
-			</bounds>
+			<bounds x="246" y="410" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="206" y="408" width="40" height="30">
-			</bounds>
+			<bounds x="206" y="408" width="40" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="208" y="410" width="36" height="26">
-			</bounds>
+			<bounds x="208" y="410" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="221" y="436" width="52" height="32">
-			</bounds>
+			<bounds x="221" y="436" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="223" y="438" width="48" height="28">
-			</bounds>
+			<bounds x="223" y="438" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="175" y="412" width="22" height="22">
-			</bounds>
+			<bounds x="175" y="412" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="177" y="414" width="18" height="18">
-			</bounds>
+			<bounds x="177" y="414" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="149" y="412" width="22" height="22">
-			</bounds>
+			<bounds x="149" y="412" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="151" y="414" width="18" height="18">
-			</bounds>
+			<bounds x="151" y="414" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="319" y="436" width="52" height="32">
-			</bounds>
+			<bounds x="319" y="436" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="321" y="438" width="48" height="28">
-			</bounds>
+			<bounds x="321" y="438" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="74" y="349" width="52" height="32">
-			</bounds>
+			<bounds x="74" y="349" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="76" y="351" width="48" height="28">
-			</bounds>
+			<bounds x="76" y="351" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="74" y="378" width="52" height="32">
-			</bounds>
+			<bounds x="74" y="378" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="76" y="380" width="48" height="28">
-			</bounds>
+			<bounds x="76" y="380" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="74" y="407" width="52" height="32">
-			</bounds>
+			<bounds x="74" y="407" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="76" y="409" width="48" height="28">
-			</bounds>
+			<bounds x="76" y="409" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="74" y="436" width="52" height="32">
-			</bounds>
+			<bounds x="74" y="436" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="76" y="438" width="48" height="28">
-			</bounds>
+			<bounds x="76" y="438" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="319" y="407" width="52" height="32">
-			</bounds>
+			<bounds x="319" y="407" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="321" y="409" width="48" height="28">
-			</bounds>
+			<bounds x="321" y="409" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="319" y="378" width="52" height="32">
-			</bounds>
+			<bounds x="319" y="378" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="321" y="380" width="48" height="28">
-			</bounds>
+			<bounds x="321" y="380" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="319" y="349" width="52" height="32">
-			</bounds>
+			<bounds x="319" y="349" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="321" y="351" width="48" height="28">
-			</bounds>
+			<bounds x="321" y="351" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="319" y="320" width="52" height="32">
-			</bounds>
+			<bounds x="319" y="320" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="321" y="322" width="48" height="28">
-			</bounds>
+			<bounds x="321" y="322" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="123" y="436" width="52" height="32">
-			</bounds>
+			<bounds x="123" y="436" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="125" y="438" width="48" height="28">
-			</bounds>
+			<bounds x="125" y="438" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="172" y="436" width="52" height="32">
-			</bounds>
+			<bounds x="172" y="436" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="174" y="438" width="48" height="28">
-			</bounds>
+			<bounds x="174" y="438" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="270" y="436" width="52" height="32">
-			</bounds>
+			<bounds x="270" y="436" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="272" y="438" width="48" height="28">
-			</bounds>
+			<bounds x="272" y="438" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="74" y="320" width="52" height="32">
-			</bounds>
+			<bounds x="74" y="320" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="76" y="322" width="48" height="28">
-			</bounds>
+			<bounds x="76" y="322" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="270" y="320" width="52" height="32">
-			</bounds>
+			<bounds x="270" y="320" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="272" y="322" width="48" height="28">
-			</bounds>
+			<bounds x="272" y="322" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="123" y="320" width="52" height="32">
-			</bounds>
+			<bounds x="123" y="320" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="125" y="322" width="48" height="28">
-			</bounds>
+			<bounds x="125" y="322" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="172" y="320" width="52" height="32">
-			</bounds>
+			<bounds x="172" y="320" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="174" y="322" width="48" height="28">
-			</bounds>
+			<bounds x="174" y="322" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="221" y="320" width="52" height="32">
-			</bounds>
+			<bounds x="221" y="320" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="223" y="322" width="48" height="28">
-			</bounds>
+			<bounds x="223" y="322" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="282" y="352" width="40" height="30">
-			</bounds>
+			<bounds x="282" y="352" width="40" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="284" y="354" width="36" height="26">
-			</bounds>
+			<bounds x="284" y="354" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="206" y="352" width="40" height="30">
-			</bounds>
+			<bounds x="206" y="352" width="40" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="208" y="354" width="36" height="26">
-			</bounds>
+			<bounds x="208" y="354" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="282" y="380" width="40" height="30">
-			</bounds>
+			<bounds x="282" y="380" width="40" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="284" y="382" width="36" height="26">
-			</bounds>
+			<bounds x="284" y="382" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="282" y="408" width="40" height="30">
-			</bounds>
+			<bounds x="282" y="408" width="40" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="284" y="410" width="36" height="26">
-			</bounds>
+			<bounds x="284" y="410" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="244" y="352" width="40" height="30">
-			</bounds>
+			<bounds x="244" y="352" width="40" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="246" y="354" width="36" height="26">
-			</bounds>
+			<bounds x="246" y="354" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="206" y="380" width="40" height="30">
-			</bounds>
+			<bounds x="206" y="380" width="40" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="208" y="382" width="36" height="26">
-			</bounds>
+			<bounds x="208" y="382" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="532" y="530" width="36" height="24">
-			</bounds>
+			<bounds x="532" y="530" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="534" y="532" width="32" height="20">
-			</bounds>
+			<bounds x="534" y="532" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="532" y="552" width="36" height="24">
-			</bounds>
+			<bounds x="532" y="552" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="534" y="554" width="32" height="20">
-			</bounds>
+			<bounds x="534" y="554" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="498" y="552" width="36" height="24">
-			</bounds>
+			<bounds x="498" y="552" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="500" y="554" width="32" height="20">
-			</bounds>
+			<bounds x="500" y="554" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="498" y="574" width="36" height="24">
-			</bounds>
+			<bounds x="498" y="574" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="500" y="576" width="32" height="20">
-			</bounds>
+			<bounds x="500" y="576" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="498" y="530" width="36" height="24">
-			</bounds>
+			<bounds x="498" y="530" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="500" y="532" width="32" height="20">
-			</bounds>
+			<bounds x="500" y="532" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="566" y="530" width="36" height="24">
-			</bounds>
+			<bounds x="566" y="530" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="568" y="532" width="32" height="20">
-			</bounds>
+			<bounds x="568" y="532" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="566" y="552" width="36" height="24">
-			</bounds>
+			<bounds x="566" y="552" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="568" y="554" width="32" height="20">
-			</bounds>
+			<bounds x="568" y="554" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="498" y="508" width="36" height="24">
-			</bounds>
+			<bounds x="498" y="508" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="500" y="510" width="32" height="20">
-			</bounds>
+			<bounds x="500" y="510" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="532" y="508" width="36" height="24">
-			</bounds>
+			<bounds x="532" y="508" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="534" y="510" width="32" height="20">
-			</bounds>
+			<bounds x="534" y="510" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="566" y="508" width="36" height="24">
-			</bounds>
+			<bounds x="566" y="508" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="568" y="510" width="32" height="20">
-			</bounds>
+			<bounds x="568" y="510" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="498" y="486" width="104" height="24">
-			</bounds>
+			<bounds x="498" y="486" width="104" height="24"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="500" y="488" width="100" height="20">
-			</bounds>
+			<bounds x="500" y="488" width="100" height="20"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="566" y="574" width="36" height="24">
-			</bounds>
+			<bounds x="566" y="574" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="568" y="576" width="32" height="20">
-			</bounds>
+			<bounds x="568" y="576" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="566" y="596" width="36" height="24">
-			</bounds>
+			<bounds x="566" y="596" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="568" y="598" width="32" height="20">
-			</bounds>
+			<bounds x="568" y="598" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="532" y="596" width="36" height="24">
-			</bounds>
+			<bounds x="532" y="596" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="534" y="598" width="32" height="20">
-			</bounds>
+			<bounds x="534" y="598" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="498" y="596" width="36" height="24">
-			</bounds>
+			<bounds x="498" y="596" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="500" y="598" width="32" height="20">
-			</bounds>
+			<bounds x="500" y="598" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="532" y="574" width="36" height="24">
-			</bounds>
+			<bounds x="532" y="574" width="36" height="24"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="534" y="576" width="32" height="20">
-			</bounds>
+			<bounds x="534" y="576" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="563" y="278" width="47" height="19">
-			</bounds>
+			<bounds x="563" y="278" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="565" y="280" width="43" height="15">
-			</bounds>
+			<bounds x="565" y="280" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="563" y="239" width="47" height="19">
-			</bounds>
+			<bounds x="563" y="239" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="565" y="241" width="43" height="15">
-			</bounds>
+			<bounds x="565" y="241" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="720" y="239" width="47" height="19">
-			</bounds>
+			<bounds x="720" y="239" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="722" y="241" width="43" height="15">
-			</bounds>
+			<bounds x="722" y="241" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="609" y="192" width="105" height="32">
-			</bounds>
+			<bounds x="609" y="192" width="105" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="611" y="194" width="101" height="28">
-			</bounds>
+			<bounds x="611" y="194" width="101" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="563" y="315" width="47" height="19">
-			</bounds>
+			<bounds x="563" y="315" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="565" y="317" width="43" height="15">
-			</bounds>
+			<bounds x="565" y="317" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="721" y="278" width="47" height="19">
-			</bounds>
+			<bounds x="721" y="278" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="723" y="280" width="43" height="15">
-			</bounds>
+			<bounds x="723" y="280" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="723" y="315" width="47" height="19">
-			</bounds>
+			<bounds x="723" y="315" width="47" height="19"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="725" y="317" width="43" height="15">
-			</bounds>
+			<bounds x="725" y="317" width="43" height="15"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="642" y="311" width="19" height="19">
-			</bounds>
+			<bounds x="642" y="311" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="644" y="313" width="15" height="15">
-			</bounds>
+			<bounds x="644" y="313" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="680" y="311" width="19" height="19">
-			</bounds>
+			<bounds x="680" y="311" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="682" y="313" width="15" height="15">
-			</bounds>
+			<bounds x="682" y="313" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="661" y="311" width="19" height="19">
-			</bounds>
+			<bounds x="661" y="311" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="663" y="313" width="15" height="15">
-			</bounds>
+			<bounds x="663" y="313" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="623" y="311" width="19" height="19">
-			</bounds>
+			<bounds x="623" y="311" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="625" y="313" width="15" height="15">
-			</bounds>
+			<bounds x="625" y="313" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="658" y="43" width="35" height="43">
-			</bounds>
+			<bounds x="658" y="43" width="35" height="43"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="660" y="45" width="31" height="39">
-			</bounds>
+			<bounds x="660" y="45" width="31" height="39"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_160_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="557" y="685" width="51" height="40">
-			</bounds>
+			<bounds x="557" y="685" width="51" height="40"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_160" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="559" y="687" width="47" height="36">
-			</bounds>
+			<bounds x="559" y="687" width="47" height="36"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_161_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="60" y="264" width="105" height="59">
-			</bounds>
+			<bounds x="60" y="264" width="105" height="59"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_161" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="62" y="266" width="101" height="55">
-			</bounds>
+			<bounds x="62" y="266" width="101" height="55"/>
 		</backdrop>
 		<backdrop name="lamp56" element="colour_button_162_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="464" y="399" width="49" height="38">
-			</bounds>
+			<bounds x="464" y="399" width="49" height="38"/>
 		</backdrop>
 		<backdrop name="lamp56" element="colour_button_162" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="466" y="401" width="45" height="34">
-			</bounds>
+			<bounds x="466" y="401" width="45" height="34"/>
 		</backdrop>
 		<backdrop name="lamp57" element="colour_button_163_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="403" y="398" width="49" height="38">
-			</bounds>
+			<bounds x="403" y="398" width="49" height="38"/>
 		</backdrop>
 		<backdrop name="lamp57" element="colour_button_163" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="405" y="400" width="45" height="34">
-			</bounds>
+			<bounds x="405" y="400" width="45" height="34"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_164_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="379" y="694" width="75" height="27">
-			</bounds>
+			<bounds x="379" y="694" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_164" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="381" y="696" width="71" height="23">
-			</bounds>
+			<bounds x="381" y="696" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_165_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="289" y="694" width="75" height="27">
-			</bounds>
+			<bounds x="289" y="694" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_165" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="291" y="696" width="71" height="23">
-			</bounds>
+			<bounds x="291" y="696" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_166_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="32" y="694" width="75" height="27">
-			</bounds>
+			<bounds x="32" y="694" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_166" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="34" y="696" width="71" height="23">
-			</bounds>
+			<bounds x="34" y="696" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_167_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="115" y="694" width="75" height="27">
-			</bounds>
+			<bounds x="115" y="694" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_167" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="117" y="696" width="71" height="23">
-			</bounds>
+			<bounds x="117" y="696" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_168_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="201" y="694" width="75" height="27">
-			</bounds>
+			<bounds x="201" y="694" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_168" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="203" y="696" width="71" height="23">
-			</bounds>
+			<bounds x="203" y="696" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_169_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="463" y="694" width="75" height="27">
-			</bounds>
+			<bounds x="463" y="694" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_169" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="465" y="696" width="71" height="23">
-			</bounds>
+			<bounds x="465" y="696" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp8" element="colour_button_171_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="35" y="579" width="57" height="38">
-			</bounds>
+			<bounds x="35" y="579" width="57" height="38"/>
 		</backdrop>
 		<backdrop name="lamp8" element="colour_button_171" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="37" y="581" width="53" height="34">
-			</bounds>
+			<bounds x="37" y="581" width="53" height="34"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="467" y="440" width="20" height="24">
-			</bounds>
+			<bounds x="467" y="440" width="20" height="24"/>
 		</backdrop>
 		<backdrop name="digit14" element="led_digit_red">
-			<bounds x="467" y="440" width="20" height="24">
-			</bounds>
+			<bounds x="467" y="440" width="20" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="467" y="440" width="20" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="467" y="440" width="20" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="485" y="440" width="20" height="24">
-			</bounds>
+			<bounds x="485" y="440" width="20" height="24"/>
 		</backdrop>
 		<backdrop name="digit12" element="led_digit_red">
-			<bounds x="485" y="440" width="20" height="24">
-			</bounds>
+			<bounds x="485" y="440" width="20" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="485" y="440" width="20" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="485" y="440" width="20" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="408" y="440" width="20" height="24">
-			</bounds>
+			<bounds x="408" y="440" width="20" height="24"/>
 		</backdrop>
 		<backdrop name="digit10" element="led_digit_red">
-			<bounds x="408" y="440" width="20" height="24">
-			</bounds>
+			<bounds x="408" y="440" width="20" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="408" y="440" width="20" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="408" y="440" width="20" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="426" y="440" width="20" height="24">
-			</bounds>
+			<bounds x="426" y="440" width="20" height="24"/>
 		</backdrop>
 		<backdrop name="digit8" element="led_digit_red">
-			<bounds x="426" y="440" width="20" height="24">
-			</bounds>
+			<bounds x="426" y="440" width="20" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="426" y="440" width="20" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="426" y="440" width="20" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="60" y="532" width="24" height="32">
-			</bounds>
+			<bounds x="60" y="532" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit16" element="led_digit_red">
-			<bounds x="60" y="532" width="24" height="32">
-			</bounds>
+			<bounds x="60" y="532" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="60" y="532" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="60" y="532" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="37" y="532" width="24" height="32">
-			</bounds>
+			<bounds x="37" y="532" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit39" element="led_digit_red">
-			<bounds x="37" y="532" width="24" height="32">
-			</bounds>
+			<bounds x="37" y="532" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="37" y="532" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="37" y="532" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="230" y="279" width="18" height="24">
-			</bounds>
+			<bounds x="230" y="279" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="digit4" element="led_digit_red">
-			<bounds x="230" y="279" width="18" height="24">
-			</bounds>
+			<bounds x="230" y="279" width="18" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="230" y="279" width="18" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="230" y="279" width="18" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="212" y="279" width="18" height="24">
-			</bounds>
+			<bounds x="212" y="279" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="212" y="279" width="18" height="24">
-			</bounds>
+			<bounds x="212" y="279" width="18" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="212" y="279" width="18" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="212" y="279" width="18" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="247" y="279" width="18" height="24">
-			</bounds>
+			<bounds x="247" y="279" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="247" y="279" width="18" height="24">
-			</bounds>
+			<bounds x="247" y="279" width="18" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="247" y="279" width="18" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="247" y="279" width="18" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="264" y="279" width="18" height="24">
-			</bounds>
+			<bounds x="264" y="279" width="18" height="24"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="264" y="279" width="18" height="24">
-			</bounds>
+			<bounds x="264" y="279" width="18" height="24"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="264" y="279" width="18" height="24">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="264" y="279" width="18" height="24"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="124" y="471" width="227" height="20">
-			</bounds>
+			<bounds x="124" y="471" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="124" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="124" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="138" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="138" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="152" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="152" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="166" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="166" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="180" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="180" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="194" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="194" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="208" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="208" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="222" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="222" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="236" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="236" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="250" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="250" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="264" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="264" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="278" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="278" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="292" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="292" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="306" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="306" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="320" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="320" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="334" y="471" width="14" height="20">
-			</bounds>
+			<bounds x="334" y="471" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="247" y="387" width="36" height="20">
-			</bounds>
+			<bounds x="247" y="387" width="36" height="20"/>
 		</backdrop>
 		<backdrop name="label130" element="label_130">
-			<bounds x="192" y="273" width="16" height="34">
-			</bounds>
+			<bounds x="192" y="273" width="16" height="34"/>
 		</backdrop>
 		<backdrop name="label154" element="label_154">
-			<bounds x="643" y="250" width="39" height="52">
-			</bounds>
+			<bounds x="643" y="250" width="39" height="52"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_button" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_button" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_button" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="312.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1100.0000" y="312.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="322.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1105.0000" y="322.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="332.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1110.0000" y="332.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="342.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1115.0000" y="342.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="352.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1120.0000" y="352.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="362.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1125.0000" y="362.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel6" element="debug_stepper_value">
-			<bounds x="1100" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="552" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_5">
-			<bounds x="1180" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="552" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4chick.lay
+++ b/src/mame/layout/sc4chick.lay
@@ -8,6810 +8,4961 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Chickendales">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chickendales">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="nUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="nUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_34_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_34_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_96_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_96">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_97_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_97">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_98_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_98">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Auto">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_99_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_99">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_100_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_100">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_101_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_101">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_102_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_102">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="748" height="503">
-			</bounds>
+			<bounds x="0" y="0" width="748" height="503"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="101" y="316" width="80" height="140">
-			</bounds>
+			<bounds x="101" y="316" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="316.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="101.0000" y="316.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.3333" y="317.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="104.3333" y="317.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="107.6667" y="319.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="107.6667" y="319.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="111.0000" y="321.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="111.0000" y="321.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="114.3333" y="323.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="114.3333" y="323.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="117.6667" y="325.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="117.6667" y="325.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="362.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="101.0000" y="362.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.3333" y="364.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="104.3333" y="364.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="107.6667" y="366.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="107.6667" y="366.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="111.0000" y="368.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="111.0000" y="368.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="114.3333" y="370.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="114.3333" y="370.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="117.6667" y="372.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="117.6667" y="372.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="409.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="101.0000" y="409.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.3333" y="411.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="104.3333" y="411.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="107.6667" y="413.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="107.6667" y="413.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="111.0000" y="415.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="111.0000" y="415.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="114.3333" y="417.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="114.3333" y="417.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="117.6667" y="419.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="117.6667" y="419.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="101" y="316" width="80" height="140">
-			</bounds>
+			<bounds x="101" y="316" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="185" y="316" width="80" height="140">
-			</bounds>
+			<bounds x="185" y="316" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="185.0000" y="316.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="185.0000" y="316.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="188.3333" y="317.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="188.3333" y="317.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="191.6667" y="319.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="191.6667" y="319.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="195.0000" y="321.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="195.0000" y="321.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="198.3333" y="323.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="198.3333" y="323.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="201.6667" y="325.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="201.6667" y="325.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="185.0000" y="362.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="185.0000" y="362.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="188.3333" y="364.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="188.3333" y="364.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="191.6667" y="366.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="191.6667" y="366.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="195.0000" y="368.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="195.0000" y="368.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="198.3333" y="370.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="198.3333" y="370.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="201.6667" y="372.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="201.6667" y="372.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="185.0000" y="409.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="185.0000" y="409.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="188.3333" y="411.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="188.3333" y="411.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="191.6667" y="413.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="191.6667" y="413.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="195.0000" y="415.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="195.0000" y="415.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="198.3333" y="417.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="198.3333" y="417.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="201.6667" y="419.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="201.6667" y="419.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="185" y="316" width="80" height="140">
-			</bounds>
+			<bounds x="185" y="316" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="269" y="316" width="80" height="140">
-			</bounds>
+			<bounds x="269" y="316" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="269.0000" y="316.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="269.0000" y="316.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="272.3333" y="317.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="272.3333" y="317.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="275.6667" y="319.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="275.6667" y="319.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="279.0000" y="321.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="279.0000" y="321.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="282.3333" y="323.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="282.3333" y="323.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="285.6667" y="325.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="285.6667" y="325.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="269.0000" y="362.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="269.0000" y="362.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="272.3333" y="364.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="272.3333" y="364.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="275.6667" y="366.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="275.6667" y="366.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="279.0000" y="368.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="279.0000" y="368.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="282.3333" y="370.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="282.3333" y="370.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="285.6667" y="372.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="285.6667" y="372.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="269.0000" y="409.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="269.0000" y="409.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="272.3333" y="411.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="272.3333" y="411.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="275.6667" y="413.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="275.6667" y="413.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="279.0000" y="415.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="279.0000" y="415.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="282.3333" y="417.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="282.3333" y="417.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="285.6667" y="419.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="285.6667" y="419.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="269" y="316" width="80" height="140">
-			</bounds>
+			<bounds x="269" y="316" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="89" y="6" width="257" height="37">
-			</bounds>
+			<bounds x="89" y="6" width="257" height="37"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="91" y="8" width="253" height="33">
-			</bounds>
+			<bounds x="91" y="8" width="253" height="33"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="33" y="390" width="37" height="32">
-			</bounds>
+			<bounds x="33" y="390" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="35" y="392" width="33" height="28">
-			</bounds>
+			<bounds x="35" y="392" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="21" y="425" width="52" height="32">
-			</bounds>
+			<bounds x="21" y="425" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="23" y="427" width="48" height="28">
-			</bounds>
+			<bounds x="23" y="427" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="26" y="355" width="37" height="32">
-			</bounds>
+			<bounds x="26" y="355" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="28" y="357" width="33" height="28">
-			</bounds>
+			<bounds x="28" y="357" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1_border" state="0">
-			<bounds x="19" y="321" width="37" height="32">
-			</bounds>
+			<bounds x="19" y="321" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp34" element="lamp_34_1" state="0">
-			<bounds x="21" y="323" width="33" height="28">
-			</bounds>
+			<bounds x="21" y="323" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="247" y="160" width="22" height="22">
-			</bounds>
+			<bounds x="247" y="160" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="249" y="162" width="18" height="18">
-			</bounds>
+			<bounds x="249" y="162" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="248" y="98" width="22" height="22">
-			</bounds>
+			<bounds x="248" y="98" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="250" y="100" width="18" height="18">
-			</bounds>
+			<bounds x="250" y="100" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="173" y="98" width="22" height="22">
-			</bounds>
+			<bounds x="173" y="98" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="175" y="100" width="18" height="18">
-			</bounds>
+			<bounds x="175" y="100" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="173" y="160" width="22" height="22">
-			</bounds>
+			<bounds x="173" y="160" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="175" y="162" width="18" height="18">
-			</bounds>
+			<bounds x="175" y="162" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_96_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="418" y="8" width="75" height="27">
-			</bounds>
+			<bounds x="418" y="8" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_96" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="420" y="10" width="71" height="23">
-			</bounds>
+			<bounds x="420" y="10" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_97_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="444" y="466" width="75" height="27">
-			</bounds>
+			<bounds x="444" y="466" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_97" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="446" y="468" width="71" height="23">
-			</bounds>
+			<bounds x="446" y="468" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_98_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="360" y="466" width="75" height="27">
-			</bounds>
+			<bounds x="360" y="466" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_98" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="362" y="468" width="71" height="23">
-			</bounds>
+			<bounds x="362" y="468" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_99_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1" y="466" width="75" height="27">
-			</bounds>
+			<bounds x="1" y="466" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_99" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="3" y="468" width="71" height="23">
-			</bounds>
+			<bounds x="3" y="468" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_100_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="274" y="466" width="75" height="27">
-			</bounds>
+			<bounds x="274" y="466" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_100" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="276" y="468" width="71" height="23">
-			</bounds>
+			<bounds x="276" y="468" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_101_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="188" y="466" width="75" height="27">
-			</bounds>
+			<bounds x="188" y="466" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_101" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="190" y="468" width="71" height="23">
-			</bounds>
+			<bounds x="190" y="468" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_102_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="103" y="466" width="75" height="27">
-			</bounds>
+			<bounds x="103" y="466" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_102" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="105" y="468" width="71" height="23">
-			</bounds>
+			<bounds x="105" y="468" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="59" y="279" width="323" height="27">
-			</bounds>
+			<bounds x="59" y="279" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="59" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="59" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="79" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="79" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="99" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="99" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="119" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="119" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="139" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="139" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="159" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="159" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="179" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="179" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="199" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="199" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="219" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="219" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="239" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="239" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="259" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="259" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="279" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="279" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="299" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="299" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="319" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="319" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="339" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="339" y="279" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="359" y="279" width="20" height="27">
-			</bounds>
+			<bounds x="359" y="279" width="20" height="27"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4chuba.lay
+++ b/src/mame/layout/sc4chuba.lay
@@ -8,13588 +8,7841 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Blind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Date">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Blind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Date">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
 		<text string="The Strat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="+1??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="The Strat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="+1??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Hit The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hit The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Top">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Star">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Star">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
 		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="Shot +1?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="Shot +1?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Strat +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Strat +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Shot +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Shot +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
 		<text string="The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Star">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Star">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Pontoon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Pontoon">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Limo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Limo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Blind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Date">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Blind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Date">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Big Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Big Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Star">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Star">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="High">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Roller">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="High">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Roller">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7 UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7 UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Golden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nugget">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Golden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nugget">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Blind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Date">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Blind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Date">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
 		<text string="The Strat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="+2??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="The Strat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="+2??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Star">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Dust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Star">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Dust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Limo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Limo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
 		<text string="Bus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Bus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Cash your Chips">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Cash your Chips">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Deported">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Deported">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Taxi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Taxi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Scrounge Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Scrounge Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Change Direction">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Change Direction">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Roll Even">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Roll Even">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Bonus Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Bonus Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Stardust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stardust">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Chubby's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Blind Date">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Chubby's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Blind Date">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
 		<text string="Beg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Beg">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="On The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="On The">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Full">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Monty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Full">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Monty">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_143_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_143_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Golden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nugget">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Golden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nugget">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MGM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MGM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="End">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="End">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="End">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="End">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="End">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bell">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="End">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_194_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_194">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_195_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_195">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_197_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_197">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_198_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_198">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_199_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_199">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_200_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_200">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_201_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_201">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_202_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_202">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_124">
 		<text string="Chubby">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_125">
 		<text string="Does">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_126">
 		<text string="Vegas">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_188">
 		<text string="Winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_189">
 		<text string="Winline">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_191">
 		<text string="MFME 9.4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="677">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="677"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="332" y="458" width="80" height="120">
-			</bounds>
+			<bounds x="332" y="458" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="332.0000" y="458.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="332.0000" y="458.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="335.3333" y="459.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="335.3333" y="459.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="338.6667" y="461.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="338.6667" y="461.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="342.0000" y="463.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="342.0000" y="463.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="345.3333" y="464.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="345.3333" y="464.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="348.6667" y="466.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="348.6667" y="466.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="332.0000" y="498.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="332.0000" y="498.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="335.3333" y="499.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="335.3333" y="499.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="338.6667" y="501.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="338.6667" y="501.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="342.0000" y="503.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="342.0000" y="503.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="345.3333" y="504.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="345.3333" y="504.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="348.6667" y="506.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="348.6667" y="506.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="332.0000" y="538.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="332.0000" y="538.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="335.3333" y="539.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="335.3333" y="539.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="338.6667" y="541.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="338.6667" y="541.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="342.0000" y="543.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="342.0000" y="543.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="345.3333" y="544.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="345.3333" y="544.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="348.6667" y="546.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="348.6667" y="546.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="332" y="458" width="80" height="120">
-			</bounds>
+			<bounds x="332" y="458" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="414" y="458" width="80" height="120">
-			</bounds>
+			<bounds x="414" y="458" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="414.0000" y="458.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="414.0000" y="458.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="459.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="417.3333" y="459.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="420.6667" y="461.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="420.6667" y="461.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="424.0000" y="463.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="424.0000" y="463.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="464.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="427.3333" y="464.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="430.6667" y="466.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="430.6667" y="466.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="414.0000" y="498.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="414.0000" y="498.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="499.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="417.3333" y="499.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="420.6667" y="501.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="420.6667" y="501.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="424.0000" y="503.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="424.0000" y="503.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="504.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="427.3333" y="504.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="430.6667" y="506.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="430.6667" y="506.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="414.0000" y="538.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="414.0000" y="538.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="417.3333" y="539.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="417.3333" y="539.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="420.6667" y="541.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="420.6667" y="541.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="424.0000" y="543.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="424.0000" y="543.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="544.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="427.3333" y="544.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="430.6667" y="546.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="430.6667" y="546.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="414" y="458" width="80" height="120">
-			</bounds>
+			<bounds x="414" y="458" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="496" y="458" width="80" height="120">
-			</bounds>
+			<bounds x="496" y="458" width="80" height="120"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="496.0000" y="458.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="496.0000" y="458.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="499.3333" y="459.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="499.3333" y="459.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="502.6667" y="461.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="502.6667" y="461.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="506.0000" y="463.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="506.0000" y="463.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="509.3333" y="464.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="509.3333" y="464.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="512.6667" y="466.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="512.6667" y="466.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="496.0000" y="498.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="496.0000" y="498.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="499.3333" y="499.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="499.3333" y="499.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="502.6667" y="501.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="502.6667" y="501.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="506.0000" y="503.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="506.0000" y="503.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="509.3333" y="504.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="509.3333" y="504.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="512.6667" y="506.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="512.6667" y="506.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="496.0000" y="538.0000" width="80.0000" height="40.0000">
-			</bounds>
+			<bounds x="496.0000" y="538.0000" width="80.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="499.3333" y="539.6667" width="73.3333" height="36.6667">
-			</bounds>
+			<bounds x="499.3333" y="539.6667" width="73.3333" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="502.6667" y="541.3333" width="66.6667" height="33.3333">
-			</bounds>
+			<bounds x="502.6667" y="541.3333" width="66.6667" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="506.0000" y="543.0000" width="60.0000" height="30.0000">
-			</bounds>
+			<bounds x="506.0000" y="543.0000" width="60.0000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="509.3333" y="544.6667" width="53.3333" height="26.6667">
-			</bounds>
+			<bounds x="509.3333" y="544.6667" width="53.3333" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="512.6667" y="546.3333" width="46.6667" height="23.3333">
-			</bounds>
+			<bounds x="512.6667" y="546.3333" width="46.6667" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="496" y="458" width="80" height="120">
-			</bounds>
+			<bounds x="496" y="458" width="80" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="48" y="199" width="80" height="80">
-			</bounds>
+			<bounds x="48" y="199" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="48.0000" y="199.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="48.0000" y="199.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="51.3333" y="202.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="51.3333" y="202.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="54.6667" y="205.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="54.6667" y="205.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="58.0000" y="209.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="58.0000" y="209.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="61.3333" y="212.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="61.3333" y="212.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="64.6667" y="215.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="64.6667" y="215.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="48" y="199" width="80" height="80">
-			</bounds>
+			<bounds x="48" y="199" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="9" y="228" width="32" height="32">
-			</bounds>
+			<bounds x="9" y="228" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="11" y="230" width="28" height="28">
-			</bounds>
+			<bounds x="11" y="230" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="596" y="584" width="72" height="47">
-			</bounds>
+			<bounds x="596" y="584" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="598" y="586" width="68" height="43">
-			</bounds>
+			<bounds x="598" y="586" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="525" y="583" width="72" height="47">
-			</bounds>
+			<bounds x="525" y="583" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="527" y="585" width="68" height="43">
-			</bounds>
+			<bounds x="527" y="585" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="454" y="583" width="72" height="47">
-			</bounds>
+			<bounds x="454" y="583" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="456" y="585" width="68" height="43">
-			</bounds>
+			<bounds x="456" y="585" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="383" y="583" width="72" height="47">
-			</bounds>
+			<bounds x="383" y="583" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="385" y="585" width="68" height="43">
-			</bounds>
+			<bounds x="385" y="585" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="312" y="584" width="72" height="47">
-			</bounds>
+			<bounds x="312" y="584" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="314" y="586" width="68" height="43">
-			</bounds>
+			<bounds x="314" y="586" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="242" y="584" width="72" height="47">
-			</bounds>
+			<bounds x="242" y="584" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="244" y="586" width="68" height="43">
-			</bounds>
+			<bounds x="244" y="586" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="334" y="367" width="52" height="32">
-			</bounds>
+			<bounds x="334" y="367" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="336" y="369" width="48" height="28">
-			</bounds>
+			<bounds x="336" y="369" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="429" y="381" width="52" height="29">
-			</bounds>
+			<bounds x="429" y="381" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="431" y="383" width="48" height="25">
-			</bounds>
+			<bounds x="431" y="383" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="430" y="353" width="52" height="29">
-			</bounds>
+			<bounds x="430" y="353" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="432" y="355" width="48" height="25">
-			</bounds>
+			<bounds x="432" y="355" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="430" y="325" width="52" height="29">
-			</bounds>
+			<bounds x="430" y="325" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="432" y="327" width="48" height="25">
-			</bounds>
+			<bounds x="432" y="327" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="430" y="297" width="52" height="29">
-			</bounds>
+			<bounds x="430" y="297" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="432" y="299" width="48" height="25">
-			</bounds>
+			<bounds x="432" y="299" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="430" y="269" width="52" height="29">
-			</bounds>
+			<bounds x="430" y="269" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="432" y="271" width="48" height="25">
-			</bounds>
+			<bounds x="432" y="271" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="430" y="241" width="52" height="29">
-			</bounds>
+			<bounds x="430" y="241" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="432" y="243" width="48" height="25">
-			</bounds>
+			<bounds x="432" y="243" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="430" y="214" width="52" height="29">
-			</bounds>
+			<bounds x="430" y="214" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="432" y="216" width="48" height="25">
-			</bounds>
+			<bounds x="432" y="216" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="377" y="171" width="82" height="42">
-			</bounds>
+			<bounds x="377" y="171" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="379" y="173" width="78" height="38">
-			</bounds>
+			<bounds x="379" y="173" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="537" y="171" width="72" height="42">
-			</bounds>
+			<bounds x="537" y="171" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="539" y="173" width="68" height="38">
-			</bounds>
+			<bounds x="539" y="173" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="458" y="171" width="82" height="42">
-			</bounds>
+			<bounds x="458" y="171" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="460" y="173" width="78" height="38">
-			</bounds>
+			<bounds x="460" y="173" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="308" y="171" width="72" height="42">
-			</bounds>
+			<bounds x="308" y="171" width="72" height="42"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="310" y="173" width="68" height="38">
-			</bounds>
+			<bounds x="310" y="173" width="68" height="38"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="248" y="187" width="62" height="62">
-			</bounds>
+			<bounds x="248" y="187" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="250" y="189" width="58" height="58">
-			</bounds>
+			<bounds x="250" y="189" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="607" y="184" width="62" height="62">
-			</bounds>
+			<bounds x="607" y="184" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="609" y="186" width="58" height="58">
-			</bounds>
+			<bounds x="609" y="186" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="667" y="191" width="62" height="62">
-			</bounds>
+			<bounds x="667" y="191" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="669" y="193" width="58" height="58">
-			</bounds>
+			<bounds x="669" y="193" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="667" y="253" width="72" height="47">
-			</bounds>
+			<bounds x="667" y="253" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="669" y="255" width="68" height="43">
-			</bounds>
+			<bounds x="669" y="255" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="667" y="300" width="72" height="47">
-			</bounds>
+			<bounds x="667" y="300" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="669" y="302" width="68" height="43">
-			</bounds>
+			<bounds x="669" y="302" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="667" y="347" width="72" height="47">
-			</bounds>
+			<bounds x="667" y="347" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="669" y="349" width="68" height="43">
-			</bounds>
+			<bounds x="669" y="349" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="667" y="394" width="72" height="47">
-			</bounds>
+			<bounds x="667" y="394" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="669" y="396" width="68" height="43">
-			</bounds>
+			<bounds x="669" y="396" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="667" y="441" width="72" height="47">
-			</bounds>
+			<bounds x="667" y="441" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="669" y="443" width="68" height="43">
-			</bounds>
+			<bounds x="669" y="443" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="667" y="488" width="72" height="47">
-			</bounds>
+			<bounds x="667" y="488" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="669" y="490" width="68" height="43">
-			</bounds>
+			<bounds x="669" y="490" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="667" y="535" width="72" height="47">
-			</bounds>
+			<bounds x="667" y="535" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="669" y="537" width="68" height="43">
-			</bounds>
+			<bounds x="669" y="537" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="667" y="582" width="72" height="47">
-			</bounds>
+			<bounds x="667" y="582" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="669" y="584" width="68" height="43">
-			</bounds>
+			<bounds x="669" y="584" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="187" y="195" width="62" height="62">
-			</bounds>
+			<bounds x="187" y="195" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="189" y="197" width="58" height="58">
-			</bounds>
+			<bounds x="189" y="197" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="178" y="257" width="72" height="47">
-			</bounds>
+			<bounds x="178" y="257" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="180" y="259" width="68" height="43">
-			</bounds>
+			<bounds x="180" y="259" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="178" y="304" width="72" height="47">
-			</bounds>
+			<bounds x="178" y="304" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="180" y="306" width="68" height="43">
-			</bounds>
+			<bounds x="180" y="306" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="178" y="351" width="72" height="47">
-			</bounds>
+			<bounds x="178" y="351" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="180" y="353" width="68" height="43">
-			</bounds>
+			<bounds x="180" y="353" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="178" y="398" width="72" height="47">
-			</bounds>
+			<bounds x="178" y="398" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="180" y="400" width="68" height="43">
-			</bounds>
+			<bounds x="180" y="400" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="178" y="445" width="72" height="47">
-			</bounds>
+			<bounds x="178" y="445" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="180" y="447" width="68" height="43">
-			</bounds>
+			<bounds x="180" y="447" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="178" y="492" width="72" height="47">
-			</bounds>
+			<bounds x="178" y="492" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="180" y="494" width="68" height="43">
-			</bounds>
+			<bounds x="180" y="494" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="178" y="539" width="72" height="47">
-			</bounds>
+			<bounds x="178" y="539" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="180" y="541" width="68" height="43">
-			</bounds>
+			<bounds x="180" y="541" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="764" y="193" width="52" height="52">
-			</bounds>
+			<bounds x="764" y="193" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="766" y="195" width="48" height="48">
-			</bounds>
+			<bounds x="766" y="195" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="671" y="62" width="122" height="22">
-			</bounds>
+			<bounds x="671" y="62" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="673" y="64" width="118" height="18">
-			</bounds>
+			<bounds x="673" y="64" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="670" y="143" width="122" height="22">
-			</bounds>
+			<bounds x="670" y="143" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="672" y="145" width="118" height="18">
-			</bounds>
+			<bounds x="672" y="145" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="672" y="82" width="122" height="22">
-			</bounds>
+			<bounds x="672" y="82" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="674" y="84" width="118" height="18">
-			</bounds>
+			<bounds x="674" y="84" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="671" y="102" width="122" height="22">
-			</bounds>
+			<bounds x="671" y="102" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="673" y="104" width="118" height="18">
-			</bounds>
+			<bounds x="673" y="104" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="671" y="123" width="122" height="22">
-			</bounds>
+			<bounds x="671" y="123" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="673" y="125" width="118" height="18">
-			</bounds>
+			<bounds x="673" y="125" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="671" y="43" width="122" height="22">
-			</bounds>
+			<bounds x="671" y="43" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="673" y="45" width="118" height="18">
-			</bounds>
+			<bounds x="673" y="45" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="670" y="164" width="122" height="22">
-			</bounds>
+			<bounds x="670" y="164" width="122" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="672" y="166" width="118" height="18">
-			</bounds>
+			<bounds x="672" y="166" width="118" height="18"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="662" y="3" width="142" height="42">
-			</bounds>
+			<bounds x="662" y="3" width="142" height="42"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="664" y="5" width="138" height="38">
-			</bounds>
+			<bounds x="664" y="5" width="138" height="38"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="833" y="294" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="294" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="835" y="296" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="296" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="833" y="230" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="230" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="835" y="232" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="232" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="833" y="358" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="358" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="835" y="360" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="360" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="833" y="326" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="326" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="835" y="328" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="328" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="833" y="262" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="262" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="835" y="264" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="264" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="833" y="166" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="166" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="835" y="168" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="168" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="833" y="199" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="199" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="835" y="201" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="201" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="830" y="5" width="77" height="32">
-			</bounds>
+			<bounds x="830" y="5" width="77" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="832" y="7" width="73" height="28">
-			</bounds>
+			<bounds x="832" y="7" width="73" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="833" y="390" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="390" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="835" y="392" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="392" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="832" y="37" width="72" height="32">
-			</bounds>
+			<bounds x="832" y="37" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="834" y="39" width="68" height="28">
-			</bounds>
+			<bounds x="834" y="39" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="832" y="69" width="72" height="32">
-			</bounds>
+			<bounds x="832" y="69" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="834" y="71" width="68" height="28">
-			</bounds>
+			<bounds x="834" y="71" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="832" y="102" width="72" height="32">
-			</bounds>
+			<bounds x="832" y="102" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="834" y="104" width="68" height="28">
-			</bounds>
+			<bounds x="834" y="104" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="833" y="134" width="72" height="32">
-			</bounds>
+			<bounds x="833" y="134" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="835" y="136" width="68" height="28">
-			</bounds>
+			<bounds x="835" y="136" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="103" y="8" width="142" height="42">
-			</bounds>
+			<bounds x="103" y="8" width="142" height="42"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="105" y="10" width="138" height="38">
-			</bounds>
+			<bounds x="105" y="10" width="138" height="38"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="150" y="80" width="52" height="32">
-			</bounds>
+			<bounds x="150" y="80" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="152" y="82" width="48" height="28">
-			</bounds>
+			<bounds x="152" y="82" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="150" y="144" width="52" height="32">
-			</bounds>
+			<bounds x="150" y="144" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="152" y="146" width="48" height="28">
-			</bounds>
+			<bounds x="152" y="146" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="150" y="112" width="52" height="32">
-			</bounds>
+			<bounds x="150" y="112" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="152" y="114" width="48" height="28">
-			</bounds>
+			<bounds x="152" y="114" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="150" y="48" width="52" height="32">
-			</bounds>
+			<bounds x="150" y="48" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="152" y="50" width="48" height="28">
-			</bounds>
+			<bounds x="152" y="50" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="106" y="144" width="42" height="32">
-			</bounds>
+			<bounds x="106" y="144" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="108" y="146" width="38" height="28">
-			</bounds>
+			<bounds x="108" y="146" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="106" y="48" width="42" height="32">
-			</bounds>
+			<bounds x="106" y="48" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="108" y="50" width="38" height="28">
-			</bounds>
+			<bounds x="108" y="50" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="106" y="80" width="42" height="32">
-			</bounds>
+			<bounds x="106" y="80" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="108" y="82" width="38" height="28">
-			</bounds>
+			<bounds x="108" y="82" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="106" y="112" width="42" height="32">
-			</bounds>
+			<bounds x="106" y="112" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="108" y="114" width="38" height="28">
-			</bounds>
+			<bounds x="108" y="114" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="383" y="305" width="24" height="24">
-			</bounds>
+			<bounds x="383" y="305" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="385" y="307" width="20" height="20">
-			</bounds>
+			<bounds x="385" y="307" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="383" y="266" width="24" height="24">
-			</bounds>
+			<bounds x="383" y="266" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="385" y="268" width="20" height="20">
-			</bounds>
+			<bounds x="385" y="268" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1_border" state="0">
-			<bounds x="383" y="286" width="24" height="24">
-			</bounds>
+			<bounds x="383" y="286" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp143" element="lamp_143_1" state="0">
-			<bounds x="385" y="288" width="20" height="20">
-			</bounds>
+			<bounds x="385" y="288" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="324" y="225" width="82" height="42">
-			</bounds>
+			<bounds x="324" y="225" width="82" height="42"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="326" y="227" width="78" height="38">
-			</bounds>
+			<bounds x="326" y="227" width="78" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="546" y="226" width="37" height="32">
-			</bounds>
+			<bounds x="546" y="226" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="548" y="228" width="33" height="28">
-			</bounds>
+			<bounds x="548" y="228" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="512" y="226" width="37" height="32">
-			</bounds>
+			<bounds x="512" y="226" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="514" y="228" width="33" height="28">
-			</bounds>
+			<bounds x="514" y="228" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="517" y="260" width="27" height="27">
-			</bounds>
+			<bounds x="517" y="260" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="519" y="262" width="23" height="23">
-			</bounds>
+			<bounds x="519" y="262" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="517" y="314" width="27" height="27">
-			</bounds>
+			<bounds x="517" y="314" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="519" y="316" width="23" height="23">
-			</bounds>
+			<bounds x="519" y="316" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="517" y="368" width="27" height="27">
-			</bounds>
+			<bounds x="517" y="368" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="519" y="370" width="23" height="23">
-			</bounds>
+			<bounds x="519" y="370" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="517" y="341" width="27" height="27">
-			</bounds>
+			<bounds x="517" y="341" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="519" y="343" width="23" height="23">
-			</bounds>
+			<bounds x="519" y="343" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="517" y="287" width="27" height="27">
-			</bounds>
+			<bounds x="517" y="287" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="519" y="289" width="23" height="23">
-			</bounds>
+			<bounds x="519" y="289" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="517" y="395" width="27" height="27">
-			</bounds>
+			<bounds x="517" y="395" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="519" y="397" width="23" height="23">
-			</bounds>
+			<bounds x="519" y="397" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="545" y="395" width="32" height="27">
-			</bounds>
+			<bounds x="545" y="395" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="547" y="397" width="28" height="23">
-			</bounds>
+			<bounds x="547" y="397" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="545" y="368" width="32" height="27">
-			</bounds>
+			<bounds x="545" y="368" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="547" y="370" width="28" height="23">
-			</bounds>
+			<bounds x="547" y="370" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="545" y="341" width="32" height="27">
-			</bounds>
+			<bounds x="545" y="341" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="547" y="343" width="28" height="23">
-			</bounds>
+			<bounds x="547" y="343" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="545" y="314" width="32" height="27">
-			</bounds>
+			<bounds x="545" y="314" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="547" y="316" width="28" height="23">
-			</bounds>
+			<bounds x="547" y="316" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="545" y="287" width="32" height="27">
-			</bounds>
+			<bounds x="545" y="287" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="547" y="289" width="28" height="23">
-			</bounds>
+			<bounds x="547" y="289" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="545" y="260" width="32" height="27">
-			</bounds>
+			<bounds x="545" y="260" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="547" y="262" width="28" height="23">
-			</bounds>
+			<bounds x="547" y="262" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="941" y="447" width="40" height="40">
-			</bounds>
+			<bounds x="941" y="447" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="943" y="449" width="36" height="36">
-			</bounds>
+			<bounds x="943" y="449" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="964" y="519" width="40" height="40">
-			</bounds>
+			<bounds x="964" y="519" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="966" y="521" width="36" height="36">
-			</bounds>
+			<bounds x="966" y="521" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="942" y="584" width="40" height="40">
-			</bounds>
+			<bounds x="942" y="584" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="944" y="586" width="36" height="36">
-			</bounds>
+			<bounds x="944" y="586" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="795" y="588" width="40" height="40">
-			</bounds>
+			<bounds x="795" y="588" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="797" y="590" width="36" height="36">
-			</bounds>
+			<bounds x="797" y="590" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="795" y="445" width="40" height="40">
-			</bounds>
+			<bounds x="795" y="445" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="797" y="447" width="36" height="36">
-			</bounds>
+			<bounds x="797" y="447" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="863" y="616" width="40" height="40">
-			</bounds>
+			<bounds x="863" y="616" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="865" y="618" width="36" height="36">
-			</bounds>
+			<bounds x="865" y="618" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="862" y="426" width="40" height="40">
-			</bounds>
+			<bounds x="862" y="426" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="864" y="428" width="36" height="36">
-			</bounds>
+			<bounds x="864" y="428" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="819" y="547" width="32" height="32">
-			</bounds>
+			<bounds x="819" y="547" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="821" y="549" width="28" height="28">
-			</bounds>
+			<bounds x="821" y="549" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="818" y="492" width="32" height="32">
-			</bounds>
+			<bounds x="818" y="492" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="820" y="494" width="28" height="28">
-			</bounds>
+			<bounds x="820" y="494" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="868" y="578" width="32" height="32">
-			</bounds>
+			<bounds x="868" y="578" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="870" y="580" width="28" height="28">
-			</bounds>
+			<bounds x="870" y="580" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="917" y="488" width="32" height="32">
-			</bounds>
+			<bounds x="917" y="488" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="919" y="490" width="28" height="28">
-			</bounds>
+			<bounds x="919" y="490" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="917" y="546" width="32" height="32">
-			</bounds>
+			<bounds x="917" y="546" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="919" y="548" width="28" height="28">
-			</bounds>
+			<bounds x="919" y="548" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="866" y="470" width="32" height="32">
-			</bounds>
+			<bounds x="866" y="470" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="868" y="472" width="28" height="28">
-			</bounds>
+			<bounds x="868" y="472" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="766" y="517" width="40" height="40">
-			</bounds>
+			<bounds x="766" y="517" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="768" y="519" width="36" height="36">
-			</bounds>
+			<bounds x="768" y="519" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="135" y="226" width="32" height="32">
-			</bounds>
+			<bounds x="135" y="226" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="137" y="228" width="28" height="28">
-			</bounds>
+			<bounds x="137" y="228" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="454" y="5" width="82" height="32">
-			</bounds>
+			<bounds x="454" y="5" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="456" y="7" width="78" height="28">
-			</bounds>
+			<bounds x="456" y="7" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="384" y="5" width="72" height="32">
-			</bounds>
+			<bounds x="384" y="5" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="386" y="7" width="68" height="28">
-			</bounds>
+			<bounds x="386" y="7" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="423" y="116" width="67" height="29">
-			</bounds>
+			<bounds x="423" y="116" width="67" height="29"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="425" y="118" width="63" height="25">
-			</bounds>
+			<bounds x="425" y="118" width="63" height="25"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="419" y="62" width="77" height="29">
-			</bounds>
+			<bounds x="419" y="62" width="77" height="29"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="421" y="64" width="73" height="25">
-			</bounds>
+			<bounds x="421" y="64" width="73" height="25"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="410" y="35" width="92" height="29">
-			</bounds>
+			<bounds x="410" y="35" width="92" height="29"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="412" y="37" width="88" height="25">
-			</bounds>
+			<bounds x="412" y="37" width="88" height="25"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="421" y="89" width="72" height="29">
-			</bounds>
+			<bounds x="421" y="89" width="72" height="29"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="423" y="91" width="68" height="25">
-			</bounds>
+			<bounds x="423" y="91" width="68" height="25"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="425" y="143" width="62" height="29">
-			</bounds>
+			<bounds x="425" y="143" width="62" height="29"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="427" y="145" width="58" height="25">
-			</bounds>
+			<bounds x="427" y="145" width="58" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="colour_button_193_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="416" y="410" width="75" height="27">
-			</bounds>
+			<bounds x="416" y="410" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp188" element="colour_button_193" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="418" y="412" width="71" height="23">
-			</bounds>
+			<bounds x="418" y="412" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_194_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="136" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="136" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_194" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="138" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="138" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_195_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="232" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="232" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_195" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="234" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="234" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_196_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="327" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="327" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_196" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="329" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="329" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_197_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="413" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="413" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_197" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="415" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="415" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_198_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="496" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="496" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_198" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="498" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="498" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_199_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="587" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="587" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_199" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="589" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="589" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_200_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="672" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="672" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_200" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="674" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="674" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_201_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="759" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="759" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_201" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="761" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="761" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp54" element="colour_button_202_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="852" y="509" width="62" height="62">
-			</bounds>
+			<bounds x="852" y="509" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp54" element="colour_button_202" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="854" y="511" width="58" height="58">
-			</bounds>
+			<bounds x="854" y="511" width="58" height="58"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="182" y="587" width="30" height="44">
-			</bounds>
+			<bounds x="182" y="587" width="30" height="44"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="182" y="587" width="30" height="44">
-			</bounds>
+			<bounds x="182" y="587" width="30" height="44"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="182" y="587" width="30" height="44">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="182" y="587" width="30" height="44"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="211" y="587" width="30" height="44">
-			</bounds>
+			<bounds x="211" y="587" width="30" height="44"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="211" y="587" width="30" height="44">
-			</bounds>
+			<bounds x="211" y="587" width="30" height="44"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="211" y="587" width="30" height="44">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="211" y="587" width="30" height="44"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="347" y="437" width="227" height="20">
-			</bounds>
+			<bounds x="347" y="437" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="347" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="347" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="361" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="361" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="375" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="375" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="389" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="389" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="403" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="403" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="417" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="417" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="431" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="431" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="445" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="445" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="459" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="459" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="473" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="473" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="487" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="487" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="501" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="501" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="515" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="515" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="529" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="529" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="543" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="543" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="557" y="437" width="14" height="20">
-			</bounds>
+			<bounds x="557" y="437" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="label124" element="label_124">
-			<bounds x="23" y="313" width="129" height="45">
-			</bounds>
+			<bounds x="23" y="313" width="129" height="45"/>
 		</backdrop>
 		<backdrop name="label125" element="label_125">
-			<bounds x="46" y="359" width="87" height="45">
-			</bounds>
+			<bounds x="46" y="359" width="87" height="45"/>
 		</backdrop>
 		<backdrop name="label126" element="label_126">
-			<bounds x="33" y="409" width="108" height="45">
-			</bounds>
+			<bounds x="33" y="409" width="108" height="45"/>
 		</backdrop>
 		<backdrop name="label188" element="label_188">
-			<bounds x="586" y="510" width="44" height="15">
-			</bounds>
+			<bounds x="586" y="510" width="44" height="15"/>
 		</backdrop>
 		<backdrop name="label189" element="label_189">
-			<bounds x="274" y="510" width="44" height="15">
-			</bounds>
+			<bounds x="274" y="510" width="44" height="15"/>
 		</backdrop>
 		<backdrop name="label191" element="label_191">
-			<bounds x="31" y="57" width="35" height="30">
-			</bounds>
+			<bounds x="31" y="57" width="35" height="30"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_button" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_button" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4clashd.lay
+++ b/src/mame/layout/sc4clashd.lay
@@ -8,16986 +8,9406 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="STAGGER HOME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="STAGGER HOME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8 ACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 ACE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CHASE THE BIRDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHASE THE BIRDS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="BIFF THE BOUNCER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="BIFF THE BOUNCER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BONU">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ON THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ON THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="20P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="40P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="60P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="80P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string=".40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string=".40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="YOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="YOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ROUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ROUND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MILLION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MILLION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LIGHT ALL 3 BEER GLASSES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LIGHT ALL 3 BEER GLASSES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="TO ACTIVATE PICKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="TO ACTIVATE PICKS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.22"/>
 		</text>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.28" width="0.90" height="0.22"/>
 		</text>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.22"/>
 		</text>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.28" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.22">
-			</bounds>
-		</text>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.72" width="0.90" height="0.22">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.72" width="0.90" height="0.22"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BTL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="WIN SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIN SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HAPPY HOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="HAPPY HOUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="kO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="kO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WHICH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="NEXT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WHICH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="BAR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="NEXT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FIRKIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FIRKIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="REELY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="DRUNK!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="REELY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="DRUNK!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BOTTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BOTTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PUB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CRAWL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="PUB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CRAWL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ON THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="ON THE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="JACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="5 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="BOTTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="BOTTLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="4 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PULL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="PULL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_236_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_236">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_237_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_237">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_238_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_238">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_239_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_239">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_240_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_240">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_242_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_242">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EX">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHANG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_244_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_244">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GAMBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_245_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_245">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HAVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_246_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_246">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
 		<text string="UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_247_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_247">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="PICK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_248_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_248">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HAVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_249_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_249">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_190">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_191">
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_192">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_193">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_194">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_195">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_196">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_197">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_198">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_199">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_200">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_201">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_202">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_203">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_205">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_233">
 		<text string="LIGHT ALL BOTTLES FOR BIG MONEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_234">
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="648" height="672">
-			</bounds>
+			<bounds x="0" y="0" width="648" height="672"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="180" y="435" width="70" height="120">
-			</bounds>
+			<bounds x="180" y="435" width="70" height="120"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="180.0000" y="435.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="180.0000" y="435.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="182.9167" y="436.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="182.9167" y="436.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="185.8333" y="438.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="185.8333" y="438.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="188.7500" y="440.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="188.7500" y="440.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="191.6667" y="441.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="191.6667" y="441.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="194.5833" y="443.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="194.5833" y="443.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="180.0000" y="475.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="180.0000" y="475.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="182.9167" y="476.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="182.9167" y="476.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="185.8333" y="478.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="185.8333" y="478.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="188.7500" y="480.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="188.7500" y="480.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="191.6667" y="481.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="191.6667" y="481.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="194.5833" y="483.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="194.5833" y="483.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="180.0000" y="515.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="180.0000" y="515.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="182.9167" y="516.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="182.9167" y="516.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="185.8333" y="518.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="185.8333" y="518.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="188.7500" y="520.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="188.7500" y="520.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="191.6667" y="521.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="191.6667" y="521.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="194.5833" y="523.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="194.5833" y="523.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="180" y="435" width="70" height="120">
-			</bounds>
+			<bounds x="180" y="435" width="70" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="260" y="435" width="70" height="120">
-			</bounds>
+			<bounds x="260" y="435" width="70" height="120"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="260.0000" y="435.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="260.0000" y="435.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="262.9167" y="436.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="262.9167" y="436.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="265.8333" y="438.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="265.8333" y="438.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="268.7500" y="440.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="268.7500" y="440.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="271.6667" y="441.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="271.6667" y="441.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.5833" y="443.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="274.5833" y="443.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="260.0000" y="475.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="260.0000" y="475.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="262.9167" y="476.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="262.9167" y="476.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="265.8333" y="478.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="265.8333" y="478.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="268.7500" y="480.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="268.7500" y="480.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="271.6667" y="481.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="271.6667" y="481.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.5833" y="483.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="274.5833" y="483.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="260.0000" y="515.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="260.0000" y="515.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="262.9167" y="516.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="262.9167" y="516.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="265.8333" y="518.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="265.8333" y="518.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="268.7500" y="520.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="268.7500" y="520.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="271.6667" y="521.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="271.6667" y="521.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="274.5833" y="523.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="274.5833" y="523.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="260" y="435" width="70" height="120">
-			</bounds>
+			<bounds x="260" y="435" width="70" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="340" y="435" width="70" height="120">
-			</bounds>
+			<bounds x="340" y="435" width="70" height="120"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="340.0000" y="435.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="340.0000" y="435.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.9167" y="436.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="342.9167" y="436.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.8333" y="438.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="345.8333" y="438.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="348.7500" y="440.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="348.7500" y="440.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="351.6667" y="441.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="351.6667" y="441.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="354.5833" y="443.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="354.5833" y="443.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="340.0000" y="475.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="340.0000" y="475.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.9167" y="476.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="342.9167" y="476.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.8333" y="478.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="345.8333" y="478.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="348.7500" y="480.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="348.7500" y="480.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="351.6667" y="481.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="351.6667" y="481.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="354.5833" y="483.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="354.5833" y="483.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="340.0000" y="515.0000" width="70.0000" height="40.0000">
-			</bounds>
+			<bounds x="340.0000" y="515.0000" width="70.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="342.9167" y="516.6667" width="64.1667" height="36.6667">
-			</bounds>
+			<bounds x="342.9167" y="516.6667" width="64.1667" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="345.8333" y="518.3333" width="58.3333" height="33.3333">
-			</bounds>
+			<bounds x="345.8333" y="518.3333" width="58.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="348.7500" y="520.0000" width="52.5000" height="30.0000">
-			</bounds>
+			<bounds x="348.7500" y="520.0000" width="52.5000" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="351.6667" y="521.6667" width="46.6667" height="26.6667">
-			</bounds>
+			<bounds x="351.6667" y="521.6667" width="46.6667" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="354.5833" y="523.3333" width="40.8333" height="23.3333">
-			</bounds>
+			<bounds x="354.5833" y="523.3333" width="40.8333" height="23.3333"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="340" y="435" width="70" height="120">
-			</bounds>
+			<bounds x="340" y="435" width="70" height="120"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="315" y="273" width="60" height="60">
-			</bounds>
+			<bounds x="315" y="273" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="315.0000" y="273.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="315.0000" y="273.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="317.5000" y="275.5000" width="55.0000" height="55.0000">
-			</bounds>
+			<bounds x="317.5000" y="275.5000" width="55.0000" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="320.0000" y="278.0000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="320.0000" y="278.0000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="322.5000" y="280.5000" width="45.0000" height="45.0000">
-			</bounds>
+			<bounds x="322.5000" y="280.5000" width="45.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="325.0000" y="283.0000" width="40.0000" height="40.0000">
-			</bounds>
+			<bounds x="325.0000" y="283.0000" width="40.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="327.5000" y="285.5000" width="35.0000" height="35.0000">
-			</bounds>
+			<bounds x="327.5000" y="285.5000" width="35.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="315" y="273" width="60" height="60">
-			</bounds>
+			<bounds x="315" y="273" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="62" y="529" width="62" height="42">
-			</bounds>
+			<bounds x="62" y="529" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="64" y="531" width="58" height="38">
-			</bounds>
+			<bounds x="64" y="531" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="6" y="433" width="52" height="32">
-			</bounds>
+			<bounds x="6" y="433" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="8" y="435" width="48" height="28">
-			</bounds>
+			<bounds x="8" y="435" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="6" y="465" width="52" height="32">
-			</bounds>
+			<bounds x="6" y="465" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="8" y="467" width="48" height="28">
-			</bounds>
+			<bounds x="8" y="467" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="62" y="490" width="62" height="42">
-			</bounds>
+			<bounds x="62" y="490" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="64" y="492" width="58" height="38">
-			</bounds>
+			<bounds x="64" y="492" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="62" y="451" width="62" height="42">
-			</bounds>
+			<bounds x="62" y="451" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="64" y="453" width="58" height="38">
-			</bounds>
+			<bounds x="64" y="453" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="62" y="412" width="62" height="42">
-			</bounds>
+			<bounds x="62" y="412" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="64" y="414" width="58" height="38">
-			</bounds>
+			<bounds x="64" y="414" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="6" y="497" width="52" height="32">
-			</bounds>
+			<bounds x="6" y="497" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="8" y="499" width="48" height="28">
-			</bounds>
+			<bounds x="8" y="499" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="62" y="373" width="62" height="42">
-			</bounds>
+			<bounds x="62" y="373" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="64" y="375" width="58" height="38">
-			</bounds>
+			<bounds x="64" y="375" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="6" y="529" width="52" height="32">
-			</bounds>
+			<bounds x="6" y="529" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="8" y="531" width="48" height="28">
-			</bounds>
+			<bounds x="8" y="531" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="26" y="560" width="32" height="19">
-			</bounds>
+			<bounds x="26" y="560" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="28" y="562" width="28" height="15">
-			</bounds>
+			<bounds x="28" y="562" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="105" y="573" width="47" height="32">
-			</bounds>
+			<bounds x="105" y="573" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="107" y="575" width="43" height="28">
-			</bounds>
+			<bounds x="107" y="575" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="151" y="573" width="47" height="32">
-			</bounds>
+			<bounds x="151" y="573" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="153" y="575" width="43" height="28">
-			</bounds>
+			<bounds x="153" y="575" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="197" y="573" width="47" height="32">
-			</bounds>
+			<bounds x="197" y="573" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="199" y="575" width="43" height="28">
-			</bounds>
+			<bounds x="199" y="575" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="243" y="573" width="47" height="32">
-			</bounds>
+			<bounds x="243" y="573" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="245" y="575" width="43" height="28">
-			</bounds>
+			<bounds x="245" y="575" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="290" y="573" width="32" height="32">
-			</bounds>
+			<bounds x="290" y="573" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="292" y="575" width="28" height="28">
-			</bounds>
+			<bounds x="292" y="575" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="322" y="573" width="47" height="32">
-			</bounds>
+			<bounds x="322" y="573" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="324" y="575" width="43" height="28">
-			</bounds>
+			<bounds x="324" y="575" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="368" y="573" width="47" height="32">
-			</bounds>
+			<bounds x="368" y="573" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="370" y="575" width="43" height="28">
-			</bounds>
+			<bounds x="370" y="575" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="414" y="573" width="47" height="32">
-			</bounds>
+			<bounds x="414" y="573" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="416" y="575" width="43" height="28">
-			</bounds>
+			<bounds x="416" y="575" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="460" y="573" width="47" height="32">
-			</bounds>
+			<bounds x="460" y="573" width="47" height="32"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="462" y="575" width="43" height="28">
-			</bounds>
+			<bounds x="462" y="575" width="43" height="28"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="38" y="585" width="57" height="32">
-			</bounds>
+			<bounds x="38" y="585" width="57" height="32"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="40" y="587" width="53" height="28">
-			</bounds>
+			<bounds x="40" y="587" width="53" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="480" y="546" width="62" height="19">
-			</bounds>
+			<bounds x="480" y="546" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="482" y="548" width="58" height="15">
-			</bounds>
+			<bounds x="482" y="548" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="480" y="530" width="62" height="19">
-			</bounds>
+			<bounds x="480" y="530" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="482" y="532" width="58" height="15">
-			</bounds>
+			<bounds x="482" y="532" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="480" y="492" width="62" height="19">
-			</bounds>
+			<bounds x="480" y="492" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="482" y="494" width="58" height="15">
-			</bounds>
+			<bounds x="482" y="494" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="480" y="508" width="62" height="19">
-			</bounds>
+			<bounds x="480" y="508" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="482" y="510" width="58" height="15">
-			</bounds>
+			<bounds x="482" y="510" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="480" y="470" width="62" height="19">
-			</bounds>
+			<bounds x="480" y="470" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="482" y="472" width="58" height="15">
-			</bounds>
+			<bounds x="482" y="472" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="480" y="454" width="62" height="19">
-			</bounds>
+			<bounds x="480" y="454" width="62" height="19"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="482" y="456" width="58" height="15">
-			</bounds>
+			<bounds x="482" y="456" width="58" height="15"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="562" y="403" width="32" height="19">
-			</bounds>
+			<bounds x="562" y="403" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="564" y="405" width="28" height="15">
-			</bounds>
+			<bounds x="564" y="405" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="562" y="363" width="32" height="19">
-			</bounds>
+			<bounds x="562" y="363" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="564" y="365" width="28" height="15">
-			</bounds>
+			<bounds x="564" y="365" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="562" y="324" width="32" height="19">
-			</bounds>
+			<bounds x="562" y="324" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="564" y="326" width="28" height="15">
-			</bounds>
+			<bounds x="564" y="326" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="562" y="283" width="32" height="19">
-			</bounds>
+			<bounds x="562" y="283" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="564" y="285" width="28" height="15">
-			</bounds>
+			<bounds x="564" y="285" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="562" y="242" width="32" height="19">
-			</bounds>
+			<bounds x="562" y="242" width="32" height="19"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="564" y="244" width="28" height="15">
-			</bounds>
+			<bounds x="564" y="244" width="28" height="15"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="559" y="223" width="37" height="19">
-			</bounds>
+			<bounds x="559" y="223" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="561" y="225" width="33" height="15">
-			</bounds>
+			<bounds x="561" y="225" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="559" y="181" width="37" height="19">
-			</bounds>
+			<bounds x="559" y="181" width="37" height="19"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="561" y="183" width="33" height="15">
-			</bounds>
+			<bounds x="561" y="183" width="33" height="15"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="576" y="143" width="19" height="19">
-			</bounds>
+			<bounds x="576" y="143" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="578" y="145" width="15" height="15">
-			</bounds>
+			<bounds x="578" y="145" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="559" y="143" width="19" height="19">
-			</bounds>
+			<bounds x="559" y="143" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="561" y="145" width="15" height="15">
-			</bounds>
+			<bounds x="561" y="145" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="559" y="125" width="19" height="19">
-			</bounds>
+			<bounds x="559" y="125" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="561" y="127" width="15" height="15">
-			</bounds>
+			<bounds x="561" y="127" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="576" y="125" width="22" height="19">
-			</bounds>
+			<bounds x="576" y="125" width="22" height="19"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="578" y="127" width="18" height="15">
-			</bounds>
+			<bounds x="578" y="127" width="18" height="15"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="576" y="86" width="19" height="19">
-			</bounds>
+			<bounds x="576" y="86" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="578" y="88" width="15" height="15">
-			</bounds>
+			<bounds x="578" y="88" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="559" y="86" width="19" height="19">
-			</bounds>
+			<bounds x="559" y="86" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="561" y="88" width="15" height="15">
-			</bounds>
+			<bounds x="561" y="88" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="559" y="68" width="19" height="19">
-			</bounds>
+			<bounds x="559" y="68" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="561" y="70" width="15" height="15">
-			</bounds>
+			<bounds x="561" y="70" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="576" y="68" width="19" height="19">
-			</bounds>
+			<bounds x="576" y="68" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="578" y="70" width="15" height="15">
-			</bounds>
+			<bounds x="578" y="70" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="568" y="28" width="19" height="19">
-			</bounds>
+			<bounds x="568" y="28" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="570" y="30" width="15" height="15">
-			</bounds>
+			<bounds x="570" y="30" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="551" y="28" width="19" height="19">
-			</bounds>
+			<bounds x="551" y="28" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="553" y="30" width="15" height="15">
-			</bounds>
+			<bounds x="553" y="30" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="585" y="28" width="19" height="19">
-			</bounds>
+			<bounds x="585" y="28" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="587" y="30" width="15" height="15">
-			</bounds>
+			<bounds x="587" y="30" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="488" y="183" width="42" height="42">
-			</bounds>
+			<bounds x="488" y="183" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="490" y="185" width="38" height="38">
-			</bounds>
+			<bounds x="490" y="185" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="488" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="488" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="490" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="490" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="488" y="124" width="42" height="42">
-			</bounds>
+			<bounds x="488" y="124" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="490" y="126" width="38" height="38">
-			</bounds>
+			<bounds x="490" y="126" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="488" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="488" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="490" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="490" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="478" y="66" width="52" height="22">
-			</bounds>
+			<bounds x="478" y="66" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="480" y="68" width="48" height="18">
-			</bounds>
+			<bounds x="480" y="68" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="478" y="85" width="52" height="22">
-			</bounds>
+			<bounds x="478" y="85" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="480" y="87" width="48" height="18">
-			</bounds>
+			<bounds x="480" y="87" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="470" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="470" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="472" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="472" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="479" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="479" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="481" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="481" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="439" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="439" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="441" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="441" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="430" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="430" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="432" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="432" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="373" y="4" width="27" height="19">
-			</bounds>
+			<bounds x="373" y="4" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="375" y="6" width="23" height="15">
-			</bounds>
+			<bounds x="375" y="6" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="343" y="4" width="27" height="19">
-			</bounds>
+			<bounds x="343" y="4" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="345" y="6" width="23" height="15">
-			</bounds>
+			<bounds x="345" y="6" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="390" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="390" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="392" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="392" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="399" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="399" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="401" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="401" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="359" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="359" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="361" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="361" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="350" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="350" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="352" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="352" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="312" y="4" width="27" height="19">
-			</bounds>
+			<bounds x="312" y="4" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="314" y="6" width="23" height="15">
-			</bounds>
+			<bounds x="314" y="6" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="281" y="4" width="27" height="19">
-			</bounds>
+			<bounds x="281" y="4" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="283" y="6" width="23" height="15">
-			</bounds>
+			<bounds x="283" y="6" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="250" y="4" width="27" height="19">
-			</bounds>
+			<bounds x="250" y="4" width="27" height="19"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="252" y="6" width="23" height="15">
-			</bounds>
+			<bounds x="252" y="6" width="23" height="15"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="310" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="310" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="312" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="312" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="319" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="319" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="321" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="321" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="278" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="278" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="280" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="280" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="269" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="269" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="271" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="271" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="230" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="230" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="232" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="232" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="239" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="239" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="241" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="241" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="199" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="199" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="201" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="201" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="190" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="190" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="192" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="192" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="151" y="29" width="12" height="27">
-			</bounds>
+			<bounds x="151" y="29" width="12" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="153" y="31" width="8" height="23">
-			</bounds>
+			<bounds x="153" y="31" width="8" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="160" y="29" width="27" height="27">
-			</bounds>
+			<bounds x="160" y="29" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="162" y="31" width="23" height="23">
-			</bounds>
+			<bounds x="162" y="31" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="21" y="2" width="62" height="32">
-			</bounds>
+			<bounds x="21" y="2" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="23" y="4" width="58" height="28">
-			</bounds>
+			<bounds x="23" y="4" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="1" y="2" width="22" height="32">
-			</bounds>
+			<bounds x="1" y="2" width="22" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="3" y="4" width="18" height="28">
-			</bounds>
+			<bounds x="3" y="4" width="18" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="26" y="33" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="33" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="28" y="35" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="35" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="26" y="53" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="53" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="28" y="55" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="55" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="26" y="73" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="73" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="28" y="75" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="75" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="26" y="93" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="93" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="28" y="95" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="95" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="26" y="113" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="113" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="28" y="115" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="115" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="26" y="133" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="133" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="28" y="135" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="135" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="26" y="153" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="153" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="28" y="155" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="155" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="26" y="173" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="173" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="28" y="175" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="175" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="26" y="193" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="193" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="28" y="195" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="195" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="26" y="213" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="213" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="28" y="215" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="215" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="26" y="233" width="22" height="22">
-			</bounds>
+			<bounds x="26" y="233" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="28" y="235" width="18" height="18">
-			</bounds>
+			<bounds x="28" y="235" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="8" y="302" width="92" height="42">
-			</bounds>
+			<bounds x="8" y="302" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="10" y="304" width="88" height="38">
-			</bounds>
+			<bounds x="10" y="304" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="8" y="341" width="92" height="32">
-			</bounds>
+			<bounds x="8" y="341" width="92" height="32"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="10" y="343" width="88" height="28">
-			</bounds>
+			<bounds x="10" y="343" width="88" height="28"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="99" y="316" width="19" height="57">
-			</bounds>
+			<bounds x="99" y="316" width="19" height="57"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="101" y="318" width="15" height="53">
-			</bounds>
+			<bounds x="101" y="318" width="15" height="53"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="117" y="316" width="19" height="57">
-			</bounds>
+			<bounds x="117" y="316" width="19" height="57"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="119" y="318" width="15" height="53">
-			</bounds>
+			<bounds x="119" y="318" width="15" height="53"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="135" y="316" width="19" height="57">
-			</bounds>
+			<bounds x="135" y="316" width="19" height="57"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="137" y="318" width="15" height="53">
-			</bounds>
+			<bounds x="137" y="318" width="15" height="53"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="181" y="278" width="42" height="27">
-			</bounds>
+			<bounds x="181" y="278" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="183" y="280" width="38" height="23">
-			</bounds>
+			<bounds x="183" y="280" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="377" y="276" width="19" height="19">
-			</bounds>
+			<bounds x="377" y="276" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="379" y="278" width="15" height="15">
-			</bounds>
+			<bounds x="379" y="278" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="377" y="311" width="19" height="19">
-			</bounds>
+			<bounds x="377" y="311" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="379" y="313" width="15" height="15">
-			</bounds>
+			<bounds x="379" y="313" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="181" y="303" width="42" height="27">
-			</bounds>
+			<bounds x="181" y="303" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="183" y="305" width="38" height="23">
-			</bounds>
+			<bounds x="183" y="305" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="199" y="328" width="42" height="27">
-			</bounds>
+			<bounds x="199" y="328" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="201" y="330" width="38" height="23">
-			</bounds>
+			<bounds x="201" y="330" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="224" y="353" width="42" height="27">
-			</bounds>
+			<bounds x="224" y="353" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="226" y="355" width="38" height="23">
-			</bounds>
+			<bounds x="226" y="355" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="264" y="353" width="42" height="27">
-			</bounds>
+			<bounds x="264" y="353" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="266" y="355" width="38" height="23">
-			</bounds>
+			<bounds x="266" y="355" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="304" y="353" width="42" height="27">
-			</bounds>
+			<bounds x="304" y="353" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="306" y="355" width="38" height="23">
-			</bounds>
+			<bounds x="306" y="355" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="344" y="353" width="42" height="27">
-			</bounds>
+			<bounds x="344" y="353" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="346" y="355" width="38" height="23">
-			</bounds>
+			<bounds x="346" y="355" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="384" y="353" width="42" height="27">
-			</bounds>
+			<bounds x="384" y="353" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="386" y="355" width="38" height="23">
-			</bounds>
+			<bounds x="386" y="355" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="423" y="353" width="42" height="27">
-			</bounds>
+			<bounds x="423" y="353" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="425" y="355" width="38" height="23">
-			</bounds>
+			<bounds x="425" y="355" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="446" y="328" width="42" height="27">
-			</bounds>
+			<bounds x="446" y="328" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="448" y="330" width="38" height="23">
-			</bounds>
+			<bounds x="448" y="330" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="466" y="303" width="42" height="27">
-			</bounds>
+			<bounds x="466" y="303" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="468" y="305" width="38" height="23">
-			</bounds>
+			<bounds x="468" y="305" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="9" y="385" width="47" height="37">
-			</bounds>
+			<bounds x="9" y="385" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="11" y="387" width="43" height="33">
-			</bounds>
+			<bounds x="11" y="387" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="466" y="278" width="42" height="27">
-			</bounds>
+			<bounds x="466" y="278" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="468" y="280" width="38" height="23">
-			</bounds>
+			<bounds x="468" y="280" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="446" y="253" width="42" height="27">
-			</bounds>
+			<bounds x="446" y="253" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="448" y="255" width="38" height="23">
-			</bounds>
+			<bounds x="448" y="255" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="423" y="228" width="42" height="27">
-			</bounds>
+			<bounds x="423" y="228" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="425" y="230" width="38" height="23">
-			</bounds>
+			<bounds x="425" y="230" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="384" y="228" width="42" height="27">
-			</bounds>
+			<bounds x="384" y="228" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="386" y="230" width="38" height="23">
-			</bounds>
+			<bounds x="386" y="230" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="344" y="228" width="42" height="27">
-			</bounds>
+			<bounds x="344" y="228" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="346" y="230" width="38" height="23">
-			</bounds>
+			<bounds x="346" y="230" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="304" y="228" width="42" height="27">
-			</bounds>
+			<bounds x="304" y="228" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="306" y="230" width="38" height="23">
-			</bounds>
+			<bounds x="306" y="230" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="264" y="228" width="42" height="27">
-			</bounds>
+			<bounds x="264" y="228" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="266" y="230" width="38" height="23">
-			</bounds>
+			<bounds x="266" y="230" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="224" y="228" width="42" height="27">
-			</bounds>
+			<bounds x="224" y="228" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="226" y="230" width="38" height="23">
-			</bounds>
+			<bounds x="226" y="230" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="199" y="253" width="42" height="27">
-			</bounds>
+			<bounds x="199" y="253" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="201" y="255" width="38" height="23">
-			</bounds>
+			<bounds x="201" y="255" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="100" y="183" width="42" height="42">
-			</bounds>
+			<bounds x="100" y="183" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="102" y="185" width="38" height="38">
-			</bounds>
+			<bounds x="102" y="185" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="141" y="183" width="42" height="42">
-			</bounds>
+			<bounds x="141" y="183" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="143" y="185" width="38" height="38">
-			</bounds>
+			<bounds x="143" y="185" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="182" y="183" width="62" height="42">
-			</bounds>
+			<bounds x="182" y="183" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="184" y="185" width="58" height="38">
-			</bounds>
+			<bounds x="184" y="185" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="243" y="183" width="42" height="42">
-			</bounds>
+			<bounds x="243" y="183" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="245" y="185" width="38" height="38">
-			</bounds>
+			<bounds x="245" y="185" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="284" y="183" width="62" height="42">
-			</bounds>
+			<bounds x="284" y="183" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="286" y="185" width="58" height="38">
-			</bounds>
+			<bounds x="286" y="185" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="345" y="183" width="42" height="42">
-			</bounds>
+			<bounds x="345" y="183" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="347" y="185" width="38" height="38">
-			</bounds>
+			<bounds x="347" y="185" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="386" y="183" width="62" height="42">
-			</bounds>
+			<bounds x="386" y="183" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="388" y="185" width="58" height="38">
-			</bounds>
+			<bounds x="388" y="185" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="447" y="183" width="42" height="42">
-			</bounds>
+			<bounds x="447" y="183" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="449" y="185" width="38" height="38">
-			</bounds>
+			<bounds x="449" y="185" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="447" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="447" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="449" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="449" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="396" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="396" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="398" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="398" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="345" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="345" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="347" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="347" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="296" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="296" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="298" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="298" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="243" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="243" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="245" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="245" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="191" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="191" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="193" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="193" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="141" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="141" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="143" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="143" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="100" y="165" width="42" height="19">
-			</bounds>
+			<bounds x="100" y="165" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="102" y="167" width="38" height="15">
-			</bounds>
+			<bounds x="102" y="167" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="100" y="124" width="42" height="42">
-			</bounds>
+			<bounds x="100" y="124" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="102" y="126" width="38" height="38">
-			</bounds>
+			<bounds x="102" y="126" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="141" y="124" width="42" height="42">
-			</bounds>
+			<bounds x="141" y="124" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="143" y="126" width="38" height="38">
-			</bounds>
+			<bounds x="143" y="126" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="182" y="124" width="62" height="42">
-			</bounds>
+			<bounds x="182" y="124" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="184" y="126" width="58" height="38">
-			</bounds>
+			<bounds x="184" y="126" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="243" y="124" width="42" height="42">
-			</bounds>
+			<bounds x="243" y="124" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="245" y="126" width="38" height="38">
-			</bounds>
+			<bounds x="245" y="126" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="284" y="124" width="62" height="42">
-			</bounds>
+			<bounds x="284" y="124" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="286" y="126" width="58" height="38">
-			</bounds>
+			<bounds x="286" y="126" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="345" y="124" width="42" height="42">
-			</bounds>
+			<bounds x="345" y="124" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="347" y="126" width="38" height="38">
-			</bounds>
+			<bounds x="347" y="126" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="386" y="124" width="52" height="42">
-			</bounds>
+			<bounds x="386" y="124" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="388" y="126" width="48" height="38">
-			</bounds>
+			<bounds x="388" y="126" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="437" y="124" width="52" height="42">
-			</bounds>
+			<bounds x="437" y="124" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="439" y="126" width="48" height="38">
-			</bounds>
+			<bounds x="439" y="126" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="441" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="441" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="443" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="443" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="396" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="396" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="398" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="398" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="345" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="345" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="347" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="347" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="296" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="296" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="298" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="298" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="243" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="243" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="245" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="245" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="191" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="191" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="193" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="193" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="141" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="141" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="143" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="143" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="100" y="106" width="42" height="19">
-			</bounds>
+			<bounds x="100" y="106" width="42" height="19"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="102" y="108" width="38" height="15">
-			</bounds>
+			<bounds x="102" y="108" width="38" height="15"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="101" y="66" width="42" height="22">
-			</bounds>
+			<bounds x="101" y="66" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="103" y="68" width="38" height="18">
-			</bounds>
+			<bounds x="103" y="68" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="142" y="66" width="62" height="22">
-			</bounds>
+			<bounds x="142" y="66" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="144" y="68" width="58" height="18">
-			</bounds>
+			<bounds x="144" y="68" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="203" y="66" width="42" height="22">
-			</bounds>
+			<bounds x="203" y="66" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="205" y="68" width="38" height="18">
-			</bounds>
+			<bounds x="205" y="68" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="244" y="66" width="42" height="22">
-			</bounds>
+			<bounds x="244" y="66" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="246" y="68" width="38" height="18">
-			</bounds>
+			<bounds x="246" y="68" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="285" y="66" width="62" height="22">
-			</bounds>
+			<bounds x="285" y="66" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="287" y="68" width="58" height="18">
-			</bounds>
+			<bounds x="287" y="68" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="346" y="66" width="51" height="22">
-			</bounds>
+			<bounds x="346" y="66" width="51" height="22"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="348" y="68" width="47" height="18">
-			</bounds>
+			<bounds x="348" y="68" width="47" height="18"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="396" y="66" width="42" height="22">
-			</bounds>
+			<bounds x="396" y="66" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="398" y="68" width="38" height="18">
-			</bounds>
+			<bounds x="398" y="68" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="437" y="66" width="42" height="22">
-			</bounds>
+			<bounds x="437" y="66" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="439" y="68" width="38" height="18">
-			</bounds>
+			<bounds x="439" y="68" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="437" y="85" width="42" height="22">
-			</bounds>
+			<bounds x="437" y="85" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="439" y="87" width="38" height="18">
-			</bounds>
+			<bounds x="439" y="87" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="396" y="85" width="42" height="22">
-			</bounds>
+			<bounds x="396" y="85" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="398" y="87" width="38" height="18">
-			</bounds>
+			<bounds x="398" y="87" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="346" y="85" width="51" height="22">
-			</bounds>
+			<bounds x="346" y="85" width="51" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="348" y="87" width="47" height="18">
-			</bounds>
+			<bounds x="348" y="87" width="47" height="18"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="285" y="85" width="62" height="22">
-			</bounds>
+			<bounds x="285" y="85" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="287" y="87" width="58" height="18">
-			</bounds>
+			<bounds x="287" y="87" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="244" y="85" width="42" height="22">
-			</bounds>
+			<bounds x="244" y="85" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="246" y="87" width="38" height="18">
-			</bounds>
+			<bounds x="246" y="87" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="203" y="85" width="42" height="22">
-			</bounds>
+			<bounds x="203" y="85" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="205" y="87" width="38" height="18">
-			</bounds>
+			<bounds x="205" y="87" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="142" y="85" width="62" height="22">
-			</bounds>
+			<bounds x="142" y="85" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="144" y="87" width="58" height="18">
-			</bounds>
+			<bounds x="144" y="87" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="101" y="85" width="42" height="22">
-			</bounds>
+			<bounds x="101" y="85" width="42" height="22"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="103" y="87" width="38" height="18">
-			</bounds>
+			<bounds x="103" y="87" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_236_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="104" y="621" width="62" height="42">
-			</bounds>
+			<bounds x="104" y="621" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_236" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="106" y="623" width="58" height="38">
-			</bounds>
+			<bounds x="106" y="623" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_237_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="24" y="621" width="62" height="42">
-			</bounds>
+			<bounds x="24" y="621" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_237" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="26" y="623" width="58" height="38">
-			</bounds>
+			<bounds x="26" y="623" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_238_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="183" y="621" width="62" height="42">
-			</bounds>
+			<bounds x="183" y="621" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_238" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="185" y="623" width="58" height="38">
-			</bounds>
+			<bounds x="185" y="623" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_239_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="263" y="621" width="62" height="42">
-			</bounds>
+			<bounds x="263" y="621" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_239" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="265" y="623" width="58" height="38">
-			</bounds>
+			<bounds x="265" y="623" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_240_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="344" y="621" width="62" height="42">
-			</bounds>
+			<bounds x="344" y="621" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_240" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="346" y="623" width="58" height="38">
-			</bounds>
+			<bounds x="346" y="623" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_242_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="426" y="621" width="62" height="42">
-			</bounds>
+			<bounds x="426" y="621" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_242" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="428" y="623" width="58" height="38">
-			</bounds>
+			<bounds x="428" y="623" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_244_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="507" y="621" width="62" height="42">
-			</bounds>
+			<bounds x="507" y="621" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_244" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="509" y="623" width="58" height="38">
-			</bounds>
+			<bounds x="509" y="623" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp75" element="colour_button_245_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="497" y="404" width="47" height="47">
-			</bounds>
+			<bounds x="497" y="404" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp75" element="colour_button_245" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="499" y="406" width="43" height="43">
-			</bounds>
+			<bounds x="499" y="406" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp177" element="colour_button_246_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="498" y="227" width="47" height="42">
-			</bounds>
+			<bounds x="498" y="227" width="47" height="42"/>
 		</backdrop>
 		<backdrop name="lamp177" element="colour_button_246" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="500" y="229" width="43" height="38">
-			</bounds>
+			<bounds x="500" y="229" width="43" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="colour_button_247_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="156" y="334" width="42" height="42">
-			</bounds>
+			<bounds x="156" y="334" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp185" element="colour_button_247" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="158" y="336" width="38" height="38">
-			</bounds>
+			<bounds x="158" y="336" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp151" element="colour_button_248_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="1" y="255" width="47" height="47">
-			</bounds>
+			<bounds x="1" y="255" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp151" element="colour_button_248" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="3" y="257" width="43" height="43">
-			</bounds>
+			<bounds x="3" y="257" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_249_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="606" y="2" width="27" height="27">
-			</bounds>
+			<bounds x="606" y="2" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_249" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="608" y="4" width="23" height="23">
-			</bounds>
+			<bounds x="608" y="4" width="23" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="124" y="282" width="24" height="32">
-			</bounds>
+			<bounds x="124" y="282" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="124" y="282" width="24" height="32">
-			</bounds>
+			<bounds x="124" y="282" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="124" y="282" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="124" y="282" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="100" y="282" width="24" height="32">
-			</bounds>
+			<bounds x="100" y="282" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="100" y="282" width="24" height="32">
-			</bounds>
+			<bounds x="100" y="282" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="100" y="282" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="100" y="282" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="133" y="395" width="323" height="27">
-			</bounds>
+			<bounds x="133" y="395" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="133" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="133" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="153" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="153" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="173" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="173" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="193" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="193" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="213" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="213" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="233" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="233" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="253" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="253" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="273" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="273" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="293" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="293" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="313" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="313" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="333" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="333" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="353" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="353" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="373" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="373" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="393" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="393" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="413" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="413" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="433" y="395" width="20" height="27">
-			</bounds>
+			<bounds x="433" y="395" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label190" element="label_190">
-			<bounds x="151" y="489" width="20" height="14">
-			</bounds>
+			<bounds x="151" y="489" width="20" height="14"/>
 		</backdrop>
 		<backdrop name="label191" element="label_191">
-			<bounds x="412" y="489" width="23" height="14">
-			</bounds>
+			<bounds x="412" y="489" width="23" height="14"/>
 		</backdrop>
 		<backdrop name="label192" element="label_192">
-			<bounds x="138" y="382" width="29" height="14">
-			</bounds>
+			<bounds x="138" y="382" width="29" height="14"/>
 		</backdrop>
 		<backdrop name="label193" element="label_193">
-			<bounds x="399" y="382" width="45" height="14">
-			</bounds>
+			<bounds x="399" y="382" width="45" height="14"/>
 		</backdrop>
 		<backdrop name="label194" element="label_194">
-			<bounds x="237" y="602" width="6" height="14">
-			</bounds>
+			<bounds x="237" y="602" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label195" element="label_195">
-			<bounds x="282" y="602" width="6" height="14">
-			</bounds>
+			<bounds x="282" y="602" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label196" element="label_196">
-			<bounds x="406" y="602" width="6" height="14">
-			</bounds>
+			<bounds x="406" y="602" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label197" element="label_197">
-			<bounds x="361" y="602" width="6" height="14">
-			</bounds>
+			<bounds x="361" y="602" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label198" element="label_198">
-			<bounds x="542" y="552" width="6" height="14">
-			</bounds>
+			<bounds x="542" y="552" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label199" element="label_199">
-			<bounds x="500" y="602" width="6" height="14">
-			</bounds>
+			<bounds x="500" y="602" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label200" element="label_200">
-			<bounds x="454" y="602" width="6" height="14">
-			</bounds>
+			<bounds x="454" y="602" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label201" element="label_201">
-			<bounds x="542" y="476" width="11" height="14">
-			</bounds>
+			<bounds x="542" y="476" width="11" height="14"/>
 		</backdrop>
 		<backdrop name="label202" element="label_202">
-			<bounds x="542" y="514" width="12" height="14">
-			</bounds>
+			<bounds x="542" y="514" width="12" height="14"/>
 		</backdrop>
 		<backdrop name="label203" element="label_203">
-			<bounds x="190" y="602" width="6" height="14">
-			</bounds>
+			<bounds x="190" y="602" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label205" element="label_205">
-			<bounds x="145" y="602" width="6" height="14">
-			</bounds>
+			<bounds x="145" y="602" width="6" height="14"/>
 		</backdrop>
 		<backdrop name="label233" element="label_233">
-			<bounds x="108" y="2" width="112" height="28">
-			</bounds>
+			<bounds x="108" y="2" width="112" height="28"/>
 		</backdrop>
 		<backdrop name="label234" element="label_234">
-			<bounds x="408" y="267" width="35" height="14">
-			</bounds>
+			<bounds x="408" y="267" width="35" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_button" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_button" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_button" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_button" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_button" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4clue.lay
+++ b/src/mame/layout/sc4clue.lay
@@ -8,19074 +8,10309 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
+			<color red="0.50" green="0.10" blue="0.10"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
+			<color red="0.12" green="0.02" blue="0.02"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.20" blue="0.20">
-			</color>
+			<color red="1.00" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
+			<color red="0.25" green="0.05" blue="0.05"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.10" blue="0.10">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.02" blue="0.02">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.20" blue="0.20">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="MURDERED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="MURDERED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="CAUGHT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RED HANDED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="CAUGHT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RED HANDED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="COURT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="APPEAREN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="COURT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="APPEAREN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="GO TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KITCHEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="GO TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KITCHEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="COURT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="FEES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="COURT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="FEES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="ADD TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="BACK TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="BACK TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="FOUND NOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GUILTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="FOUND NOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GUILTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_238_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_238_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="COURT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="COURT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED HANDED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED HANDED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
+			<color red="0.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
+			<color red="0.00" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
+			<color red="0.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
+			<color red="0.00" green="0.14" blue="0.14"/>
 		</rect>
 		<text string="3 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
-		</rect>
-		<text string="3 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="NOTE PAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="NOTE PAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JACK POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JACK POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MURDERED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MURDERED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
+			<color red="0.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
+			<color red="0.00" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
+			<color red="0.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
+			<color red="0.00" green="0.14" blue="0.14"/>
 		</rect>
 		<text string="9 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
-		</rect>
-		<text string="9 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="MAGNIFYNG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="MAGNIFYNG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUSPECT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUSPECT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
+			<color red="0.29" green="0.29" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
+			<color red="0.58" green="0.58" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
+			<color red="0.15" green="0.15" blue="0.00"/>
 		</rect>
 		<text string="4 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
+			<color red="0.50" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
+			<color red="1.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="HIDDEN LOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="HIDDEN LOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
+			<color red="0.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
+			<color red="0.00" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
+			<color red="0.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
+			<color red="0.00" green="0.14" blue="0.14"/>
 		</rect>
 		<text string="4 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
-		</rect>
-		<text string="4 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="JURY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JUTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="JURY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JUTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="MAGNIFYING GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="MAGNIFYING GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
+			<color red="0.29" green="0.29" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
+			<color red="0.58" green="0.58" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
+			<color red="0.15" green="0.15" blue="0.00"/>
 		</rect>
 		<text string="3 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUSPECT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUSPECT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUSPECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUSPECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="NOTE PAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="NOTE PAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
+			<color red="0.29" green="0.29" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
+			<color red="0.58" green="0.58" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
+			<color red="0.15" green="0.15" blue="0.00"/>
 		</rect>
 		<text string="10 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="NOTE PAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="NOTE PAD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
+			<color red="0.29" green="0.29" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
+			<color red="0.58" green="0.58" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
+			<color red="0.15" green="0.15" blue="0.00"/>
 		</rect>
 		<text string="5 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="8 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="8 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="GO TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COURT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="GO TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="COURT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
+			<color red="0.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
+			<color red="0.00" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
+			<color red="0.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
+			<color red="0.00" green="0.14" blue="0.14"/>
 		</rect>
 		<text string="7 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
-		</rect>
-		<text string="7 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
+			<color red="0.36" green="0.36" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
+			<color red="0.09" green="0.09" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="0.73" green="0.73" blue="0.00">
-			</color>
+			<color red="0.73" green="0.73" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
+			<color red="0.18" green="0.18" blue="0.00"/>
 		</rect>
 		<text string="BACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HANDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.36" green="0.36" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.73" green="0.73" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.18" green="0.18" blue="0.00">
-			</color>
-		</rect>
-		<text string="BACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HANDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
+			<color red="0.29" green="0.29" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
+			<color red="0.07" green="0.07" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
+			<color red="0.58" green="0.58" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
+			<color red="0.15" green="0.15" blue="0.00"/>
 		</rect>
 		<text string="7 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.29" green="0.29" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.07" green="0.07" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.58" green="0.58" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.15" green="0.15" blue="0.00">
-			</color>
-		</rect>
-		<text string="7 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
+			<color red="0.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
+			<color red="0.00" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
+			<color red="0.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
+			<color red="0.00" green="0.14" blue="0.14"/>
 		</rect>
 		<text string="6 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
-		</rect>
-		<text string="6 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="5 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="5 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="MAGNIFYING GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="MAGNIFYING GLASS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SEARCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SEARCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
+			<color red="0.00" green="0.29" blue="0.29"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
+			<color red="0.00" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
+			<color red="0.00" green="0.58" blue="0.58"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
+			<color red="0.00" green="0.14" blue="0.14"/>
 		</rect>
 		<text string="5 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.29" blue="0.29">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.58" blue="0.58">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.14" blue="0.14">
-			</color>
-		</rect>
-		<text string="5 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUSPECT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUSPECT ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.43">
-			</color>
+			<color red="0.50" green="0.36" blue="0.43"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.11">
-			</color>
+			<color red="0.12" green="0.09" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.86">
-			</color>
+			<color red="1.00" green="0.73" blue="0.86"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.22">
-			</color>
+			<color red="0.25" green="0.18" blue="0.22"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.43">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.11">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.86">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.22">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.43">
-			</color>
+			<color red="0.50" green="0.36" blue="0.43"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.11">
-			</color>
+			<color red="0.12" green="0.09" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.86">
-			</color>
+			<color red="1.00" green="0.73" blue="0.86"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.22">
-			</color>
+			<color red="0.25" green="0.18" blue="0.22"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.43">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.11">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.86">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.22">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.43">
-			</color>
+			<color red="0.50" green="0.36" blue="0.43"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.11">
-			</color>
+			<color red="0.12" green="0.09" blue="0.11"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.86">
-			</color>
+			<color red="1.00" green="0.73" blue="0.86"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.22">
-			</color>
+			<color red="0.25" green="0.18" blue="0.22"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.36" blue="0.43">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.09" blue="0.11">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.73" blue="0.86">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.18" blue="0.22">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
+			<color red="0.00" green="0.03" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
+			<color red="0.00" green="0.06" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
+			<color red="0.00" green="0.03" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
+			<color red="0.00" green="0.06" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
+			<color red="0.00" green="0.03" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
+			<color red="0.00" green="0.06" blue="0.13"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
-		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="NOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GUILTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="NOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GUILTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CLEUDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLEUDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_62_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_62_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="W">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
+			<color red="0.25" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
+			<color red="0.06" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
+			<color red="0.50" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
+			<color red="0.13" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUSPECT 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUSPECT 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUSPECT 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUSPECT 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUSPECT 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUSPECT 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="SUSPECT 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUSPECT 4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LIGHT ALL FOUR FOR ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIGHT ALL FOUR FOR ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="INVISABILITY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="INVISABILITY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.12">
-			</color>
+			<color red="0.50" green="0.31" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
+			<color red="0.12" green="0.07" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.24">
-			</color>
+			<color red="1.00" green="0.62" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
+			<color red="0.25" green="0.15" blue="0.06"/>
 		</rect>
 		<text string="BONUS START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.31" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.62" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.15" blue="0.06">
-			</color>
-		</rect>
-		<text string="BONUS START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.28">
-			</color>
+			<color red="0.50" green="0.28" blue="0.28"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
+			<color red="0.12" green="0.07" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.57">
-			</color>
+			<color red="1.00" green="0.57" blue="0.57"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.14">
-			</color>
+			<color red="0.25" green="0.14" blue="0.14"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.28" blue="0.28">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.07" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.57" blue="0.57">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.14" blue="0.14">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="SUPER START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="GO TO CRIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SCENE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="GO TO CRIME">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SCENE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="BACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HANDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="BACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HANDER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="BACK TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="BACK TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="HALL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="STRAIGHT TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LOUNGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="STRAIGHT TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LOUNGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="ADD TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASHPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="HIDDEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="HIDDEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LOOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="ADD CRIME SCENE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD CRIME SCENE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
+			<color red="0.00" green="0.13" blue="0.27"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
+			<color red="0.00" green="0.03" blue="0.07"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
+			<color red="0.00" green="0.27" blue="0.53"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
+			<color red="0.00" green="0.07" blue="0.13"/>
 		</rect>
 		<text string="FOUND NOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="GUILTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.27">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.07">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.27" blue="0.53">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.07" blue="0.13">
-			</color>
-		</rect>
-		<text string="FOUND NOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="GUILTY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
+			<color red="0.50" green="0.02" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.05" blue="0.05">
-			</color>
+			<color red="1.00" green="0.05" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
+			<color red="0.25" green="0.01" blue="0.01"/>
 		</rect>
 		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
-		</rect>
-		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.20" blue="0.00">
-			</color>
+			<color red="0.40" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.05" blue="0.00">
-			</color>
+			<color red="0.10" green="0.05" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.81" green="0.40" blue="0.00">
-			</color>
+			<color red="0.81" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.10" blue="0.00">
-			</color>
+			<color red="0.20" green="0.10" blue="0.00"/>
 		</rect>
 		<text string="LIGHT A ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.05" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.81" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.10" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIGHT A ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.12" blue="0.12">
-			</color>
+			<color red="0.50" green="0.12" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.24" blue="0.24">
-			</color>
+			<color red="1.00" green="0.24" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="+2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.12" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.24" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="+2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="+3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="+3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.40" green="0.20" blue="0.00">
-			</color>
+			<color red="0.40" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.10" green="0.05" blue="0.00">
-			</color>
+			<color red="0.10" green="0.05" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="0.81" green="0.40" blue="0.00">
-			</color>
+			<color red="0.81" green="0.40" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.20" green="0.10" blue="0.00">
-			</color>
+			<color red="0.20" green="0.10" blue="0.00"/>
 		</rect>
 		<text string="LIGHT A ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.40" green="0.20" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.10" green="0.05" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.81" green="0.40" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.20" green="0.10" blue="0.00">
-			</color>
-		</rect>
-		<text string="LIGHT A ROOM">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
+			<color red="0.50" green="0.02" blue="0.02"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.05" blue="0.05">
-			</color>
+			<color red="1.00" green="0.05" blue="0.05"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
+			<color red="0.25" green="0.01" blue="0.01"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.02" blue="0.02">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.05" blue="0.05">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.01" blue="0.01">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.12" blue="0.12">
-			</color>
+			<color red="0.50" green="0.12" blue="0.12"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
+			<color red="0.12" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.24" blue="0.24">
-			</color>
+			<color red="1.00" green="0.24" blue="0.24"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
+			<color red="0.25" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.12" blue="0.12">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.24" blue="0.24">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLUEDO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+3 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="+??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="+??">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHANCE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="MILLION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="MILLION">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="4 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_14_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_14_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_228_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_228">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_229_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_229">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_230_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_230">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_231_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_231">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="FAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="TRACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_232_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_232">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_233_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_233">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_234_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_234">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_235_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_235">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD/HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_236_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_236">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_237_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_237">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_238_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_238">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_240_border">
 		<rect state="1">
-			<color red="0.00" green="0.33" blue="0.00">
-			</color>
+			<color red="0.00" green="0.33" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.08" blue="0.00">
-			</color>
+			<color red="0.00" green="0.08" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_240">
 		<rect state="1">
-			<color red="0.00" green="0.66" blue="0.00">
-			</color>
+			<color red="0.00" green="0.66" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.16" blue="0.00">
-			</color>
+			<color red="0.00" green="0.16" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_241_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_241">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_105">
 		<text string="K=Knife">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_106">
 		<text string="W=Wrench">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_107">
 		<text string="R=Rope">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_108">
 		<text string="G=Gun">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_135">
 		<text string="1-6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_166">
 		<text string="1-12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_211">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_212">
 		<text string="Dark-Blue-Conservatory">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_213">
 		<text string="Pink-Library">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_214">
 		<text string="Light-Blue-Ball-Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_215">
 		<text string="Orange-Kitchen">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_216">
 		<text string="Geen-Hall">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_217">
 		<text string="Purple-Billiard-Room">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_218">
 		<text string="Red-Lounge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_219">
 		<text string="Yellow-Study">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_220">
 		<text string="+ Repeat Chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="678">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="678"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="246" y="450" width="80" height="140">
-			</bounds>
+			<bounds x="246" y="450" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="246.0000" y="450.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="246.0000" y="450.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="249.3333" y="451.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="249.3333" y="451.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="252.6667" y="453.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="252.6667" y="453.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="256.0000" y="455.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="256.0000" y="455.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="259.3333" y="457.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="259.3333" y="457.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="262.6667" y="459.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="262.6667" y="459.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="246.0000" y="496.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="246.0000" y="496.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="249.3333" y="498.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="249.3333" y="498.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="252.6667" y="500.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="252.6667" y="500.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="256.0000" y="502.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="256.0000" y="502.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="259.3333" y="504.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="259.3333" y="504.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="262.6667" y="506.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="262.6667" y="506.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="246.0000" y="543.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="246.0000" y="543.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="249.3333" y="545.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="249.3333" y="545.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="252.6667" y="547.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="252.6667" y="547.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="256.0000" y="549.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="256.0000" y="549.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="259.3333" y="551.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="259.3333" y="551.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="262.6667" y="553.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="262.6667" y="553.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="246" y="450" width="80" height="140">
-			</bounds>
+			<bounds x="246" y="450" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="328" y="450" width="80" height="140">
-			</bounds>
+			<bounds x="328" y="450" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="328.0000" y="450.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="328.0000" y="450.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="331.3333" y="451.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="331.3333" y="451.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="334.6667" y="453.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="334.6667" y="453.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="338.0000" y="455.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="338.0000" y="455.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="341.3333" y="457.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="341.3333" y="457.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="344.6667" y="459.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="344.6667" y="459.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="328.0000" y="496.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="328.0000" y="496.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="331.3333" y="498.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="331.3333" y="498.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="334.6667" y="500.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="334.6667" y="500.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="338.0000" y="502.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="338.0000" y="502.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="341.3333" y="504.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="341.3333" y="504.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="344.6667" y="506.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="344.6667" y="506.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="328.0000" y="543.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="328.0000" y="543.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="331.3333" y="545.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="331.3333" y="545.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="334.6667" y="547.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="334.6667" y="547.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="338.0000" y="549.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="338.0000" y="549.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="341.3333" y="551.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="341.3333" y="551.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="344.6667" y="553.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="344.6667" y="553.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="328" y="450" width="80" height="140">
-			</bounds>
+			<bounds x="328" y="450" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="410" y="450" width="80" height="140">
-			</bounds>
+			<bounds x="410" y="450" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="410.0000" y="450.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="410.0000" y="450.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="413.3333" y="451.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="413.3333" y="451.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="416.6667" y="453.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="416.6667" y="453.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="420.0000" y="455.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="420.0000" y="455.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="423.3333" y="457.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="423.3333" y="457.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="426.6667" y="459.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="426.6667" y="459.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="410.0000" y="496.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="410.0000" y="496.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="413.3333" y="498.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="413.3333" y="498.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="416.6667" y="500.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="416.6667" y="500.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="420.0000" y="502.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="420.0000" y="502.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="423.3333" y="504.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="423.3333" y="504.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="426.6667" y="506.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="426.6667" y="506.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="410.0000" y="543.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="410.0000" y="543.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="413.3333" y="545.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="413.3333" y="545.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="416.6667" y="547.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="416.6667" y="547.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="420.0000" y="549.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="420.0000" y="549.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="423.3333" y="551.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="423.3333" y="551.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="426.6667" y="553.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="426.6667" y="553.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="410" y="450" width="80" height="140">
-			</bounds>
+			<bounds x="410" y="450" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="747" y="493" width="80" height="60">
-			</bounds>
+			<bounds x="747" y="493" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="747.0000" y="493.0000" width="80.0000" height="60.0000">
-			</bounds>
+			<bounds x="747.0000" y="493.0000" width="80.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="750.3333" y="495.5000" width="73.3333" height="55.0000">
-			</bounds>
+			<bounds x="750.3333" y="495.5000" width="73.3333" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="753.6667" y="498.0000" width="66.6667" height="50.0000">
-			</bounds>
+			<bounds x="753.6667" y="498.0000" width="66.6667" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="757.0000" y="500.5000" width="60.0000" height="45.0000">
-			</bounds>
+			<bounds x="757.0000" y="500.5000" width="60.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="760.3333" y="503.0000" width="53.3333" height="40.0000">
-			</bounds>
+			<bounds x="760.3333" y="503.0000" width="53.3333" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="763.6667" y="505.5000" width="46.6667" height="35.0000">
-			</bounds>
+			<bounds x="763.6667" y="505.5000" width="46.6667" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="747" y="493" width="80" height="60">
-			</bounds>
+			<bounds x="747" y="493" width="80" height="60"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="359" y="163" width="80" height="60">
-			</bounds>
+			<bounds x="359" y="163" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="359" y="163" width="80" height="60">
-			</bounds>
+			<bounds x="359" y="163" width="80" height="60"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="725" y="364" width="50" height="30">
-			</bounds>
+			<bounds x="725" y="364" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="727" y="366" width="46" height="26">
-			</bounds>
+			<bounds x="727" y="366" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="186" y="215" width="70" height="30">
-			</bounds>
+			<bounds x="186" y="215" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="188" y="217" width="66" height="26">
-			</bounds>
+			<bounds x="188" y="217" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="220" y="185" width="76" height="30">
-			</bounds>
+			<bounds x="220" y="185" width="76" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="222" y="187" width="72" height="26">
-			</bounds>
+			<bounds x="222" y="187" width="72" height="26"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="145" y="185" width="76" height="30">
-			</bounds>
+			<bounds x="145" y="185" width="76" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="147" y="187" width="72" height="26">
-			</bounds>
+			<bounds x="147" y="187" width="72" height="26"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="244" y="156" width="70" height="30">
-			</bounds>
+			<bounds x="244" y="156" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="246" y="158" width="66" height="26">
-			</bounds>
+			<bounds x="246" y="158" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="186" y="156" width="58" height="30">
-			</bounds>
+			<bounds x="186" y="156" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="188" y="158" width="54" height="26">
-			</bounds>
+			<bounds x="188" y="158" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="128" y="156" width="58" height="30">
-			</bounds>
+			<bounds x="128" y="156" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="130" y="158" width="54" height="26">
-			</bounds>
+			<bounds x="130" y="158" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="221" y="126" width="58" height="30">
-			</bounds>
+			<bounds x="221" y="126" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="223" y="128" width="54" height="26">
-			</bounds>
+			<bounds x="223" y="128" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="151" y="126" width="70" height="30">
-			</bounds>
+			<bounds x="151" y="126" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="153" y="128" width="66" height="26">
-			</bounds>
+			<bounds x="153" y="128" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="712" y="192" width="14" height="30">
-			</bounds>
+			<bounds x="712" y="192" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="714" y="194" width="10" height="26">
-			</bounds>
+			<bounds x="714" y="194" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="712" y="222" width="14" height="30">
-			</bounds>
+			<bounds x="712" y="222" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="714" y="224" width="10" height="26">
-			</bounds>
+			<bounds x="714" y="224" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="712" y="282" width="14" height="30">
-			</bounds>
+			<bounds x="712" y="282" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="714" y="284" width="10" height="26">
-			</bounds>
+			<bounds x="714" y="284" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="578" y="297" width="66" height="14">
-			</bounds>
+			<bounds x="578" y="297" width="66" height="14"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="580" y="299" width="62" height="10">
-			</bounds>
+			<bounds x="580" y="299" width="62" height="10"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="435" y="297" width="70" height="14">
-			</bounds>
+			<bounds x="435" y="297" width="70" height="14"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="437" y="299" width="66" height="10">
-			</bounds>
+			<bounds x="437" y="299" width="66" height="10"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="74" y="192" width="14" height="30">
-			</bounds>
+			<bounds x="74" y="192" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="76" y="194" width="10" height="26">
-			</bounds>
+			<bounds x="76" y="194" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="74" y="222" width="14" height="30">
-			</bounds>
+			<bounds x="74" y="222" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="76" y="224" width="10" height="26">
-			</bounds>
+			<bounds x="76" y="224" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1_border" state="0">
-			<bounds x="74" y="282" width="14" height="30">
-			</bounds>
+			<bounds x="74" y="282" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="lamp_238_1" state="0">
-			<bounds x="76" y="284" width="10" height="26">
-			</bounds>
+			<bounds x="76" y="284" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="74" y="162" width="50" height="30">
-			</bounds>
+			<bounds x="74" y="162" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="76" y="164" width="46" height="26">
-			</bounds>
+			<bounds x="76" y="164" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="85" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="85" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="87" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="87" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="155" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="155" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="157" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="157" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="225" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="225" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="227" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="227" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="295" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="295" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="297" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="297" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="365" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="365" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="367" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="367" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="435" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="435" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="437" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="437" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="505" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="505" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="507" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="507" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="575" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="575" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="577" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="577" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="645" y="310" width="70" height="30">
-			</bounds>
+			<bounds x="645" y="310" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="647" y="312" width="66" height="26">
-			</bounds>
+			<bounds x="647" y="312" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="11" y="13" width="74" height="30">
-			</bounds>
+			<bounds x="11" y="13" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="13" y="15" width="70" height="26">
-			</bounds>
+			<bounds x="13" y="15" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="17" y="42" width="58" height="30">
-			</bounds>
+			<bounds x="17" y="42" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="19" y="44" width="54" height="26">
-			</bounds>
+			<bounds x="19" y="44" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="17" y="72" width="58" height="30">
-			</bounds>
+			<bounds x="17" y="72" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="19" y="74" width="54" height="26">
-			</bounds>
+			<bounds x="19" y="74" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="17" y="102" width="70" height="30">
-			</bounds>
+			<bounds x="17" y="102" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="19" y="104" width="66" height="26">
-			</bounds>
+			<bounds x="19" y="104" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="17" y="132" width="58" height="30">
-			</bounds>
+			<bounds x="17" y="132" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="19" y="134" width="54" height="26">
-			</bounds>
+			<bounds x="19" y="134" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="17" y="162" width="58" height="30">
-			</bounds>
+			<bounds x="17" y="162" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="19" y="164" width="54" height="26">
-			</bounds>
+			<bounds x="19" y="164" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="17" y="192" width="58" height="30">
-			</bounds>
+			<bounds x="17" y="192" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="19" y="194" width="54" height="26">
-			</bounds>
+			<bounds x="19" y="194" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="17" y="222" width="58" height="30">
-			</bounds>
+			<bounds x="17" y="222" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="19" y="224" width="54" height="26">
-			</bounds>
+			<bounds x="19" y="224" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="17" y="252" width="70" height="30">
-			</bounds>
+			<bounds x="17" y="252" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="19" y="254" width="66" height="26">
-			</bounds>
+			<bounds x="19" y="254" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="17" y="282" width="58" height="30">
-			</bounds>
+			<bounds x="17" y="282" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="19" y="284" width="54" height="26">
-			</bounds>
+			<bounds x="19" y="284" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="11" y="311" width="74" height="34">
-			</bounds>
+			<bounds x="11" y="311" width="74" height="34"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="13" y="313" width="70" height="30">
-			</bounds>
+			<bounds x="13" y="313" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="715" y="311" width="74" height="30">
-			</bounds>
+			<bounds x="715" y="311" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="717" y="313" width="70" height="26">
-			</bounds>
+			<bounds x="717" y="313" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="725" y="282" width="58" height="30">
-			</bounds>
+			<bounds x="725" y="282" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="727" y="284" width="54" height="26">
-			</bounds>
+			<bounds x="727" y="284" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="713" y="252" width="70" height="30">
-			</bounds>
+			<bounds x="713" y="252" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="715" y="254" width="66" height="26">
-			</bounds>
+			<bounds x="715" y="254" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="85" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="85" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="87" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="87" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="725" y="222" width="58" height="30">
-			</bounds>
+			<bounds x="725" y="222" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="727" y="224" width="54" height="26">
-			</bounds>
+			<bounds x="727" y="224" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="155" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="155" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="157" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="157" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="225" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="225" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="227" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="227" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="725" y="192" width="58" height="30">
-			</bounds>
+			<bounds x="725" y="192" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="727" y="194" width="54" height="26">
-			</bounds>
+			<bounds x="727" y="194" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="713" y="162" width="70" height="30">
-			</bounds>
+			<bounds x="713" y="162" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="715" y="164" width="66" height="26">
-			</bounds>
+			<bounds x="715" y="164" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="725" y="132" width="58" height="30">
-			</bounds>
+			<bounds x="725" y="132" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="727" y="134" width="54" height="26">
-			</bounds>
+			<bounds x="727" y="134" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="713" y="102" width="70" height="30">
-			</bounds>
+			<bounds x="713" y="102" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="715" y="104" width="66" height="26">
-			</bounds>
+			<bounds x="715" y="104" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="725" y="72" width="58" height="30">
-			</bounds>
+			<bounds x="725" y="72" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="727" y="74" width="54" height="26">
-			</bounds>
+			<bounds x="727" y="74" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="725" y="42" width="58" height="30">
-			</bounds>
+			<bounds x="725" y="42" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="727" y="44" width="54" height="26">
-			</bounds>
+			<bounds x="727" y="44" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="645" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="645" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="647" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="647" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="575" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="575" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="577" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="577" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="505" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="505" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="507" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="507" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="435" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="435" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="437" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="437" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="365" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="365" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="367" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="367" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="295" y="15" width="70" height="30">
-			</bounds>
+			<bounds x="295" y="15" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="297" y="17" width="66" height="26">
-			</bounds>
+			<bounds x="297" y="17" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="715" y="13" width="74" height="30">
-			</bounds>
+			<bounds x="715" y="13" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="717" y="15" width="70" height="26">
-			</bounds>
+			<bounds x="717" y="15" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="155" y="297" width="70" height="14">
-			</bounds>
+			<bounds x="155" y="297" width="70" height="14"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="157" y="299" width="66" height="10">
-			</bounds>
+			<bounds x="157" y="299" width="66" height="10"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="294" y="297" width="70" height="14">
-			</bounds>
+			<bounds x="294" y="297" width="70" height="14"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="296" y="299" width="66" height="10">
-			</bounds>
+			<bounds x="296" y="299" width="66" height="10"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="74" y="42" width="14" height="30">
-			</bounds>
+			<bounds x="74" y="42" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="76" y="44" width="10" height="26">
-			</bounds>
+			<bounds x="76" y="44" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="74" y="72" width="14" height="30">
-			</bounds>
+			<bounds x="74" y="72" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="76" y="74" width="10" height="26">
-			</bounds>
+			<bounds x="76" y="74" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="74" y="132" width="14" height="30">
-			</bounds>
+			<bounds x="74" y="132" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="76" y="134" width="10" height="26">
-			</bounds>
+			<bounds x="76" y="134" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="295" y="44" width="70" height="14">
-			</bounds>
+			<bounds x="295" y="44" width="70" height="14"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="297" y="46" width="66" height="10">
-			</bounds>
+			<bounds x="297" y="46" width="66" height="10"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="225" y="44" width="70" height="14">
-			</bounds>
+			<bounds x="225" y="44" width="70" height="14"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="227" y="46" width="66" height="10">
-			</bounds>
+			<bounds x="227" y="46" width="66" height="10"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="88" y="44" width="66" height="14">
-			</bounds>
+			<bounds x="88" y="44" width="66" height="14"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="90" y="46" width="62" height="10">
-			</bounds>
+			<bounds x="90" y="46" width="62" height="10"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="645" y="44" width="66" height="14">
-			</bounds>
+			<bounds x="645" y="44" width="66" height="14"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="647" y="46" width="62" height="10">
-			</bounds>
+			<bounds x="647" y="46" width="62" height="10"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="575" y="44" width="70" height="14">
-			</bounds>
+			<bounds x="575" y="44" width="70" height="14"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="577" y="46" width="66" height="10">
-			</bounds>
+			<bounds x="577" y="46" width="66" height="10"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="435" y="44" width="70" height="14">
-			</bounds>
+			<bounds x="435" y="44" width="70" height="14"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="437" y="46" width="66" height="10">
-			</bounds>
+			<bounds x="437" y="46" width="66" height="10"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="712" y="42" width="14" height="30">
-			</bounds>
+			<bounds x="712" y="42" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="714" y="44" width="10" height="26">
-			</bounds>
+			<bounds x="714" y="44" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="712" y="72" width="14" height="30">
-			</bounds>
+			<bounds x="712" y="72" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="714" y="74" width="10" height="26">
-			</bounds>
+			<bounds x="714" y="74" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="712" y="132" width="14" height="30">
-			</bounds>
+			<bounds x="712" y="132" width="14" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="714" y="134" width="10" height="26">
-			</bounds>
+			<bounds x="714" y="134" width="10" height="26"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="257" y="247" width="50" height="30">
-			</bounds>
+			<bounds x="257" y="247" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="259" y="249" width="46" height="26">
-			</bounds>
+			<bounds x="259" y="249" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="110" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="110" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="112" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="112" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="136" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="136" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="138" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="138" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="162" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="162" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="164" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="164" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="188" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="188" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="190" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="190" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="214" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="214" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="216" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="216" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="240" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="240" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="242" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="242" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="266" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="266" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="268" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="268" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="292" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="292" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="294" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="294" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="318" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="318" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="320" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="320" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="344" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="344" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="346" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="346" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="370" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="370" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="372" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="372" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="448" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="448" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="450" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="450" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="422" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="422" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="424" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="424" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="396" y="340" width="26" height="26">
-			</bounds>
+			<bounds x="396" y="340" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="398" y="342" width="22" height="22">
-			</bounds>
+			<bounds x="398" y="342" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="110" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="110" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="112" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="112" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="136" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="136" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="138" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="138" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="162" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="162" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="164" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="164" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="188" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="188" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="190" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="190" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="586" y="360" width="50" height="26">
-			</bounds>
+			<bounds x="586" y="360" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="588" y="362" width="46" height="22">
-			</bounds>
+			<bounds x="588" y="362" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="564" y="412" width="50" height="26">
-			</bounds>
+			<bounds x="564" y="412" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="566" y="414" width="46" height="22">
-			</bounds>
+			<bounds x="566" y="414" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="574" y="386" width="50" height="26">
-			</bounds>
+			<bounds x="574" y="386" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="576" y="388" width="46" height="22">
-			</bounds>
+			<bounds x="576" y="388" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="214" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="214" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="216" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="216" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="370" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="370" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="372" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="372" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="396" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="396" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="398" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="398" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="240" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="240" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="242" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="242" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="292" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="292" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="294" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="294" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1_border" state="0">
-			<bounds x="266" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="266" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp62" element="lamp_62_1" state="0">
-			<bounds x="268" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="268" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="344" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="344" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="346" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="346" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="318" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="318" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="320" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="320" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="448" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="448" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="450" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="450" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="422" y="366" width="26" height="26">
-			</bounds>
+			<bounds x="422" y="366" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="424" y="368" width="22" height="22">
-			</bounds>
+			<bounds x="424" y="368" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="140" y="468" width="30" height="30">
-			</bounds>
+			<bounds x="140" y="468" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="142" y="470" width="26" height="26">
-			</bounds>
+			<bounds x="142" y="470" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="140" y="498" width="30" height="30">
-			</bounds>
+			<bounds x="140" y="498" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="142" y="500" width="26" height="26">
-			</bounds>
+			<bounds x="142" y="500" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="140" y="528" width="30" height="30">
-			</bounds>
+			<bounds x="140" y="528" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="142" y="530" width="26" height="26">
-			</bounds>
+			<bounds x="142" y="530" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="140" y="558" width="30" height="30">
-			</bounds>
+			<bounds x="140" y="558" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="142" y="560" width="26" height="26">
-			</bounds>
+			<bounds x="142" y="560" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="139" y="593" width="32" height="18">
-			</bounds>
+			<bounds x="139" y="593" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="141" y="595" width="28" height="14">
-			</bounds>
+			<bounds x="141" y="595" width="28" height="14"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="551" y="226" width="58" height="30">
-			</bounds>
+			<bounds x="551" y="226" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="553" y="228" width="54" height="26">
-			</bounds>
+			<bounds x="553" y="228" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="609" y="226" width="58" height="30">
-			</bounds>
+			<bounds x="609" y="226" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="611" y="228" width="54" height="26">
-			</bounds>
+			<bounds x="611" y="228" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="551" y="256" width="58" height="30">
-			</bounds>
+			<bounds x="551" y="256" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="553" y="258" width="54" height="26">
-			</bounds>
+			<bounds x="553" y="258" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="609" y="256" width="58" height="30">
-			</bounds>
+			<bounds x="609" y="256" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="611" y="258" width="54" height="26">
-			</bounds>
+			<bounds x="611" y="258" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="537" y="196" width="66" height="30">
-			</bounds>
+			<bounds x="537" y="196" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="539" y="198" width="62" height="26">
-			</bounds>
+			<bounds x="539" y="198" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="602" y="196" width="74" height="30">
-			</bounds>
+			<bounds x="602" y="196" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="604" y="198" width="70" height="26">
-			</bounds>
+			<bounds x="604" y="198" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="531" y="593" width="62" height="38">
-			</bounds>
+			<bounds x="531" y="593" width="62" height="38"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="533" y="595" width="58" height="34">
-			</bounds>
+			<bounds x="533" y="595" width="58" height="34"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="474" y="602" width="58" height="34">
-			</bounds>
+			<bounds x="474" y="602" width="58" height="34"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="476" y="604" width="54" height="30">
-			</bounds>
+			<bounds x="476" y="604" width="54" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="530" y="560" width="62" height="34">
-			</bounds>
+			<bounds x="530" y="560" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="532" y="562" width="58" height="30">
-			</bounds>
+			<bounds x="532" y="562" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="530" y="527" width="62" height="34">
-			</bounds>
+			<bounds x="530" y="527" width="62" height="34"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="532" y="529" width="58" height="30">
-			</bounds>
+			<bounds x="532" y="529" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="202" y="606" width="38" height="30">
-			</bounds>
+			<bounds x="202" y="606" width="38" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="204" y="608" width="34" height="26">
-			</bounds>
+			<bounds x="204" y="608" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="610" y="99" width="76" height="30">
-			</bounds>
+			<bounds x="610" y="99" width="76" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="612" y="101" width="72" height="26">
-			</bounds>
+			<bounds x="612" y="101" width="72" height="26"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="612" y="129" width="58" height="30">
-			</bounds>
+			<bounds x="612" y="129" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="614" y="131" width="54" height="26">
-			</bounds>
+			<bounds x="614" y="131" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="616" y="69" width="58" height="30">
-			</bounds>
+			<bounds x="616" y="69" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="618" y="71" width="54" height="26">
-			</bounds>
+			<bounds x="618" y="71" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="612" y="159" width="76" height="30">
-			</bounds>
+			<bounds x="612" y="159" width="76" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="614" y="161" width="72" height="26">
-			</bounds>
+			<bounds x="614" y="161" width="72" height="26"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="554" y="159" width="58" height="30">
-			</bounds>
+			<bounds x="554" y="159" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="556" y="161" width="54" height="26">
-			</bounds>
+			<bounds x="556" y="161" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="552" y="99" width="58" height="30">
-			</bounds>
+			<bounds x="552" y="99" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="554" y="101" width="54" height="26">
-			</bounds>
+			<bounds x="554" y="101" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="538" y="129" width="74" height="30">
-			</bounds>
+			<bounds x="538" y="129" width="74" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="540" y="131" width="70" height="26">
-			</bounds>
+			<bounds x="540" y="131" width="70" height="26"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="546" y="69" width="70" height="30">
-			</bounds>
+			<bounds x="546" y="69" width="70" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="548" y="71" width="66" height="26">
-			</bounds>
+			<bounds x="548" y="71" width="66" height="26"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="919" y="564" width="50" height="30">
-			</bounds>
+			<bounds x="919" y="564" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="921" y="566" width="46" height="26">
-			</bounds>
+			<bounds x="921" y="566" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="919" y="534" width="50" height="30">
-			</bounds>
+			<bounds x="919" y="534" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="921" y="536" width="46" height="26">
-			</bounds>
+			<bounds x="921" y="536" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="919" y="504" width="50" height="30">
-			</bounds>
+			<bounds x="919" y="504" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="921" y="506" width="46" height="26">
-			</bounds>
+			<bounds x="921" y="506" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="919" y="474" width="50" height="30">
-			</bounds>
+			<bounds x="919" y="474" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="921" y="476" width="46" height="26">
-			</bounds>
+			<bounds x="921" y="476" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="919" y="444" width="50" height="30">
-			</bounds>
+			<bounds x="919" y="444" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="921" y="446" width="46" height="26">
-			</bounds>
+			<bounds x="921" y="446" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="869" y="444" width="50" height="30">
-			</bounds>
+			<bounds x="869" y="444" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="871" y="446" width="46" height="26">
-			</bounds>
+			<bounds x="871" y="446" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="819" y="444" width="50" height="30">
-			</bounds>
+			<bounds x="819" y="444" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="821" y="446" width="46" height="26">
-			</bounds>
+			<bounds x="821" y="446" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="769" y="444" width="50" height="30">
-			</bounds>
+			<bounds x="769" y="444" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="771" y="446" width="46" height="26">
-			</bounds>
+			<bounds x="771" y="446" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="719" y="444" width="50" height="30">
-			</bounds>
+			<bounds x="719" y="444" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="721" y="446" width="46" height="26">
-			</bounds>
+			<bounds x="721" y="446" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="669" y="444" width="50" height="30">
-			</bounds>
+			<bounds x="669" y="444" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="671" y="446" width="46" height="26">
-			</bounds>
+			<bounds x="671" y="446" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="619" y="504" width="50" height="30">
-			</bounds>
+			<bounds x="619" y="504" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="621" y="506" width="46" height="26">
-			</bounds>
+			<bounds x="621" y="506" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="619" y="534" width="50" height="30">
-			</bounds>
+			<bounds x="619" y="534" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="621" y="536" width="46" height="26">
-			</bounds>
+			<bounds x="621" y="536" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="619" y="564" width="50" height="30">
-			</bounds>
+			<bounds x="619" y="564" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="621" y="566" width="46" height="26">
-			</bounds>
+			<bounds x="621" y="566" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="669" y="564" width="50" height="30">
-			</bounds>
+			<bounds x="669" y="564" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="671" y="566" width="46" height="26">
-			</bounds>
+			<bounds x="671" y="566" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="619" y="444" width="50" height="30">
-			</bounds>
+			<bounds x="619" y="444" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="621" y="446" width="46" height="26">
-			</bounds>
+			<bounds x="621" y="446" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="619" y="474" width="50" height="30">
-			</bounds>
+			<bounds x="619" y="474" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="621" y="476" width="46" height="26">
-			</bounds>
+			<bounds x="621" y="476" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="869" y="564" width="50" height="30">
-			</bounds>
+			<bounds x="869" y="564" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="871" y="566" width="46" height="26">
-			</bounds>
+			<bounds x="871" y="566" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="819" y="564" width="50" height="30">
-			</bounds>
+			<bounds x="819" y="564" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="821" y="566" width="46" height="26">
-			</bounds>
+			<bounds x="821" y="566" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="769" y="564" width="50" height="30">
-			</bounds>
+			<bounds x="769" y="564" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="771" y="566" width="46" height="26">
-			</bounds>
+			<bounds x="771" y="566" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="719" y="564" width="50" height="30">
-			</bounds>
+			<bounds x="719" y="564" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="721" y="566" width="46" height="26">
-			</bounds>
+			<bounds x="721" y="566" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="828" y="537" width="26" height="26">
-			</bounds>
+			<bounds x="828" y="537" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="830" y="539" width="22" height="22">
-			</bounds>
+			<bounds x="830" y="539" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="720" y="475" width="26" height="26">
-			</bounds>
+			<bounds x="720" y="475" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="722" y="477" width="22" height="22">
-			</bounds>
+			<bounds x="722" y="477" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="802" y="79" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="79" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="804" y="81" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="81" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="802" y="109" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="109" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="804" y="111" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="111" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="802" y="139" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="139" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="804" y="141" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="141" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="802" y="169" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="169" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="804" y="171" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="171" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="802" y="199" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="199" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="804" y="201" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="201" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="802" y="229" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="229" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="804" y="231" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="231" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="802" y="259" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="259" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="804" y="261" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="261" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="802" y="289" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="289" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="804" y="291" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="291" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="802" y="319" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="319" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="804" y="321" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="321" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="802" y="349" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="349" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="804" y="351" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="351" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="802" y="379" width="50" height="30">
-			</bounds>
+			<bounds x="802" y="379" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="804" y="381" width="46" height="26">
-			</bounds>
+			<bounds x="804" y="381" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="876" y="3" width="52" height="22">
-			</bounds>
+			<bounds x="876" y="3" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="878" y="5" width="48" height="18">
-			</bounds>
+			<bounds x="878" y="5" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="876" y="24" width="52" height="22">
-			</bounds>
+			<bounds x="876" y="24" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="878" y="26" width="48" height="18">
-			</bounds>
+			<bounds x="878" y="26" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="872" y="46" width="58" height="34">
-			</bounds>
+			<bounds x="872" y="46" width="58" height="34"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="874" y="48" width="54" height="30">
-			</bounds>
+			<bounds x="874" y="48" width="54" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="876" y="379" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="379" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="878" y="381" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="381" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="876" y="349" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="349" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="878" y="351" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="351" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="876" y="319" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="319" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="878" y="321" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="321" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="876" y="289" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="289" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="878" y="291" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="291" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="876" y="259" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="259" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="878" y="261" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="261" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="876" y="229" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="229" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="878" y="231" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="231" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="876" y="199" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="199" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="878" y="201" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="201" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="876" y="169" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="169" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="878" y="171" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="171" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="876" y="139" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="139" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="878" y="141" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="141" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="876" y="109" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="109" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="878" y="111" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="111" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="876" y="79" width="50" height="30">
-			</bounds>
+			<bounds x="876" y="79" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="878" y="81" width="46" height="26">
-			</bounds>
+			<bounds x="878" y="81" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="804" y="5" width="50" height="30">
-			</bounds>
+			<bounds x="804" y="5" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="806" y="7" width="46" height="26">
-			</bounds>
+			<bounds x="806" y="7" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="799" y="35" width="58" height="22">
-			</bounds>
+			<bounds x="799" y="35" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="801" y="37" width="54" height="18">
-			</bounds>
+			<bounds x="801" y="37" width="54" height="18"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="799" y="57" width="58" height="22">
-			</bounds>
+			<bounds x="799" y="57" width="58" height="22"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="801" y="59" width="54" height="18">
-			</bounds>
+			<bounds x="801" y="59" width="54" height="18"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="474" y="78" width="38" height="38">
-			</bounds>
+			<bounds x="474" y="78" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="476" y="80" width="34" height="34">
-			</bounds>
+			<bounds x="476" y="80" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="289" y="78" width="38" height="38">
-			</bounds>
+			<bounds x="289" y="78" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="291" y="80" width="34" height="34">
-			</bounds>
+			<bounds x="291" y="80" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="326" y="78" width="38" height="38">
-			</bounds>
+			<bounds x="326" y="78" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="328" y="80" width="34" height="34">
-			</bounds>
+			<bounds x="328" y="80" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="363" y="78" width="38" height="38">
-			</bounds>
+			<bounds x="363" y="78" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="365" y="80" width="34" height="34">
-			</bounds>
+			<bounds x="365" y="80" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="437" y="78" width="38" height="38">
-			</bounds>
+			<bounds x="437" y="78" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="439" y="80" width="34" height="34">
-			</bounds>
+			<bounds x="439" y="80" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="400" y="78" width="38" height="38">
-			</bounds>
+			<bounds x="400" y="78" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="402" y="80" width="34" height="34">
-			</bounds>
+			<bounds x="402" y="80" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="445" y="606" width="30" height="30">
-			</bounds>
+			<bounds x="445" y="606" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="447" y="608" width="26" height="26">
-			</bounds>
+			<bounds x="447" y="608" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="415" y="606" width="30" height="30">
-			</bounds>
+			<bounds x="415" y="606" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="417" y="608" width="26" height="26">
-			</bounds>
+			<bounds x="417" y="608" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="385" y="606" width="30" height="30">
-			</bounds>
+			<bounds x="385" y="606" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="387" y="608" width="26" height="26">
-			</bounds>
+			<bounds x="387" y="608" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="335" y="606" width="50" height="30">
-			</bounds>
+			<bounds x="335" y="606" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="337" y="608" width="46" height="26">
-			</bounds>
+			<bounds x="337" y="608" width="46" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="305" y="606" width="30" height="30">
-			</bounds>
+			<bounds x="305" y="606" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="307" y="608" width="26" height="26">
-			</bounds>
+			<bounds x="307" y="608" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="275" y="606" width="30" height="30">
-			</bounds>
+			<bounds x="275" y="606" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="277" y="608" width="26" height="26">
-			</bounds>
+			<bounds x="277" y="608" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1_border" state="0">
-			<bounds x="241" y="606" width="34" height="30">
-			</bounds>
+			<bounds x="241" y="606" width="34" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="lamp_14_1" state="0">
-			<bounds x="243" y="608" width="30" height="26">
-			</bounds>
+			<bounds x="243" y="608" width="30" height="26"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_228_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="959" y="7" width="38" height="38">
-			</bounds>
+			<bounds x="959" y="7" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_228" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="961" y="9" width="34" height="34">
-			</bounds>
+			<bounds x="961" y="9" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_229_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="181" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="181" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_229" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="183" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="183" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp237" element="colour_button_230_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="309" y="242" width="50" height="38">
-			</bounds>
+			<bounds x="309" y="242" width="50" height="38"/>
 		</backdrop>
 		<backdrop name="lamp237" element="colour_button_230" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="311" y="244" width="46" height="34">
-			</bounds>
+			<bounds x="311" y="244" width="46" height="34"/>
 		</backdrop>
 		<backdrop name="lamp84" element="colour_button_231_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="59" y="348" width="50" height="38">
-			</bounds>
+			<bounds x="59" y="348" width="50" height="38"/>
 		</backdrop>
 		<backdrop name="lamp84" element="colour_button_231" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="61" y="350" width="46" height="34">
-			</bounds>
+			<bounds x="61" y="350" width="46" height="34"/>
 		</backdrop>
 		<backdrop name="lamp248" element="colour_button_232_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="533" y="359" width="50" height="27">
-			</bounds>
+			<bounds x="533" y="359" width="50" height="27"/>
 		</backdrop>
 		<backdrop name="lamp248" element="colour_button_232" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="535" y="361" width="46" height="23">
-			</bounds>
+			<bounds x="535" y="361" width="46" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_233_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="556" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="556" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_233" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="558" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="558" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_234_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="406" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="406" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_234" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="408" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="408" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_235_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="331" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="331" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_235" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="333" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="333" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_236_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="256" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="256" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_236" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="258" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="258" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_237_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="481" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="481" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_237" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="483" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="483" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_238_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="631" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="631" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_238" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="633" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="633" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="colour_button_240_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="794" y="412" width="66" height="30">
-			</bounds>
+			<bounds x="794" y="412" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="colour_button_240" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="796" y="414" width="62" height="26">
-			</bounds>
+			<bounds x="796" y="414" width="62" height="26"/>
 		</backdrop>
 		<backdrop name="lamp99" element="colour_button_241_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="872" y="412" width="66" height="30">
-			</bounds>
+			<bounds x="872" y="412" width="66" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="colour_button_241" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="874" y="414" width="62" height="26">
-			</bounds>
+			<bounds x="874" y="414" width="62" height="26"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="429" y="245" width="24" height="32">
-			</bounds>
+			<bounds x="429" y="245" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit22" element="led_digit_red">
-			<bounds x="429" y="245" width="24" height="32">
-			</bounds>
+			<bounds x="429" y="245" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="429" y="245" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="429" y="245" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="406" y="245" width="24" height="32">
-			</bounds>
+			<bounds x="406" y="245" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit20" element="led_digit_red">
-			<bounds x="406" y="245" width="24" height="32">
-			</bounds>
+			<bounds x="406" y="245" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="406" y="245" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="406" y="245" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="382" y="245" width="24" height="32">
-			</bounds>
+			<bounds x="382" y="245" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit18" element="led_digit_red">
-			<bounds x="382" y="245" width="24" height="32">
-			</bounds>
+			<bounds x="382" y="245" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="382" y="245" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="382" y="245" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="358" y="245" width="24" height="32">
-			</bounds>
+			<bounds x="358" y="245" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit16" element="led_digit_red">
-			<bounds x="358" y="245" width="24" height="32">
-			</bounds>
+			<bounds x="358" y="245" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="358" y="245" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="358" y="245" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="486" y="353" width="24" height="32">
-			</bounds>
+			<bounds x="486" y="353" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="486" y="353" width="24" height="32">
-			</bounds>
+			<bounds x="486" y="353" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="486" y="353" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="486" y="353" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="510" y="353" width="24" height="32">
-			</bounds>
+			<bounds x="510" y="353" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="510" y="353" width="24" height="32">
-			</bounds>
+			<bounds x="510" y="353" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="510" y="353" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="510" y="353" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="189" y="417" width="323" height="27">
-			</bounds>
+			<bounds x="189" y="417" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="189" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="189" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="209" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="209" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="229" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="229" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="249" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="249" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="269" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="269" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="289" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="289" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="309" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="309" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="329" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="329" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="349" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="349" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="369" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="369" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="389" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="389" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="409" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="409" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="429" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="429" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="449" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="449" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="469" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="469" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="489" y="417" width="20" height="27">
-			</bounds>
+			<bounds x="489" y="417" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label105" element="label_105">
-			<bounds x="167" y="396" width="37" height="13">
-			</bounds>
+			<bounds x="167" y="396" width="37" height="13"/>
 		</backdrop>
 		<backdrop name="label106" element="label_106">
-			<bounds x="268" y="396" width="55" height="13">
-			</bounds>
+			<bounds x="268" y="396" width="55" height="13"/>
 		</backdrop>
 		<backdrop name="label107" element="label_107">
-			<bounds x="116" y="396" width="40" height="13">
-			</bounds>
+			<bounds x="116" y="396" width="40" height="13"/>
 		</backdrop>
 		<backdrop name="label108" element="label_108">
-			<bounds x="214" y="396" width="34" height="13">
-			</bounds>
+			<bounds x="214" y="396" width="34" height="13"/>
 		</backdrop>
 		<backdrop name="label135" element="label_135">
-			<bounds x="392" y="147" width="22" height="16">
-			</bounds>
+			<bounds x="392" y="147" width="22" height="16"/>
 		</backdrop>
 		<backdrop name="label166" element="label_166">
-			<bounds x="775" y="477" width="30" height="16">
-			</bounds>
+			<bounds x="775" y="477" width="30" height="16"/>
 		</backdrop>
 		<backdrop name="label211" element="label_211">
-			<bounds x="167" y="412" width="20" height="37">
-			</bounds>
+			<bounds x="167" y="412" width="20" height="37"/>
 		</backdrop>
 		<backdrop name="label212" element="label_212">
-			<bounds x="12" y="432" width="112" height="13">
-			</bounds>
+			<bounds x="12" y="432" width="112" height="13"/>
 		</backdrop>
 		<backdrop name="label213" element="label_213">
-			<bounds x="12" y="447" width="55" height="13">
-			</bounds>
+			<bounds x="12" y="447" width="55" height="13"/>
 		</backdrop>
 		<backdrop name="label214" element="label_214">
-			<bounds x="12" y="462" width="98" height="13">
-			</bounds>
+			<bounds x="12" y="462" width="98" height="13"/>
 		</backdrop>
 		<backdrop name="label215" element="label_215">
-			<bounds x="12" y="477" width="74" height="13">
-			</bounds>
+			<bounds x="12" y="477" width="74" height="13"/>
 		</backdrop>
 		<backdrop name="label216" element="label_216">
-			<bounds x="12" y="507" width="47" height="13">
-			</bounds>
+			<bounds x="12" y="507" width="47" height="13"/>
 		</backdrop>
 		<backdrop name="label217" element="label_217">
-			<bounds x="12" y="492" width="94" height="13">
-			</bounds>
+			<bounds x="12" y="492" width="94" height="13"/>
 		</backdrop>
 		<backdrop name="label218" element="label_218">
-			<bounds x="12" y="402" width="59" height="13">
-			</bounds>
+			<bounds x="12" y="402" width="59" height="13"/>
 		</backdrop>
 		<backdrop name="label219" element="label_219">
-			<bounds x="12" y="417" width="61" height="13">
-			</bounds>
+			<bounds x="12" y="417" width="61" height="13"/>
 		</backdrop>
 		<backdrop name="label220" element="label_220">
-			<bounds x="354" y="277" width="120" height="16">
-			</bounds>
+			<bounds x="354" y="277" width="120" height="16"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_button" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_button" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_button" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_button" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_button" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cmania.lay
+++ b/src/mame/layout/sc4cmania.lay
@@ -8,14424 +8,8511 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
+			<color red="0.50" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
+			<color red="0.12" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
+			<color red="1.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
+			<color red="0.25" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="&#xA3;4+ REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="&#xA3;4+ REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="CASH GAMBLER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="CASH GAMBLER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="&#xA3;3 CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="&#xA3;3 CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="ARROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="ARROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="STEP WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="STEP WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="CASHCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="CASHCADE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MIX 'N' MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MIX 'N' MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3+ REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3+ REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="TURBO WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="TURBO WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="GOLDEN SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="GOLDEN SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="MONEY MAKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="MONEY MAKER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5 CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5 CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="GREED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="GREED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="REEL ROULETTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="REEL ROULETTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ARROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4 TURBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4 TURBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="&#xA3;5 TURBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="&#xA3;5 TURBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="STOP 'N' MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="STOP 'N' MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="SUPER MONEYBELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="SUPER MONEYBELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="UP THE ANTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="UP THE ANTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="COLOUR MANIA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="DOUBLE TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="DOUBLE TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5+ REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5+ REPEAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="WEAKEST LINK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="WEAKEST LINK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FRUIT SQUASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FRUIT SQUASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHOOSE A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3 TURBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3 TURBO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4 CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4 CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="SUPER HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="SUPER HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ARROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ARROW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="FAST CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="FAST CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="L">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_65_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_65_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="U">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="M">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="TRAIL HELD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_52_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_52_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="HO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
-		</rect>
-		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="EXTRA LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LUCKY 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LUCKY 7s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NO LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="TRIPLE SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRIPLE SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLOUR MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="COLOUR MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="COLOUR SHIFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="COLOUR SHIFT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_310_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_310">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_311_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_311">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_312_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="colour_button_312">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="BLUE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_313_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_313">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_314_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="colour_button_314">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_315_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_315">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_316_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_316">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_317_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_317">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_318_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.31">
-			</color>
+			<color red="0.00" green="0.00" blue="0.31"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.08">
-			</color>
+			<color red="0.00" green="0.00" blue="0.08"/>
 		</rect>
 	</element>
 	<element name="colour_button_318">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.63">
-			</color>
+			<color red="0.00" green="0.00" blue="0.63"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.16">
-			</color>
+			<color red="0.00" green="0.00" blue="0.16"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_319_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_319">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_320_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_320">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_321_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_321">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_322_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_322">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_323_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_323">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_324_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_324">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_325_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_325">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_326_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_326">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_327_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.50">
-			</color>
+			<color red="0.25" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.12">
-			</color>
+			<color red="0.06" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_327">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="1.00">
-			</color>
+			<color red="0.50" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.25">
-			</color>
+			<color red="0.13" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_329_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_329">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="GREEN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_330_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_330">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel5" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="5" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_4">
 		<text string="ALL LIT PAYS JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_10">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_5">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1028" height="682">
-			</bounds>
+			<bounds x="0" y="0" width="1028" height="682"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="377" y="492" width="80" height="140">
-			</bounds>
+			<bounds x="377" y="492" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="377.0000" y="492.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="377.0000" y="492.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="380.3333" y="493.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="380.3333" y="493.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="383.6667" y="495.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="383.6667" y="495.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="387.0000" y="497.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="387.0000" y="497.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="390.3333" y="499.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="390.3333" y="499.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="393.6667" y="501.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="393.6667" y="501.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="377.0000" y="538.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="377.0000" y="538.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="380.3333" y="540.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="380.3333" y="540.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="383.6667" y="542.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="383.6667" y="542.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="387.0000" y="544.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="387.0000" y="544.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="390.3333" y="546.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="390.3333" y="546.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="393.6667" y="548.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="393.6667" y="548.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="377.0000" y="585.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="377.0000" y="585.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="380.3333" y="587.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="380.3333" y="587.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="383.6667" y="589.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="383.6667" y="589.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="387.0000" y="591.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="387.0000" y="591.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="390.3333" y="593.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="390.3333" y="593.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="393.6667" y="595.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="393.6667" y="595.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="377" y="492" width="80" height="140">
-			</bounds>
+			<bounds x="377" y="492" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="459" y="492" width="80" height="140">
-			</bounds>
+			<bounds x="459" y="492" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="459.0000" y="492.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="459.0000" y="492.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="462.3333" y="493.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="462.3333" y="493.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="465.6667" y="495.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="465.6667" y="495.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="469.0000" y="497.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="469.0000" y="497.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="472.3333" y="499.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="472.3333" y="499.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="475.6667" y="501.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="475.6667" y="501.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="459.0000" y="538.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="459.0000" y="538.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="462.3333" y="540.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="462.3333" y="540.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="465.6667" y="542.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="465.6667" y="542.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="469.0000" y="544.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="469.0000" y="544.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="472.3333" y="546.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="472.3333" y="546.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="475.6667" y="548.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="475.6667" y="548.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="459.0000" y="585.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="459.0000" y="585.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="462.3333" y="587.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="462.3333" y="587.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="465.6667" y="589.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="465.6667" y="589.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="469.0000" y="591.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="469.0000" y="591.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="472.3333" y="593.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="472.3333" y="593.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="475.6667" y="595.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="475.6667" y="595.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="459" y="492" width="80" height="140">
-			</bounds>
+			<bounds x="459" y="492" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="541" y="492" width="80" height="140">
-			</bounds>
+			<bounds x="541" y="492" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="541.0000" y="492.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="541.0000" y="492.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="544.3333" y="493.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="544.3333" y="493.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="547.6667" y="495.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="547.6667" y="495.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="551.0000" y="497.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="551.0000" y="497.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="554.3333" y="499.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="554.3333" y="499.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="557.6667" y="501.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="557.6667" y="501.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="541.0000" y="538.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="541.0000" y="538.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="544.3333" y="540.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="544.3333" y="540.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="547.6667" y="542.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="547.6667" y="542.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="551.0000" y="544.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="551.0000" y="544.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="554.3333" y="546.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="554.3333" y="546.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="557.6667" y="548.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="557.6667" y="548.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="541.0000" y="585.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="541.0000" y="585.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="544.3333" y="587.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="544.3333" y="587.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="547.6667" y="589.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="547.6667" y="589.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="551.0000" y="591.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="551.0000" y="591.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="554.3333" y="593.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="554.3333" y="593.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="557.6667" y="595.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="557.6667" y="595.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="541" y="492" width="80" height="140">
-			</bounds>
+			<bounds x="541" y="492" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="394" y="354" width="200" height="60">
-			</bounds>
+			<bounds x="394" y="354" width="200" height="60"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="394.0000" y="354.0000" width="200.0000" height="12.0000">
-			</bounds>
+			<bounds x="394.0000" y="354.0000" width="200.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="402.3333" y="354.5000" width="183.3333" height="11.0000">
-			</bounds>
+			<bounds x="402.3333" y="354.5000" width="183.3333" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="410.6667" y="355.0000" width="166.6667" height="10.0000">
-			</bounds>
+			<bounds x="410.6667" y="355.0000" width="166.6667" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="419.0000" y="355.5000" width="150.0000" height="9.0000">
-			</bounds>
+			<bounds x="419.0000" y="355.5000" width="150.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="356.0000" width="133.3333" height="8.0000">
-			</bounds>
+			<bounds x="427.3333" y="356.0000" width="133.3333" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="435.6667" y="356.5000" width="116.6667" height="7.0000">
-			</bounds>
+			<bounds x="435.6667" y="356.5000" width="116.6667" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="394.0000" y="366.0000" width="200.0000" height="12.0000">
-			</bounds>
+			<bounds x="394.0000" y="366.0000" width="200.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="402.3333" y="366.5000" width="183.3333" height="11.0000">
-			</bounds>
+			<bounds x="402.3333" y="366.5000" width="183.3333" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="410.6667" y="367.0000" width="166.6667" height="10.0000">
-			</bounds>
+			<bounds x="410.6667" y="367.0000" width="166.6667" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="419.0000" y="367.5000" width="150.0000" height="9.0000">
-			</bounds>
+			<bounds x="419.0000" y="367.5000" width="150.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="368.0000" width="133.3333" height="8.0000">
-			</bounds>
+			<bounds x="427.3333" y="368.0000" width="133.3333" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="435.6667" y="368.5000" width="116.6667" height="7.0000">
-			</bounds>
+			<bounds x="435.6667" y="368.5000" width="116.6667" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="394.0000" y="378.0000" width="200.0000" height="12.0000">
-			</bounds>
+			<bounds x="394.0000" y="378.0000" width="200.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="402.3333" y="378.5000" width="183.3333" height="11.0000">
-			</bounds>
+			<bounds x="402.3333" y="378.5000" width="183.3333" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="410.6667" y="379.0000" width="166.6667" height="10.0000">
-			</bounds>
+			<bounds x="410.6667" y="379.0000" width="166.6667" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="419.0000" y="379.5000" width="150.0000" height="9.0000">
-			</bounds>
+			<bounds x="419.0000" y="379.5000" width="150.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="380.0000" width="133.3333" height="8.0000">
-			</bounds>
+			<bounds x="427.3333" y="380.0000" width="133.3333" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="435.6667" y="380.5000" width="116.6667" height="7.0000">
-			</bounds>
+			<bounds x="435.6667" y="380.5000" width="116.6667" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="394.0000" y="390.0000" width="200.0000" height="12.0000">
-			</bounds>
+			<bounds x="394.0000" y="390.0000" width="200.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="402.3333" y="390.5000" width="183.3333" height="11.0000">
-			</bounds>
+			<bounds x="402.3333" y="390.5000" width="183.3333" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="410.6667" y="391.0000" width="166.6667" height="10.0000">
-			</bounds>
+			<bounds x="410.6667" y="391.0000" width="166.6667" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="419.0000" y="391.5000" width="150.0000" height="9.0000">
-			</bounds>
+			<bounds x="419.0000" y="391.5000" width="150.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="392.0000" width="133.3333" height="8.0000">
-			</bounds>
+			<bounds x="427.3333" y="392.0000" width="133.3333" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="435.6667" y="392.5000" width="116.6667" height="7.0000">
-			</bounds>
+			<bounds x="435.6667" y="392.5000" width="116.6667" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="394.0000" y="402.0000" width="200.0000" height="12.0000">
-			</bounds>
+			<bounds x="394.0000" y="402.0000" width="200.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="402.3333" y="402.5000" width="183.3333" height="11.0000">
-			</bounds>
+			<bounds x="402.3333" y="402.5000" width="183.3333" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="410.6667" y="403.0000" width="166.6667" height="10.0000">
-			</bounds>
+			<bounds x="410.6667" y="403.0000" width="166.6667" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="419.0000" y="403.5000" width="150.0000" height="9.0000">
-			</bounds>
+			<bounds x="419.0000" y="403.5000" width="150.0000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="427.3333" y="404.0000" width="133.3333" height="8.0000">
-			</bounds>
+			<bounds x="427.3333" y="404.0000" width="133.3333" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="435.6667" y="404.5000" width="116.6667" height="7.0000">
-			</bounds>
+			<bounds x="435.6667" y="404.5000" width="116.6667" height="7.0000"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="394" y="354" width="200" height="60">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="394" y="354" width="200" height="60"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="891" y="52" width="72" height="30">
-			</bounds>
+			<bounds x="891" y="52" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="893" y="54" width="68" height="26">
-			</bounds>
+			<bounds x="893" y="54" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="818" y="52" width="72" height="30">
-			</bounds>
+			<bounds x="818" y="52" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="820" y="54" width="68" height="26">
-			</bounds>
+			<bounds x="820" y="54" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="745" y="52" width="72" height="30">
-			</bounds>
+			<bounds x="745" y="52" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="747" y="54" width="68" height="26">
-			</bounds>
+			<bounds x="747" y="54" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="217" y="451" width="38" height="26">
-			</bounds>
+			<bounds x="217" y="451" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="219" y="453" width="34" height="22">
-			</bounds>
+			<bounds x="219" y="453" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="217" y="481" width="38" height="26">
-			</bounds>
+			<bounds x="217" y="481" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="219" y="483" width="34" height="22">
-			</bounds>
+			<bounds x="219" y="483" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="217" y="511" width="38" height="26">
-			</bounds>
+			<bounds x="217" y="511" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="219" y="513" width="34" height="22">
-			</bounds>
+			<bounds x="219" y="513" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="217" y="541" width="38" height="26">
-			</bounds>
+			<bounds x="217" y="541" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="219" y="543" width="34" height="22">
-			</bounds>
+			<bounds x="219" y="543" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="217" y="571" width="38" height="26">
-			</bounds>
+			<bounds x="217" y="571" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="219" y="573" width="34" height="22">
-			</bounds>
+			<bounds x="219" y="573" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="217" y="601" width="38" height="26">
-			</bounds>
+			<bounds x="217" y="601" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="219" y="603" width="34" height="22">
-			</bounds>
+			<bounds x="219" y="603" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="216" y="632" width="38" height="26">
-			</bounds>
+			<bounds x="216" y="632" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="218" y="634" width="34" height="22">
-			</bounds>
+			<bounds x="218" y="634" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="217" y="361" width="58" height="30">
-			</bounds>
+			<bounds x="217" y="361" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="219" y="363" width="54" height="26">
-			</bounds>
+			<bounds x="219" y="363" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="217" y="391" width="38" height="26">
-			</bounds>
+			<bounds x="217" y="391" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="219" y="393" width="34" height="22">
-			</bounds>
+			<bounds x="219" y="393" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="217" y="421" width="38" height="26">
-			</bounds>
+			<bounds x="217" y="421" width="38" height="26"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="219" y="423" width="34" height="22">
-			</bounds>
+			<bounds x="219" y="423" width="34" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="314" y="619" width="34" height="26">
-			</bounds>
+			<bounds x="314" y="619" width="34" height="26"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="316" y="621" width="30" height="22">
-			</bounds>
+			<bounds x="316" y="621" width="30" height="22"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="318" y="591" width="26" height="26">
-			</bounds>
+			<bounds x="318" y="591" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="320" y="593" width="22" height="22">
-			</bounds>
+			<bounds x="320" y="593" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="318" y="512" width="26" height="26">
-			</bounds>
+			<bounds x="318" y="512" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="320" y="514" width="22" height="22">
-			</bounds>
+			<bounds x="320" y="514" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="318" y="538" width="26" height="26">
-			</bounds>
+			<bounds x="318" y="538" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="320" y="540" width="22" height="22">
-			</bounds>
+			<bounds x="320" y="540" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="318" y="564" width="26" height="26">
-			</bounds>
+			<bounds x="318" y="564" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="320" y="566" width="22" height="22">
-			</bounds>
+			<bounds x="320" y="566" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="588" y="255" width="72" height="30">
-			</bounds>
+			<bounds x="588" y="255" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="590" y="257" width="68" height="26">
-			</bounds>
+			<bounds x="590" y="257" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="588" y="75" width="72" height="30">
-			</bounds>
+			<bounds x="588" y="75" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="590" y="77" width="68" height="26">
-			</bounds>
+			<bounds x="590" y="77" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="588" y="105" width="72" height="30">
-			</bounds>
+			<bounds x="588" y="105" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="590" y="107" width="68" height="26">
-			</bounds>
+			<bounds x="590" y="107" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="588" y="165" width="72" height="30">
-			</bounds>
+			<bounds x="588" y="165" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="590" y="167" width="68" height="26">
-			</bounds>
+			<bounds x="590" y="167" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="588" y="225" width="72" height="30">
-			</bounds>
+			<bounds x="588" y="225" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="590" y="227" width="68" height="26">
-			</bounds>
+			<bounds x="590" y="227" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="588" y="135" width="72" height="30">
-			</bounds>
+			<bounds x="588" y="135" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="590" y="137" width="68" height="26">
-			</bounds>
+			<bounds x="590" y="137" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="588" y="195" width="72" height="30">
-			</bounds>
+			<bounds x="588" y="195" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="590" y="197" width="68" height="26">
-			</bounds>
+			<bounds x="590" y="197" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="427" y="255" width="72" height="30">
-			</bounds>
+			<bounds x="427" y="255" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="429" y="257" width="68" height="26">
-			</bounds>
+			<bounds x="429" y="257" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="427" y="195" width="72" height="30">
-			</bounds>
+			<bounds x="427" y="195" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="429" y="197" width="68" height="26">
-			</bounds>
+			<bounds x="429" y="197" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="427" y="135" width="72" height="30">
-			</bounds>
+			<bounds x="427" y="135" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="429" y="137" width="68" height="26">
-			</bounds>
+			<bounds x="429" y="137" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="427" y="75" width="72" height="30">
-			</bounds>
+			<bounds x="427" y="75" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="429" y="77" width="68" height="26">
-			</bounds>
+			<bounds x="429" y="77" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="503" y="216" width="72" height="30">
-			</bounds>
+			<bounds x="503" y="216" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="505" y="218" width="68" height="26">
-			</bounds>
+			<bounds x="505" y="218" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="503" y="156" width="72" height="30">
-			</bounds>
+			<bounds x="503" y="156" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="505" y="158" width="68" height="26">
-			</bounds>
+			<bounds x="505" y="158" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="503" y="96" width="72" height="30">
-			</bounds>
+			<bounds x="503" y="96" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="505" y="98" width="68" height="26">
-			</bounds>
+			<bounds x="505" y="98" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="848" y="143" width="50" height="26">
-			</bounds>
+			<bounds x="848" y="143" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="850" y="145" width="46" height="22">
-			</bounds>
+			<bounds x="850" y="145" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="748" y="143" width="50" height="26">
-			</bounds>
+			<bounds x="748" y="143" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="750" y="145" width="46" height="22">
-			</bounds>
+			<bounds x="750" y="145" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="798" y="143" width="50" height="26">
-			</bounds>
+			<bounds x="798" y="143" width="50" height="26"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="800" y="145" width="46" height="22">
-			</bounds>
+			<bounds x="800" y="145" width="46" height="22"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="503" y="126" width="72" height="30">
-			</bounds>
+			<bounds x="503" y="126" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="505" y="128" width="68" height="26">
-			</bounds>
+			<bounds x="505" y="128" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="503" y="186" width="72" height="30">
-			</bounds>
+			<bounds x="503" y="186" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="505" y="188" width="68" height="26">
-			</bounds>
+			<bounds x="505" y="188" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="503" y="246" width="72" height="30">
-			</bounds>
+			<bounds x="503" y="246" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="505" y="248" width="68" height="26">
-			</bounds>
+			<bounds x="505" y="248" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="427" y="105" width="72" height="30">
-			</bounds>
+			<bounds x="427" y="105" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="429" y="107" width="68" height="26">
-			</bounds>
+			<bounds x="429" y="107" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="427" y="165" width="72" height="30">
-			</bounds>
+			<bounds x="427" y="165" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="429" y="167" width="68" height="26">
-			</bounds>
+			<bounds x="429" y="167" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="427" y="225" width="72" height="30">
-			</bounds>
+			<bounds x="427" y="225" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="429" y="227" width="68" height="26">
-			</bounds>
+			<bounds x="429" y="227" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="667" y="96" width="72" height="30">
-			</bounds>
+			<bounds x="667" y="96" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="669" y="98" width="68" height="26">
-			</bounds>
+			<bounds x="669" y="98" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="667" y="126" width="72" height="30">
-			</bounds>
+			<bounds x="667" y="126" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="669" y="128" width="68" height="26">
-			</bounds>
+			<bounds x="669" y="128" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="667" y="156" width="72" height="30">
-			</bounds>
+			<bounds x="667" y="156" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="669" y="158" width="68" height="26">
-			</bounds>
+			<bounds x="669" y="158" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="667" y="186" width="72" height="30">
-			</bounds>
+			<bounds x="667" y="186" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="669" y="188" width="68" height="26">
-			</bounds>
+			<bounds x="669" y="188" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="667" y="216" width="72" height="30">
-			</bounds>
+			<bounds x="667" y="216" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="669" y="218" width="68" height="26">
-			</bounds>
+			<bounds x="669" y="218" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="667" y="246" width="72" height="30">
-			</bounds>
+			<bounds x="667" y="246" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="669" y="248" width="68" height="26">
-			</bounds>
+			<bounds x="669" y="248" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="336" y="246" width="72" height="30">
-			</bounds>
+			<bounds x="336" y="246" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="338" y="248" width="68" height="26">
-			</bounds>
+			<bounds x="338" y="248" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="336" y="216" width="72" height="30">
-			</bounds>
+			<bounds x="336" y="216" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="338" y="218" width="68" height="26">
-			</bounds>
+			<bounds x="338" y="218" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="336" y="156" width="72" height="30">
-			</bounds>
+			<bounds x="336" y="156" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="338" y="158" width="68" height="26">
-			</bounds>
+			<bounds x="338" y="158" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="336" y="126" width="72" height="30">
-			</bounds>
+			<bounds x="336" y="126" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="338" y="128" width="68" height="26">
-			</bounds>
+			<bounds x="338" y="128" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="336" y="96" width="72" height="30">
-			</bounds>
+			<bounds x="336" y="96" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="338" y="98" width="68" height="26">
-			</bounds>
+			<bounds x="338" y="98" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="336" y="186" width="72" height="30">
-			</bounds>
+			<bounds x="336" y="186" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="338" y="188" width="68" height="26">
-			</bounds>
+			<bounds x="338" y="188" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="251" y="75" width="72" height="30">
-			</bounds>
+			<bounds x="251" y="75" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="253" y="77" width="68" height="26">
-			</bounds>
+			<bounds x="253" y="77" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="251" y="105" width="72" height="30">
-			</bounds>
+			<bounds x="251" y="105" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="253" y="107" width="68" height="26">
-			</bounds>
+			<bounds x="253" y="107" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="251" y="225" width="72" height="30">
-			</bounds>
+			<bounds x="251" y="225" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="253" y="227" width="68" height="26">
-			</bounds>
+			<bounds x="253" y="227" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="251" y="195" width="72" height="30">
-			</bounds>
+			<bounds x="251" y="195" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="253" y="197" width="68" height="26">
-			</bounds>
+			<bounds x="253" y="197" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="251" y="165" width="72" height="30">
-			</bounds>
+			<bounds x="251" y="165" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="253" y="167" width="68" height="26">
-			</bounds>
+			<bounds x="253" y="167" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="251" y="135" width="72" height="30">
-			</bounds>
+			<bounds x="251" y="135" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="253" y="137" width="68" height="26">
-			</bounds>
+			<bounds x="253" y="137" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="251" y="255" width="72" height="30">
-			</bounds>
+			<bounds x="251" y="255" width="72" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="253" y="257" width="68" height="26">
-			</bounds>
+			<bounds x="253" y="257" width="68" height="26"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="380" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="380" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="382" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="382" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1_border" state="0">
-			<bounds x="349" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="349" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="lamp_65_1" state="0">
-			<bounds x="351" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="351" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="318" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="318" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="320" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="320" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="410" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="410" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="412" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="412" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="441" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="441" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="443" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="443" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="472" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="472" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="474" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="474" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="510" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="510" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="512" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="512" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="541" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="541" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="543" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="543" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="571" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="571" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="573" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="573" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="602" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="602" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="604" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="604" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="632" y="5" width="30" height="30">
-			</bounds>
+			<bounds x="632" y="5" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="634" y="7" width="26" height="26">
-			</bounds>
+			<bounds x="634" y="7" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="783" y="615" width="58" height="26">
-			</bounds>
+			<bounds x="783" y="615" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="785" y="617" width="54" height="22">
-			</bounds>
+			<bounds x="785" y="617" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="797" y="586" width="36" height="25">
-			</bounds>
+			<bounds x="797" y="586" width="36" height="25"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="799" y="588" width="32" height="21">
-			</bounds>
+			<bounds x="799" y="588" width="32" height="21"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="797" y="435" width="36" height="26">
-			</bounds>
+			<bounds x="797" y="435" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="799" y="437" width="32" height="22">
-			</bounds>
+			<bounds x="799" y="437" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="797" y="460" width="36" height="26">
-			</bounds>
+			<bounds x="797" y="460" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="799" y="462" width="32" height="22">
-			</bounds>
+			<bounds x="799" y="462" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="797" y="485" width="36" height="26">
-			</bounds>
+			<bounds x="797" y="485" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="799" y="487" width="32" height="22">
-			</bounds>
+			<bounds x="799" y="487" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1_border" state="0">
-			<bounds x="787" y="510" width="58" height="26">
-			</bounds>
+			<bounds x="787" y="510" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp52" element="lamp_52_1" state="0">
-			<bounds x="789" y="512" width="54" height="22">
-			</bounds>
+			<bounds x="789" y="512" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="797" y="560" width="36" height="26">
-			</bounds>
+			<bounds x="797" y="560" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="799" y="562" width="32" height="22">
-			</bounds>
+			<bounds x="799" y="562" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="797" y="535" width="36" height="26">
-			</bounds>
+			<bounds x="797" y="535" width="36" height="26"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="799" y="537" width="32" height="22">
-			</bounds>
+			<bounds x="799" y="537" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="802" y="169" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="169" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="804" y="171" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="171" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="802" y="191" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="191" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="804" y="193" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="193" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="802" y="213" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="213" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="804" y="215" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="215" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="802" y="235" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="235" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="804" y="237" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="237" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="802" y="257" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="257" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="804" y="259" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="259" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="802" y="279" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="279" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="804" y="281" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="281" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="802" y="301" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="301" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="804" y="303" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="303" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="802" y="323" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="323" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="804" y="325" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="325" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="802" y="345" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="345" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="804" y="347" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="347" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="802" y="367" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="367" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="804" y="369" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="369" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="802" y="411" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="411" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="804" y="413" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="413" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="802" y="389" width="36" height="22">
-			</bounds>
+			<bounds x="802" y="389" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="804" y="391" width="32" height="18">
-			</bounds>
+			<bounds x="804" y="391" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="836" y="411" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="411" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="838" y="413" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="413" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="836" y="389" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="389" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="838" y="391" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="391" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="836" y="367" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="367" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="838" y="369" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="369" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="836" y="345" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="345" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="838" y="347" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="347" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="836" y="323" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="323" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="838" y="325" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="325" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="836" y="301" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="301" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="838" y="303" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="303" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="836" y="279" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="279" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="838" y="281" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="281" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="836" y="257" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="257" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="838" y="259" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="259" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="836" y="235" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="235" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="838" y="237" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="237" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="836" y="213" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="213" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="838" y="215" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="215" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="836" y="191" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="191" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="838" y="193" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="193" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="836" y="168" width="36" height="22">
-			</bounds>
+			<bounds x="836" y="168" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="838" y="170" width="32" height="18">
-			</bounds>
+			<bounds x="838" y="170" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="768" y="169" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="169" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="770" y="171" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="171" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="768" y="191" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="191" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="770" y="193" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="193" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="768" y="213" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="213" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="770" y="215" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="215" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="767" y="235" width="36" height="22">
-			</bounds>
+			<bounds x="767" y="235" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="769" y="237" width="32" height="18">
-			</bounds>
+			<bounds x="769" y="237" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="768" y="257" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="257" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="770" y="259" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="259" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="768" y="279" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="279" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="770" y="281" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="281" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="768" y="301" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="301" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="770" y="303" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="303" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="768" y="323" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="323" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="770" y="325" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="325" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="768" y="345" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="345" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="770" y="347" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="347" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="768" y="367" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="367" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="770" y="369" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="369" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="768" y="389" width="36" height="22">
-			</bounds>
+			<bounds x="768" y="389" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="770" y="391" width="32" height="18">
-			</bounds>
+			<bounds x="770" y="391" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="767" y="412" width="36" height="22">
-			</bounds>
+			<bounds x="767" y="412" width="36" height="22"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="769" y="414" width="32" height="18">
-			</bounds>
+			<bounds x="769" y="414" width="32" height="18"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="34" y="45" width="58" height="30">
-			</bounds>
+			<bounds x="34" y="45" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="36" y="47" width="54" height="26">
-			</bounds>
+			<bounds x="36" y="47" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="58" y="105" width="58" height="30">
-			</bounds>
+			<bounds x="58" y="105" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="60" y="107" width="54" height="26">
-			</bounds>
+			<bounds x="60" y="107" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="70" y="135" width="58" height="30">
-			</bounds>
+			<bounds x="70" y="135" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="72" y="137" width="54" height="26">
-			</bounds>
+			<bounds x="72" y="137" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="82" y="165" width="58" height="30">
-			</bounds>
+			<bounds x="82" y="165" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="84" y="167" width="54" height="26">
-			</bounds>
+			<bounds x="84" y="167" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="94" y="195" width="58" height="30">
-			</bounds>
+			<bounds x="94" y="195" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="96" y="197" width="54" height="26">
-			</bounds>
+			<bounds x="96" y="197" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="46" y="75" width="58" height="30">
-			</bounds>
+			<bounds x="46" y="75" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="48" y="77" width="54" height="26">
-			</bounds>
+			<bounds x="48" y="77" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="118" y="255" width="58" height="30">
-			</bounds>
+			<bounds x="118" y="255" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="120" y="257" width="54" height="26">
-			</bounds>
+			<bounds x="120" y="257" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="106" y="225" width="58" height="30">
-			</bounds>
+			<bounds x="106" y="225" width="58" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="108" y="227" width="54" height="26">
-			</bounds>
+			<bounds x="108" y="227" width="54" height="26"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_310_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="977" y="9" width="46" height="36">
-			</bounds>
+			<bounds x="977" y="9" width="46" height="36"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_310" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="979" y="11" width="42" height="32">
-			</bounds>
+			<bounds x="979" y="11" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="colour_button_311_border" state="0" inputtag="IN-9" inputmask="0x10">
-			<bounds x="309" y="372" width="58" height="26">
-			</bounds>
+			<bounds x="309" y="372" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp176" element="colour_button_311" state="0" inputtag="IN-9" inputmask="0x10">
-			<bounds x="311" y="374" width="54" height="22">
-			</bounds>
+			<bounds x="311" y="374" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp167" element="colour_button_312_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="628" y="289" width="58" height="27">
-			</bounds>
+			<bounds x="628" y="289" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp167" element="colour_button_312" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="630" y="291" width="54" height="23">
-			</bounds>
+			<bounds x="630" y="291" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp76" element="colour_button_313_border" state="0" inputtag="IN-10" inputmask="0x01">
-			<bounds x="465" y="289" width="58" height="27">
-			</bounds>
+			<bounds x="465" y="289" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp76" element="colour_button_313" state="0" inputtag="IN-10" inputmask="0x01">
-			<bounds x="467" y="291" width="54" height="23">
-			</bounds>
+			<bounds x="467" y="291" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp226" element="colour_button_314_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="549" y="418" width="46" height="27">
-			</bounds>
+			<bounds x="549" y="418" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="colour_button_314" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="551" y="420" width="42" height="23">
-			</bounds>
+			<bounds x="551" y="420" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="colour_button_315_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="392" y="418" width="46" height="27">
-			</bounds>
+			<bounds x="392" y="418" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="colour_button_315" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="394" y="420" width="42" height="23">
-			</bounds>
+			<bounds x="394" y="420" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="colour_button_316_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="473" y="418" width="46" height="27">
-			</bounds>
+			<bounds x="473" y="418" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp224" element="colour_button_316" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="475" y="420" width="42" height="23">
-			</bounds>
+			<bounds x="475" y="420" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp180" element="colour_button_317_border" state="0" inputtag="IN-9" inputmask="0x08">
-			<bounds x="393" y="324" width="46" height="27">
-			</bounds>
+			<bounds x="393" y="324" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp180" element="colour_button_317" state="0" inputtag="IN-9" inputmask="0x08">
-			<bounds x="395" y="326" width="42" height="23">
-			</bounds>
+			<bounds x="395" y="326" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp181" element="colour_button_318_border" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="549" y="324" width="46" height="27">
-			</bounds>
+			<bounds x="549" y="324" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp181" element="colour_button_318" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="551" y="326" width="42" height="23">
-			</bounds>
+			<bounds x="551" y="326" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp178" element="colour_button_319_border" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="472" y="325" width="46" height="27">
-			</bounds>
+			<bounds x="472" y="325" width="46" height="27"/>
 		</backdrop>
 		<backdrop name="lamp178" element="colour_button_319" state="0" inputtag="IN-9" inputmask="0x04">
-			<bounds x="474" y="327" width="42" height="23">
-			</bounds>
+			<bounds x="474" y="327" width="42" height="23"/>
 		</backdrop>
 		<backdrop name="lamp182" element="colour_button_320_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="606" y="371" width="58" height="26">
-			</bounds>
+			<bounds x="606" y="371" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp182" element="colour_button_320" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="608" y="373" width="54" height="22">
-			</bounds>
+			<bounds x="608" y="373" width="54" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_321_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="303" y="653" width="75" height="27">
-			</bounds>
+			<bounds x="303" y="653" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_321" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="305" y="655" width="71" height="23">
-			</bounds>
+			<bounds x="305" y="655" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_322_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="603" y="653" width="75" height="27">
-			</bounds>
+			<bounds x="603" y="653" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_322" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="605" y="655" width="71" height="23">
-			</bounds>
+			<bounds x="605" y="655" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_323_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="378" y="653" width="75" height="27">
-			</bounds>
+			<bounds x="378" y="653" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_323" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="380" y="655" width="71" height="23">
-			</bounds>
+			<bounds x="380" y="655" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_324_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="452" y="653" width="75" height="27">
-			</bounds>
+			<bounds x="452" y="653" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_324" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="454" y="655" width="71" height="23">
-			</bounds>
+			<bounds x="454" y="655" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_325_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="528" y="653" width="75" height="27">
-			</bounds>
+			<bounds x="528" y="653" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_325" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="530" y="655" width="71" height="23">
-			</bounds>
+			<bounds x="530" y="655" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_326_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="760" y="653" width="75" height="27">
-			</bounds>
+			<bounds x="760" y="653" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_326" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="762" y="655" width="71" height="23">
-			</bounds>
+			<bounds x="762" y="655" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_327_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="678" y="653" width="82" height="27">
-			</bounds>
+			<bounds x="678" y="653" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_327" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="680" y="655" width="78" height="23">
-			</bounds>
+			<bounds x="680" y="655" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="colour_button_329_border" state="0" inputtag="IN-10" inputmask="0x02">
-			<bounds x="295" y="289" width="58" height="27">
-			</bounds>
+			<bounds x="295" y="289" width="58" height="27"/>
 		</backdrop>
 		<backdrop name="lamp83" element="colour_button_329" state="0" inputtag="IN-10" inputmask="0x02">
-			<bounds x="297" y="291" width="54" height="23">
-			</bounds>
+			<bounds x="297" y="291" width="54" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="colour_button_330_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="890" y="411" width="58" height="26">
-			</bounds>
+			<bounds x="890" y="411" width="58" height="26"/>
 		</backdrop>
 		<backdrop name="lamp227" element="colour_button_330" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="892" y="413" width="54" height="22">
-			</bounds>
+			<bounds x="892" y="413" width="54" height="22"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="338" y="339" width="24" height="32">
-			</bounds>
+			<bounds x="338" y="339" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="338" y="339" width="24" height="32">
-			</bounds>
+			<bounds x="338" y="339" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="338" y="339" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="338" y="339" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="315" y="339" width="24" height="32">
-			</bounds>
+			<bounds x="315" y="339" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit1" element="led_digit_red">
-			<bounds x="315" y="339" width="24" height="32">
-			</bounds>
+			<bounds x="315" y="339" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="315" y="339" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="315" y="339" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="337" y="458" width="323" height="27">
-			</bounds>
+			<bounds x="337" y="458" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="337" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="337" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="357" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="357" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="377" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="377" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="397" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="397" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="417" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="417" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="437" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="437" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="457" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="457" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="477" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="477" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="497" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="497" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="517" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="517" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="537" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="537" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="557" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="557" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="577" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="577" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="597" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="597" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="617" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="617" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="637" y="458" width="20" height="27">
-			</bounds>
+			<bounds x="637" y="458" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label4" element="label_4">
-			<bounds x="810" y="82" width="86" height="26">
-			</bounds>
+			<bounds x="810" y="82" width="86" height="26"/>
 		</backdrop>
 		<backdrop name="label10" element="label_10">
-			<bounds x="321" y="458" width="12" height="24">
-			</bounds>
+			<bounds x="321" y="458" width="12" height="24"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_button" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_button" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_button" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_button" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_button" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_button" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_button" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_button" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_button" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_button" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_button" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_button" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="312.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="312.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="314.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="314.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="316.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="316.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="318.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="318.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="320.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="320.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="322.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="322.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="360.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="360.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="362.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="362.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="364.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="364.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="366.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="366.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="368.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="368.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="370.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="370.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="408.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="408.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="410.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="410.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="412.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="412.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="414.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="414.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="416.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="416.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="418.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="418.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="456.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="456.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="458.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="458.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="460.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="460.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="462.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="462.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="464.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="464.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="466.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="466.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="504.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="504.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="506.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="506.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="508.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="508.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="510.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="510.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="512.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="512.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="514.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="514.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel6" element="debug_stepper_value">
-			<bounds x="1100" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="552" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_5">
-			<bounds x="1180" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="552" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cmous.lay
+++ b/src/mame/layout/sc4cmous.lay
@@ -8,14882 +8,8886 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="EXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LIFE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Trail Held ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail Held ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="DOG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="DOG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</disk>
 		<text string="MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</disk>
-		<text string="MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</disk>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</disk>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</disk>
 		<text string="MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</disk>
-		<text string="MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_256_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_256_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="QPS CASH 'N' MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="QPS CASH 'N' MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="QPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="QPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="SUPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="SUPER ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="XTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="XTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="XTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="XTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="MO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="MO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="US">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="US">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="D">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="Spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="3 X ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="3 X ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="1 X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="1 X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="2x ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="2x ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</disk>
 		<text string="MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
-		</disk>
-		<text string="MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</disk>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</disk>
 		<text string="DOG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="DOG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="3x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="3x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</disk>
 		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</disk>
-		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</disk>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</disk>
 		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</disk>
-		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="8X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="8X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3X ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3X ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="DOUBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="DOUBLE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="DRAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PIPE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="DRAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PIPE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="CATS ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="EYES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.00">
-			</color>
+			<color red="0.00" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="CATS ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="EYES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2XREEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2XREEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CASH POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="6X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="5X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="5X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.03">
-			</color>
+			<color red="0.03" green="0.00" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 		<text string="3 BLIND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.03" green="0.00" blue="0.03">
-			</color>
+			<color red="0.03" green="0.00" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 		<text string="3 BLIND">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="4X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4X REEL ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4X REEL ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4X ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WINSPI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4X ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WINSPI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CAT1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CAT1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="DRAIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PIPE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="DRAIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PIPE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ANIMAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="ANIMAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="QPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="QPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="10X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="10X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="FUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ENOUGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="FUR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ENOUGH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="9X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="9X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HUNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="MOUSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="HUNT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="BIG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CHEESE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WINSPI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WINSPI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="DRAIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PIPE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.00">
-			</color>
+			<color red="0.06" green="0.03" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.00">
-			</color>
+			<color red="0.13" green="0.06" blue="0.00"/>
 		</rect>
 		<text string="DRAIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="PIPE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
+			<color red="0.00" green="0.50" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
+			<color red="0.00" green="0.12" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
+			<color red="0.00" green="1.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
+			<color red="0.00" green="0.25" blue="0.06"/>
 		</rect>
 		<text string="8X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.06">
-			</color>
-		</rect>
-		<text string="8X">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WINSP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHEESEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CHEESEY">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7X REEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CAT2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="CAT2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_145_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_145">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="Refill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_146_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_146">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="EXCHANGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_147_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_147">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="TAKE SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_148_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_148">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_149_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_149">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_150_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_150">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_151_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_151">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_152_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_152">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_153_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_153">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.40"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.50" width="0.80" height="0.40">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.50" width="0.80" height="0.40"/>
 		</text>
 	</element>
 	<element name="colour_button_155_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_155">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="TAKE CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="POT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_97">
 		<text string="Many Thanks to,  Gee Gee, Tokes, Hit The 6, Adyb, Baz and all who helped on my first projext">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1255" height="921">
-			</bounds>
+			<bounds x="0" y="0" width="1255" height="921"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="418" y="681" width="80" height="140">
-			</bounds>
+			<bounds x="418" y="681" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="418.0000" y="681.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="418.0000" y="681.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="421.3333" y="682.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="421.3333" y="682.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="424.6667" y="684.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="424.6667" y="684.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="428.0000" y="686.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="428.0000" y="686.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="431.3333" y="688.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="431.3333" y="688.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="434.6667" y="690.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="434.6667" y="690.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="418.0000" y="727.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="418.0000" y="727.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="421.3333" y="729.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="421.3333" y="729.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="424.6667" y="731.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="424.6667" y="731.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="428.0000" y="733.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="428.0000" y="733.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="431.3333" y="735.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="431.3333" y="735.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="434.6667" y="737.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="434.6667" y="737.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="418.0000" y="774.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="418.0000" y="774.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="421.3333" y="776.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="421.3333" y="776.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="424.6667" y="778.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="424.6667" y="778.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="428.0000" y="780.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="428.0000" y="780.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="431.3333" y="782.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="431.3333" y="782.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="434.6667" y="784.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="434.6667" y="784.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="418" y="681" width="80" height="140">
-			</bounds>
+			<bounds x="418" y="681" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="509" y="680" width="80" height="140">
-			</bounds>
+			<bounds x="509" y="680" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="509.0000" y="680.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="509.0000" y="680.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="512.3333" y="681.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="512.3333" y="681.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="515.6667" y="683.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="515.6667" y="683.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="519.0000" y="685.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="519.0000" y="685.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="522.3333" y="687.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="522.3333" y="687.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="525.6667" y="689.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="525.6667" y="689.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="509.0000" y="726.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="509.0000" y="726.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="512.3333" y="728.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="512.3333" y="728.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="515.6667" y="730.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="515.6667" y="730.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="519.0000" y="732.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="519.0000" y="732.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="522.3333" y="734.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="522.3333" y="734.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="525.6667" y="736.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="525.6667" y="736.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="509.0000" y="773.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="509.0000" y="773.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="512.3333" y="775.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="512.3333" y="775.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="515.6667" y="777.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="515.6667" y="777.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="519.0000" y="779.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="519.0000" y="779.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="522.3333" y="781.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="522.3333" y="781.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="525.6667" y="783.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="525.6667" y="783.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="509" y="680" width="80" height="140">
-			</bounds>
+			<bounds x="509" y="680" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="600" y="680" width="80" height="140">
-			</bounds>
+			<bounds x="600" y="680" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="600.0000" y="680.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="600.0000" y="680.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="603.3333" y="681.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="603.3333" y="681.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="606.6667" y="683.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="606.6667" y="683.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="610.0000" y="685.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="610.0000" y="685.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="613.3333" y="687.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="613.3333" y="687.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="616.6667" y="689.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="616.6667" y="689.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="600.0000" y="726.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="600.0000" y="726.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="603.3333" y="728.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="603.3333" y="728.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="606.6667" y="730.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="606.6667" y="730.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="610.0000" y="732.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="610.0000" y="732.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="613.3333" y="734.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="613.3333" y="734.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="616.6667" y="736.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="616.6667" y="736.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="600.0000" y="773.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="600.0000" y="773.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="603.3333" y="775.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="603.3333" y="775.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="606.6667" y="777.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="606.6667" y="777.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="610.0000" y="779.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="610.0000" y="779.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="613.3333" y="781.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="613.3333" y="781.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="616.6667" y="783.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="616.6667" y="783.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="600" y="680" width="80" height="140">
-			</bounds>
+			<bounds x="600" y="680" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="711" y="715" width="80" height="70">
-			</bounds>
+			<bounds x="711" y="715" width="80" height="70"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="711.0000" y="715.0000" width="80.0000" height="70.0000">
-			</bounds>
+			<bounds x="711.0000" y="715.0000" width="80.0000" height="70.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="714.3333" y="717.9167" width="73.3333" height="64.1667">
-			</bounds>
+			<bounds x="714.3333" y="717.9167" width="73.3333" height="64.1667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="717.6667" y="720.8333" width="66.6667" height="58.3333">
-			</bounds>
+			<bounds x="717.6667" y="720.8333" width="66.6667" height="58.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="721.0000" y="723.7500" width="60.0000" height="52.5000">
-			</bounds>
+			<bounds x="721.0000" y="723.7500" width="60.0000" height="52.5000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="724.3333" y="726.6667" width="53.3333" height="46.6667">
-			</bounds>
+			<bounds x="724.3333" y="726.6667" width="53.3333" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="727.6667" y="729.5833" width="46.6667" height="40.8333">
-			</bounds>
+			<bounds x="727.6667" y="729.5833" width="46.6667" height="40.8333"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="711" y="715" width="80" height="70">
-			</bounds>
+			<bounds x="711" y="715" width="80" height="70"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="253" y="346" width="80" height="80">
-			</bounds>
+			<bounds x="253" y="346" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="253.0000" y="346.0000" width="80.0000" height="80.0000">
-			</bounds>
+			<bounds x="253.0000" y="346.0000" width="80.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="256.3333" y="349.3333" width="73.3333" height="73.3333">
-			</bounds>
+			<bounds x="256.3333" y="349.3333" width="73.3333" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="259.6667" y="352.6667" width="66.6667" height="66.6667">
-			</bounds>
+			<bounds x="259.6667" y="352.6667" width="66.6667" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="263.0000" y="356.0000" width="60.0000" height="60.0000">
-			</bounds>
+			<bounds x="263.0000" y="356.0000" width="60.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="266.3333" y="359.3333" width="53.3333" height="53.3333">
-			</bounds>
+			<bounds x="266.3333" y="359.3333" width="53.3333" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="269.6667" y="362.6667" width="46.6667" height="46.6667">
-			</bounds>
+			<bounds x="269.6667" y="362.6667" width="46.6667" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="253" y="346" width="80" height="80">
-			</bounds>
+			<bounds x="253" y="346" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="802" y="744" width="27" height="27">
-			</bounds>
+			<bounds x="802" y="744" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="804" y="746" width="23" height="23">
-			</bounds>
+			<bounds x="804" y="746" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="521" y="507" width="52" height="52">
-			</bounds>
+			<bounds x="521" y="507" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="523" y="509" width="48" height="48">
-			</bounds>
+			<bounds x="523" y="509" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="681" y="737" width="27" height="27">
-			</bounds>
+			<bounds x="681" y="737" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="683" y="739" width="23" height="23">
-			</bounds>
+			<bounds x="683" y="739" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="726" y="608" width="72" height="46">
-			</bounds>
+			<bounds x="726" y="608" width="72" height="46"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="728" y="610" width="68" height="42">
-			</bounds>
+			<bounds x="728" y="610" width="68" height="42"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="385" y="580" width="52" height="42">
-			</bounds>
+			<bounds x="385" y="580" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="387" y="582" width="48" height="38">
-			</bounds>
+			<bounds x="387" y="582" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="820" y="345" width="52" height="52">
-			</bounds>
+			<bounds x="820" y="345" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="822" y="347" width="48" height="48">
-			</bounds>
+			<bounds x="822" y="347" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="669" y="352" width="52" height="52">
-			</bounds>
+			<bounds x="669" y="352" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="671" y="354" width="48" height="48">
-			</bounds>
+			<bounds x="671" y="354" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="619" y="353" width="52" height="52">
-			</bounds>
+			<bounds x="619" y="353" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="621" y="355" width="48" height="48">
-			</bounds>
+			<bounds x="621" y="355" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="567" y="354" width="52" height="52">
-			</bounds>
+			<bounds x="567" y="354" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="569" y="356" width="48" height="48">
-			</bounds>
+			<bounds x="569" y="356" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="518" y="352" width="52" height="52">
-			</bounds>
+			<bounds x="518" y="352" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="520" y="354" width="48" height="48">
-			</bounds>
+			<bounds x="520" y="354" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="467" y="351" width="52" height="52">
-			</bounds>
+			<bounds x="467" y="351" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="469" y="353" width="48" height="48">
-			</bounds>
+			<bounds x="469" y="353" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="417" y="352" width="52" height="52">
-			</bounds>
+			<bounds x="417" y="352" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="419" y="354" width="48" height="48">
-			</bounds>
+			<bounds x="419" y="354" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="368" y="350" width="52" height="52">
-			</bounds>
+			<bounds x="368" y="350" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="370" y="352" width="48" height="48">
-			</bounds>
+			<bounds x="370" y="352" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp256" element="lamp_256_1_border" state="0">
-			<bounds x="94" y="1" width="202" height="102">
-			</bounds>
+			<bounds x="94" y="1" width="202" height="102"/>
 		</backdrop>
 		<backdrop name="lamp256" element="lamp_256_1" state="0">
-			<bounds x="96" y="3" width="198" height="98">
-			</bounds>
+			<bounds x="96" y="3" width="198" height="98"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="406" y="621" width="27" height="27">
-			</bounds>
+			<bounds x="406" y="621" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="408" y="623" width="23" height="23">
-			</bounds>
+			<bounds x="408" y="623" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="432" y="621" width="27" height="27">
-			</bounds>
+			<bounds x="432" y="621" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="434" y="623" width="23" height="23">
-			</bounds>
+			<bounds x="434" y="623" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="457" y="621" width="27" height="27">
-			</bounds>
+			<bounds x="457" y="621" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="459" y="623" width="23" height="23">
-			</bounds>
+			<bounds x="459" y="623" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="482" y="621" width="27" height="27">
-			</bounds>
+			<bounds x="482" y="621" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="484" y="623" width="23" height="23">
-			</bounds>
+			<bounds x="484" y="623" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="506" y="622" width="27" height="27">
-			</bounds>
+			<bounds x="506" y="622" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="508" y="624" width="23" height="23">
-			</bounds>
+			<bounds x="508" y="624" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="533" y="622" width="27" height="27">
-			</bounds>
+			<bounds x="533" y="622" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="535" y="624" width="23" height="23">
-			</bounds>
+			<bounds x="535" y="624" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="684" y="607" width="44" height="44">
-			</bounds>
+			<bounds x="684" y="607" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="686" y="609" width="40" height="40">
-			</bounds>
+			<bounds x="686" y="609" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="644" y="608" width="44" height="44">
-			</bounds>
+			<bounds x="644" y="608" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="646" y="610" width="40" height="40">
-			</bounds>
+			<bounds x="646" y="610" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="381" y="621" width="27" height="27">
-			</bounds>
+			<bounds x="381" y="621" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="383" y="623" width="23" height="23">
-			</bounds>
+			<bounds x="383" y="623" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="601" y="606" width="47" height="47">
-			</bounds>
+			<bounds x="601" y="606" width="47" height="47"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="603" y="608" width="43" height="43">
-			</bounds>
+			<bounds x="603" y="608" width="43" height="43"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="559" y="608" width="44" height="44">
-			</bounds>
+			<bounds x="559" y="608" width="44" height="44"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="561" y="610" width="40" height="40">
-			</bounds>
+			<bounds x="561" y="610" width="40" height="40"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="683" y="419" width="36" height="36">
-			</bounds>
+			<bounds x="683" y="419" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="685" y="421" width="32" height="32">
-			</bounds>
+			<bounds x="685" y="421" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="751" y="419" width="36" height="36">
-			</bounds>
+			<bounds x="751" y="419" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="753" y="421" width="32" height="32">
-			</bounds>
+			<bounds x="753" y="421" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="717" y="419" width="36" height="36">
-			</bounds>
+			<bounds x="717" y="419" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="719" y="421" width="32" height="32">
-			</bounds>
+			<bounds x="719" y="421" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="496" y="417" width="36" height="36">
-			</bounds>
+			<bounds x="496" y="417" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="498" y="419" width="32" height="32">
-			</bounds>
+			<bounds x="498" y="419" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="462" y="416" width="36" height="36">
-			</bounds>
+			<bounds x="462" y="416" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="464" y="418" width="32" height="32">
-			</bounds>
+			<bounds x="464" y="418" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="428" y="416" width="36" height="36">
-			</bounds>
+			<bounds x="428" y="416" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="430" y="418" width="32" height="32">
-			</bounds>
+			<bounds x="430" y="418" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="816" y="454" width="52" height="52">
-			</bounds>
+			<bounds x="816" y="454" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="818" y="456" width="48" height="48">
-			</bounds>
+			<bounds x="818" y="456" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="766" y="456" width="52" height="52">
-			</bounds>
+			<bounds x="766" y="456" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="768" y="458" width="48" height="48">
-			</bounds>
+			<bounds x="768" y="458" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="717" y="459" width="52" height="52">
-			</bounds>
+			<bounds x="717" y="459" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="719" y="461" width="48" height="48">
-			</bounds>
+			<bounds x="719" y="461" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="668" y="456" width="52" height="52">
-			</bounds>
+			<bounds x="668" y="456" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="670" y="458" width="48" height="48">
-			</bounds>
+			<bounds x="670" y="458" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="618" y="454" width="52" height="52">
-			</bounds>
+			<bounds x="618" y="454" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="620" y="456" width="48" height="48">
-			</bounds>
+			<bounds x="620" y="456" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="569" y="456" width="52" height="52">
-			</bounds>
+			<bounds x="569" y="456" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="571" y="458" width="48" height="48">
-			</bounds>
+			<bounds x="571" y="458" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="519" y="456" width="52" height="52">
-			</bounds>
+			<bounds x="519" y="456" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="521" y="458" width="48" height="48">
-			</bounds>
+			<bounds x="521" y="458" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="470" y="455" width="52" height="52">
-			</bounds>
+			<bounds x="470" y="455" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="472" y="457" width="48" height="48">
-			</bounds>
+			<bounds x="472" y="457" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="420" y="457" width="52" height="52">
-			</bounds>
+			<bounds x="420" y="457" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="422" y="459" width="48" height="48">
-			</bounds>
+			<bounds x="422" y="459" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="370" y="454" width="52" height="52">
-			</bounds>
+			<bounds x="370" y="454" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="372" y="456" width="48" height="48">
-			</bounds>
+			<bounds x="372" y="456" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="368" y="405" width="52" height="52">
-			</bounds>
+			<bounds x="368" y="405" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="370" y="407" width="48" height="48">
-			</bounds>
+			<bounds x="370" y="407" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="822" y="403" width="52" height="52">
-			</bounds>
+			<bounds x="822" y="403" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="824" y="405" width="48" height="48">
-			</bounds>
+			<bounds x="824" y="405" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="720" y="350" width="52" height="52">
-			</bounds>
+			<bounds x="720" y="350" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="722" y="352" width="48" height="48">
-			</bounds>
+			<bounds x="722" y="352" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="771" y="349" width="52" height="52">
-			</bounds>
+			<bounds x="771" y="349" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="773" y="351" width="48" height="48">
-			</bounds>
+			<bounds x="773" y="351" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="712" y="519" width="36" height="36">
-			</bounds>
+			<bounds x="712" y="519" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="714" y="521" width="32" height="32">
-			</bounds>
+			<bounds x="714" y="521" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="678" y="519" width="36" height="36">
-			</bounds>
+			<bounds x="678" y="519" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="680" y="521" width="32" height="32">
-			</bounds>
+			<bounds x="680" y="521" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="644" y="519" width="36" height="36">
-			</bounds>
+			<bounds x="644" y="519" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="646" y="521" width="32" height="32">
-			</bounds>
+			<bounds x="646" y="521" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="610" y="519" width="36" height="36">
-			</bounds>
+			<bounds x="610" y="519" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="612" y="521" width="32" height="32">
-			</bounds>
+			<bounds x="612" y="521" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="746" y="519" width="36" height="36">
-			</bounds>
+			<bounds x="746" y="519" width="36" height="36"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="748" y="521" width="32" height="32">
-			</bounds>
+			<bounds x="748" y="521" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="973" y="96" width="52" height="52">
-			</bounds>
+			<bounds x="973" y="96" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="975" y="98" width="48" height="48">
-			</bounds>
+			<bounds x="975" y="98" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="330" y="243" width="52" height="52">
-			</bounds>
+			<bounds x="330" y="243" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="332" y="245" width="48" height="48">
-			</bounds>
+			<bounds x="332" y="245" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="331" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="331" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="333" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="333" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="972" y="145" width="52" height="52">
-			</bounds>
+			<bounds x="972" y="145" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="974" y="147" width="48" height="48">
-			</bounds>
+			<bounds x="974" y="147" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="972" y="145" width="52" height="52">
-			</bounds>
+			<bounds x="972" y="145" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="974" y="147" width="48" height="48">
-			</bounds>
+			<bounds x="974" y="147" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="479" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="479" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="481" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="481" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="578" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="578" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="580" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="580" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="775" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="775" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="777" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="777" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="725" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="725" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="727" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="727" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="676" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="676" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="678" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="678" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="676" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="676" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="678" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="678" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="628" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="628" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="630" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="630" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="628" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="628" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="630" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="630" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="529" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="529" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="531" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="531" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="430" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="430" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="432" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="432" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="380" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="380" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="382" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="382" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="931" y="253" width="52" height="52">
-			</bounds>
+			<bounds x="931" y="253" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="933" y="255" width="48" height="48">
-			</bounds>
+			<bounds x="933" y="255" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="938" y="460" width="42" height="42">
-			</bounds>
+			<bounds x="938" y="460" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="940" y="462" width="38" height="38">
-			</bounds>
+			<bounds x="940" y="462" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="938" y="499" width="42" height="42">
-			</bounds>
+			<bounds x="938" y="499" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="940" y="501" width="38" height="38">
-			</bounds>
+			<bounds x="940" y="501" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="938" y="538" width="42" height="42">
-			</bounds>
+			<bounds x="938" y="538" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="940" y="540" width="38" height="38">
-			</bounds>
+			<bounds x="940" y="540" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="938" y="421" width="42" height="42">
-			</bounds>
+			<bounds x="938" y="421" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="940" y="423" width="38" height="38">
-			</bounds>
+			<bounds x="940" y="423" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="938" y="381" width="42" height="42">
-			</bounds>
+			<bounds x="938" y="381" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="940" y="383" width="38" height="38">
-			</bounds>
+			<bounds x="940" y="383" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="938" y="342" width="42" height="42">
-			</bounds>
+			<bounds x="938" y="342" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="940" y="344" width="38" height="38">
-			</bounds>
+			<bounds x="940" y="344" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="938" y="303" width="42" height="42">
-			</bounds>
+			<bounds x="938" y="303" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="940" y="305" width="38" height="38">
-			</bounds>
+			<bounds x="940" y="305" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="939" y="656" width="42" height="42">
-			</bounds>
+			<bounds x="939" y="656" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="941" y="658" width="38" height="38">
-			</bounds>
+			<bounds x="941" y="658" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="939" y="696" width="42" height="42">
-			</bounds>
+			<bounds x="939" y="696" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="941" y="698" width="38" height="38">
-			</bounds>
+			<bounds x="941" y="698" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="939" y="617" width="42" height="42">
-			</bounds>
+			<bounds x="939" y="617" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="941" y="619" width="38" height="38">
-			</bounds>
+			<bounds x="941" y="619" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="939" y="578" width="42" height="42">
-			</bounds>
+			<bounds x="939" y="578" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="941" y="580" width="38" height="38">
-			</bounds>
+			<bounds x="941" y="580" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="872" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="872" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="874" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="874" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="824" y="292" width="52" height="52">
-			</bounds>
+			<bounds x="824" y="292" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="826" y="294" width="48" height="48">
-			</bounds>
+			<bounds x="826" y="294" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="387" y="40" width="19" height="19">
-			</bounds>
+			<bounds x="387" y="40" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="389" y="42" width="15" height="15">
-			</bounds>
+			<bounds x="389" y="42" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="542" y="39" width="19" height="19">
-			</bounds>
+			<bounds x="542" y="39" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="544" y="41" width="15" height="15">
-			</bounds>
+			<bounds x="544" y="41" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="509" y="41" width="19" height="19">
-			</bounds>
+			<bounds x="509" y="41" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="511" y="43" width="15" height="15">
-			</bounds>
+			<bounds x="511" y="43" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="466" y="40" width="19" height="19">
-			</bounds>
+			<bounds x="466" y="40" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="468" y="42" width="15" height="15">
-			</bounds>
+			<bounds x="468" y="42" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="823" y="196" width="52" height="52">
-			</bounds>
+			<bounds x="823" y="196" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="825" y="198" width="48" height="48">
-			</bounds>
+			<bounds x="825" y="198" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="773" y="196" width="52" height="52">
-			</bounds>
+			<bounds x="773" y="196" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="775" y="198" width="48" height="48">
-			</bounds>
+			<bounds x="775" y="198" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="723" y="197" width="52" height="52">
-			</bounds>
+			<bounds x="723" y="197" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="725" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="725" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="674" y="196" width="52" height="52">
-			</bounds>
+			<bounds x="674" y="196" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="676" y="198" width="48" height="48">
-			</bounds>
+			<bounds x="676" y="198" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="627" y="197" width="52" height="52">
-			</bounds>
+			<bounds x="627" y="197" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="629" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="629" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="627" y="197" width="52" height="52">
-			</bounds>
+			<bounds x="627" y="197" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="629" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="629" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="578" y="197" width="52" height="52">
-			</bounds>
+			<bounds x="578" y="197" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="580" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="580" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="529" y="197" width="52" height="52">
-			</bounds>
+			<bounds x="529" y="197" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="531" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="531" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="479" y="197" width="52" height="52">
-			</bounds>
+			<bounds x="479" y="197" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="481" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="481" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="429" y="197" width="52" height="52">
-			</bounds>
+			<bounds x="429" y="197" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="431" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="431" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="380" y="197" width="52" height="52">
-			</bounds>
+			<bounds x="380" y="197" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="382" y="199" width="48" height="48">
-			</bounds>
+			<bounds x="382" y="199" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="873" y="196" width="52" height="52">
-			</bounds>
+			<bounds x="873" y="196" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="875" y="198" width="48" height="48">
-			</bounds>
+			<bounds x="875" y="198" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="873" y="196" width="52" height="52">
-			</bounds>
+			<bounds x="873" y="196" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="875" y="198" width="48" height="48">
-			</bounds>
+			<bounds x="875" y="198" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="923" y="196" width="52" height="52">
-			</bounds>
+			<bounds x="923" y="196" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="925" y="198" width="48" height="48">
-			</bounds>
+			<bounds x="925" y="198" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="923" y="196" width="52" height="52">
-			</bounds>
+			<bounds x="923" y="196" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="925" y="198" width="48" height="48">
-			</bounds>
+			<bounds x="925" y="198" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="973" y="196" width="52" height="52">
-			</bounds>
+			<bounds x="973" y="196" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="975" y="198" width="48" height="48">
-			</bounds>
+			<bounds x="975" y="198" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="331" y="195" width="52" height="52">
-			</bounds>
+			<bounds x="331" y="195" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="333" y="197" width="48" height="48">
-			</bounds>
+			<bounds x="333" y="197" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="331" y="195" width="52" height="52">
-			</bounds>
+			<bounds x="331" y="195" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="333" y="197" width="48" height="48">
-			</bounds>
+			<bounds x="333" y="197" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="1064" y="215" width="27" height="27">
-			</bounds>
+			<bounds x="1064" y="215" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="1066" y="217" width="23" height="23">
-			</bounds>
+			<bounds x="1066" y="217" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="1064" y="215" width="27" height="27">
-			</bounds>
+			<bounds x="1064" y="215" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="1066" y="217" width="23" height="23">
-			</bounds>
+			<bounds x="1066" y="217" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="36" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="36" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="38" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="38" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="428" y="40" width="19" height="19">
-			</bounds>
+			<bounds x="428" y="40" width="19" height="19"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="430" y="42" width="15" height="15">
-			</bounds>
+			<bounds x="430" y="42" width="15" height="15"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="231" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="231" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="233" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="233" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="281" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="281" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="283" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="283" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="332" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="332" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="334" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="334" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="332" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="332" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="334" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="334" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="381" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="381" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="383" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="383" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="430" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="430" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="432" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="432" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="578" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="578" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="580" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="580" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="479" y="99" width="52" height="52">
-			</bounds>
+			<bounds x="479" y="99" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="481" y="101" width="48" height="48">
-			</bounds>
+			<bounds x="481" y="101" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="479" y="99" width="52" height="52">
-			</bounds>
+			<bounds x="479" y="99" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="481" y="101" width="48" height="48">
-			</bounds>
+			<bounds x="481" y="101" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="181" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="181" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="183" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="183" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="83" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="83" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="85" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="85" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="83" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="83" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="85" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="85" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="132" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="132" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="134" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="134" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="132" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="132" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="134" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="134" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="528" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="528" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="530" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="530" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="677" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="677" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="679" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="679" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="677" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="677" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="679" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="679" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="724" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="724" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="726" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="726" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="724" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="724" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="726" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="726" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="773" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="773" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="775" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="775" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="822" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="822" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="824" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="824" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="872" y="97" width="52" height="52">
-			</bounds>
+			<bounds x="872" y="97" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="874" y="99" width="48" height="48">
-			</bounds>
+			<bounds x="874" y="99" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="872" y="97" width="52" height="52">
-			</bounds>
+			<bounds x="872" y="97" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="874" y="99" width="48" height="48">
-			</bounds>
+			<bounds x="874" y="99" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="921" y="97" width="52" height="52">
-			</bounds>
+			<bounds x="921" y="97" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="923" y="99" width="48" height="48">
-			</bounds>
+			<bounds x="923" y="99" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="627" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="627" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="629" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="629" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="627" y="98" width="52" height="52">
-			</bounds>
+			<bounds x="627" y="98" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="629" y="100" width="48" height="48">
-			</bounds>
+			<bounds x="629" y="100" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="379" y="1" width="42" height="42">
-			</bounds>
+			<bounds x="379" y="1" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="381" y="3" width="38" height="38">
-			</bounds>
+			<bounds x="381" y="3" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="340" y="1" width="42" height="42">
-			</bounds>
+			<bounds x="340" y="1" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="342" y="3" width="38" height="38">
-			</bounds>
+			<bounds x="342" y="3" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="418" y="1" width="42" height="42">
-			</bounds>
+			<bounds x="418" y="1" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="420" y="3" width="38" height="38">
-			</bounds>
+			<bounds x="420" y="3" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="456" y="1" width="42" height="42">
-			</bounds>
+			<bounds x="456" y="1" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="458" y="3" width="38" height="38">
-			</bounds>
+			<bounds x="458" y="3" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="495" y="1" width="42" height="42">
-			</bounds>
+			<bounds x="495" y="1" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="497" y="3" width="38" height="38">
-			</bounds>
+			<bounds x="497" y="3" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="533" y="1" width="42" height="42">
-			</bounds>
+			<bounds x="533" y="1" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="535" y="3" width="38" height="38">
-			</bounds>
+			<bounds x="535" y="3" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_145_border" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1242" y="8" width="75" height="27">
-			</bounds>
+			<bounds x="1242" y="8" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_145" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1244" y="10" width="71" height="23">
-			</bounds>
+			<bounds x="1244" y="10" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_146_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="317" y="857" width="75" height="42">
-			</bounds>
+			<bounds x="317" y="857" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_146" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="319" y="859" width="71" height="38">
-			</bounds>
+			<bounds x="319" y="859" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_147_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="242" y="306" width="75" height="27">
-			</bounds>
+			<bounds x="242" y="306" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_147" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="244" y="308" width="71" height="23">
-			</bounds>
+			<bounds x="244" y="308" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_148_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="790" y="844" width="75" height="42">
-			</bounds>
+			<bounds x="790" y="844" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_148" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="792" y="846" width="71" height="38">
-			</bounds>
+			<bounds x="792" y="846" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_149_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="386" y="512" width="57" height="37">
-			</bounds>
+			<bounds x="386" y="512" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_149" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="388" y="514" width="53" height="33">
-			</bounds>
+			<bounds x="388" y="514" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_150_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="609" y="853" width="75" height="42">
-			</bounds>
+			<bounds x="609" y="853" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_150" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="611" y="855" width="71" height="38">
-			</bounds>
+			<bounds x="611" y="855" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_151_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="511" y="853" width="75" height="42">
-			</bounds>
+			<bounds x="511" y="853" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_151" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="513" y="855" width="71" height="38">
-			</bounds>
+			<bounds x="513" y="855" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_152_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="414" y="853" width="75" height="42">
-			</bounds>
+			<bounds x="414" y="853" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_152" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="416" y="855" width="71" height="38">
-			</bounds>
+			<bounds x="416" y="855" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_153_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="700" y="850" width="75" height="42">
-			</bounds>
+			<bounds x="700" y="850" width="75" height="42"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_153" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="702" y="852" width="71" height="38">
-			</bounds>
+			<bounds x="702" y="852" width="71" height="38"/>
 		</backdrop>
 		<backdrop name="lamp131" element="colour_button_155_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="444" y="512" width="72" height="37">
-			</bounds>
+			<bounds x="444" y="512" width="72" height="37"/>
 		</backdrop>
 		<backdrop name="lamp131" element="colour_button_155" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="446" y="514" width="68" height="33">
-			</bounds>
+			<bounds x="446" y="514" width="68" height="33"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_156_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1037" y="189" width="75" height="27">
-			</bounds>
+			<bounds x="1037" y="189" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_156" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1039" y="191" width="71" height="23">
-			</bounds>
+			<bounds x="1039" y="191" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="413" y="549" width="24" height="32">
-			</bounds>
+			<bounds x="413" y="549" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="413" y="549" width="24" height="32">
-			</bounds>
+			<bounds x="413" y="549" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="413" y="549" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="413" y="549" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="389" y="549" width="24" height="32">
-			</bounds>
+			<bounds x="389" y="549" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="389" y="549" width="24" height="32">
-			</bounds>
+			<bounds x="389" y="549" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="389" y="549" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="389" y="549" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="287" y="275" width="24" height="32">
-			</bounds>
+			<bounds x="287" y="275" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit4" element="led_digit_red">
-			<bounds x="287" y="275" width="24" height="32">
-			</bounds>
+			<bounds x="287" y="275" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="287" y="275" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="287" y="275" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="263" y="275" width="24" height="32">
-			</bounds>
+			<bounds x="263" y="275" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="263" y="275" width="24" height="32">
-			</bounds>
+			<bounds x="263" y="275" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="263" y="275" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="263" y="275" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="444" y="550" width="24" height="32">
-			</bounds>
+			<bounds x="444" y="550" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit12" element="led_digit_red">
-			<bounds x="444" y="550" width="24" height="32">
-			</bounds>
+			<bounds x="444" y="550" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="444" y="550" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="444" y="550" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="467" y="550" width="24" height="32">
-			</bounds>
+			<bounds x="467" y="550" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit10" element="led_digit_red">
-			<bounds x="467" y="550" width="24" height="32">
-			</bounds>
+			<bounds x="467" y="550" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="467" y="550" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="467" y="550" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="491" y="550" width="24" height="32">
-			</bounds>
+			<bounds x="491" y="550" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit8" element="led_digit_red">
-			<bounds x="491" y="550" width="24" height="32">
-			</bounds>
+			<bounds x="491" y="550" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="491" y="550" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="491" y="550" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="383" y="650" width="323" height="27">
-			</bounds>
+			<bounds x="383" y="650" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="383" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="383" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="403" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="403" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="423" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="423" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="443" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="443" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="463" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="463" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="483" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="483" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="503" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="503" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="523" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="523" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="543" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="543" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="563" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="563" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="583" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="583" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="603" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="603" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="623" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="623" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="643" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="643" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="663" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="663" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="683" y="650" width="20" height="27">
-			</bounds>
+			<bounds x="683" y="650" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label97" element="label_97">
-			<bounds x="121" y="219" width="36" height="208">
-			</bounds>
+			<bounds x="121" y="219" width="36" height="208"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_button" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cnfr.lay
+++ b/src/mame/layout/sc4cnfr.lay
@@ -8,11268 +8,7032 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Rep">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Unlock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="The Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Unlock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="The Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Stoppa Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Stoppa Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Money Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Money Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fruit Pursuit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fruit Pursuit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Pick Your Own">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pick Your Own">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Bounty Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bounty Bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Golden Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Golden Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Nudge Frenzy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Nudge Frenzy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Tutti Frutti">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Tutti Frutti">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Down And Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Down And Out">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Add A Key">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Add A Key">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Skill Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Skill Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Out Of Juice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Out Of Juice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hi Lo Continue ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Hi Lo Continue ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Fruit Shoot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit Shoot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Squashed?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Squashed?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Held!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Trail">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Held!">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_33_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_33_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Palmtree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Palmtree">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_37_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_37_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Spin 'n'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Spin 'n'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_38_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_38_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Money ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Steppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Money ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Steppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_39_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_39_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Lines">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Graphic">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fruits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Graphic">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fruits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_36_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_36_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Juicy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fruits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Juicy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Fruits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_35_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_35_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Heat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Wave">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Heat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Wave">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="'n'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="'n'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="a">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="h">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="h">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="t">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="u">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="u">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="F">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_208_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_208">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_209_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_209">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Take Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_210_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_210">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_212_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_212">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_213_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_213">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_214_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_214">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_215_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_215">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_216_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_216">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_217_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_217">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_218_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_218">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_219_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_219">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_220_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_220">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_222_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_222">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_223_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_223">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="1" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_86">
 		<text string="MFME 9.4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_103">
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_104">
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_105">
 		<text string="Features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_153">
 		<text string="Nudge Ladder">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_172">
 		<text string="Plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_173">
 		<text string="Bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_183">
 		<text string="Shot Matrix">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_184">
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="677">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="677"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="304" y="478" width="80" height="140">
-			</bounds>
+			<bounds x="304" y="478" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="304.0000" y="478.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="304.0000" y="478.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="307.3333" y="479.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="307.3333" y="479.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="310.6667" y="481.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="310.6667" y="481.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="314.0000" y="483.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="314.0000" y="483.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="317.3333" y="485.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="317.3333" y="485.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="320.6667" y="487.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="320.6667" y="487.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="304.0000" y="524.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="304.0000" y="524.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="307.3333" y="526.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="307.3333" y="526.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="310.6667" y="528.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="310.6667" y="528.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="314.0000" y="530.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="314.0000" y="530.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="317.3333" y="532.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="317.3333" y="532.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="320.6667" y="534.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="320.6667" y="534.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="304.0000" y="571.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="304.0000" y="571.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="307.3333" y="573.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="307.3333" y="573.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="310.6667" y="575.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="310.6667" y="575.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="314.0000" y="577.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="314.0000" y="577.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="317.3333" y="579.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="317.3333" y="579.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="320.6667" y="581.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="320.6667" y="581.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="304" y="478" width="80" height="140">
-			</bounds>
+			<bounds x="304" y="478" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="386" y="478" width="80" height="140">
-			</bounds>
+			<bounds x="386" y="478" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="478.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="386.0000" y="478.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="479.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="389.3333" y="479.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="481.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="392.6667" y="481.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="483.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="396.0000" y="483.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="485.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="399.3333" y="485.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="487.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="402.6667" y="487.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="524.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="386.0000" y="524.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="526.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="389.3333" y="526.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="528.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="392.6667" y="528.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="530.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="396.0000" y="530.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="532.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="399.3333" y="532.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="534.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="402.6667" y="534.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="386.0000" y="571.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="386.0000" y="571.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="389.3333" y="573.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="389.3333" y="573.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="392.6667" y="575.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="392.6667" y="575.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="396.0000" y="577.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="396.0000" y="577.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="399.3333" y="579.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="399.3333" y="579.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="402.6667" y="581.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="402.6667" y="581.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="386" y="478" width="80" height="140">
-			</bounds>
+			<bounds x="386" y="478" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="468" y="478" width="80" height="140">
-			</bounds>
+			<bounds x="468" y="478" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="468.0000" y="478.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="468.0000" y="478.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="471.3333" y="479.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="471.3333" y="479.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="474.6667" y="481.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="474.6667" y="481.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="478.0000" y="483.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="478.0000" y="483.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="481.3333" y="485.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="481.3333" y="485.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="484.6667" y="487.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="484.6667" y="487.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="468.0000" y="524.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="468.0000" y="524.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="471.3333" y="526.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="471.3333" y="526.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="474.6667" y="528.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="474.6667" y="528.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="478.0000" y="530.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="478.0000" y="530.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="481.3333" y="532.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="481.3333" y="532.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="484.6667" y="534.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="484.6667" y="534.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="468.0000" y="571.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="468.0000" y="571.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="471.3333" y="573.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="471.3333" y="573.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="474.6667" y="575.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="474.6667" y="575.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="478.0000" y="577.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="478.0000" y="577.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="481.3333" y="579.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="481.3333" y="579.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="484.6667" y="581.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="484.6667" y="581.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="468" y="478" width="80" height="140">
-			</bounds>
+			<bounds x="468" y="478" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="328" y="178" width="50" height="50">
-			</bounds>
+			<bounds x="328" y="178" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="328.0000" y="178.0000" width="50.0000" height="50.0000">
-			</bounds>
+			<bounds x="328.0000" y="178.0000" width="50.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.0833" y="180.0833" width="45.8333" height="45.8333">
-			</bounds>
+			<bounds x="330.0833" y="180.0833" width="45.8333" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="332.1667" y="182.1667" width="41.6667" height="41.6667">
-			</bounds>
+			<bounds x="332.1667" y="182.1667" width="41.6667" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="334.2500" y="184.2500" width="37.5000" height="37.5000">
-			</bounds>
+			<bounds x="334.2500" y="184.2500" width="37.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="336.3333" y="186.3333" width="33.3333" height="33.3333">
-			</bounds>
+			<bounds x="336.3333" y="186.3333" width="33.3333" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="338.4167" y="188.4167" width="29.1667" height="29.1667">
-			</bounds>
+			<bounds x="338.4167" y="188.4167" width="29.1667" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="328" y="178" width="50" height="50">
-			</bounds>
+			<bounds x="328" y="178" width="50" height="50"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="391" y="96" width="42" height="42">
-			</bounds>
+			<bounds x="391" y="96" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="393" y="98" width="38" height="38">
-			</bounds>
+			<bounds x="393" y="98" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="555" y="136" width="42" height="42">
-			</bounds>
+			<bounds x="555" y="136" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="557" y="138" width="38" height="38">
-			</bounds>
+			<bounds x="557" y="138" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="555" y="177" width="42" height="42">
-			</bounds>
+			<bounds x="555" y="177" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="557" y="179" width="38" height="38">
-			</bounds>
+			<bounds x="557" y="179" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="473" y="382" width="42" height="42">
-			</bounds>
+			<bounds x="473" y="382" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="475" y="384" width="38" height="38">
-			</bounds>
+			<bounds x="475" y="384" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="391" y="382" width="42" height="42">
-			</bounds>
+			<bounds x="391" y="382" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="393" y="384" width="38" height="38">
-			</bounds>
+			<bounds x="393" y="384" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="268" y="341" width="42" height="42">
-			</bounds>
+			<bounds x="268" y="341" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="270" y="343" width="38" height="38">
-			</bounds>
+			<bounds x="270" y="343" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="268" y="218" width="42" height="42">
-			</bounds>
+			<bounds x="268" y="218" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="270" y="220" width="38" height="38">
-			</bounds>
+			<bounds x="270" y="220" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="338" y="142" width="32" height="32">
-			</bounds>
+			<bounds x="338" y="142" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="340" y="144" width="28" height="28">
-			</bounds>
+			<bounds x="340" y="144" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="337" y="232" width="32" height="32">
-			</bounds>
+			<bounds x="337" y="232" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="339" y="234" width="28" height="28">
-			</bounds>
+			<bounds x="339" y="234" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="435" y="346" width="32" height="32">
-			</bounds>
+			<bounds x="435" y="346" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="437" y="348" width="28" height="28">
-			</bounds>
+			<bounds x="437" y="348" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="467" y="334" width="32" height="32">
-			</bounds>
+			<bounds x="467" y="334" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="469" y="336" width="28" height="28">
-			</bounds>
+			<bounds x="469" y="336" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="435" y="284" width="32" height="32">
-			</bounds>
+			<bounds x="435" y="284" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="437" y="286" width="28" height="28">
-			</bounds>
+			<bounds x="437" y="286" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="499" y="283" width="32" height="32">
-			</bounds>
+			<bounds x="499" y="283" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="501" y="285" width="28" height="28">
-			</bounds>
+			<bounds x="501" y="285" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="467" y="302" width="32" height="32">
-			</bounds>
+			<bounds x="467" y="302" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="469" y="304" width="28" height="28">
-			</bounds>
+			<bounds x="469" y="304" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="499" y="314" width="32" height="32">
-			</bounds>
+			<bounds x="499" y="314" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="501" y="316" width="28" height="28">
-			</bounds>
+			<bounds x="501" y="316" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="435" y="315" width="32" height="32">
-			</bounds>
+			<bounds x="435" y="315" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="437" y="317" width="28" height="28">
-			</bounds>
+			<bounds x="437" y="317" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="499" y="345" width="32" height="32">
-			</bounds>
+			<bounds x="499" y="345" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="501" y="347" width="28" height="28">
-			</bounds>
+			<bounds x="501" y="347" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="460" y="54" width="70" height="36">
-			</bounds>
+			<bounds x="460" y="54" width="70" height="36"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="462" y="56" width="66" height="32">
-			</bounds>
+			<bounds x="462" y="56" width="66" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="882" y="27" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="27" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="884" y="29" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="29" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="882" y="363" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="363" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="884" y="365" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="365" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="882" y="195" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="195" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="884" y="197" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="197" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="882" y="279" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="279" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="884" y="281" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="281" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="882" y="237" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="237" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="884" y="239" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="239" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="882" y="321" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="321" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="884" y="323" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="323" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="882" y="153" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="153" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="884" y="155" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="155" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="882" y="111" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="111" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="884" y="113" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="113" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="882" y="69" width="52" height="42">
-			</bounds>
+			<bounds x="882" y="69" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="884" y="71" width="48" height="38">
-			</bounds>
+			<bounds x="884" y="71" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="632" y="281" width="92" height="27">
-			</bounds>
+			<bounds x="632" y="281" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="634" y="283" width="88" height="23">
-			</bounds>
+			<bounds x="634" y="283" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="632" y="255" width="92" height="27">
-			</bounds>
+			<bounds x="632" y="255" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="634" y="257" width="88" height="23">
-			</bounds>
+			<bounds x="634" y="257" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="632" y="229" width="92" height="27">
-			</bounds>
+			<bounds x="632" y="229" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="634" y="231" width="88" height="23">
-			</bounds>
+			<bounds x="634" y="231" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="632" y="203" width="92" height="27">
-			</bounds>
+			<bounds x="632" y="203" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="634" y="205" width="88" height="23">
-			</bounds>
+			<bounds x="634" y="205" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="632" y="177" width="92" height="27">
-			</bounds>
+			<bounds x="632" y="177" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="634" y="179" width="88" height="23">
-			</bounds>
+			<bounds x="634" y="179" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="632" y="151" width="92" height="27">
-			</bounds>
+			<bounds x="632" y="151" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="634" y="153" width="88" height="23">
-			</bounds>
+			<bounds x="634" y="153" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="632" y="125" width="92" height="27">
-			</bounds>
+			<bounds x="632" y="125" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="634" y="127" width="88" height="23">
-			</bounds>
+			<bounds x="634" y="127" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="632" y="99" width="92" height="27">
-			</bounds>
+			<bounds x="632" y="99" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="634" y="101" width="88" height="23">
-			</bounds>
+			<bounds x="634" y="101" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="134" y="282" width="92" height="27">
-			</bounds>
+			<bounds x="134" y="282" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="136" y="284" width="88" height="23">
-			</bounds>
+			<bounds x="136" y="284" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="134" y="256" width="92" height="27">
-			</bounds>
+			<bounds x="134" y="256" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="136" y="258" width="88" height="23">
-			</bounds>
+			<bounds x="136" y="258" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="135" y="152" width="92" height="27">
-			</bounds>
+			<bounds x="135" y="152" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="137" y="154" width="88" height="23">
-			</bounds>
+			<bounds x="137" y="154" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="134" y="204" width="92" height="27">
-			</bounds>
+			<bounds x="134" y="204" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="136" y="206" width="88" height="23">
-			</bounds>
+			<bounds x="136" y="206" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="135" y="126" width="92" height="27">
-			</bounds>
+			<bounds x="135" y="126" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="137" y="128" width="88" height="23">
-			</bounds>
+			<bounds x="137" y="128" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="135" y="100" width="92" height="27">
-			</bounds>
+			<bounds x="135" y="100" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="137" y="102" width="88" height="23">
-			</bounds>
+			<bounds x="137" y="102" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="134" y="230" width="92" height="27">
-			</bounds>
+			<bounds x="134" y="230" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="136" y="232" width="88" height="23">
-			</bounds>
+			<bounds x="136" y="232" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="134" y="178" width="92" height="27">
-			</bounds>
+			<bounds x="134" y="178" width="92" height="27"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="136" y="180" width="88" height="23">
-			</bounds>
+			<bounds x="136" y="180" width="88" height="23"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="605" y="572" width="52" height="38">
-			</bounds>
+			<bounds x="605" y="572" width="52" height="38"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="607" y="574" width="48" height="34">
-			</bounds>
+			<bounds x="607" y="574" width="48" height="34"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1_border" state="0">
-			<bounds x="805" y="532" width="72" height="38">
-			</bounds>
+			<bounds x="805" y="532" width="72" height="38"/>
 		</backdrop>
 		<backdrop name="lamp33" element="lamp_33_1" state="0">
-			<bounds x="807" y="534" width="68" height="34">
-			</bounds>
+			<bounds x="807" y="534" width="68" height="34"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1_border" state="0">
-			<bounds x="839" y="439" width="52" height="32">
-			</bounds>
+			<bounds x="839" y="439" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp37" element="lamp_37_1" state="0">
-			<bounds x="841" y="441" width="48" height="28">
-			</bounds>
+			<bounds x="841" y="441" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1_border" state="0">
-			<bounds x="838" y="501" width="52" height="32">
-			</bounds>
+			<bounds x="838" y="501" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp38" element="lamp_38_1" state="0">
-			<bounds x="840" y="503" width="48" height="28">
-			</bounds>
+			<bounds x="840" y="503" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1_border" state="0">
-			<bounds x="787" y="439" width="52" height="32">
-			</bounds>
+			<bounds x="787" y="439" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp39" element="lamp_39_1" state="0">
-			<bounds x="789" y="441" width="48" height="28">
-			</bounds>
+			<bounds x="789" y="441" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="787" y="501" width="52" height="32">
-			</bounds>
+			<bounds x="787" y="501" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="789" y="503" width="48" height="28">
-			</bounds>
+			<bounds x="789" y="503" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1_border" state="0">
-			<bounds x="787" y="470" width="52" height="32">
-			</bounds>
+			<bounds x="787" y="470" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp36" element="lamp_36_1" state="0">
-			<bounds x="789" y="472" width="48" height="28">
-			</bounds>
+			<bounds x="789" y="472" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1_border" state="0">
-			<bounds x="838" y="470" width="52" height="32">
-			</bounds>
+			<bounds x="838" y="470" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp35" element="lamp_35_1" state="0">
-			<bounds x="840" y="472" width="48" height="28">
-			</bounds>
+			<bounds x="840" y="472" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="571" y="599" width="22" height="22">
-			</bounds>
+			<bounds x="571" y="599" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="573" y="601" width="18" height="18">
-			</bounds>
+			<bounds x="573" y="601" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="571" y="578" width="22" height="22">
-			</bounds>
+			<bounds x="571" y="578" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="573" y="580" width="18" height="18">
-			</bounds>
+			<bounds x="573" y="580" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="571" y="557" width="22" height="22">
-			</bounds>
+			<bounds x="571" y="557" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="573" y="559" width="18" height="18">
-			</bounds>
+			<bounds x="573" y="559" width="18" height="18"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="552" y="536" width="62" height="22">
-			</bounds>
+			<bounds x="552" y="536" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="554" y="538" width="58" height="18">
-			</bounds>
+			<bounds x="554" y="538" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="570" y="513" width="24" height="24">
-			</bounds>
+			<bounds x="570" y="513" width="24" height="24"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="572" y="515" width="20" height="20">
-			</bounds>
+			<bounds x="572" y="515" width="20" height="20"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="569" y="488" width="26" height="26">
-			</bounds>
+			<bounds x="569" y="488" width="26" height="26"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="571" y="490" width="22" height="22">
-			</bounds>
+			<bounds x="571" y="490" width="22" height="22"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="566" y="427" width="34" height="34">
-			</bounds>
+			<bounds x="566" y="427" width="34" height="34"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="568" y="429" width="30" height="30">
-			</bounds>
+			<bounds x="568" y="429" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="568" y="460" width="29" height="29">
-			</bounds>
+			<bounds x="568" y="460" width="29" height="29"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="570" y="462" width="25" height="25">
-			</bounds>
+			<bounds x="570" y="462" width="25" height="25"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="182" y="530" width="32" height="32">
-			</bounds>
+			<bounds x="182" y="530" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="184" y="532" width="28" height="28">
-			</bounds>
+			<bounds x="184" y="532" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="182" y="499" width="32" height="32">
-			</bounds>
+			<bounds x="182" y="499" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="184" y="501" width="28" height="28">
-			</bounds>
+			<bounds x="184" y="501" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="182" y="468" width="32" height="32">
-			</bounds>
+			<bounds x="182" y="468" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="184" y="470" width="28" height="28">
-			</bounds>
+			<bounds x="184" y="470" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="182" y="437" width="32" height="32">
-			</bounds>
+			<bounds x="182" y="437" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="184" y="439" width="28" height="28">
-			</bounds>
+			<bounds x="184" y="439" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="390" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="390" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="392" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="392" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="257" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="257" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="259" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="259" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="299" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="299" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="301" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="301" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="341" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="341" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="343" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="343" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="215" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="215" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="217" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="217" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="606" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="606" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="608" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="608" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="564" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="564" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="566" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="566" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="480" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="480" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="482" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="482" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="522" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="522" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="524" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="524" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="438" y="6" width="42" height="42">
-			</bounds>
+			<bounds x="438" y="6" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="440" y="8" width="38" height="38">
-			</bounds>
+			<bounds x="440" y="8" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp249" element="colour_button_208_border" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="321" y="332" width="67" height="32">
-			</bounds>
+			<bounds x="321" y="332" width="67" height="32"/>
 		</backdrop>
 		<backdrop name="lamp249" element="colour_button_208" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="323" y="334" width="63" height="28">
-			</bounds>
+			<bounds x="323" y="334" width="63" height="28"/>
 		</backdrop>
 		<backdrop name="lamp54" element="colour_button_209_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="804" y="410" width="75" height="27">
-			</bounds>
+			<bounds x="804" y="410" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp54" element="colour_button_209" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="806" y="412" width="71" height="23">
-			</bounds>
+			<bounds x="806" y="412" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_210_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="953" y="27" width="42" height="42">
-			</bounds>
+			<bounds x="953" y="27" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp32" element="colour_button_210" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="955" y="29" width="38" height="38">
-			</bounds>
+			<bounds x="955" y="29" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp12" element="colour_button_212_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="243" y="477" width="42" height="42">
-			</bounds>
+			<bounds x="243" y="477" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp12" element="colour_button_212" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="245" y="479" width="38" height="38">
-			</bounds>
+			<bounds x="245" y="479" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_213_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="638" y="629" width="75" height="38">
-			</bounds>
+			<bounds x="638" y="629" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_213" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="640" y="631" width="71" height="34">
-			</bounds>
+			<bounds x="640" y="631" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_214_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="554" y="629" width="75" height="38">
-			</bounds>
+			<bounds x="554" y="629" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_214" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="556" y="631" width="71" height="34">
-			</bounds>
+			<bounds x="556" y="631" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_215_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="471" y="629" width="75" height="38">
-			</bounds>
+			<bounds x="471" y="629" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_215" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="473" y="631" width="71" height="34">
-			</bounds>
+			<bounds x="473" y="631" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_216_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="386" y="629" width="75" height="38">
-			</bounds>
+			<bounds x="386" y="629" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_216" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="388" y="631" width="71" height="34">
-			</bounds>
+			<bounds x="388" y="631" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_217_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="305" y="629" width="75" height="38">
-			</bounds>
+			<bounds x="305" y="629" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_217" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="307" y="631" width="71" height="34">
-			</bounds>
+			<bounds x="307" y="631" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_218_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="223" y="629" width="75" height="38">
-			</bounds>
+			<bounds x="223" y="629" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_218" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="225" y="631" width="71" height="34">
-			</bounds>
+			<bounds x="225" y="631" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_219_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="721" y="629" width="75" height="38">
-			</bounds>
+			<bounds x="721" y="629" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_219" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="723" y="631" width="71" height="34">
-			</bounds>
+			<bounds x="723" y="631" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_220_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="803" y="628" width="75" height="38">
-			</bounds>
+			<bounds x="803" y="628" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_220" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="805" y="630" width="71" height="34">
-			</bounds>
+			<bounds x="805" y="630" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp42" element="colour_button_222_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="804" y="570" width="75" height="38">
-			</bounds>
+			<bounds x="804" y="570" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp42" element="colour_button_222" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="806" y="572" width="71" height="34">
-			</bounds>
+			<bounds x="806" y="572" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp250" element="colour_button_223_border" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="33" y="532" width="75" height="38">
-			</bounds>
+			<bounds x="33" y="532" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp250" element="colour_button_223" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="35" y="534" width="71" height="34">
-			</bounds>
+			<bounds x="35" y="534" width="71" height="34"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="329" y="296" width="24" height="32">
-			</bounds>
+			<bounds x="329" y="296" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit3" element="led_digit_red">
-			<bounds x="329" y="296" width="24" height="32">
-			</bounds>
+			<bounds x="329" y="296" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="329" y="296" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="329" y="296" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="353" y="296" width="24" height="32">
-			</bounds>
+			<bounds x="353" y="296" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="353" y="296" width="24" height="32">
-			</bounds>
+			<bounds x="353" y="296" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="353" y="296" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="353" y="296" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="72" y="495" width="24" height="32">
-			</bounds>
+			<bounds x="72" y="495" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="72" y="495" width="24" height="32">
-			</bounds>
+			<bounds x="72" y="495" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="72" y="495" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="72" y="495" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="48" y="495" width="24" height="32">
-			</bounds>
+			<bounds x="48" y="495" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit1" element="led_digit_red">
-			<bounds x="48" y="495" width="24" height="32">
-			</bounds>
+			<bounds x="48" y="495" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="48" y="495" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="48" y="495" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="315" y="450" width="227" height="20">
-			</bounds>
+			<bounds x="315" y="450" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="315" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="315" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="329" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="329" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="343" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="343" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="357" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="357" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="371" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="371" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="385" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="385" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="399" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="399" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="413" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="413" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="427" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="427" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="441" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="441" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="455" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="455" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="469" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="469" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="483" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="483" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="497" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="497" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="511" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="511" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="525" y="450" width="14" height="20">
-			</bounds>
+			<bounds x="525" y="450" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="label86" element="label_86">
-			<bounds x="53" y="58" width="35" height="30">
-			</bounds>
+			<bounds x="53" y="58" width="35" height="30"/>
 		</backdrop>
 		<backdrop name="label103" element="label_103">
-			<bounds x="407" y="329" width="18" height="38">
-			</bounds>
+			<bounds x="407" y="329" width="18" height="38"/>
 		</backdrop>
 		<backdrop name="label104" element="label_104">
-			<bounds x="168" y="306" width="21" height="50">
-			</bounds>
+			<bounds x="168" y="306" width="21" height="50"/>
 		</backdrop>
 		<backdrop name="label105" element="label_105">
-			<bounds x="638" y="317" width="79" height="23">
-			</bounds>
+			<bounds x="638" y="317" width="79" height="23"/>
 		</backdrop>
 		<backdrop name="label153" element="label_153">
-			<bounds x="4" y="464" width="124" height="23">
-			</bounds>
+			<bounds x="4" y="464" width="124" height="23"/>
 		</backdrop>
 		<backdrop name="label172" element="label_172">
-			<bounds x="503" y="428" width="38" height="18">
-			</bounds>
+			<bounds x="503" y="428" width="38" height="18"/>
 		</backdrop>
 		<backdrop name="label173" element="label_173">
-			<bounds x="321" y="430" width="37" height="18">
-			</bounds>
+			<bounds x="321" y="430" width="37" height="18"/>
 		</backdrop>
 		<backdrop name="label183" element="label_183">
-			<bounds x="438" y="265" width="83" height="18">
-			</bounds>
+			<bounds x="438" y="265" width="83" height="18"/>
 		</backdrop>
 		<backdrop name="label184" element="label_184">
-			<bounds x="170" y="570" width="55" height="18">
-			</bounds>
+			<bounds x="170" y="570" width="55" height="18"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_button" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_button" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_button" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_button" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_button" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_button" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_button_standard" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_button_standard" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1525.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1530.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1535.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1540.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp68" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1545.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4coro.lay
+++ b/src/mame/layout/sc4coro.lay
@@ -8,16454 +8,10389 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.06"/>
 		</text>
 		<text string="y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.11" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.17" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.11" width="0.90" height="0.06"/>
 		</text>
 		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.23" width="0.90" height="0.06"/>
 		</text>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.29" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.29" width="0.90" height="0.06"/>
 		</text>
 		<text string="u">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.06"/>
 		</text>
 		<text string="c">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.41" width="0.90" height="0.06"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.47" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.53" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.47" width="0.90" height="0.06"/>
 		</text>
 		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.59" width="0.90" height="0.06"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.06"/>
 		</text>
 		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.71" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.71" width="0.90" height="0.06"/>
 		</text>
 		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.77" width="0.90" height="0.06"/>
 		</text>
 		<text string="g">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.83" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.83" width="0.90" height="0.06"/>
 		</text>
 		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.89" width="0.90" height="0.06">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.11" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.17" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="B">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.23" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.29" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="u">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="c">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.41" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.47" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.53" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="G">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.59" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.71" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="r">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.77" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="g">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.83" width="0.90" height="0.06">
-			</bounds>
-		</text>
-		<text string="e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.89" width="0.90" height="0.06">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.89" width="0.90" height="0.06"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="T">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="I">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_158_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_158_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="O">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="N">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="T.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="T.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_125_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_125_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Turbo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Turbo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Nearest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Nearest">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_127_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_127_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_141_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_141_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.60+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.60+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_142_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_142_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Master">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Blaster">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Master">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Blaster">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Attack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Attack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Mega">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO'S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="'Em In">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="'Em In">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Tutti">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fruiti">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Tutti">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Fruiti">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;2.40+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string=" Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string=" Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Streak">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string=" Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string=" Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_206_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_206_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Fast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Fast">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="High">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Roller">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="High">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Roller">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Level">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="KO's">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60+">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="rc">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_222_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_222_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="Shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="pint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="pint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Skill stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Skill stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Multi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Multi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="add">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Respin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="ST.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="ST.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="eXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LEVEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="eXTRA">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="LEVEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="ST.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="ST.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="ADD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="SUPER">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDG">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="ST.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="ST.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_79_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
+			<color red="0.00" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_79_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
+			<color red="0.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="Stoppa">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Taxi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Taxi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="ST.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="ST.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="TRIAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="TRIAL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="RUN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="PINT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="BONUS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="STEP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="extra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="life">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_11_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_11_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_12_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_12_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1 million nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 million nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="pint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="pint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="pint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="pint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="pint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="pint">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="LIGHT ALL 3 TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="OPEN SUPER SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="LIGHT ALL 3 TO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="OPEN SUPER SHOTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="fire">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="cross">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="fire">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="fruit">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="whirl wind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="whirl wind">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="skill seven">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="skill seven">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="RED">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BARS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="hot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_95_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_95_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5+repeat chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5+repeat chance">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_111_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_111_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_110_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_110_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="40p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="80p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_94_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_94_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="20p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
+			<color red="0.00" green="0.03" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
+			<color red="0.00" green="0.06" blue="0.13"/>
 		</rect>
 		<text string="Trial">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.03" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.13">
-			</color>
-		</rect>
-		<text string="Trial">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_31_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_31_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_30_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_30_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Super Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Super Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Skill Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Skill Shuffle">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_47_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_47_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Bonus Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Bonus Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_156_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_156">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="hold/lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold/hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.25" green="0.50" blue="0.50">
-			</color>
+			<color red="0.25" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.12" blue="0.12">
-			</color>
+			<color red="0.06" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="0.50" green="1.00" blue="1.00">
-			</color>
+			<color red="0.50" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.25" blue="0.25">
-			</color>
+			<color red="0.13" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_169_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_169">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_170_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.12">
-			</color>
+			<color red="0.12" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_170">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="1.00">
-			</color>
+			<color red="1.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_171_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_171">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_172_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_172">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_173_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_173">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="STEPS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_175_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_175">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_176_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_176">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_177_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_177">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_150">
 		<text string="super shots">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_151">
 		<text string="keys">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.07"/>
 		</text>
 		<text string="start = space bar">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.12" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.12" width="0.90" height="0.07"/>
 		</text>
 		<text string="exchange = e">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.19" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.19" width="0.90" height="0.07"/>
 		</text>
 		<text string="holds = 1,2,3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.26" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.26" width="0.90" height="0.07"/>
 		</text>
 		<text string="collect = c">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.33" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.33" width="0.90" height="0.07"/>
 		</text>
 		<text string="cancel = `">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.40" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.40" width="0.90" height="0.07"/>
 		</text>
 		<text string="level 1 = u">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.47" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.47" width="0.90" height="0.07"/>
 		</text>
 		<text string="level 2 = i">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.53" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.53" width="0.90" height="0.07"/>
 		</text>
 		<text string="level 3 = o">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.60" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.60" width="0.90" height="0.07"/>
 		</text>
 		<text string="level 4 = p">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.67" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.67" width="0.90" height="0.07"/>
 		</text>
 		<text string="steps=s">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.74" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.74" width="0.90" height="0.07"/>
 		</text>
 		<text string="nudges=n">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.81" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.81" width="0.90" height="0.07"/>
 		</text>
 		<text string="cash=x">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.88" width="0.90" height="0.07">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.88" width="0.90" height="0.07"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1008" height="679">
-			</bounds>
+			<bounds x="0" y="0" width="1008" height="679"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="188" y="501" width="75" height="110">
-			</bounds>
+			<bounds x="188" y="501" width="75" height="110"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="188.0000" y="501.0000" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="188.0000" y="501.0000" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="191.1250" y="502.5278" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="191.1250" y="502.5278" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="194.2500" y="504.0555" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="194.2500" y="504.0555" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.3750" y="505.5833" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="197.3750" y="505.5833" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.5000" y="507.1111" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="200.5000" y="507.1111" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6250" y="508.6389" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="203.6250" y="508.6389" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="188.0000" y="537.6667" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="188.0000" y="537.6667" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="191.1250" y="539.1945" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="191.1250" y="539.1945" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="194.2500" y="540.7222" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="194.2500" y="540.7222" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.3750" y="542.2500" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="197.3750" y="542.2500" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.5000" y="543.7778" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="200.5000" y="543.7778" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6250" y="545.3056" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="203.6250" y="545.3056" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="188.0000" y="574.3333" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="188.0000" y="574.3333" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="191.1250" y="575.8611" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="191.1250" y="575.8611" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="194.2500" y="577.3889" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="194.2500" y="577.3889" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="197.3750" y="578.9166" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="197.3750" y="578.9166" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="200.5000" y="580.4444" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="200.5000" y="580.4444" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="203.6250" y="581.9722" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="203.6250" y="581.9722" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="188" y="501" width="75" height="110">
-			</bounds>
+			<bounds x="188" y="501" width="75" height="110"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="264" y="501" width="75" height="110">
-			</bounds>
+			<bounds x="264" y="501" width="75" height="110"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="264.0000" y="501.0000" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="264.0000" y="501.0000" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="267.1250" y="502.5278" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="267.1250" y="502.5278" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="270.2500" y="504.0555" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="270.2500" y="504.0555" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="273.3750" y="505.5833" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="273.3750" y="505.5833" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="276.5000" y="507.1111" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="276.5000" y="507.1111" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="279.6250" y="508.6389" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="279.6250" y="508.6389" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="264.0000" y="537.6667" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="264.0000" y="537.6667" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="267.1250" y="539.1945" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="267.1250" y="539.1945" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="270.2500" y="540.7222" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="270.2500" y="540.7222" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="273.3750" y="542.2500" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="273.3750" y="542.2500" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="276.5000" y="543.7778" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="276.5000" y="543.7778" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="279.6250" y="545.3056" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="279.6250" y="545.3056" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="264.0000" y="574.3333" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="264.0000" y="574.3333" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="267.1250" y="575.8611" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="267.1250" y="575.8611" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="270.2500" y="577.3889" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="270.2500" y="577.3889" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="273.3750" y="578.9166" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="273.3750" y="578.9166" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="276.5000" y="580.4444" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="276.5000" y="580.4444" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="279.6250" y="581.9722" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="279.6250" y="581.9722" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="264" y="501" width="75" height="110">
-			</bounds>
+			<bounds x="264" y="501" width="75" height="110"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="340" y="501" width="75" height="110">
-			</bounds>
+			<bounds x="340" y="501" width="75" height="110"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="340.0000" y="501.0000" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="340.0000" y="501.0000" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="343.1250" y="502.5278" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="343.1250" y="502.5278" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="346.2500" y="504.0555" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="346.2500" y="504.0555" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.3750" y="505.5833" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="349.3750" y="505.5833" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.5000" y="507.1111" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="352.5000" y="507.1111" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6250" y="508.6389" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="355.6250" y="508.6389" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="340.0000" y="537.6667" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="340.0000" y="537.6667" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="343.1250" y="539.1945" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="343.1250" y="539.1945" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="346.2500" y="540.7222" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="346.2500" y="540.7222" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.3750" y="542.2500" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="349.3750" y="542.2500" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.5000" y="543.7778" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="352.5000" y="543.7778" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6250" y="545.3056" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="355.6250" y="545.3056" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="340.0000" y="574.3333" width="75.0000" height="36.6667">
-			</bounds>
+			<bounds x="340.0000" y="574.3333" width="75.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="343.1250" y="575.8611" width="68.7500" height="33.6111">
-			</bounds>
+			<bounds x="343.1250" y="575.8611" width="68.7500" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="346.2500" y="577.3889" width="62.5000" height="30.5556">
-			</bounds>
+			<bounds x="346.2500" y="577.3889" width="62.5000" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="349.3750" y="578.9166" width="56.2500" height="27.5000">
-			</bounds>
+			<bounds x="349.3750" y="578.9166" width="56.2500" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="352.5000" y="580.4444" width="50.0000" height="24.4444">
-			</bounds>
+			<bounds x="352.5000" y="580.4444" width="50.0000" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="355.6250" y="581.9722" width="43.7500" height="21.3889">
-			</bounds>
+			<bounds x="355.6250" y="581.9722" width="43.7500" height="21.3889"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="340" y="501" width="75" height="110">
-			</bounds>
+			<bounds x="340" y="501" width="75" height="110"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="238" y="294" width="65" height="65">
-			</bounds>
+			<bounds x="238" y="294" width="65" height="65"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="238.0000" y="294.0000" width="65.0000" height="65.0000">
-			</bounds>
+			<bounds x="238.0000" y="294.0000" width="65.0000" height="65.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="240.7083" y="296.7083" width="59.5833" height="59.5833">
-			</bounds>
+			<bounds x="240.7083" y="296.7083" width="59.5833" height="59.5833"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="243.4167" y="299.4167" width="54.1667" height="54.1667">
-			</bounds>
+			<bounds x="243.4167" y="299.4167" width="54.1667" height="54.1667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="246.1250" y="302.1250" width="48.7500" height="48.7500">
-			</bounds>
+			<bounds x="246.1250" y="302.1250" width="48.7500" height="48.7500"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="248.8333" y="304.8333" width="43.3333" height="43.3333">
-			</bounds>
+			<bounds x="248.8333" y="304.8333" width="43.3333" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="251.5417" y="307.5417" width="37.9167" height="37.9167">
-			</bounds>
+			<bounds x="251.5417" y="307.5417" width="37.9167" height="37.9167"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="238" y="294" width="65" height="65">
-			</bounds>
+			<bounds x="238" y="294" width="65" height="65"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="986" y="457" width="22" height="222">
-			</bounds>
+			<bounds x="986" y="457" width="22" height="222"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="988" y="459" width="18" height="218">
-			</bounds>
+			<bounds x="988" y="459" width="18" height="218"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="3" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="3" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="5" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="5" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="3" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="3" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="5" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="5" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="57" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="57" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="59" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="59" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="57" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="57" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="59" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="59" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="111" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="111" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="113" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="113" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="111" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="111" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="113" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="113" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="165" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="165" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="167" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="167" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="165" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="165" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="167" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="167" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="219" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="219" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="221" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="221" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="219" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="219" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="221" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="221" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="273" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="273" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="275" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="275" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="273" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="273" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="275" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="275" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="327" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="327" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="329" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="329" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="327" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="327" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="329" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="329" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="381" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="381" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="383" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="383" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="381" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="381" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="383" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="383" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="435" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="435" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="437" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="437" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1_border" state="0">
-			<bounds x="435" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="435" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp158" element="lamp_158_1" state="0">
-			<bounds x="437" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="437" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="489" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="489" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="491" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="491" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="489" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="489" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="491" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="491" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="543" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="543" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="545" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="545" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="543" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="543" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="545" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="545" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="597" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="597" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="599" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="599" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="597" y="3" width="57" height="47">
-			</bounds>
+			<bounds x="597" y="3" width="57" height="47"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="599" y="5" width="53" height="43">
-			</bounds>
+			<bounds x="599" y="5" width="53" height="43"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="520" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="520" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="522" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="522" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="520" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="520" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="522" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="522" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1_border" state="0">
-			<bounds x="465" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="465" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp125" element="lamp_125_1" state="0">
-			<bounds x="467" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="467" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="465" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="465" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="467" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="467" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="410" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="410" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="412" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="412" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="410" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="410" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="412" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="412" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="520" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="520" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="522" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="522" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="520" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="520" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="522" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="522" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="465" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="465" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="467" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="467" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="465" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="465" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="467" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="467" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="410" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="410" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="412" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="412" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1_border" state="0">
-			<bounds x="410" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="410" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp127" element="lamp_127_1" state="0">
-			<bounds x="412" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="412" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1_border" state="0">
-			<bounds x="520" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="520" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp141" element="lamp_141_1" state="0">
-			<bounds x="522" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="522" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="520" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="520" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="522" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="522" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1_border" state="0">
-			<bounds x="465" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="465" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp142" element="lamp_142_1" state="0">
-			<bounds x="467" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="467" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="410" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="410" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="412" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="412" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="410" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="410" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="412" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="412" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="520" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="520" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="522" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="522" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="520" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="520" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="522" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="522" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="465" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="465" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="467" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="467" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="465" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="465" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="467" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="467" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="410" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="410" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="412" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="412" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="410" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="410" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="412" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="412" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="300" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="300" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="302" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="302" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="300" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="300" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="302" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="302" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="355" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="355" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="357" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="357" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="355" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="355" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="357" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="357" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="245" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="245" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="247" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="247" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="245" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="245" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="247" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="247" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="190" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="190" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="192" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="192" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="190" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="190" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="192" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="192" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="135" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="135" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="137" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="137" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="135" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="135" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="137" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="137" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="80" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="80" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="82" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="82" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="80" y="49" width="57" height="37">
-			</bounds>
+			<bounds x="80" y="49" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="82" y="51" width="53" height="33">
-			</bounds>
+			<bounds x="82" y="51" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="80" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="80" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="82" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="82" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="80" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="80" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="82" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="82" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="135" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="135" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="137" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="137" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="135" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="135" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="137" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="137" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="190" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="190" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="192" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="192" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="190" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="190" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="192" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="192" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="245" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="245" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="247" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="247" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="245" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="245" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="247" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="247" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="300" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="300" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="302" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="302" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="300" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="300" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="302" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="302" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="355" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="355" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="357" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="357" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="355" y="84" width="57" height="37">
-			</bounds>
+			<bounds x="355" y="84" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="357" y="86" width="53" height="33">
-			</bounds>
+			<bounds x="357" y="86" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="355" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="355" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="357" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="357" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="355" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="355" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="357" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="357" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="300" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="300" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="302" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="302" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="300" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="300" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="302" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="302" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1_border" state="0">
-			<bounds x="245" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="245" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp206" element="lamp_206_1" state="0">
-			<bounds x="247" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="247" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="245" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="245" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="247" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="247" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="190" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="190" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="192" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="192" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="190" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="190" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="192" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="192" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="135" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="135" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="137" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="137" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="80" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="80" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="82" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="82" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="80" y="119" width="57" height="37">
-			</bounds>
+			<bounds x="80" y="119" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="82" y="121" width="53" height="33">
-			</bounds>
+			<bounds x="82" y="121" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="355" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="355" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="357" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="357" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="355" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="355" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="357" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="357" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="300" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="300" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="302" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="302" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="245" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="245" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="247" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="247" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="245" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="245" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="247" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="247" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="190" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="190" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="192" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="192" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="190" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="190" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="192" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="192" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="135" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="135" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="137" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="137" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="135" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="135" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="137" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="137" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1_border" state="0">
-			<bounds x="80" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="80" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp222" element="lamp_222_1" state="0">
-			<bounds x="82" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="82" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="80" y="154" width="57" height="37">
-			</bounds>
+			<bounds x="80" y="154" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="82" y="156" width="53" height="33">
-			</bounds>
+			<bounds x="82" y="156" width="53" height="33"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="322" y="338" width="42" height="42">
-			</bounds>
+			<bounds x="322" y="338" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="324" y="340" width="38" height="38">
-			</bounds>
+			<bounds x="324" y="340" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="322" y="297" width="42" height="42">
-			</bounds>
+			<bounds x="322" y="297" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="324" y="299" width="38" height="38">
-			</bounds>
+			<bounds x="324" y="299" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="322" y="256" width="42" height="42">
-			</bounds>
+			<bounds x="322" y="256" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="324" y="258" width="38" height="38">
-			</bounds>
+			<bounds x="324" y="258" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="158" y="372" width="42" height="37">
-			</bounds>
+			<bounds x="158" y="372" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="160" y="374" width="38" height="33">
-			</bounds>
+			<bounds x="160" y="374" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="158" y="335" width="42" height="37">
-			</bounds>
+			<bounds x="158" y="335" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="160" y="337" width="38" height="33">
-			</bounds>
+			<bounds x="160" y="337" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="158" y="299" width="42" height="37">
-			</bounds>
+			<bounds x="158" y="299" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="160" y="301" width="38" height="33">
-			</bounds>
+			<bounds x="160" y="301" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="158" y="262" width="42" height="37">
-			</bounds>
+			<bounds x="158" y="262" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="160" y="264" width="38" height="33">
-			</bounds>
+			<bounds x="160" y="264" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="178" y="226" width="42" height="37">
-			</bounds>
+			<bounds x="178" y="226" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="180" y="228" width="38" height="33">
-			</bounds>
+			<bounds x="180" y="228" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="137" y="226" width="42" height="37">
-			</bounds>
+			<bounds x="137" y="226" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="139" y="228" width="38" height="33">
-			</bounds>
+			<bounds x="139" y="228" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="137" y="190" width="42" height="37">
-			</bounds>
+			<bounds x="137" y="190" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="139" y="192" width="38" height="33">
-			</bounds>
+			<bounds x="139" y="192" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="178" y="190" width="42" height="37">
-			</bounds>
+			<bounds x="178" y="190" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="180" y="192" width="38" height="33">
-			</bounds>
+			<bounds x="180" y="192" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="219" y="208" width="42" height="37">
-			</bounds>
+			<bounds x="219" y="208" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="221" y="210" width="38" height="33">
-			</bounds>
+			<bounds x="221" y="210" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="260" y="208" width="42" height="37">
-			</bounds>
+			<bounds x="260" y="208" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="262" y="210" width="38" height="33">
-			</bounds>
+			<bounds x="262" y="210" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="301" y="208" width="42" height="37">
-			</bounds>
+			<bounds x="301" y="208" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="303" y="210" width="38" height="33">
-			</bounds>
+			<bounds x="303" y="210" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="342" y="208" width="42" height="37">
-			</bounds>
+			<bounds x="342" y="208" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="344" y="210" width="38" height="33">
-			</bounds>
+			<bounds x="344" y="210" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="383" y="190" width="42" height="37">
-			</bounds>
+			<bounds x="383" y="190" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="385" y="192" width="38" height="33">
-			</bounds>
+			<bounds x="385" y="192" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="424" y="190" width="42" height="37">
-			</bounds>
+			<bounds x="424" y="190" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="426" y="192" width="38" height="33">
-			</bounds>
+			<bounds x="426" y="192" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="424" y="226" width="42" height="37">
-			</bounds>
+			<bounds x="424" y="226" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="426" y="228" width="38" height="33">
-			</bounds>
+			<bounds x="426" y="228" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="383" y="226" width="42" height="37">
-			</bounds>
+			<bounds x="383" y="226" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="385" y="228" width="38" height="33">
-			</bounds>
+			<bounds x="385" y="228" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="406" y="262" width="42" height="37">
-			</bounds>
+			<bounds x="406" y="262" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="408" y="264" width="38" height="33">
-			</bounds>
+			<bounds x="408" y="264" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="406" y="299" width="42" height="37">
-			</bounds>
+			<bounds x="406" y="299" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="408" y="301" width="38" height="33">
-			</bounds>
+			<bounds x="408" y="301" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="406" y="372" width="42" height="37">
-			</bounds>
+			<bounds x="406" y="372" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="408" y="374" width="38" height="33">
-			</bounds>
+			<bounds x="408" y="374" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="406" y="335" width="42" height="37">
-			</bounds>
+			<bounds x="406" y="335" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="408" y="337" width="38" height="33">
-			</bounds>
+			<bounds x="408" y="337" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="178" y="408" width="42" height="37">
-			</bounds>
+			<bounds x="178" y="408" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="180" y="410" width="38" height="33">
-			</bounds>
+			<bounds x="180" y="410" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1_border" state="0">
-			<bounds x="137" y="408" width="42" height="37">
-			</bounds>
+			<bounds x="137" y="408" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp79" element="lamp_79_1" state="0">
-			<bounds x="139" y="410" width="38" height="33">
-			</bounds>
+			<bounds x="139" y="410" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="137" y="444" width="42" height="37">
-			</bounds>
+			<bounds x="137" y="444" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="139" y="446" width="38" height="33">
-			</bounds>
+			<bounds x="139" y="446" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="178" y="444" width="42" height="37">
-			</bounds>
+			<bounds x="178" y="444" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="180" y="446" width="38" height="33">
-			</bounds>
+			<bounds x="180" y="446" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="219" y="427" width="42" height="37">
-			</bounds>
+			<bounds x="219" y="427" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="221" y="429" width="38" height="33">
-			</bounds>
+			<bounds x="221" y="429" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="260" y="427" width="42" height="37">
-			</bounds>
+			<bounds x="260" y="427" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="262" y="429" width="38" height="33">
-			</bounds>
+			<bounds x="262" y="429" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="301" y="427" width="42" height="37">
-			</bounds>
+			<bounds x="301" y="427" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="303" y="429" width="38" height="33">
-			</bounds>
+			<bounds x="303" y="429" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="342" y="427" width="42" height="37">
-			</bounds>
+			<bounds x="342" y="427" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="344" y="429" width="38" height="33">
-			</bounds>
+			<bounds x="344" y="429" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="383" y="408" width="42" height="37">
-			</bounds>
+			<bounds x="383" y="408" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="385" y="410" width="38" height="33">
-			</bounds>
+			<bounds x="385" y="410" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="383" y="444" width="42" height="37">
-			</bounds>
+			<bounds x="383" y="444" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="385" y="446" width="38" height="33">
-			</bounds>
+			<bounds x="385" y="446" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="424" y="444" width="42" height="37">
-			</bounds>
+			<bounds x="424" y="444" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="426" y="446" width="38" height="33">
-			</bounds>
+			<bounds x="426" y="446" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="424" y="408" width="42" height="37">
-			</bounds>
+			<bounds x="424" y="408" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="426" y="410" width="38" height="33">
-			</bounds>
+			<bounds x="426" y="410" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="469" y="215" width="37" height="32">
-			</bounds>
+			<bounds x="469" y="215" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="471" y="217" width="33" height="28">
-			</bounds>
+			<bounds x="471" y="217" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="11" y="486" width="37" height="37">
-			</bounds>
+			<bounds x="11" y="486" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="13" y="488" width="33" height="33">
-			</bounds>
+			<bounds x="13" y="488" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="11" y="486" width="37" height="37">
-			</bounds>
+			<bounds x="11" y="486" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="13" y="488" width="33" height="33">
-			</bounds>
+			<bounds x="13" y="488" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="11" y="523" width="32" height="17">
-			</bounds>
+			<bounds x="11" y="523" width="32" height="17"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="13" y="525" width="28" height="13">
-			</bounds>
+			<bounds x="13" y="525" width="28" height="13"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1_border" state="0">
-			<bounds x="47" y="486" width="37" height="37">
-			</bounds>
+			<bounds x="47" y="486" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp11" element="lamp_11_1" state="0">
-			<bounds x="49" y="488" width="33" height="33">
-			</bounds>
+			<bounds x="49" y="488" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1_border" state="0">
-			<bounds x="83" y="486" width="37" height="37">
-			</bounds>
+			<bounds x="83" y="486" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp12" element="lamp_12_1" state="0">
-			<bounds x="85" y="488" width="33" height="33">
-			</bounds>
+			<bounds x="85" y="488" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="119" y="486" width="37" height="37">
-			</bounds>
+			<bounds x="119" y="486" width="37" height="37"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="121" y="488" width="33" height="33">
-			</bounds>
+			<bounds x="121" y="488" width="33" height="33"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="590" y="48" width="92" height="37">
-			</bounds>
+			<bounds x="590" y="48" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="592" y="50" width="88" height="33">
-			</bounds>
+			<bounds x="592" y="50" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="255" y="262" width="32" height="32">
-			</bounds>
+			<bounds x="255" y="262" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="257" y="264" width="28" height="28">
-			</bounds>
+			<bounds x="257" y="264" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="255" y="359" width="32" height="32">
-			</bounds>
+			<bounds x="255" y="359" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="257" y="361" width="28" height="28">
-			</bounds>
+			<bounds x="257" y="361" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="17" y="245" width="32" height="32">
-			</bounds>
+			<bounds x="17" y="245" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="19" y="247" width="28" height="28">
-			</bounds>
+			<bounds x="19" y="247" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="52" y="245" width="32" height="32">
-			</bounds>
+			<bounds x="52" y="245" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="54" y="247" width="28" height="28">
-			</bounds>
+			<bounds x="54" y="247" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="87" y="245" width="32" height="32">
-			</bounds>
+			<bounds x="87" y="245" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="89" y="247" width="28" height="28">
-			</bounds>
+			<bounds x="89" y="247" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="17" y="276" width="102" height="32">
-			</bounds>
+			<bounds x="17" y="276" width="102" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="19" y="278" width="98" height="28">
-			</bounds>
+			<bounds x="19" y="278" width="98" height="28"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="112" y="622" width="52" height="27">
-			</bounds>
+			<bounds x="112" y="622" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="114" y="624" width="48" height="23">
-			</bounds>
+			<bounds x="114" y="624" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="61" y="609" width="52" height="27">
-			</bounds>
+			<bounds x="61" y="609" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="63" y="611" width="48" height="23">
-			</bounds>
+			<bounds x="63" y="611" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="10" y="623" width="52" height="27">
-			</bounds>
+			<bounds x="10" y="623" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="12" y="625" width="48" height="23">
-			</bounds>
+			<bounds x="12" y="625" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="10" y="597" width="52" height="27">
-			</bounds>
+			<bounds x="10" y="597" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="12" y="599" width="48" height="23">
-			</bounds>
+			<bounds x="12" y="599" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="61" y="570" width="52" height="32">
-			</bounds>
+			<bounds x="61" y="570" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="63" y="572" width="48" height="28">
-			</bounds>
+			<bounds x="63" y="572" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="112" y="596" width="52" height="27">
-			</bounds>
+			<bounds x="112" y="596" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="114" y="598" width="48" height="23">
-			</bounds>
+			<bounds x="114" y="598" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="616" y="84" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="84" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="618" y="86" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="86" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="616" y="120" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="120" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="618" y="122" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="122" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="616" y="157" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="157" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="618" y="159" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="159" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="616" y="193" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="193" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="618" y="195" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="195" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="616" y="229" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="229" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="618" y="231" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="231" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="616" y="266" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="266" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="618" y="268" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="268" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="616" y="302" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="302" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="618" y="304" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="304" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1_border" state="0">
-			<bounds x="616" y="339" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="339" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp95" element="lamp_95_1" state="0">
-			<bounds x="618" y="341" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="341" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="616" y="375" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="375" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="618" y="377" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="377" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="616" y="412" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="412" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="618" y="414" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="414" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="616" y="448" width="42" height="37">
-			</bounds>
+			<bounds x="616" y="448" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="618" y="450" width="38" height="33">
-			</bounds>
+			<bounds x="618" y="450" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="682" y="48" width="92" height="37">
-			</bounds>
+			<bounds x="682" y="48" width="92" height="37"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="684" y="50" width="88" height="33">
-			</bounds>
+			<bounds x="684" y="50" width="88" height="33"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="709" y="84" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="84" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="711" y="86" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="86" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="709" y="120" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="120" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="711" y="122" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="122" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="709" y="157" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="157" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="711" y="159" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="159" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1_border" state="0">
-			<bounds x="709" y="193" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="193" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp111" element="lamp_111_1" state="0">
-			<bounds x="711" y="195" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="195" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1_border" state="0">
-			<bounds x="709" y="229" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="229" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp110" element="lamp_110_1" state="0">
-			<bounds x="711" y="231" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="231" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="709" y="412" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="412" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="711" y="414" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="414" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="709" y="375" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="375" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="711" y="377" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="377" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1_border" state="0">
-			<bounds x="709" y="339" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="339" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp94" element="lamp_94_1" state="0">
-			<bounds x="711" y="341" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="341" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="709" y="302" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="302" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="711" y="304" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="304" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="709" y="266" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="266" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="711" y="268" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="268" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="709" y="448" width="42" height="37">
-			</bounds>
+			<bounds x="709" y="448" width="42" height="37"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="711" y="450" width="38" height="33">
-			</bounds>
+			<bounds x="711" y="450" width="38" height="33"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="188" y="616" width="42" height="32">
-			</bounds>
+			<bounds x="188" y="616" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="190" y="618" width="38" height="28">
-			</bounds>
+			<bounds x="190" y="618" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="229" y="611" width="42" height="42">
-			</bounds>
+			<bounds x="229" y="611" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="231" y="613" width="38" height="38">
-			</bounds>
+			<bounds x="231" y="613" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="270" y="611" width="42" height="42">
-			</bounds>
+			<bounds x="270" y="611" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="272" y="613" width="38" height="38">
-			</bounds>
+			<bounds x="272" y="613" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="475" y="611" width="42" height="42">
-			</bounds>
+			<bounds x="475" y="611" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="477" y="613" width="38" height="38">
-			</bounds>
+			<bounds x="477" y="613" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="434" y="611" width="42" height="42">
-			</bounds>
+			<bounds x="434" y="611" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="436" y="613" width="38" height="38">
-			</bounds>
+			<bounds x="436" y="613" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="393" y="611" width="42" height="42">
-			</bounds>
+			<bounds x="393" y="611" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="395" y="613" width="38" height="38">
-			</bounds>
+			<bounds x="395" y="613" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1_border" state="0">
-			<bounds x="352" y="611" width="42" height="42">
-			</bounds>
+			<bounds x="352" y="611" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp31" element="lamp_31_1" state="0">
-			<bounds x="354" y="613" width="38" height="38">
-			</bounds>
+			<bounds x="354" y="613" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1_border" state="0">
-			<bounds x="311" y="611" width="42" height="42">
-			</bounds>
+			<bounds x="311" y="611" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp30" element="lamp_30_1" state="0">
-			<bounds x="313" y="613" width="38" height="38">
-			</bounds>
+			<bounds x="313" y="613" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="516" y="621" width="72" height="32">
-			</bounds>
+			<bounds x="516" y="621" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="518" y="623" width="68" height="28">
-			</bounds>
+			<bounds x="518" y="623" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="516" y="528" width="72" height="32">
-			</bounds>
+			<bounds x="516" y="528" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="518" y="530" width="68" height="28">
-			</bounds>
+			<bounds x="518" y="530" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="516" y="559" width="72" height="32">
-			</bounds>
+			<bounds x="516" y="559" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="518" y="561" width="68" height="28">
-			</bounds>
+			<bounds x="518" y="561" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1_border" state="0">
-			<bounds x="516" y="590" width="72" height="32">
-			</bounds>
+			<bounds x="516" y="590" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp47" element="lamp_47_1" state="0">
-			<bounds x="518" y="592" width="68" height="28">
-			</bounds>
+			<bounds x="518" y="592" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_156_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="339" y="652" width="77" height="27">
-			</bounds>
+			<bounds x="339" y="652" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_156" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="341" y="654" width="73" height="23">
-			</bounds>
+			<bounds x="341" y="654" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_157_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="263" y="652" width="77" height="27">
-			</bounds>
+			<bounds x="263" y="652" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_157" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="265" y="654" width="73" height="23">
-			</bounds>
+			<bounds x="265" y="654" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_158_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="187" y="652" width="77" height="27">
-			</bounds>
+			<bounds x="187" y="652" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_158" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="189" y="654" width="73" height="23">
-			</bounds>
+			<bounds x="189" y="654" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_159_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1" y="652" width="77" height="27">
-			</bounds>
+			<bounds x="1" y="652" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_159" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="3" y="654" width="73" height="23">
-			</bounds>
+			<bounds x="3" y="654" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_160_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="99" y="652" width="77" height="27">
-			</bounds>
+			<bounds x="99" y="652" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_160" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="101" y="654" width="73" height="23">
-			</bounds>
+			<bounds x="101" y="654" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_161_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="616" y="652" width="77" height="27">
-			</bounds>
+			<bounds x="616" y="652" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_161" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="618" y="654" width="73" height="23">
-			</bounds>
+			<bounds x="618" y="654" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_168_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="801" y="1" width="32" height="52">
-			</bounds>
+			<bounds x="801" y="1" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_168" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="803" y="3" width="28" height="48">
-			</bounds>
+			<bounds x="803" y="3" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp189" element="colour_button_169_border" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="4" y="54" width="77" height="27">
-			</bounds>
+			<bounds x="4" y="54" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp189" element="colour_button_169" state="0" inputtag="IN-9" inputmask="0x02">
-			<bounds x="6" y="56" width="73" height="23">
-			</bounds>
+			<bounds x="6" y="56" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp192" element="colour_button_170_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="4" y="89" width="77" height="27">
-			</bounds>
+			<bounds x="4" y="89" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp192" element="colour_button_170" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="6" y="91" width="73" height="23">
-			</bounds>
+			<bounds x="6" y="91" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp211" element="colour_button_171_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="4" y="125" width="77" height="27">
-			</bounds>
+			<bounds x="4" y="125" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp211" element="colour_button_171" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="6" y="127" width="73" height="23">
-			</bounds>
+			<bounds x="6" y="127" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="colour_button_172_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="4" y="160" width="77" height="27">
-			</bounds>
+			<bounds x="4" y="160" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp224" element="colour_button_172" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="6" y="162" width="73" height="23">
-			</bounds>
+			<bounds x="6" y="162" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp82" element="colour_button_173_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="305" y="379" width="77" height="27">
-			</bounds>
+			<bounds x="305" y="379" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp82" element="colour_button_173" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="307" y="381" width="73" height="23">
-			</bounds>
+			<bounds x="307" y="381" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_175_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="755" y="652" width="77" height="27">
-			</bounds>
+			<bounds x="755" y="652" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_175" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="757" y="654" width="73" height="23">
-			</bounds>
+			<bounds x="757" y="654" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp62" element="colour_button_176_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="598" y="484" width="77" height="27">
-			</bounds>
+			<bounds x="598" y="484" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp62" element="colour_button_176" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="600" y="486" width="73" height="23">
-			</bounds>
+			<bounds x="600" y="486" width="73" height="23"/>
 		</backdrop>
 		<backdrop name="lamp61" element="colour_button_177_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="690" y="484" width="77" height="27">
-			</bounds>
+			<bounds x="690" y="484" width="77" height="27"/>
 		</backdrop>
 		<backdrop name="lamp61" element="colour_button_177" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="692" y="486" width="73" height="23">
-			</bounds>
+			<bounds x="692" y="486" width="73" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="67" y="208" width="24" height="32">
-			</bounds>
+			<bounds x="67" y="208" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="67" y="208" width="24" height="32">
-			</bounds>
+			<bounds x="67" y="208" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="67" y="208" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="67" y="208" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="43" y="208" width="24" height="32">
-			</bounds>
+			<bounds x="43" y="208" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="43" y="208" width="24" height="32">
-			</bounds>
+			<bounds x="43" y="208" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="43" y="208" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="43" y="208" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="188" y="481" width="227" height="20">
-			</bounds>
+			<bounds x="188" y="481" width="227" height="20"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="188" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="188" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="202" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="202" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="216" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="216" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="230" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="230" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="244" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="244" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="258" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="258" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="272" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="272" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="286" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="286" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="300" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="300" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="314" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="314" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="328" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="328" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="342" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="342" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="356" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="356" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="370" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="370" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="384" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="384" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="398" y="481" width="14" height="20">
-			</bounds>
+			<bounds x="398" y="481" width="14" height="20"/>
 		</backdrop>
 		<backdrop name="label150" element="label_150">
-			<bounds x="33" y="189" width="44" height="10">
-			</bounds>
+			<bounds x="33" y="189" width="44" height="10"/>
 		</backdrop>
 		<backdrop name="label151" element="label_151">
-			<bounds x="848" y="481" width="97" height="195">
-			</bounds>
+			<bounds x="848" y="481" width="97" height="195"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_button" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_button" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_button" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_button" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_button" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_button" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_button" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4crc.lay
+++ b/src/mame/layout/sc4crc.lay
@@ -8,15200 +8,8664 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25 jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25 jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_8_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_8_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="drop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="drop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="Bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Moore">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Moore">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="gold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="nudge now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="nudge now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string=" +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string=" +1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="move">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string=" +3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="moves">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string=" +3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="moves">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="moves">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="moves">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_209_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_209_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="live twice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="live twice">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25 jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25 jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Kill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="him">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Kill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="him">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="5 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="5 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="golden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="golden">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="8 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="8 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="11 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="11 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="6 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="4 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="4 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="10 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="repeater">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="reel roulette">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="reel roulette">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="pick a win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="pick a win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="9 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="9 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="quick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="quick">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="big">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="8 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="8 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="3 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="3 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="skill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="crazy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="crazy">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="4 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="4 knock">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="outs">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="7 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="7 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
+			<color red="0.00" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
+			<color red="0.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="mix 'n'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="mix 'n'">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="match">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3 win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="spins">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2 reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="blasts">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ca">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ca">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="sh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="sh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string=" ra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string=" ra">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="ke">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="ke">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="r  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="r  ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</disk>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</disk>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
+			<color red="0.00" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
+			<color red="0.00" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
+			<color red="0.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
+			<color red="0.00" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="watch">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_274_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_274">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold / Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_275_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_275">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold / Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_276_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_276">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_277_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_277">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_278_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_278">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_279_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_279">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_280_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_280">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_281_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_281">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_282_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_282">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_283_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_283">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_284_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_284">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_285_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_285">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_286_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_286">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_287_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_287">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_250">
 		<text string="all lit enters big money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_251">
 		<text string="all lit enters super board">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_252">
 		<text string="bank">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_253">
 		<text string="credits">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_254">
 		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_260">
 		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="line">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_261">
 		<text string="1-12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_270">
 		<text string="start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_271">
 		<text string="all lit awards super">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="794" height="681">
-			</bounds>
+			<bounds x="0" y="0" width="794" height="681"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="148" y="506" width="80" height="110">
-			</bounds>
+			<bounds x="148" y="506" width="80" height="110"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="148.0000" y="506.0000" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="148.0000" y="506.0000" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="151.3333" y="507.5278" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="151.3333" y="507.5278" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="154.6667" y="509.0555" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="154.6667" y="509.0555" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="158.0000" y="510.5833" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="158.0000" y="510.5833" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="161.3333" y="512.1111" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="161.3333" y="512.1111" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="164.6667" y="513.6389" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="164.6667" y="513.6389" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="148.0000" y="542.6667" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="148.0000" y="542.6667" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="151.3333" y="544.1945" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="151.3333" y="544.1945" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="154.6667" y="545.7222" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="154.6667" y="545.7222" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="158.0000" y="547.2500" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="158.0000" y="547.2500" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="161.3333" y="548.7778" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="161.3333" y="548.7778" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="164.6667" y="550.3056" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="164.6667" y="550.3056" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="148.0000" y="579.3333" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="148.0000" y="579.3333" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="151.3333" y="580.8611" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="151.3333" y="580.8611" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="154.6667" y="582.3889" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="154.6667" y="582.3889" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="158.0000" y="583.9166" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="158.0000" y="583.9166" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="161.3333" y="585.4444" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="161.3333" y="585.4444" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="164.6667" y="586.9722" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="164.6667" y="586.9722" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="148" y="506" width="80" height="110">
-			</bounds>
+			<bounds x="148" y="506" width="80" height="110"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="230" y="506" width="80" height="110">
-			</bounds>
+			<bounds x="230" y="506" width="80" height="110"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="506.0000" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="230.0000" y="506.0000" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="507.5278" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="233.3333" y="507.5278" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="509.0555" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="236.6667" y="509.0555" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="510.5833" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="240.0000" y="510.5833" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="512.1111" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="243.3333" y="512.1111" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="513.6389" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="246.6667" y="513.6389" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="542.6667" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="230.0000" y="542.6667" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="544.1945" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="233.3333" y="544.1945" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="545.7222" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="236.6667" y="545.7222" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="547.2500" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="240.0000" y="547.2500" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="548.7778" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="243.3333" y="548.7778" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="550.3056" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="246.6667" y="550.3056" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="230.0000" y="579.3333" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="230.0000" y="579.3333" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="233.3333" y="580.8611" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="233.3333" y="580.8611" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="236.6667" y="582.3889" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="236.6667" y="582.3889" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="240.0000" y="583.9166" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="240.0000" y="583.9166" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="243.3333" y="585.4444" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="243.3333" y="585.4444" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="246.6667" y="586.9722" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="246.6667" y="586.9722" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="230" y="506" width="80" height="110">
-			</bounds>
+			<bounds x="230" y="506" width="80" height="110"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="312" y="506" width="80" height="110">
-			</bounds>
+			<bounds x="312" y="506" width="80" height="110"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="312.0000" y="506.0000" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="312.0000" y="506.0000" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="315.3333" y="507.5278" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="315.3333" y="507.5278" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="318.6667" y="509.0555" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="318.6667" y="509.0555" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="322.0000" y="510.5833" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="322.0000" y="510.5833" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="325.3333" y="512.1111" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="325.3333" y="512.1111" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="328.6667" y="513.6389" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="328.6667" y="513.6389" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="312.0000" y="542.6667" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="312.0000" y="542.6667" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="315.3333" y="544.1945" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="315.3333" y="544.1945" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="318.6667" y="545.7222" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="318.6667" y="545.7222" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="322.0000" y="547.2500" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="322.0000" y="547.2500" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="325.3333" y="548.7778" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="325.3333" y="548.7778" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="328.6667" y="550.3056" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="328.6667" y="550.3056" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="312.0000" y="579.3333" width="80.0000" height="36.6667">
-			</bounds>
+			<bounds x="312.0000" y="579.3333" width="80.0000" height="36.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="315.3333" y="580.8611" width="73.3333" height="33.6111">
-			</bounds>
+			<bounds x="315.3333" y="580.8611" width="73.3333" height="33.6111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="318.6667" y="582.3889" width="66.6667" height="30.5556">
-			</bounds>
+			<bounds x="318.6667" y="582.3889" width="66.6667" height="30.5556"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="322.0000" y="583.9166" width="60.0000" height="27.5000">
-			</bounds>
+			<bounds x="322.0000" y="583.9166" width="60.0000" height="27.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="325.3333" y="585.4444" width="53.3333" height="24.4444">
-			</bounds>
+			<bounds x="325.3333" y="585.4444" width="53.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="328.6667" y="586.9722" width="46.6667" height="21.3889">
-			</bounds>
+			<bounds x="328.6667" y="586.9722" width="46.6667" height="21.3889"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="312" y="506" width="80" height="110">
-			</bounds>
+			<bounds x="312" y="506" width="80" height="110"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="433" y="534" width="80" height="45">
-			</bounds>
+			<bounds x="433" y="534" width="80" height="45"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="433.0000" y="534.0000" width="80.0000" height="45.0000">
-			</bounds>
+			<bounds x="433.0000" y="534.0000" width="80.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="436.3333" y="535.8750" width="73.3333" height="41.2500">
-			</bounds>
+			<bounds x="436.3333" y="535.8750" width="73.3333" height="41.2500"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="439.6667" y="537.7500" width="66.6667" height="37.5000">
-			</bounds>
+			<bounds x="439.6667" y="537.7500" width="66.6667" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="443.0000" y="539.6250" width="60.0000" height="33.7500">
-			</bounds>
+			<bounds x="443.0000" y="539.6250" width="60.0000" height="33.7500"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="446.3333" y="541.5000" width="53.3333" height="30.0000">
-			</bounds>
+			<bounds x="446.3333" y="541.5000" width="53.3333" height="30.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="449.6667" y="543.3750" width="46.6667" height="26.2500">
-			</bounds>
+			<bounds x="449.6667" y="543.3750" width="46.6667" height="26.2500"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="433" y="534" width="80" height="45">
-			</bounds>
+			<bounds x="433" y="534" width="80" height="45"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="37" y="1" width="72" height="47">
-			</bounds>
+			<bounds x="37" y="1" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="39" y="3" width="68" height="43">
-			</bounds>
+			<bounds x="39" y="3" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1_border" state="0">
-			<bounds x="573" y="617" width="62" height="32">
-			</bounds>
+			<bounds x="573" y="617" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp8" element="lamp_8_1" state="0">
-			<bounds x="575" y="619" width="58" height="28">
-			</bounds>
+			<bounds x="575" y="619" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="573" y="572" width="62" height="37">
-			</bounds>
+			<bounds x="573" y="572" width="62" height="37"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="575" y="574" width="58" height="33">
-			</bounds>
+			<bounds x="575" y="574" width="58" height="33"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="514" y="586" width="52" height="27">
-			</bounds>
+			<bounds x="514" y="586" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="516" y="588" width="48" height="23">
-			</bounds>
+			<bounds x="516" y="588" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="515" y="617" width="42" height="32">
-			</bounds>
+			<bounds x="515" y="617" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="517" y="619" width="38" height="28">
-			</bounds>
+			<bounds x="517" y="619" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="454" y="617" width="42" height="32">
-			</bounds>
+			<bounds x="454" y="617" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="456" y="619" width="38" height="28">
-			</bounds>
+			<bounds x="456" y="619" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="394" y="617" width="42" height="32">
-			</bounds>
+			<bounds x="394" y="617" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="396" y="619" width="38" height="28">
-			</bounds>
+			<bounds x="396" y="619" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="322" y="617" width="62" height="32">
-			</bounds>
+			<bounds x="322" y="617" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="324" y="619" width="58" height="28">
-			</bounds>
+			<bounds x="324" y="619" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="265" y="617" width="42" height="32">
-			</bounds>
+			<bounds x="265" y="617" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="267" y="619" width="38" height="28">
-			</bounds>
+			<bounds x="267" y="619" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="202" y="617" width="42" height="32">
-			</bounds>
+			<bounds x="202" y="617" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="204" y="619" width="38" height="28">
-			</bounds>
+			<bounds x="204" y="619" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="145" y="617" width="42" height="32">
-			</bounds>
+			<bounds x="145" y="617" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="147" y="619" width="38" height="28">
-			</bounds>
+			<bounds x="147" y="619" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="573" y="467" width="62" height="47">
-			</bounds>
+			<bounds x="573" y="467" width="62" height="47"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="575" y="469" width="58" height="43">
-			</bounds>
+			<bounds x="575" y="469" width="58" height="43"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="573" y="522" width="62" height="42">
-			</bounds>
+			<bounds x="573" y="522" width="62" height="42"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="575" y="524" width="58" height="38">
-			</bounds>
+			<bounds x="575" y="524" width="58" height="38"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="57" y="493" width="52" height="42">
-			</bounds>
+			<bounds x="57" y="493" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="59" y="495" width="48" height="38">
-			</bounds>
+			<bounds x="59" y="495" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="543" y="388" width="54" height="32">
-			</bounds>
+			<bounds x="543" y="388" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="545" y="390" width="50" height="28">
-			</bounds>
+			<bounds x="545" y="390" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="115" y="388" width="54" height="32">
-			</bounds>
+			<bounds x="115" y="388" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="117" y="390" width="50" height="28">
-			</bounds>
+			<bounds x="117" y="390" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="86" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="86" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="88" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="88" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="140" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="140" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="142" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="142" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="194" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="194" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="196" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="196" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="248" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="248" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="250" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="250" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="302" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="302" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="304" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="304" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="356" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="356" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="358" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="358" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="410" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="410" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="412" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="412" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="464" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="464" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="466" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="466" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="518" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="518" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="520" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="520" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="572" y="425" width="54" height="32">
-			</bounds>
+			<bounds x="572" y="425" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="574" y="427" width="50" height="28">
-			</bounds>
+			<bounds x="574" y="427" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="140" y="351" width="54" height="32">
-			</bounds>
+			<bounds x="140" y="351" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="142" y="353" width="50" height="28">
-			</bounds>
+			<bounds x="142" y="353" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="194" y="351" width="54" height="32">
-			</bounds>
+			<bounds x="194" y="351" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="196" y="353" width="50" height="28">
-			</bounds>
+			<bounds x="196" y="353" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="248" y="351" width="54" height="32">
-			</bounds>
+			<bounds x="248" y="351" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="250" y="353" width="50" height="28">
-			</bounds>
+			<bounds x="250" y="353" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="302" y="351" width="54" height="32">
-			</bounds>
+			<bounds x="302" y="351" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="304" y="353" width="50" height="28">
-			</bounds>
+			<bounds x="304" y="353" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="356" y="351" width="54" height="32">
-			</bounds>
+			<bounds x="356" y="351" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="358" y="353" width="50" height="28">
-			</bounds>
+			<bounds x="358" y="353" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="410" y="351" width="54" height="32">
-			</bounds>
+			<bounds x="410" y="351" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="412" y="353" width="50" height="28">
-			</bounds>
+			<bounds x="412" y="353" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="464" y="351" width="54" height="32">
-			</bounds>
+			<bounds x="464" y="351" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="466" y="353" width="50" height="28">
-			</bounds>
+			<bounds x="466" y="353" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="518" y="351" width="54" height="32">
-			</bounds>
+			<bounds x="518" y="351" width="54" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="520" y="353" width="50" height="28">
-			</bounds>
+			<bounds x="520" y="353" width="50" height="28"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1_border" state="0">
-			<bounds x="249" y="314" width="47" height="37">
-			</bounds>
+			<bounds x="249" y="314" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp209" element="lamp_209_1" state="0">
-			<bounds x="251" y="316" width="43" height="33">
-			</bounds>
+			<bounds x="251" y="316" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="605" y="1" width="72" height="47">
-			</bounds>
+			<bounds x="605" y="1" width="72" height="47"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="607" y="3" width="68" height="43">
-			</bounds>
+			<bounds x="607" y="3" width="68" height="43"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="621" y="50" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="50" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="623" y="52" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="52" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="621" y="77" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="77" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="623" y="79" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="79" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="621" y="104" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="104" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="623" y="106" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="106" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="621" y="131" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="131" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="623" y="133" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="133" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="621" y="158" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="158" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="623" y="160" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="160" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="621" y="185" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="185" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="623" y="187" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="187" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="621" y="212" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="212" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="623" y="214" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="214" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="621" y="239" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="239" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="623" y="241" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="241" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="621" y="266" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="266" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="623" y="268" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="268" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="621" y="293" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="293" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="623" y="295" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="295" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="621" y="320" width="40" height="27">
-			</bounds>
+			<bounds x="621" y="320" width="40" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="623" y="322" width="36" height="23">
-			</bounds>
+			<bounds x="623" y="322" width="36" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="55" y="320" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="320" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="57" y="322" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="322" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="55" y="293" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="293" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="57" y="295" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="295" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="55" y="266" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="266" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="57" y="268" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="268" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="55" y="239" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="239" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="57" y="241" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="241" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="55" y="212" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="212" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="57" y="214" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="214" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="55" y="185" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="185" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="57" y="187" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="187" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="55" y="158" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="158" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="57" y="160" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="160" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="55" y="131" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="131" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="57" y="133" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="133" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="55" y="104" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="104" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="57" y="106" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="106" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="55" y="77" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="77" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="57" y="79" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="79" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="55" y="50" width="37" height="27">
-			</bounds>
+			<bounds x="55" y="50" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="57" y="52" width="33" height="23">
-			</bounds>
+			<bounds x="57" y="52" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="412" y="314" width="47" height="37">
-			</bounds>
+			<bounds x="412" y="314" width="47" height="37"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="414" y="316" width="43" height="33">
-			</bounds>
+			<bounds x="414" y="316" width="43" height="33"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="538" y="168" width="72" height="32">
-			</bounds>
+			<bounds x="538" y="168" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="540" y="170" width="68" height="28">
-			</bounds>
+			<bounds x="540" y="170" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="106" y="136" width="72" height="32">
-			</bounds>
+			<bounds x="106" y="136" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="108" y="138" width="68" height="28">
-			</bounds>
+			<bounds x="108" y="138" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="178" y="136" width="72" height="32">
-			</bounds>
+			<bounds x="178" y="136" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="180" y="138" width="68" height="28">
-			</bounds>
+			<bounds x="180" y="138" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="250" y="136" width="72" height="32">
-			</bounds>
+			<bounds x="250" y="136" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="252" y="138" width="68" height="28">
-			</bounds>
+			<bounds x="252" y="138" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="322" y="136" width="72" height="32">
-			</bounds>
+			<bounds x="322" y="136" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="324" y="138" width="68" height="28">
-			</bounds>
+			<bounds x="324" y="138" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="394" y="136" width="72" height="32">
-			</bounds>
+			<bounds x="394" y="136" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="396" y="138" width="68" height="28">
-			</bounds>
+			<bounds x="396" y="138" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="466" y="136" width="72" height="32">
-			</bounds>
+			<bounds x="466" y="136" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="468" y="138" width="68" height="28">
-			</bounds>
+			<bounds x="468" y="138" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="538" y="136" width="72" height="32">
-			</bounds>
+			<bounds x="538" y="136" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="540" y="138" width="68" height="28">
-			</bounds>
+			<bounds x="540" y="138" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="106" y="72" width="72" height="32">
-			</bounds>
+			<bounds x="106" y="72" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="108" y="74" width="68" height="28">
-			</bounds>
+			<bounds x="108" y="74" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="178" y="72" width="72" height="32">
-			</bounds>
+			<bounds x="178" y="72" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="180" y="74" width="68" height="28">
-			</bounds>
+			<bounds x="180" y="74" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="250" y="72" width="72" height="32">
-			</bounds>
+			<bounds x="250" y="72" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="252" y="74" width="68" height="28">
-			</bounds>
+			<bounds x="252" y="74" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="322" y="72" width="72" height="32">
-			</bounds>
+			<bounds x="322" y="72" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="324" y="74" width="68" height="28">
-			</bounds>
+			<bounds x="324" y="74" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="394" y="72" width="72" height="32">
-			</bounds>
+			<bounds x="394" y="72" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="396" y="74" width="68" height="28">
-			</bounds>
+			<bounds x="396" y="74" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="538" y="72" width="72" height="32">
-			</bounds>
+			<bounds x="538" y="72" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="540" y="74" width="68" height="28">
-			</bounds>
+			<bounds x="540" y="74" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="466" y="72" width="72" height="32">
-			</bounds>
+			<bounds x="466" y="72" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="468" y="74" width="68" height="28">
-			</bounds>
+			<bounds x="468" y="74" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="106" y="104" width="72" height="32">
-			</bounds>
+			<bounds x="106" y="104" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="108" y="106" width="68" height="28">
-			</bounds>
+			<bounds x="108" y="106" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="178" y="104" width="72" height="32">
-			</bounds>
+			<bounds x="178" y="104" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="180" y="106" width="68" height="28">
-			</bounds>
+			<bounds x="180" y="106" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="250" y="104" width="72" height="32">
-			</bounds>
+			<bounds x="250" y="104" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="252" y="106" width="68" height="28">
-			</bounds>
+			<bounds x="252" y="106" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="322" y="104" width="72" height="32">
-			</bounds>
+			<bounds x="322" y="104" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="324" y="106" width="68" height="28">
-			</bounds>
+			<bounds x="324" y="106" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="394" y="104" width="72" height="32">
-			</bounds>
+			<bounds x="394" y="104" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="396" y="106" width="68" height="28">
-			</bounds>
+			<bounds x="396" y="106" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="466" y="104" width="72" height="32">
-			</bounds>
+			<bounds x="466" y="104" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="468" y="106" width="68" height="28">
-			</bounds>
+			<bounds x="468" y="106" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="538" y="104" width="72" height="32">
-			</bounds>
+			<bounds x="538" y="104" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="540" y="106" width="68" height="28">
-			</bounds>
+			<bounds x="540" y="106" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="466" y="168" width="72" height="32">
-			</bounds>
+			<bounds x="466" y="168" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="468" y="170" width="68" height="28">
-			</bounds>
+			<bounds x="468" y="170" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="394" y="168" width="72" height="32">
-			</bounds>
+			<bounds x="394" y="168" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="396" y="170" width="68" height="28">
-			</bounds>
+			<bounds x="396" y="170" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="322" y="168" width="72" height="32">
-			</bounds>
+			<bounds x="322" y="168" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="324" y="170" width="68" height="28">
-			</bounds>
+			<bounds x="324" y="170" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="250" y="168" width="72" height="32">
-			</bounds>
+			<bounds x="250" y="168" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="252" y="170" width="68" height="28">
-			</bounds>
+			<bounds x="252" y="170" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="178" y="168" width="72" height="32">
-			</bounds>
+			<bounds x="178" y="168" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="180" y="170" width="68" height="28">
-			</bounds>
+			<bounds x="180" y="170" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="106" y="168" width="72" height="32">
-			</bounds>
+			<bounds x="106" y="168" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="108" y="170" width="68" height="28">
-			</bounds>
+			<bounds x="108" y="170" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="538" y="200" width="72" height="32">
-			</bounds>
+			<bounds x="538" y="200" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="540" y="202" width="68" height="28">
-			</bounds>
+			<bounds x="540" y="202" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="466" y="200" width="72" height="32">
-			</bounds>
+			<bounds x="466" y="200" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="468" y="202" width="68" height="28">
-			</bounds>
+			<bounds x="468" y="202" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="394" y="200" width="72" height="32">
-			</bounds>
+			<bounds x="394" y="200" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="396" y="202" width="68" height="28">
-			</bounds>
+			<bounds x="396" y="202" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="322" y="200" width="72" height="32">
-			</bounds>
+			<bounds x="322" y="200" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="324" y="202" width="68" height="28">
-			</bounds>
+			<bounds x="324" y="202" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="250" y="200" width="72" height="32">
-			</bounds>
+			<bounds x="250" y="200" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="252" y="202" width="68" height="28">
-			</bounds>
+			<bounds x="252" y="202" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="178" y="200" width="72" height="32">
-			</bounds>
+			<bounds x="178" y="200" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="180" y="202" width="68" height="28">
-			</bounds>
+			<bounds x="180" y="202" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="106" y="200" width="72" height="32">
-			</bounds>
+			<bounds x="106" y="200" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="108" y="202" width="68" height="28">
-			</bounds>
+			<bounds x="108" y="202" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="538" y="232" width="72" height="32">
-			</bounds>
+			<bounds x="538" y="232" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="540" y="234" width="68" height="28">
-			</bounds>
+			<bounds x="540" y="234" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="466" y="232" width="72" height="32">
-			</bounds>
+			<bounds x="466" y="232" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="468" y="234" width="68" height="28">
-			</bounds>
+			<bounds x="468" y="234" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="394" y="232" width="72" height="32">
-			</bounds>
+			<bounds x="394" y="232" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="396" y="234" width="68" height="28">
-			</bounds>
+			<bounds x="396" y="234" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="322" y="232" width="72" height="32">
-			</bounds>
+			<bounds x="322" y="232" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="324" y="234" width="68" height="28">
-			</bounds>
+			<bounds x="324" y="234" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="250" y="232" width="72" height="32">
-			</bounds>
+			<bounds x="250" y="232" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="252" y="234" width="68" height="28">
-			</bounds>
+			<bounds x="252" y="234" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="178" y="232" width="72" height="32">
-			</bounds>
+			<bounds x="178" y="232" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="180" y="234" width="68" height="28">
-			</bounds>
+			<bounds x="180" y="234" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="106" y="232" width="72" height="32">
-			</bounds>
+			<bounds x="106" y="232" width="72" height="32"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="108" y="234" width="68" height="28">
-			</bounds>
+			<bounds x="108" y="234" width="68" height="28"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="334" y="44" width="42" height="17">
-			</bounds>
+			<bounds x="334" y="44" width="42" height="17"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="336" y="46" width="38" height="13">
-			</bounds>
+			<bounds x="336" y="46" width="38" height="13"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="292" y="44" width="42" height="17">
-			</bounds>
+			<bounds x="292" y="44" width="42" height="17"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="294" y="46" width="38" height="13">
-			</bounds>
+			<bounds x="294" y="46" width="38" height="13"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="376" y="44" width="42" height="17">
-			</bounds>
+			<bounds x="376" y="44" width="42" height="17"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="378" y="46" width="38" height="13">
-			</bounds>
+			<bounds x="378" y="46" width="38" height="13"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="306" y="24" width="32" height="20">
-			</bounds>
+			<bounds x="306" y="24" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="308" y="26" width="28" height="16">
-			</bounds>
+			<bounds x="308" y="26" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="338" y="24" width="32" height="20">
-			</bounds>
+			<bounds x="338" y="24" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="340" y="26" width="28" height="16">
-			</bounds>
+			<bounds x="340" y="26" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="370" y="24" width="32" height="20">
-			</bounds>
+			<bounds x="370" y="24" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="372" y="26" width="28" height="16">
-			</bounds>
+			<bounds x="372" y="26" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="434" y="24" width="32" height="20">
-			</bounds>
+			<bounds x="434" y="24" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="436" y="26" width="28" height="16">
-			</bounds>
+			<bounds x="436" y="26" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="402" y="24" width="32" height="20">
-			</bounds>
+			<bounds x="402" y="24" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="404" y="26" width="28" height="16">
-			</bounds>
+			<bounds x="404" y="26" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="274" y="24" width="32" height="20">
-			</bounds>
+			<bounds x="274" y="24" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="276" y="26" width="28" height="16">
-			</bounds>
+			<bounds x="276" y="26" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="242" y="24" width="32" height="20">
-			</bounds>
+			<bounds x="242" y="24" width="32" height="20"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="244" y="26" width="28" height="16">
-			</bounds>
+			<bounds x="244" y="26" width="28" height="16"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="274" y="3" width="32" height="22">
-			</bounds>
+			<bounds x="274" y="3" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="276" y="5" width="28" height="18">
-			</bounds>
+			<bounds x="276" y="5" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="306" y="3" width="32" height="22">
-			</bounds>
+			<bounds x="306" y="3" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="308" y="5" width="28" height="18">
-			</bounds>
+			<bounds x="308" y="5" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="338" y="3" width="32" height="22">
-			</bounds>
+			<bounds x="338" y="3" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="340" y="5" width="28" height="18">
-			</bounds>
+			<bounds x="340" y="5" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="370" y="3" width="32" height="22">
-			</bounds>
+			<bounds x="370" y="3" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="372" y="5" width="28" height="18">
-			</bounds>
+			<bounds x="372" y="5" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="402" y="3" width="32" height="22">
-			</bounds>
+			<bounds x="402" y="3" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="404" y="5" width="28" height="18">
-			</bounds>
+			<bounds x="404" y="5" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="329" y="268" width="12" height="12">
-			</bounds>
+			<bounds x="329" y="268" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="331" y="270" width="8" height="8">
-			</bounds>
+			<bounds x="331" y="270" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="367" y="268" width="12" height="12">
-			</bounds>
+			<bounds x="367" y="268" width="12" height="12"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="369" y="270" width="8" height="8">
-			</bounds>
+			<bounds x="369" y="270" width="8" height="8"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="49" y="573" width="32" height="32">
-			</bounds>
+			<bounds x="49" y="573" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="51" y="575" width="28" height="28">
-			</bounds>
+			<bounds x="51" y="575" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="49" y="541" width="32" height="32">
-			</bounds>
+			<bounds x="49" y="541" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="51" y="543" width="28" height="28">
-			</bounds>
+			<bounds x="51" y="543" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="44" y="606" width="37" height="32">
-			</bounds>
+			<bounds x="44" y="606" width="37" height="32"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="46" y="608" width="33" height="28">
-			</bounds>
+			<bounds x="46" y="608" width="33" height="28"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="81" y="557" width="32" height="32">
-			</bounds>
+			<bounds x="81" y="557" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="83" y="559" width="28" height="28">
-			</bounds>
+			<bounds x="83" y="559" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="81" y="589" width="32" height="32">
-			</bounds>
+			<bounds x="81" y="589" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="83" y="591" width="28" height="28">
-			</bounds>
+			<bounds x="83" y="591" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="429" y="269" width="52" height="22">
-			</bounds>
+			<bounds x="429" y="269" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="431" y="271" width="48" height="18">
-			</bounds>
+			<bounds x="431" y="271" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="481" y="269" width="52" height="22">
-			</bounds>
+			<bounds x="481" y="269" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="483" y="271" width="48" height="18">
-			</bounds>
+			<bounds x="483" y="271" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="533" y="269" width="52" height="22">
-			</bounds>
+			<bounds x="533" y="269" width="52" height="22"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="535" y="271" width="48" height="18">
-			</bounds>
+			<bounds x="535" y="271" width="48" height="18"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="534" y="460" width="32" height="32">
-			</bounds>
+			<bounds x="534" y="460" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="536" y="462" width="28" height="28">
-			</bounds>
+			<bounds x="536" y="462" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="486" y="460" width="32" height="32">
-			</bounds>
+			<bounds x="486" y="460" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="488" y="462" width="28" height="28">
-			</bounds>
+			<bounds x="488" y="462" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="435" y="460" width="32" height="32">
-			</bounds>
+			<bounds x="435" y="460" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="437" y="462" width="28" height="28">
-			</bounds>
+			<bounds x="437" y="462" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="384" y="460" width="32" height="32">
-			</bounds>
+			<bounds x="384" y="460" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="386" y="462" width="28" height="28">
-			</bounds>
+			<bounds x="386" y="462" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="335" y="460" width="32" height="32">
-			</bounds>
+			<bounds x="335" y="460" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="337" y="462" width="28" height="28">
-			</bounds>
+			<bounds x="337" y="462" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_274_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="311" y="651" width="82" height="32">
-			</bounds>
+			<bounds x="311" y="651" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_274" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="313" y="653" width="78" height="28">
-			</bounds>
+			<bounds x="313" y="653" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_275_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="229" y="651" width="82" height="32">
-			</bounds>
+			<bounds x="229" y="651" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_275" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="231" y="653" width="78" height="28">
-			</bounds>
+			<bounds x="231" y="653" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_276_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="147" y="651" width="82" height="32">
-			</bounds>
+			<bounds x="147" y="651" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_276" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="149" y="653" width="78" height="28">
-			</bounds>
+			<bounds x="149" y="653" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_277_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="65" y="651" width="82" height="32">
-			</bounds>
+			<bounds x="65" y="651" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_277" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="67" y="653" width="78" height="28">
-			</bounds>
+			<bounds x="67" y="653" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_278_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="485" y="651" width="82" height="32">
-			</bounds>
+			<bounds x="485" y="651" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_278" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="487" y="653" width="78" height="28">
-			</bounds>
+			<bounds x="487" y="653" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_279_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="575" y="651" width="82" height="32">
-			</bounds>
+			<bounds x="575" y="651" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_279" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="577" y="653" width="78" height="28">
-			</bounds>
+			<bounds x="577" y="653" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_280_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="395" y="651" width="82" height="32">
-			</bounds>
+			<bounds x="395" y="651" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_280" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="397" y="653" width="78" height="28">
-			</bounds>
+			<bounds x="397" y="653" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="colour_button_281_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="333" y="266" width="42" height="28">
-			</bounds>
+			<bounds x="333" y="266" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp210" element="colour_button_281" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="335" y="268" width="38" height="24">
-			</bounds>
+			<bounds x="335" y="268" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp97" element="colour_button_282_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="611" y="348" width="62" height="62">
-			</bounds>
+			<bounds x="611" y="348" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp97" element="colour_button_282" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="613" y="350" width="58" height="58">
-			</bounds>
+			<bounds x="613" y="350" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp224" element="colour_button_283_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="43" y="348" width="62" height="62">
-			</bounds>
+			<bounds x="43" y="348" width="62" height="62"/>
 		</backdrop>
 		<backdrop name="lamp224" element="colour_button_283" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="45" y="350" width="58" height="58">
-			</bounds>
+			<bounds x="45" y="350" width="58" height="58"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_284_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="671" y="651" width="75" height="27">
-			</bounds>
+			<bounds x="671" y="651" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_284" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="673" y="653" width="71" height="23">
-			</bounds>
+			<bounds x="673" y="653" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp218" element="colour_button_285_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="299" y="288" width="32" height="42">
-			</bounds>
+			<bounds x="299" y="288" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp218" element="colour_button_285" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="301" y="290" width="28" height="38">
-			</bounds>
+			<bounds x="301" y="290" width="28" height="38"/>
 		</backdrop>
 		<backdrop name="lamp96" element="colour_button_286_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="333" y="324" width="42" height="28">
-			</bounds>
+			<bounds x="333" y="324" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="lamp96" element="colour_button_286" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="335" y="326" width="38" height="24">
-			</bounds>
+			<bounds x="335" y="326" width="38" height="24"/>
 		</backdrop>
 		<backdrop name="lamp216" element="colour_button_287_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="379" y="288" width="32" height="42">
-			</bounds>
+			<bounds x="379" y="288" width="32" height="42"/>
 		</backdrop>
 		<backdrop name="lamp216" element="colour_button_287" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="381" y="290" width="28" height="38">
-			</bounds>
+			<bounds x="381" y="290" width="28" height="38"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="333" y="294" width="22" height="30">
-			</bounds>
+			<bounds x="333" y="294" width="22" height="30"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_green">
-			<bounds x="333" y="294" width="22" height="30">
-			</bounds>
+			<bounds x="333" y="294" width="22" height="30"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_green">
-			<bounds x="333" y="294" width="22" height="30">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="333" y="294" width="22" height="30"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="354" y="294" width="22" height="30">
-			</bounds>
+			<bounds x="354" y="294" width="22" height="30"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_green">
-			<bounds x="354" y="294" width="22" height="30">
-			</bounds>
+			<bounds x="354" y="294" width="22" height="30"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_green">
-			<bounds x="354" y="294" width="22" height="30">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="354" y="294" width="22" height="30"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="195" y="386" width="323" height="27">
-			</bounds>
+			<bounds x="195" y="386" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="195" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="195" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="215" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="215" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="235" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="235" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="255" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="255" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="275" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="275" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="295" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="295" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="315" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="315" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="335" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="335" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="355" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="355" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="375" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="375" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="395" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="395" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="415" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="415" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="435" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="435" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="455" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="455" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="475" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="475" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="495" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="495" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label250" element="label_250">
-			<bounds x="275" y="59" width="126" height="14">
-			</bounds>
+			<bounds x="275" y="59" width="126" height="14"/>
 		</backdrop>
 		<backdrop name="label251" element="label_251">
-			<bounds x="415" y="291" width="136" height="14">
-			</bounds>
+			<bounds x="415" y="291" width="136" height="14"/>
 		</backdrop>
 		<backdrop name="label252" element="label_252">
-			<bounds x="196" y="412" width="27" height="14">
-			</bounds>
+			<bounds x="196" y="412" width="27" height="14"/>
 		</backdrop>
 		<backdrop name="label253" element="label_253">
-			<bounds x="468" y="412" width="39" height="14">
-			</bounds>
+			<bounds x="468" y="412" width="39" height="14"/>
 		</backdrop>
 		<backdrop name="label254" element="label_254">
-			<bounds x="394" y="549" width="20" height="28">
-			</bounds>
+			<bounds x="394" y="549" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="label260" element="label_260">
-			<bounds x="118" y="549" width="20" height="28">
-			</bounds>
+			<bounds x="118" y="549" width="20" height="28"/>
 		</backdrop>
 		<backdrop name="label261" element="label_261">
-			<bounds x="458" y="580" width="25" height="16">
-			</bounds>
+			<bounds x="458" y="580" width="25" height="16"/>
 		</backdrop>
 		<backdrop name="label270" element="label_270">
-			<bounds x="502" y="490" width="26" height="14">
-			</bounds>
+			<bounds x="502" y="490" width="26" height="14"/>
 		</backdrop>
 		<backdrop name="label271" element="label_271">
-			<bounds x="356" y="490" width="105" height="14">
-			</bounds>
+			<bounds x="356" y="490" width="105" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_button" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_button" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_button" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_button" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_button" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_button" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_button" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4crcla.lay
+++ b/src/mame/layout/sc4crcla.lay
@@ -8,16628 +8,9358 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_208_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_208_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JAckpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JAckpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 2 MOVES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 2 MOVES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="MOVE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 2 NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="all lit enters big money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="all lit enters big money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_166_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_166_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_167_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_167_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="STOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="Boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="Boat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_163_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_163_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_164_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_164_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_165_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_165_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="12 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="12 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="SUPer  MONEYBELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="SUPer  MONEYBELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="7 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="7 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MONEY BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MONEY BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1 REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1 REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="6 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="REEL ROULETTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="REEL ROULETTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="9 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="9 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="2 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="3 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="3 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="HIT THE TOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="HIT THE TOP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_150_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_150_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="GOLDEN SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="GOLDEN SHOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="PICK A ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="PICK A ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="5 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="mONEY mOUNTAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="mONEY mOUNTAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="1 SUPER WIN SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="1 SUPER WIN SPIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="LINK UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="LINK UP">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4 SUPER REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4 SUPER REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="WIN ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SERIES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4 REEL BLASTS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="FAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="FAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="5 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="5 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="16 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="16 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CRAZY REELS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CRAZY REELS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="10 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="10 WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="2 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="2 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="QUICK NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="QUICK NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="6 SUPER REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="6 SUPER REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5 SUPER REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5 SUPER REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
+			<color red="0.50" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
+			<color red="0.12" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
+			<color red="1.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
+			<color red="0.25" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="4 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.13">
-			</color>
-		</rect>
-		<text string="4 SUPER WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BOAT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="MIX 'N' MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="MIX 'N' MATCH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="14 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="14 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="18 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="18 WIN SPINS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="8 SUPER REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="8 SUPER REEL BLAST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_136_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_136_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</rect>
 		<text string="LIVE TWICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<text string="LIVE TWICE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_45_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_45_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_44_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_44_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="NUDGE NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_46_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_46_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="LOSE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_29_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_29_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_42_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_42_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_21_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_21_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_126_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_126_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="JAckpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="JAckpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="E">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="K">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="R">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="H">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="S">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="A">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="C">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CLUB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLUB">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
+			<color red="0.50" green="0.50" blue="0.25"/>
 		</disk>
 		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
+			<color red="0.12" green="0.12" blue="0.06"/>
 		</disk>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
+			<color red="1.00" green="1.00" blue="0.50"/>
 		</disk>
 		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
+			<color red="0.25" green="0.25" blue="0.13"/>
 		</disk>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.25">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.12" green="0.12" blue="0.06">
-			</color>
-		</disk>
-	</element>
-	<element name="" defstate="0">
-		<disk state="1">
-			<color red="1.00" green="1.00" blue="0.50">
-			</color>
-		</disk>
-		<disk state="0">
-			<color red="0.25" green="0.25" blue="0.13">
-			</color>
-		</disk>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.10" y="0.10" width="0.80" height="0.80"/>
 		</text>
 	</element>
 	<element name="colour_button_199_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_199">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_201_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_201">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_202_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_202">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_203_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_203">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.10" y="0.10" width="0.80" height="0.80">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_204_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_204">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="colour_button_205_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_205">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="IGOR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_206_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_206">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_207_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_207">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_208_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_208">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold / hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_209_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_209">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold / lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_210_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_210">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_211_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_211">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_212_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_212">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_213_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_213">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="0" stateoffset="-18432" numsymbolsvisible="1" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_113">
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_114">
 		<text string="Super Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_198">
 		<text string="Light All For Superboard">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="12">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1028" height="693">
-			</bounds>
+			<bounds x="0" y="0" width="1028" height="693"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="220" y="474" width="80" height="130">
-			</bounds>
+			<bounds x="220" y="474" width="80" height="130"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="220.0000" y="474.0000" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="220.0000" y="474.0000" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="223.3333" y="475.8055" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="223.3333" y="475.8055" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="226.6667" y="477.6111" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="226.6667" y="477.6111" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="230.0000" y="479.4167" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="230.0000" y="479.4167" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.3333" y="481.2222" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="233.3333" y="481.2222" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="236.6667" y="483.0278" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="236.6667" y="483.0278" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="220.0000" y="517.3333" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="220.0000" y="517.3333" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="223.3333" y="519.1389" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="223.3333" y="519.1389" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="226.6667" y="520.9444" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="226.6667" y="520.9444" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="230.0000" y="522.7500" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="230.0000" y="522.7500" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.3333" y="524.5555" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="233.3333" y="524.5555" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="236.6667" y="526.3611" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="236.6667" y="526.3611" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="220.0000" y="560.6667" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="220.0000" y="560.6667" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="223.3333" y="562.4722" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="223.3333" y="562.4722" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="226.6667" y="564.2778" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="226.6667" y="564.2778" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="230.0000" y="566.0834" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="230.0000" y="566.0834" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="233.3333" y="567.8889" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="233.3333" y="567.8889" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="236.6667" y="569.6945" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="236.6667" y="569.6945" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="220" y="474" width="80" height="130">
-			</bounds>
+			<bounds x="220" y="474" width="80" height="130"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="302" y="474" width="80" height="130">
-			</bounds>
+			<bounds x="302" y="474" width="80" height="130"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="302.0000" y="474.0000" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="302.0000" y="474.0000" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="305.3333" y="475.8055" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="305.3333" y="475.8055" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="308.6667" y="477.6111" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="308.6667" y="477.6111" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="312.0000" y="479.4167" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="312.0000" y="479.4167" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="315.3333" y="481.2222" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="315.3333" y="481.2222" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="318.6667" y="483.0278" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="318.6667" y="483.0278" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="302.0000" y="517.3333" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="302.0000" y="517.3333" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="305.3333" y="519.1389" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="305.3333" y="519.1389" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="308.6667" y="520.9444" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="308.6667" y="520.9444" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="312.0000" y="522.7500" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="312.0000" y="522.7500" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="315.3333" y="524.5555" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="315.3333" y="524.5555" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="318.6667" y="526.3611" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="318.6667" y="526.3611" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="302.0000" y="560.6667" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="302.0000" y="560.6667" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="305.3333" y="562.4722" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="305.3333" y="562.4722" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="308.6667" y="564.2778" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="308.6667" y="564.2778" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="312.0000" y="566.0834" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="312.0000" y="566.0834" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="315.3333" y="567.8889" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="315.3333" y="567.8889" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="318.6667" y="569.6945" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="318.6667" y="569.6945" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="302" y="474" width="80" height="130">
-			</bounds>
+			<bounds x="302" y="474" width="80" height="130"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="384" y="474" width="80" height="130">
-			</bounds>
+			<bounds x="384" y="474" width="80" height="130"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="384.0000" y="474.0000" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="384.0000" y="474.0000" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="387.3333" y="475.8055" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="387.3333" y="475.8055" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="390.6667" y="477.6111" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="390.6667" y="477.6111" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="394.0000" y="479.4167" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="394.0000" y="479.4167" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="397.3333" y="481.2222" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="397.3333" y="481.2222" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="400.6667" y="483.0278" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="400.6667" y="483.0278" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="384.0000" y="517.3333" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="384.0000" y="517.3333" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="387.3333" y="519.1389" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="387.3333" y="519.1389" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="390.6667" y="520.9444" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="390.6667" y="520.9444" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="394.0000" y="522.7500" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="394.0000" y="522.7500" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="397.3333" y="524.5555" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="397.3333" y="524.5555" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="400.6667" y="526.3611" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="400.6667" y="526.3611" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="384.0000" y="560.6667" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="384.0000" y="560.6667" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="387.3333" y="562.4722" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="387.3333" y="562.4722" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="390.6667" y="564.2778" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="390.6667" y="564.2778" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="394.0000" y="566.0834" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="394.0000" y="566.0834" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="397.3333" y="567.8889" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="397.3333" y="567.8889" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="400.6667" y="569.6945" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="400.6667" y="569.6945" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="384" y="474" width="80" height="130">
-			</bounds>
+			<bounds x="384" y="474" width="80" height="130"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="466" y="474" width="80" height="130">
-			</bounds>
+			<bounds x="466" y="474" width="80" height="130"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="466.0000" y="474.0000" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="466.0000" y="474.0000" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="469.3333" y="475.8055" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="469.3333" y="475.8055" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="472.6667" y="477.6111" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="472.6667" y="477.6111" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="476.0000" y="479.4167" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="476.0000" y="479.4167" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="479.3333" y="481.2222" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="479.3333" y="481.2222" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="482.6667" y="483.0278" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="482.6667" y="483.0278" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="466.0000" y="517.3333" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="466.0000" y="517.3333" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="469.3333" y="519.1389" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="469.3333" y="519.1389" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="472.6667" y="520.9444" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="472.6667" y="520.9444" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="476.0000" y="522.7500" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="476.0000" y="522.7500" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="479.3333" y="524.5555" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="479.3333" y="524.5555" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="482.6667" y="526.3611" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="482.6667" y="526.3611" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="466.0000" y="560.6667" width="80.0000" height="43.3333">
-			</bounds>
+			<bounds x="466.0000" y="560.6667" width="80.0000" height="43.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="469.3333" y="562.4722" width="73.3333" height="39.7222">
-			</bounds>
+			<bounds x="469.3333" y="562.4722" width="73.3333" height="39.7222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="472.6667" y="564.2778" width="66.6667" height="36.1111">
-			</bounds>
+			<bounds x="472.6667" y="564.2778" width="66.6667" height="36.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="476.0000" y="566.0834" width="60.0000" height="32.5000">
-			</bounds>
+			<bounds x="476.0000" y="566.0834" width="60.0000" height="32.5000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="479.3333" y="567.8889" width="53.3333" height="28.8889">
-			</bounds>
+			<bounds x="479.3333" y="567.8889" width="53.3333" height="28.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="482.6667" y="569.6945" width="46.6667" height="25.2778">
-			</bounds>
+			<bounds x="482.6667" y="569.6945" width="46.6667" height="25.2778"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="466" y="474" width="80" height="130">
-			</bounds>
+			<bounds x="466" y="474" width="80" height="130"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="555" y="288" width="70" height="60">
-			</bounds>
+			<bounds x="555" y="288" width="70" height="60"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="555.0000" y="288.0000" width="70.0000" height="60.0000">
-			</bounds>
+			<bounds x="555.0000" y="288.0000" width="70.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="557.9167" y="290.5000" width="64.1667" height="55.0000">
-			</bounds>
+			<bounds x="557.9167" y="290.5000" width="64.1667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="560.8333" y="293.0000" width="58.3333" height="50.0000">
-			</bounds>
+			<bounds x="560.8333" y="293.0000" width="58.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="563.7500" y="295.5000" width="52.5000" height="45.0000">
-			</bounds>
+			<bounds x="563.7500" y="295.5000" width="52.5000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="566.6667" y="298.0000" width="46.6667" height="40.0000">
-			</bounds>
+			<bounds x="566.6667" y="298.0000" width="46.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="569.5833" y="300.5000" width="40.8333" height="35.0000">
-			</bounds>
+			<bounds x="569.5833" y="300.5000" width="40.8333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="555" y="288" width="70" height="60">
-			</bounds>
+			<bounds x="555" y="288" width="70" height="60"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="580" y="629" width="32" height="22">
-			</bounds>
+			<bounds x="580" y="629" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="582" y="631" width="28" height="18">
-			</bounds>
+			<bounds x="582" y="631" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="7" y="192" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="192" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="9" y="194" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="194" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="7" y="163" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="163" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="9" y="165" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="165" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="7" y="134" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="134" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="9" y="136" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="136" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="7" y="105" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="105" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="9" y="107" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="107" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="7" y="76" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="76" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="9" y="78" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="78" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1_border" state="0">
-			<bounds x="7" y="47" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="47" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp208" element="lamp_208_1" state="0">
-			<bounds x="9" y="49" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="49" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="1" y="3" width="92" height="42">
-			</bounds>
+			<bounds x="1" y="3" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="3" y="5" width="88" height="38">
-			</bounds>
+			<bounds x="3" y="5" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="552" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="552" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="554" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="554" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="495" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="495" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="497" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="497" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="438" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="438" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="440" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="440" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="381" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="381" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="383" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="383" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="210" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="210" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="212" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="212" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="267" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="267" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="269" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="269" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="324" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="324" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="326" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="326" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="609" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="609" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="611" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="611" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="609" y="384" width="57" height="30">
-			</bounds>
+			<bounds x="609" y="384" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="611" y="386" width="53" height="26">
-			</bounds>
+			<bounds x="611" y="386" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="609" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="609" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="611" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="611" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="96" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="96" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="98" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="98" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="153" y="354" width="57" height="30">
-			</bounds>
+			<bounds x="153" y="354" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="155" y="356" width="53" height="26">
-			</bounds>
+			<bounds x="155" y="356" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="552" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="552" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="554" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="554" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="495" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="495" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="497" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="497" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="438" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="438" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="440" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="440" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="381" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="381" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="383" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="383" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="324" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="324" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="326" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="326" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="267" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="267" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="269" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="269" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="210" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="210" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="212" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="212" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="153" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="153" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="155" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="155" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="96" y="414" width="57" height="30">
-			</bounds>
+			<bounds x="96" y="414" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="98" y="416" width="53" height="26">
-			</bounds>
+			<bounds x="98" y="416" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="96" y="384" width="57" height="30">
-			</bounds>
+			<bounds x="96" y="384" width="57" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="98" y="386" width="53" height="26">
-			</bounds>
+			<bounds x="98" y="386" width="53" height="26"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="289" y="55" width="182" height="14">
-			</bounds>
+			<bounds x="289" y="55" width="182" height="14"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="291" y="57" width="178" height="10">
-			</bounds>
+			<bounds x="291" y="57" width="178" height="10"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1_border" state="0">
-			<bounds x="112" y="10" width="62" height="32">
-			</bounds>
+			<bounds x="112" y="10" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp166" element="lamp_166_1" state="0">
-			<bounds x="114" y="12" width="58" height="28">
-			</bounds>
+			<bounds x="114" y="12" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1_border" state="0">
-			<bounds x="600" y="44" width="52" height="19">
-			</bounds>
+			<bounds x="600" y="44" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp167" element="lamp_167_1" state="0">
-			<bounds x="602" y="46" width="48" height="15">
-			</bounds>
+			<bounds x="602" y="46" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="112" y="44" width="52" height="19">
-			</bounds>
+			<bounds x="112" y="44" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="114" y="46" width="48" height="15">
-			</bounds>
+			<bounds x="114" y="46" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="287" y="32" width="62" height="22">
-			</bounds>
+			<bounds x="287" y="32" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="289" y="34" width="58" height="18">
-			</bounds>
+			<bounds x="289" y="34" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="349" y="32" width="62" height="22">
-			</bounds>
+			<bounds x="349" y="32" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="351" y="34" width="58" height="18">
-			</bounds>
+			<bounds x="351" y="34" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="411" y="32" width="62" height="22">
-			</bounds>
+			<bounds x="411" y="32" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="413" y="34" width="58" height="18">
-			</bounds>
+			<bounds x="413" y="34" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="590" y="10" width="62" height="32">
-			</bounds>
+			<bounds x="590" y="10" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="592" y="12" width="58" height="28">
-			</bounds>
+			<bounds x="592" y="12" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="513" y="3" width="52" height="27">
-			</bounds>
+			<bounds x="513" y="3" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="515" y="5" width="48" height="23">
-			</bounds>
+			<bounds x="515" y="5" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="445" y="3" width="52" height="27">
-			</bounds>
+			<bounds x="445" y="3" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="447" y="5" width="48" height="23">
-			</bounds>
+			<bounds x="447" y="5" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="379" y="3" width="52" height="27">
-			</bounds>
+			<bounds x="379" y="3" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="381" y="5" width="48" height="23">
-			</bounds>
+			<bounds x="381" y="5" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1_border" state="0">
-			<bounds x="326" y="3" width="52" height="27">
-			</bounds>
+			<bounds x="326" y="3" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp163" element="lamp_163_1" state="0">
-			<bounds x="328" y="5" width="48" height="23">
-			</bounds>
+			<bounds x="328" y="5" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1_border" state="0">
-			<bounds x="266" y="3" width="52" height="27">
-			</bounds>
+			<bounds x="266" y="3" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp164" element="lamp_164_1" state="0">
-			<bounds x="268" y="5" width="48" height="23">
-			</bounds>
+			<bounds x="268" y="5" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1_border" state="0">
-			<bounds x="197" y="3" width="52" height="27">
-			</bounds>
+			<bounds x="197" y="3" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp165" element="lamp_165_1" state="0">
-			<bounds x="199" y="5" width="48" height="23">
-			</bounds>
+			<bounds x="199" y="5" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="574" y="221" width="77" height="30">
-			</bounds>
+			<bounds x="574" y="221" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="576" y="223" width="73" height="26">
-			</bounds>
+			<bounds x="576" y="223" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="497" y="221" width="77" height="30">
-			</bounds>
+			<bounds x="497" y="221" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="499" y="223" width="73" height="26">
-			</bounds>
+			<bounds x="499" y="223" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="343" y="221" width="77" height="30">
-			</bounds>
+			<bounds x="343" y="221" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="345" y="223" width="73" height="26">
-			</bounds>
+			<bounds x="345" y="223" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="266" y="221" width="77" height="30">
-			</bounds>
+			<bounds x="266" y="221" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="268" y="223" width="73" height="26">
-			</bounds>
+			<bounds x="268" y="223" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="189" y="221" width="77" height="30">
-			</bounds>
+			<bounds x="189" y="221" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="191" y="223" width="73" height="26">
-			</bounds>
+			<bounds x="191" y="223" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="112" y="161" width="77" height="30">
-			</bounds>
+			<bounds x="112" y="161" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="114" y="163" width="73" height="26">
-			</bounds>
+			<bounds x="114" y="163" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="112" y="131" width="77" height="30">
-			</bounds>
+			<bounds x="112" y="131" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="114" y="133" width="73" height="26">
-			</bounds>
+			<bounds x="114" y="133" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="112" y="101" width="77" height="30">
-			</bounds>
+			<bounds x="112" y="101" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="114" y="103" width="73" height="26">
-			</bounds>
+			<bounds x="114" y="103" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="420" y="221" width="77" height="30">
-			</bounds>
+			<bounds x="420" y="221" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="422" y="223" width="73" height="26">
-			</bounds>
+			<bounds x="422" y="223" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="112" y="191" width="77" height="30">
-			</bounds>
+			<bounds x="112" y="191" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="114" y="193" width="73" height="26">
-			</bounds>
+			<bounds x="114" y="193" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="112" y="221" width="77" height="30">
-			</bounds>
+			<bounds x="112" y="221" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="114" y="223" width="73" height="26">
-			</bounds>
+			<bounds x="114" y="223" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="112" y="71" width="77" height="30">
-			</bounds>
+			<bounds x="112" y="71" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="114" y="73" width="73" height="26">
-			</bounds>
+			<bounds x="114" y="73" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="574" y="251" width="77" height="30">
-			</bounds>
+			<bounds x="574" y="251" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="576" y="253" width="73" height="26">
-			</bounds>
+			<bounds x="576" y="253" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="497" y="251" width="77" height="30">
-			</bounds>
+			<bounds x="497" y="251" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="499" y="253" width="73" height="26">
-			</bounds>
+			<bounds x="499" y="253" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1_border" state="0">
-			<bounds x="420" y="251" width="77" height="30">
-			</bounds>
+			<bounds x="420" y="251" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="lamp_150_1" state="0">
-			<bounds x="422" y="253" width="73" height="26">
-			</bounds>
+			<bounds x="422" y="253" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="343" y="251" width="77" height="30">
-			</bounds>
+			<bounds x="343" y="251" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="345" y="253" width="73" height="26">
-			</bounds>
+			<bounds x="345" y="253" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="266" y="251" width="77" height="30">
-			</bounds>
+			<bounds x="266" y="251" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="268" y="253" width="73" height="26">
-			</bounds>
+			<bounds x="268" y="253" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="189" y="251" width="77" height="30">
-			</bounds>
+			<bounds x="189" y="251" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="191" y="253" width="73" height="26">
-			</bounds>
+			<bounds x="191" y="253" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="112" y="251" width="77" height="30">
-			</bounds>
+			<bounds x="112" y="251" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="114" y="253" width="73" height="26">
-			</bounds>
+			<bounds x="114" y="253" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="266" y="191" width="77" height="30">
-			</bounds>
+			<bounds x="266" y="191" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="268" y="193" width="73" height="26">
-			</bounds>
+			<bounds x="268" y="193" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="189" y="191" width="77" height="30">
-			</bounds>
+			<bounds x="189" y="191" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="191" y="193" width="73" height="26">
-			</bounds>
+			<bounds x="191" y="193" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="343" y="191" width="77" height="30">
-			</bounds>
+			<bounds x="343" y="191" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="345" y="193" width="73" height="26">
-			</bounds>
+			<bounds x="345" y="193" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="420" y="191" width="77" height="30">
-			</bounds>
+			<bounds x="420" y="191" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="422" y="193" width="73" height="26">
-			</bounds>
+			<bounds x="422" y="193" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="497" y="191" width="77" height="30">
-			</bounds>
+			<bounds x="497" y="191" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="499" y="193" width="73" height="26">
-			</bounds>
+			<bounds x="499" y="193" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="574" y="191" width="77" height="30">
-			</bounds>
+			<bounds x="574" y="191" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="576" y="193" width="73" height="26">
-			</bounds>
+			<bounds x="576" y="193" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="266" y="161" width="77" height="30">
-			</bounds>
+			<bounds x="266" y="161" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="268" y="163" width="73" height="26">
-			</bounds>
+			<bounds x="268" y="163" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="189" y="161" width="77" height="30">
-			</bounds>
+			<bounds x="189" y="161" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="191" y="163" width="73" height="26">
-			</bounds>
+			<bounds x="191" y="163" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="343" y="161" width="77" height="30">
-			</bounds>
+			<bounds x="343" y="161" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="345" y="163" width="73" height="26">
-			</bounds>
+			<bounds x="345" y="163" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="420" y="161" width="77" height="30">
-			</bounds>
+			<bounds x="420" y="161" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="422" y="163" width="73" height="26">
-			</bounds>
+			<bounds x="422" y="163" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="497" y="161" width="77" height="30">
-			</bounds>
+			<bounds x="497" y="161" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="499" y="163" width="73" height="26">
-			</bounds>
+			<bounds x="499" y="163" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="574" y="161" width="77" height="30">
-			</bounds>
+			<bounds x="574" y="161" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="576" y="163" width="73" height="26">
-			</bounds>
+			<bounds x="576" y="163" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="497" y="131" width="77" height="30">
-			</bounds>
+			<bounds x="497" y="131" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="499" y="133" width="73" height="26">
-			</bounds>
+			<bounds x="499" y="133" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="420" y="131" width="77" height="30">
-			</bounds>
+			<bounds x="420" y="131" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="422" y="133" width="73" height="26">
-			</bounds>
+			<bounds x="422" y="133" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="343" y="131" width="77" height="30">
-			</bounds>
+			<bounds x="343" y="131" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="345" y="133" width="73" height="26">
-			</bounds>
+			<bounds x="345" y="133" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="266" y="131" width="77" height="30">
-			</bounds>
+			<bounds x="266" y="131" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="268" y="133" width="73" height="26">
-			</bounds>
+			<bounds x="268" y="133" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="189" y="131" width="77" height="30">
-			</bounds>
+			<bounds x="189" y="131" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="191" y="133" width="73" height="26">
-			</bounds>
+			<bounds x="191" y="133" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="574" y="131" width="77" height="30">
-			</bounds>
+			<bounds x="574" y="131" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="576" y="133" width="73" height="26">
-			</bounds>
+			<bounds x="576" y="133" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="497" y="101" width="77" height="30">
-			</bounds>
+			<bounds x="497" y="101" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="499" y="103" width="73" height="26">
-			</bounds>
+			<bounds x="499" y="103" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="420" y="101" width="77" height="30">
-			</bounds>
+			<bounds x="420" y="101" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="422" y="103" width="73" height="26">
-			</bounds>
+			<bounds x="422" y="103" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="343" y="101" width="77" height="30">
-			</bounds>
+			<bounds x="343" y="101" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="345" y="103" width="73" height="26">
-			</bounds>
+			<bounds x="345" y="103" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="266" y="101" width="77" height="30">
-			</bounds>
+			<bounds x="266" y="101" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="268" y="103" width="73" height="26">
-			</bounds>
+			<bounds x="268" y="103" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="574" y="101" width="77" height="30">
-			</bounds>
+			<bounds x="574" y="101" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="576" y="103" width="73" height="26">
-			</bounds>
+			<bounds x="576" y="103" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="189" y="101" width="77" height="30">
-			</bounds>
+			<bounds x="189" y="101" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="191" y="103" width="73" height="26">
-			</bounds>
+			<bounds x="191" y="103" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="189" y="71" width="77" height="30">
-			</bounds>
+			<bounds x="189" y="71" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="191" y="73" width="73" height="26">
-			</bounds>
+			<bounds x="191" y="73" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="266" y="71" width="77" height="30">
-			</bounds>
+			<bounds x="266" y="71" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="268" y="73" width="73" height="26">
-			</bounds>
+			<bounds x="268" y="73" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="343" y="71" width="77" height="30">
-			</bounds>
+			<bounds x="343" y="71" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="345" y="73" width="73" height="26">
-			</bounds>
+			<bounds x="345" y="73" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="420" y="71" width="77" height="30">
-			</bounds>
+			<bounds x="420" y="71" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="422" y="73" width="73" height="26">
-			</bounds>
+			<bounds x="422" y="73" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="497" y="71" width="77" height="30">
-			</bounds>
+			<bounds x="497" y="71" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="499" y="73" width="73" height="26">
-			</bounds>
+			<bounds x="499" y="73" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1_border" state="0">
-			<bounds x="574" y="71" width="77" height="30">
-			</bounds>
+			<bounds x="574" y="71" width="77" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="lamp_136_1" state="0">
-			<bounds x="576" y="73" width="73" height="26">
-			</bounds>
+			<bounds x="576" y="73" width="73" height="26"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="258" y="302" width="47" height="30">
-			</bounds>
+			<bounds x="258" y="302" width="47" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="260" y="304" width="43" height="26">
-			</bounds>
+			<bounds x="260" y="304" width="43" height="26"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="521" y="318" width="32" height="27">
-			</bounds>
+			<bounds x="521" y="318" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="523" y="320" width="28" height="23">
-			</bounds>
+			<bounds x="523" y="320" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="521" y="290" width="32" height="27">
-			</bounds>
+			<bounds x="521" y="290" width="32" height="27"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="523" y="292" width="28" height="23">
-			</bounds>
+			<bounds x="523" y="292" width="28" height="23"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="7" y="250" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="250" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="9" y="252" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="252" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="7" y="221" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="221" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="9" y="223" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="223" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="7" y="279" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="279" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="9" y="281" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="281" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="7" y="308" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="308" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="9" y="310" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="310" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="7" y="424" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="424" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="9" y="426" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="426" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="7" y="337" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="337" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="9" y="339" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="339" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="7" y="366" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="366" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="9" y="368" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="368" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="7" y="395" width="82" height="27">
-			</bounds>
+			<bounds x="7" y="395" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="9" y="397" width="78" height="23">
-			</bounds>
+			<bounds x="9" y="397" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="580" y="607" width="32" height="22">
-			</bounds>
+			<bounds x="580" y="607" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="582" y="609" width="28" height="18">
-			</bounds>
+			<bounds x="582" y="609" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="493" y="607" width="32" height="22">
-			</bounds>
+			<bounds x="493" y="607" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="495" y="609" width="28" height="18">
-			</bounds>
+			<bounds x="495" y="609" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="62" y="506" width="37" height="27">
-			</bounds>
+			<bounds x="62" y="506" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="64" y="508" width="33" height="23">
-			</bounds>
+			<bounds x="64" y="508" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="69" y="534" width="37" height="27">
-			</bounds>
+			<bounds x="69" y="534" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="71" y="536" width="33" height="23">
-			</bounds>
+			<bounds x="71" y="536" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="83" y="562" width="37" height="27">
-			</bounds>
+			<bounds x="83" y="562" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="85" y="564" width="33" height="23">
-			</bounds>
+			<bounds x="85" y="564" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1_border" state="0">
-			<bounds x="94" y="590" width="37" height="27">
-			</bounds>
+			<bounds x="94" y="590" width="37" height="27"/>
 		</backdrop>
 		<backdrop name="lamp45" element="lamp_45_1" state="0">
-			<bounds x="96" y="592" width="33" height="23">
-			</bounds>
+			<bounds x="96" y="592" width="33" height="23"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1_border" state="0">
-			<bounds x="3" y="491" width="52" height="30">
-			</bounds>
+			<bounds x="3" y="491" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="lamp_44_1" state="0">
-			<bounds x="5" y="493" width="48" height="26">
-			</bounds>
+			<bounds x="5" y="493" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1_border" state="0">
-			<bounds x="34" y="599" width="52" height="19">
-			</bounds>
+			<bounds x="34" y="599" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp46" element="lamp_46_1" state="0">
-			<bounds x="36" y="601" width="48" height="15">
-			</bounds>
+			<bounds x="36" y="601" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="404" y="629" width="32" height="22">
-			</bounds>
+			<bounds x="404" y="629" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="406" y="631" width="28" height="18">
-			</bounds>
+			<bounds x="406" y="631" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="316" y="629" width="32" height="22">
-			</bounds>
+			<bounds x="316" y="629" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="318" y="631" width="28" height="18">
-			</bounds>
+			<bounds x="318" y="631" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="228" y="629" width="32" height="22">
-			</bounds>
+			<bounds x="228" y="629" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="230" y="631" width="28" height="18">
-			</bounds>
+			<bounds x="230" y="631" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="140" y="629" width="32" height="22">
-			</bounds>
+			<bounds x="140" y="629" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="142" y="631" width="28" height="18">
-			</bounds>
+			<bounds x="142" y="631" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="404" y="607" width="32" height="22">
-			</bounds>
+			<bounds x="404" y="607" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="406" y="609" width="28" height="18">
-			</bounds>
+			<bounds x="406" y="609" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1_border" state="0">
-			<bounds x="316" y="607" width="32" height="22">
-			</bounds>
+			<bounds x="316" y="607" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp29" element="lamp_29_1" state="0">
-			<bounds x="318" y="609" width="28" height="18">
-			</bounds>
+			<bounds x="318" y="609" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="228" y="607" width="32" height="22">
-			</bounds>
+			<bounds x="228" y="607" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="230" y="609" width="28" height="18">
-			</bounds>
+			<bounds x="230" y="609" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1_border" state="0">
-			<bounds x="140" y="607" width="32" height="22">
-			</bounds>
+			<bounds x="140" y="607" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp42" element="lamp_42_1" state="0">
-			<bounds x="142" y="609" width="28" height="18">
-			</bounds>
+			<bounds x="142" y="609" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="493" y="629" width="32" height="22">
-			</bounds>
+			<bounds x="493" y="629" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="495" y="631" width="28" height="18">
-			</bounds>
+			<bounds x="495" y="631" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1_border" state="0">
-			<bounds x="669" y="631" width="32" height="22">
-			</bounds>
+			<bounds x="669" y="631" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp21" element="lamp_21_1" state="0">
-			<bounds x="671" y="633" width="28" height="18">
-			</bounds>
+			<bounds x="671" y="633" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="668" y="583" width="32" height="22">
-			</bounds>
+			<bounds x="668" y="583" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="670" y="585" width="28" height="18">
-			</bounds>
+			<bounds x="670" y="585" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="668" y="535" width="32" height="22">
-			</bounds>
+			<bounds x="668" y="535" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="670" y="537" width="28" height="18">
-			</bounds>
+			<bounds x="670" y="537" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="668" y="607" width="32" height="22">
-			</bounds>
+			<bounds x="668" y="607" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="670" y="609" width="28" height="18">
-			</bounds>
+			<bounds x="670" y="609" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="668" y="559" width="32" height="22">
-			</bounds>
+			<bounds x="668" y="559" width="32" height="22"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="670" y="561" width="28" height="18">
-			</bounds>
+			<bounds x="670" y="561" width="28" height="18"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="663" y="511" width="37" height="22">
-			</bounds>
+			<bounds x="663" y="511" width="37" height="22"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="665" y="513" width="33" height="18">
-			</bounds>
+			<bounds x="665" y="513" width="33" height="18"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1_border" state="0">
-			<bounds x="667" y="3" width="92" height="42">
-			</bounds>
+			<bounds x="667" y="3" width="92" height="42"/>
 		</backdrop>
 		<backdrop name="lamp126" element="lamp_126_1" state="0">
-			<bounds x="669" y="5" width="88" height="38">
-			</bounds>
+			<bounds x="669" y="5" width="88" height="38"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="672" y="45" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="45" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="674" y="47" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="47" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="672" y="72" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="72" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="674" y="74" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="74" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="672" y="99" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="99" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="674" y="101" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="101" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="672" y="126" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="126" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="674" y="128" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="128" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="672" y="153" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="153" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="674" y="155" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="155" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="672" y="180" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="180" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="674" y="182" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="182" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="672" y="207" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="207" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="674" y="209" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="209" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="672" y="234" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="234" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="674" y="236" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="236" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="672" y="261" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="261" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="674" y="263" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="263" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="672" y="288" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="288" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="674" y="290" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="290" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="672" y="315" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="315" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="674" y="317" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="317" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="672" y="342" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="342" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="674" y="344" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="344" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="672" y="369" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="369" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="674" y="371" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="371" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="672" y="396" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="396" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="674" y="398" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="398" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="672" y="423" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="423" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="674" y="425" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="425" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="672" y="450" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="450" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="674" y="452" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="452" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="672" y="477" width="82" height="27">
-			</bounds>
+			<bounds x="672" y="477" width="82" height="27"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="674" y="479" width="78" height="23">
-			</bounds>
+			<bounds x="674" y="479" width="78" height="23"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="563" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="563" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="565" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="565" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="519" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="519" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="521" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="521" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="475" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="475" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="477" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="477" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="431" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="431" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="433" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="433" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="387" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="387" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="389" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="389" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="343" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="343" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="345" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="345" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="299" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="299" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="301" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="301" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="255" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="255" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="257" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="257" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="211" y="445" width="42" height="27">
-			</bounds>
+			<bounds x="211" y="445" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="213" y="447" width="38" height="23">
-			</bounds>
+			<bounds x="213" y="447" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="156" y="445" width="52" height="27">
-			</bounds>
+			<bounds x="156" y="445" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="158" y="447" width="48" height="23">
-			</bounds>
+			<bounds x="158" y="447" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="180" y="286" width="32" height="32">
-			</bounds>
+			<bounds x="180" y="286" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="182" y="288" width="28" height="28">
-			</bounds>
+			<bounds x="182" y="288" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="212" y="286" width="32" height="32">
-			</bounds>
+			<bounds x="212" y="286" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="214" y="288" width="28" height="28">
-			</bounds>
+			<bounds x="214" y="288" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="148" y="286" width="32" height="32">
-			</bounds>
+			<bounds x="148" y="286" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="150" y="288" width="28" height="28">
-			</bounds>
+			<bounds x="150" y="288" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="116" y="286" width="32" height="32">
-			</bounds>
+			<bounds x="116" y="286" width="32" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="118" y="288" width="28" height="28">
-			</bounds>
+			<bounds x="118" y="288" width="28" height="28"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_199_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="800" y="5" width="75" height="27">
-			</bounds>
+			<bounds x="800" y="5" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_199" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="802" y="7" width="71" height="23">
-			</bounds>
+			<bounds x="802" y="7" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp236" element="colour_button_201_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="329" y="299" width="27" height="32">
-			</bounds>
+			<bounds x="329" y="299" width="27" height="32"/>
 		</backdrop>
 		<backdrop name="lamp236" element="colour_button_201" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="331" y="301" width="23" height="28">
-			</bounds>
+			<bounds x="331" y="301" width="23" height="28"/>
 		</backdrop>
 		<backdrop name="lamp242" element="colour_button_202_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="355" y="333" width="52" height="17">
-			</bounds>
+			<bounds x="355" y="333" width="52" height="17"/>
 		</backdrop>
 		<backdrop name="lamp242" element="colour_button_202" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="357" y="335" width="48" height="13">
-			</bounds>
+			<bounds x="357" y="335" width="48" height="13"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_203_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="406" y="300" width="27" height="32">
-			</bounds>
+			<bounds x="406" y="300" width="27" height="32"/>
 		</backdrop>
 		<backdrop name="lamp254" element="colour_button_203" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="408" y="302" width="23" height="28">
-			</bounds>
+			<bounds x="408" y="302" width="23" height="28"/>
 		</backdrop>
 		<backdrop name="lamp237" element="colour_button_204_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="353" y="283" width="52" height="17">
-			</bounds>
+			<bounds x="353" y="283" width="52" height="17"/>
 		</backdrop>
 		<backdrop name="lamp237" element="colour_button_204" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="355" y="285" width="48" height="13">
-			</bounds>
+			<bounds x="355" y="285" width="48" height="13"/>
 		</backdrop>
 		<backdrop name="lamp57" element="colour_button_205_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="20" y="461" width="75" height="27">
-			</bounds>
+			<bounds x="20" y="461" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="colour_button_205" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="22" y="463" width="71" height="23">
-			</bounds>
+			<bounds x="22" y="463" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_206_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="90" y="652" width="75" height="27">
-			</bounds>
+			<bounds x="90" y="652" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_206" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="92" y="654" width="71" height="23">
-			</bounds>
+			<bounds x="92" y="654" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_207_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="219" y="652" width="75" height="27">
-			</bounds>
+			<bounds x="219" y="652" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_207" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="221" y="654" width="71" height="23">
-			</bounds>
+			<bounds x="221" y="654" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_208_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="304" y="652" width="75" height="27">
-			</bounds>
+			<bounds x="304" y="652" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_208" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="306" y="654" width="71" height="23">
-			</bounds>
+			<bounds x="306" y="654" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_209_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="388" y="652" width="75" height="27">
-			</bounds>
+			<bounds x="388" y="652" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_209" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="390" y="654" width="71" height="23">
-			</bounds>
+			<bounds x="390" y="654" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_210_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="473" y="652" width="75" height="27">
-			</bounds>
+			<bounds x="473" y="652" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_210" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="475" y="654" width="71" height="23">
-			</bounds>
+			<bounds x="475" y="654" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_211_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="569" y="652" width="80" height="27">
-			</bounds>
+			<bounds x="569" y="652" width="80" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_211" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="571" y="654" width="76" height="23">
-			</bounds>
+			<bounds x="571" y="654" width="76" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_212_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="658" y="652" width="75" height="27">
-			</bounds>
+			<bounds x="658" y="652" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_212" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="660" y="654" width="71" height="23">
-			</bounds>
+			<bounds x="660" y="654" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_213_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="743" y="652" width="75" height="27">
-			</bounds>
+			<bounds x="743" y="652" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_213" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="745" y="654" width="71" height="23">
-			</bounds>
+			<bounds x="745" y="654" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="357" y="301" width="24" height="32">
-			</bounds>
+			<bounds x="357" y="301" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="357" y="301" width="24" height="32">
-			</bounds>
+			<bounds x="357" y="301" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="357" y="301" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="357" y="301" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="381" y="301" width="24" height="32">
-			</bounds>
+			<bounds x="381" y="301" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="381" y="301" width="24" height="32">
-			</bounds>
+			<bounds x="381" y="301" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="381" y="301" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="381" y="301" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="220" y="386" width="323" height="27">
-			</bounds>
+			<bounds x="220" y="386" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="220" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="220" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="240" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="240" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="260" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="260" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="280" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="280" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="300" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="300" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="320" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="320" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="340" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="340" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="360" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="360" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="380" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="380" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="400" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="400" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="420" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="420" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="440" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="440" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="460" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="460" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="480" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="480" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="500" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="500" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="520" y="386" width="20" height="27">
-			</bounds>
+			<bounds x="520" y="386" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label113" element="label_113">
-			<bounds x="579" y="507" width="42" height="14">
-			</bounds>
+			<bounds x="579" y="507" width="42" height="14"/>
 		</backdrop>
 		<backdrop name="label114" element="label_114">
-			<bounds x="561" y="553" width="78" height="14">
-			</bounds>
+			<bounds x="561" y="553" width="78" height="14"/>
 		</backdrop>
 		<backdrop name="label198" element="label_198">
-			<bounds x="124" y="319" width="69" height="28">
-			</bounds>
+			<bounds x="124" y="319" width="69" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_button" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_button" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_button" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_button" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_button" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_button" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="240.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000">
-			</bounds>
+			<bounds x="1665.0000" y="42.0000" width="110.0000" height="220.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000">
-			</bounds>
+			<bounds x="1670.0000" y="52.0000" width="100.0000" height="200.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000">
-			</bounds>
+			<bounds x="1675.0000" y="62.0000" width="90.0000" height="180.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000">
-			</bounds>
+			<bounds x="1680.0000" y="72.0000" width="80.0000" height="160.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000">
-			</bounds>
+			<bounds x="1685.0000" y="82.0000" width="70.0000" height="140.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4crzgna.lay
+++ b/src/mame/layout/sc4crzgna.lay
@@ -8,6588 +8,4885 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_52_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_52">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="TAKE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_53_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_53">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_54_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_54">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_55_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_55">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_56_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_56">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_57_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_57">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_42">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_43">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_44">
 		<text string="PLAYS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_45">
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_46">
 		<text string="&#xA3;15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_47">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_48">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_49">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_50">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1016" height="665">
-			</bounds>
+			<bounds x="0" y="0" width="1016" height="665"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="399" y="340" width="100" height="180">
-			</bounds>
+			<bounds x="399" y="340" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="399.0000" y="340.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="399.0000" y="340.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.1667" y="342.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="403.1667" y="342.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="407.3333" y="345.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="407.3333" y="345.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="411.5000" y="347.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="411.5000" y="347.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="415.6667" y="350.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="415.6667" y="350.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="419.8333" y="352.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="419.8333" y="352.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="399.0000" y="400.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="399.0000" y="400.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.1667" y="402.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="403.1667" y="402.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="407.3333" y="405.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="407.3333" y="405.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="411.5000" y="407.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="411.5000" y="407.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="415.6667" y="410.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="415.6667" y="410.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="419.8333" y="412.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="419.8333" y="412.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="399.0000" y="460.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="399.0000" y="460.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="403.1667" y="462.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="403.1667" y="462.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="407.3333" y="465.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="407.3333" y="465.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="411.5000" y="467.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="411.5000" y="467.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="415.6667" y="470.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="415.6667" y="470.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="419.8333" y="472.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="419.8333" y="472.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="399" y="340" width="100" height="180">
-			</bounds>
+			<bounds x="399" y="340" width="100" height="180"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="513" y="339" width="100" height="180">
-			</bounds>
+			<bounds x="513" y="339" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="513.0000" y="339.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="513.0000" y="339.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="517.1667" y="341.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="517.1667" y="341.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="521.3333" y="344.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="521.3333" y="344.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="525.5000" y="346.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="525.5000" y="346.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="529.6667" y="349.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="529.6667" y="349.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="533.8333" y="351.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="533.8333" y="351.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="513.0000" y="399.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="513.0000" y="399.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="517.1667" y="401.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="517.1667" y="401.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="521.3333" y="404.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="521.3333" y="404.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="525.5000" y="406.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="525.5000" y="406.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="529.6667" y="409.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="529.6667" y="409.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="533.8333" y="411.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="533.8333" y="411.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="513.0000" y="459.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="513.0000" y="459.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="517.1667" y="461.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="517.1667" y="461.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="521.3333" y="464.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="521.3333" y="464.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="525.5000" y="466.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="525.5000" y="466.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="529.6667" y="469.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="529.6667" y="469.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="533.8333" y="471.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="533.8333" y="471.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="513" y="339" width="100" height="180">
-			</bounds>
+			<bounds x="513" y="339" width="100" height="180"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="626" y="340" width="100" height="180">
-			</bounds>
+			<bounds x="626" y="340" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="626.0000" y="340.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="626.0000" y="340.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="630.1667" y="342.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="630.1667" y="342.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="634.3333" y="345.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="634.3333" y="345.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="638.5000" y="347.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="638.5000" y="347.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="642.6667" y="350.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="642.6667" y="350.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="646.8333" y="352.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="646.8333" y="352.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="626.0000" y="400.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="626.0000" y="400.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="630.1667" y="402.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="630.1667" y="402.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="634.3333" y="405.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="634.3333" y="405.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="638.5000" y="407.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="638.5000" y="407.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="642.6667" y="410.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="642.6667" y="410.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="646.8333" y="412.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="646.8333" y="412.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="626.0000" y="460.0000" width="100.0000" height="60.0000">
-			</bounds>
+			<bounds x="626.0000" y="460.0000" width="100.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="630.1667" y="462.5000" width="91.6667" height="55.0000">
-			</bounds>
+			<bounds x="630.1667" y="462.5000" width="91.6667" height="55.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="634.3333" y="465.0000" width="83.3333" height="50.0000">
-			</bounds>
+			<bounds x="634.3333" y="465.0000" width="83.3333" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="638.5000" y="467.5000" width="75.0000" height="45.0000">
-			</bounds>
+			<bounds x="638.5000" y="467.5000" width="75.0000" height="45.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="642.6667" y="470.0000" width="66.6667" height="40.0000">
-			</bounds>
+			<bounds x="642.6667" y="470.0000" width="66.6667" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="646.8333" y="472.5000" width="58.3333" height="35.0000">
-			</bounds>
+			<bounds x="646.8333" y="472.5000" width="58.3333" height="35.0000"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="626" y="340" width="100" height="180">
-			</bounds>
+			<bounds x="626" y="340" width="100" height="180"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="804" y="428" width="32" height="52">
-			</bounds>
+			<bounds x="804" y="428" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="806" y="430" width="28" height="48">
-			</bounds>
+			<bounds x="806" y="430" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="858" y="372" width="32" height="52">
-			</bounds>
+			<bounds x="858" y="372" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="860" y="374" width="28" height="48">
-			</bounds>
+			<bounds x="860" y="374" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="877" y="32" width="52" height="52">
-			</bounds>
+			<bounds x="877" y="32" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="879" y="34" width="48" height="48">
-			</bounds>
+			<bounds x="879" y="34" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="905" y="318" width="32" height="52">
-			</bounds>
+			<bounds x="905" y="318" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="907" y="320" width="28" height="48">
-			</bounds>
+			<bounds x="907" y="320" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_52_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="174" y="567" width="75" height="72">
-			</bounds>
+			<bounds x="174" y="567" width="75" height="72"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_52" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="176" y="569" width="71" height="68">
-			</bounds>
+			<bounds x="176" y="569" width="71" height="68"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_53_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="295" y="567" width="75" height="72">
-			</bounds>
+			<bounds x="295" y="567" width="75" height="72"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_53" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="297" y="569" width="71" height="68">
-			</bounds>
+			<bounds x="297" y="569" width="71" height="68"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_54_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="641" y="566" width="75" height="72">
-			</bounds>
+			<bounds x="641" y="566" width="75" height="72"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_54" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="643" y="568" width="71" height="68">
-			</bounds>
+			<bounds x="643" y="568" width="71" height="68"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_55_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="520" y="566" width="75" height="72">
-			</bounds>
+			<bounds x="520" y="566" width="75" height="72"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_55" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="522" y="568" width="71" height="68">
-			</bounds>
+			<bounds x="522" y="568" width="71" height="68"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_56_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="763" y="566" width="75" height="72">
-			</bounds>
+			<bounds x="763" y="566" width="75" height="72"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_56" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="765" y="568" width="71" height="68">
-			</bounds>
+			<bounds x="765" y="568" width="71" height="68"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_57_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="408" y="567" width="75" height="72">
-			</bounds>
+			<bounds x="408" y="567" width="75" height="72"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_57" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="410" y="569" width="71" height="68">
-			</bounds>
+			<bounds x="410" y="569" width="71" height="68"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="530" y="160" width="48" height="64">
-			</bounds>
+			<bounds x="530" y="160" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="digit6" element="led_digit_red">
-			<bounds x="530" y="160" width="48" height="64">
-			</bounds>
+			<bounds x="530" y="160" width="48" height="64"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="530" y="160" width="48" height="64">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="530" y="160" width="48" height="64"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="578" y="160" width="48" height="64">
-			</bounds>
+			<bounds x="578" y="160" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="digit4" element="led_digit_red">
-			<bounds x="578" y="160" width="48" height="64">
-			</bounds>
+			<bounds x="578" y="160" width="48" height="64"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="578" y="160" width="48" height="64">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="578" y="160" width="48" height="64"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="533" y="289" width="24" height="32">
-			</bounds>
+			<bounds x="533" y="289" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="533" y="289" width="24" height="32">
-			</bounds>
+			<bounds x="533" y="289" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="533" y="289" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="533" y="289" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="555" y="289" width="24" height="32">
-			</bounds>
+			<bounds x="555" y="289" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="555" y="289" width="24" height="32">
-			</bounds>
+			<bounds x="555" y="289" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="555" y="289" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="555" y="289" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="482" y="160" width="48" height="64">
-			</bounds>
+			<bounds x="482" y="160" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="digit8" element="led_digit_red">
-			<bounds x="482" y="160" width="48" height="64">
-			</bounds>
+			<bounds x="482" y="160" width="48" height="64"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="482" y="160" width="48" height="64">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="482" y="160" width="48" height="64"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="435" y="160" width="48" height="64">
-			</bounds>
+			<bounds x="435" y="160" width="48" height="64"/>
 		</backdrop>
 		<backdrop name="digit10" element="led_digit_red">
-			<bounds x="435" y="160" width="48" height="64">
-			</bounds>
+			<bounds x="435" y="160" width="48" height="64"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="435" y="160" width="48" height="64">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="435" y="160" width="48" height="64"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop name="label42" element="label_42">
-			<bounds x="493" y="232" width="70" height="29">
-			</bounds>
+			<bounds x="493" y="232" width="70" height="29"/>
 		</backdrop>
 		<backdrop name="label43" element="label_43">
-			<bounds x="378" y="143" width="51" height="90">
-			</bounds>
+			<bounds x="378" y="143" width="51" height="90"/>
 		</backdrop>
 		<backdrop name="label44" element="label_44">
-			<bounds x="444" y="290" width="82" height="29">
-			</bounds>
+			<bounds x="444" y="290" width="82" height="29"/>
 		</backdrop>
 		<backdrop name="label45" element="label_45">
-			<bounds x="836" y="493" width="109" height="29">
-			</bounds>
+			<bounds x="836" y="493" width="109" height="29"/>
 		</backdrop>
 		<backdrop name="label46" element="label_46">
-			<bounds x="263" y="232" width="74" height="37">
-			</bounds>
+			<bounds x="263" y="232" width="74" height="37"/>
 		</backdrop>
 		<backdrop name="label47" element="label_47">
-			<bounds x="266" y="289" width="57" height="37">
-			</bounds>
+			<bounds x="266" y="289" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="label48" element="label_48">
-			<bounds x="264" y="345" width="57" height="37">
-			</bounds>
+			<bounds x="264" y="345" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="label49" element="label_49">
-			<bounds x="261" y="399" width="57" height="37">
-			</bounds>
+			<bounds x="261" y="399" width="57" height="37"/>
 		</backdrop>
 		<backdrop name="label50" element="label_50">
-			<bounds x="260" y="450" width="55" height="37">
-			</bounds>
+			<bounds x="260" y="450" width="55" height="37"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4crzkya.lay
+++ b/src/mame/layout/sc4crzkya.lay
@@ -8,7710 +8,5359 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_152_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_184_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_184_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_168_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_168_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_200_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_200_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="27 ways">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.30"/>
 		</text>
 		<text string="to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.35" width="0.90" height="0.30"/>
 		</text>
 		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="27 ways">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="to">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.35" width="0.90" height="0.30">
-			</bounds>
-		</text>
-		<text string="win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.65" width="0.90" height="0.30">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.65" width="0.90" height="0.30"/>
 		</text>
 	</element>
 	<element name="lamp_15_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_15_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="CR">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_239_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_239_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AZ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="AZ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Y">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="KE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="KE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="YS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="YS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_53_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_53">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_54_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_54">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="AUTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_55_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_55">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_56_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_56">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_57_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_57">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_58_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_58">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_59_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_59">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_12">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="label_13">
 		<text string="WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="LINE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="603" height="621">
-			</bounds>
+			<bounds x="0" y="0" width="603" height="621"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="101" y="372" width="80" height="140">
-			</bounds>
+			<bounds x="101" y="372" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="372.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="101.0000" y="372.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.3333" y="373.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="104.3333" y="373.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="107.6667" y="375.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="107.6667" y="375.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="111.0000" y="377.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="111.0000" y="377.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="114.3333" y="379.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="114.3333" y="379.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="117.6667" y="381.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="117.6667" y="381.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="418.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="101.0000" y="418.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.3333" y="420.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="104.3333" y="420.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="107.6667" y="422.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="107.6667" y="422.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="111.0000" y="424.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="111.0000" y="424.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="114.3333" y="426.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="114.3333" y="426.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="117.6667" y="428.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="117.6667" y="428.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="101.0000" y="465.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="101.0000" y="465.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="104.3333" y="467.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="104.3333" y="467.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="107.6667" y="469.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="107.6667" y="469.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="111.0000" y="471.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="111.0000" y="471.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="114.3333" y="473.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="114.3333" y="473.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="117.6667" y="475.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="117.6667" y="475.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="101" y="372" width="80" height="140">
-			</bounds>
+			<bounds x="101" y="372" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="186" y="372" width="80" height="140">
-			</bounds>
+			<bounds x="186" y="372" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="186.0000" y="372.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="186.0000" y="372.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="189.3333" y="373.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="189.3333" y="373.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="192.6667" y="375.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="192.6667" y="375.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="196.0000" y="377.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="196.0000" y="377.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="199.3333" y="379.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="199.3333" y="379.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="202.6667" y="381.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="202.6667" y="381.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="186.0000" y="418.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="186.0000" y="418.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="189.3333" y="420.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="189.3333" y="420.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="192.6667" y="422.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="192.6667" y="422.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="196.0000" y="424.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="196.0000" y="424.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="199.3333" y="426.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="199.3333" y="426.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="202.6667" y="428.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="202.6667" y="428.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="186.0000" y="465.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="186.0000" y="465.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="189.3333" y="467.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="189.3333" y="467.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="192.6667" y="469.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="192.6667" y="469.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="196.0000" y="471.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="196.0000" y="471.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="199.3333" y="473.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="199.3333" y="473.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="202.6667" y="475.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="202.6667" y="475.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="186" y="372" width="80" height="140">
-			</bounds>
+			<bounds x="186" y="372" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="271" y="372" width="80" height="140">
-			</bounds>
+			<bounds x="271" y="372" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="271.0000" y="372.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="271.0000" y="372.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="274.3333" y="373.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="274.3333" y="373.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="277.6667" y="375.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="277.6667" y="375.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="281.0000" y="377.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="281.0000" y="377.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="284.3333" y="379.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="284.3333" y="379.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="287.6667" y="381.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="287.6667" y="381.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="271.0000" y="418.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="271.0000" y="418.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="274.3333" y="420.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="274.3333" y="420.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="277.6667" y="422.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="277.6667" y="422.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="281.0000" y="424.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="281.0000" y="424.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="284.3333" y="426.4444" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="284.3333" y="426.4444" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="287.6667" y="428.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="287.6667" y="428.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="271.0000" y="465.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="271.0000" y="465.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="274.3333" y="467.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="274.3333" y="467.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="277.6667" y="469.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="277.6667" y="469.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="281.0000" y="471.1667" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="281.0000" y="471.1667" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="284.3333" y="473.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="284.3333" y="473.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="287.6667" y="475.0556" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="287.6667" y="475.0556" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="271" y="372" width="80" height="140">
-			</bounds>
+			<bounds x="271" y="372" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1_border" state="0">
-			<bounds x="327" y="115" width="27" height="58">
-			</bounds>
+			<bounds x="327" y="115" width="27" height="58"/>
 		</backdrop>
 		<backdrop name="lamp152" element="lamp_152_1" state="0">
-			<bounds x="329" y="117" width="23" height="54">
-			</bounds>
+			<bounds x="329" y="117" width="23" height="54"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="351" y="115" width="42" height="58">
-			</bounds>
+			<bounds x="351" y="115" width="42" height="58"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="353" y="117" width="38" height="54">
-			</bounds>
+			<bounds x="353" y="117" width="38" height="54"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="271" y="516" width="42" height="42">
-			</bounds>
+			<bounds x="271" y="516" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="273" y="518" width="38" height="38">
-			</bounds>
+			<bounds x="273" y="518" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="265" y="555" width="52" height="19">
-			</bounds>
+			<bounds x="265" y="555" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="267" y="557" width="48" height="15">
-			</bounds>
+			<bounds x="267" y="557" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="135" y="555" width="52" height="19">
-			</bounds>
+			<bounds x="135" y="555" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="137" y="557" width="48" height="15">
-			</bounds>
+			<bounds x="137" y="557" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="140" y="516" width="42" height="42">
-			</bounds>
+			<bounds x="140" y="516" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="142" y="518" width="38" height="38">
-			</bounds>
+			<bounds x="142" y="518" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="204" y="516" width="42" height="42">
-			</bounds>
+			<bounds x="204" y="516" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="206" y="518" width="38" height="38">
-			</bounds>
+			<bounds x="206" y="518" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="199" y="555" width="52" height="19">
-			</bounds>
+			<bounds x="199" y="555" width="52" height="19"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="201" y="557" width="48" height="15">
-			</bounds>
+			<bounds x="201" y="557" width="48" height="15"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="228" y="254" width="27" height="58">
-			</bounds>
+			<bounds x="228" y="254" width="27" height="58"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="230" y="256" width="23" height="54">
-			</bounds>
+			<bounds x="230" y="256" width="23" height="54"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1_border" state="0">
-			<bounds x="204" y="254" width="27" height="58">
-			</bounds>
+			<bounds x="204" y="254" width="27" height="58"/>
 		</backdrop>
 		<backdrop name="lamp184" element="lamp_184_1" state="0">
-			<bounds x="206" y="256" width="23" height="54">
-			</bounds>
+			<bounds x="206" y="256" width="23" height="54"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="454" y="253" width="27" height="58">
-			</bounds>
+			<bounds x="454" y="253" width="27" height="58"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="456" y="255" width="23" height="54">
-			</bounds>
+			<bounds x="456" y="255" width="23" height="54"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="478" y="253" width="27" height="58">
-			</bounds>
+			<bounds x="478" y="253" width="27" height="58"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="480" y="255" width="23" height="54">
-			</bounds>
+			<bounds x="480" y="255" width="23" height="54"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1_border" state="0">
-			<bounds x="204" y="192" width="27" height="58">
-			</bounds>
+			<bounds x="204" y="192" width="27" height="58"/>
 		</backdrop>
 		<backdrop name="lamp168" element="lamp_168_1" state="0">
-			<bounds x="206" y="194" width="23" height="54">
-			</bounds>
+			<bounds x="206" y="194" width="23" height="54"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="228" y="192" width="27" height="58">
-			</bounds>
+			<bounds x="228" y="192" width="27" height="58"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="230" y="194" width="23" height="54">
-			</bounds>
+			<bounds x="230" y="194" width="23" height="54"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1_border" state="0">
-			<bounds x="454" y="191" width="27" height="58">
-			</bounds>
+			<bounds x="454" y="191" width="27" height="58"/>
 		</backdrop>
 		<backdrop name="lamp200" element="lamp_200_1" state="0">
-			<bounds x="456" y="193" width="23" height="54">
-			</bounds>
+			<bounds x="456" y="193" width="23" height="54"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="478" y="191" width="37" height="58">
-			</bounds>
+			<bounds x="478" y="191" width="37" height="58"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="480" y="193" width="33" height="54">
-			</bounds>
+			<bounds x="480" y="193" width="33" height="54"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="455" y="321" width="32" height="62">
-			</bounds>
+			<bounds x="455" y="321" width="32" height="62"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="457" y="323" width="28" height="58">
-			</bounds>
+			<bounds x="457" y="323" width="28" height="58"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="557" y="10" width="32" height="52">
-			</bounds>
+			<bounds x="557" y="10" width="32" height="52"/>
 		</backdrop>
 		<backdrop name="lamp15" element="lamp_15_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="559" y="12" width="28" height="48">
-			</bounds>
+			<bounds x="559" y="12" width="28" height="48"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="142" y="8" width="42" height="42">
-			</bounds>
+			<bounds x="142" y="8" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="144" y="10" width="38" height="38">
-			</bounds>
+			<bounds x="144" y="10" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="180" y="8" width="42" height="42">
-			</bounds>
+			<bounds x="180" y="8" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp239" element="lamp_239_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="182" y="10" width="38" height="38">
-			</bounds>
+			<bounds x="182" y="10" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="219" y="8" width="22" height="42">
-			</bounds>
+			<bounds x="219" y="8" width="22" height="42"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="221" y="10" width="18" height="38">
-			</bounds>
+			<bounds x="221" y="10" width="18" height="38"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="251" y="8" width="42" height="42">
-			</bounds>
+			<bounds x="251" y="8" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="253" y="10" width="38" height="38">
-			</bounds>
+			<bounds x="253" y="10" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="290" y="8" width="42" height="42">
-			</bounds>
+			<bounds x="290" y="8" width="42" height="42"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="292" y="10" width="38" height="38">
-			</bounds>
+			<bounds x="292" y="10" width="38" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_53_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="505" y="576" width="75" height="27">
-			</bounds>
+			<bounds x="505" y="576" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_53" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="507" y="578" width="71" height="23">
-			</bounds>
+			<bounds x="507" y="578" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_54_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="426" y="576" width="75" height="27">
-			</bounds>
+			<bounds x="426" y="576" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_54" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="428" y="578" width="71" height="23">
-			</bounds>
+			<bounds x="428" y="578" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_55_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="348" y="577" width="75" height="27">
-			</bounds>
+			<bounds x="348" y="577" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_55" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="350" y="579" width="71" height="23">
-			</bounds>
+			<bounds x="350" y="579" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_56_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="25" y="577" width="75" height="27">
-			</bounds>
+			<bounds x="25" y="577" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_56" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="27" y="579" width="71" height="23">
-			</bounds>
+			<bounds x="27" y="579" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_57_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="269" y="577" width="75" height="27">
-			</bounds>
+			<bounds x="269" y="577" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_57" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="271" y="579" width="71" height="23">
-			</bounds>
+			<bounds x="271" y="579" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_58_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="187" y="577" width="75" height="27">
-			</bounds>
+			<bounds x="187" y="577" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_58" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="189" y="579" width="71" height="23">
-			</bounds>
+			<bounds x="189" y="579" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_59_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="102" y="577" width="75" height="27">
-			</bounds>
+			<bounds x="102" y="577" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_59" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="104" y="579" width="71" height="23">
-			</bounds>
+			<bounds x="104" y="579" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="70" y="325" width="323" height="27">
-			</bounds>
+			<bounds x="70" y="325" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="70" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="70" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="90" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="90" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="110" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="110" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="130" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="130" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="150" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="150" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="170" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="170" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="190" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="190" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="210" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="210" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="230" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="230" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="250" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="250" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="270" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="270" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="290" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="290" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="310" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="310" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="330" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="330" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="350" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="350" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="370" y="325" width="20" height="27">
-			</bounds>
+			<bounds x="370" y="325" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="70" y="429" width="24" height="26">
-			</bounds>
+			<bounds x="70" y="429" width="24" height="26"/>
 		</backdrop>
 		<backdrop name="label13" element="label_13">
-			<bounds x="355" y="430" width="24" height="26">
-			</bounds>
+			<bounds x="355" y="430" width="24" height="26"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_standard" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cvanif.lay
+++ b/src/mame/layout/sc4cvanif.lay
@@ -8,14196 +8,8278 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_22_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Trail Held">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ca">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ca">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="sh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="sh">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_252_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_252_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;v">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;v">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_253_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_253_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="an">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="an">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_254_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_254_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="ia">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="ia">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 2 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 2 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_121_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_121_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_122_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_122_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_113_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_113_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_108_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_108_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_107_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_107_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_104_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_104_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_123_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_123_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_118_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_118_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_117_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_117_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_103_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_103_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_114_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_114_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="&#x3C;-">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 2 Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_236_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_236_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
+			<color red="0.38" green="0.38" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
+			<color red="0.09" green="0.09" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
+			<color red="0.75" green="0.75" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
+			<color red="0.19" green="0.19" blue="0.19"/>
 		</rect>
 		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.38" green="0.38" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.09" green="0.09" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.75" green="0.75" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.19" green="0.19" blue="0.19">
-			</color>
-		</rect>
-		<text string="Boost">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="-&#x3E;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="multi fill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="multi fill">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_17_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_17_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="extra cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="extra cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="extra features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="extra features">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_135_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_135_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1.20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="repeat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_148_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_148_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="QUICK ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="QUICK ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_149_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_149_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CASH ATTACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH ATTACK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CRAZY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="REELS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CRAZY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="REELS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="CASH BASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="CASH BASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="PICK A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="PICK A WIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="FAST CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="FAST CASH">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="REEL ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ROULETTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="REEL ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ROULETTE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="MONEY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="MONEY ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="BELT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="MONEY MOUNTAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="MONEY MOUNTAIN">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Link Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Link Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Reel Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Reel Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Winspin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Winspin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="FEATURES">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
-		</rect>
-		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vulture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="X2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_100_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_100_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_53_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_53_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_51_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_51_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_43_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_43_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_41_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_41_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="bonus">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_28_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_28_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_26_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_26_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_56_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_56_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_157_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_157">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_158_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_158">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_159_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_159">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="HI">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_160_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_160">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_161_border">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.38">
-			</color>
+			<color red="0.25" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.09">
-			</color>
+			<color red="0.06" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_161">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.75">
-			</color>
+			<color red="0.50" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.19">
-			</color>
+			<color red="0.13" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="LO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_162_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_162">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_163_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_163">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Collect">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_164_border">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_164">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_165_border">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_165">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_166_border">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.25">
-			</color>
+			<color red="0.25" green="0.00" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.06">
-			</color>
+			<color red="0.06" green="0.00" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="colour_button_166">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.50">
-			</color>
+			<color red="0.50" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.13">
-			</color>
+			<color red="0.13" green="0.00" blue="0.13"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_167_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_167">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_168_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_168">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel4" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="5" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_138">
 		<text string="All Lit Awards Super Series">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_4">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1014" height="676">
-			</bounds>
+			<bounds x="0" y="0" width="1014" height="676"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="242" y="462" width="80" height="140">
-			</bounds>
+			<bounds x="242" y="462" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="462.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="242.0000" y="462.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="463.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="245.3333" y="463.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="465.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="248.6667" y="465.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="467.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="252.0000" y="467.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="469.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="255.3333" y="469.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="471.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="258.6667" y="471.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="508.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="242.0000" y="508.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="510.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="245.3333" y="510.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="512.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="248.6667" y="512.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="514.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="252.0000" y="514.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="516.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="255.3333" y="516.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="518.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="258.6667" y="518.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="242.0000" y="555.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="242.0000" y="555.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="245.3333" y="557.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="245.3333" y="557.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.6667" y="559.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="248.6667" y="559.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.0000" y="561.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="252.0000" y="561.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="255.3333" y="563.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="255.3333" y="563.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="258.6667" y="565.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="258.6667" y="565.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="242" y="462" width="80" height="140">
-			</bounds>
+			<bounds x="242" y="462" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="335" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="335" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="463.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="335.0000" y="463.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="464.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="338.3333" y="464.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="466.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="341.6667" y="466.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="468.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="345.0000" y="468.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="470.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="348.3333" y="470.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="472.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="351.6667" y="472.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="509.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="335.0000" y="509.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="511.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="338.3333" y="511.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="513.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="341.6667" y="513.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="515.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="345.0000" y="515.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="517.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="348.3333" y="517.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="519.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="351.6667" y="519.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="335.0000" y="556.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="335.0000" y="556.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="338.3333" y="558.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="338.3333" y="558.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="341.6667" y="560.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="341.6667" y="560.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="345.0000" y="562.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="345.0000" y="562.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.3333" y="564.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="348.3333" y="564.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.6667" y="566.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="351.6667" y="566.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="335" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="335" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="428" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="428" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="428.0000" y="463.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="428.0000" y="463.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="431.3333" y="464.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="431.3333" y="464.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="434.6667" y="466.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="434.6667" y="466.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="438.0000" y="468.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="438.0000" y="468.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="441.3333" y="470.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="441.3333" y="470.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="444.6667" y="472.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="444.6667" y="472.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="428.0000" y="509.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="428.0000" y="509.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="431.3333" y="511.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="431.3333" y="511.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="434.6667" y="513.5555" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="434.6667" y="513.5555" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="438.0000" y="515.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="438.0000" y="515.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="441.3333" y="517.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="441.3333" y="517.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="444.6667" y="519.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="444.6667" y="519.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="428.0000" y="556.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="428.0000" y="556.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="431.3333" y="558.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="431.3333" y="558.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="434.6667" y="560.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="434.6667" y="560.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="438.0000" y="562.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="438.0000" y="562.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="441.3333" y="564.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="441.3333" y="564.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="444.6667" y="566.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="444.6667" y="566.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="428" y="463" width="80" height="140">
-			</bounds>
+			<bounds x="428" y="463" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="251" y="350" width="250" height="50">
-			</bounds>
+			<bounds x="251" y="350" width="250" height="50"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="251.0000" y="350.0000" width="250.0000" height="10.0000">
-			</bounds>
+			<bounds x="251.0000" y="350.0000" width="250.0000" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.4167" y="350.4167" width="229.1667" height="9.1667">
-			</bounds>
+			<bounds x="261.4167" y="350.4167" width="229.1667" height="9.1667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.8333" y="350.8333" width="208.3333" height="8.3333">
-			</bounds>
+			<bounds x="271.8333" y="350.8333" width="208.3333" height="8.3333"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.2500" y="351.2500" width="187.5000" height="7.5000">
-			</bounds>
+			<bounds x="282.2500" y="351.2500" width="187.5000" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="292.6667" y="351.6667" width="166.6667" height="6.6667">
-			</bounds>
+			<bounds x="292.6667" y="351.6667" width="166.6667" height="6.6667"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.0833" y="352.0833" width="145.8333" height="5.8333">
-			</bounds>
+			<bounds x="303.0833" y="352.0833" width="145.8333" height="5.8333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="251.0000" y="360.0000" width="250.0000" height="10.0000">
-			</bounds>
+			<bounds x="251.0000" y="360.0000" width="250.0000" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.4167" y="360.4167" width="229.1667" height="9.1667">
-			</bounds>
+			<bounds x="261.4167" y="360.4167" width="229.1667" height="9.1667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.8333" y="360.8333" width="208.3333" height="8.3333">
-			</bounds>
+			<bounds x="271.8333" y="360.8333" width="208.3333" height="8.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.2500" y="361.2500" width="187.5000" height="7.5000">
-			</bounds>
+			<bounds x="282.2500" y="361.2500" width="187.5000" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="292.6667" y="361.6667" width="166.6667" height="6.6667">
-			</bounds>
+			<bounds x="292.6667" y="361.6667" width="166.6667" height="6.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.0833" y="362.0833" width="145.8333" height="5.8333">
-			</bounds>
+			<bounds x="303.0833" y="362.0833" width="145.8333" height="5.8333"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="251.0000" y="370.0000" width="250.0000" height="10.0000">
-			</bounds>
+			<bounds x="251.0000" y="370.0000" width="250.0000" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.4167" y="370.4167" width="229.1667" height="9.1667">
-			</bounds>
+			<bounds x="261.4167" y="370.4167" width="229.1667" height="9.1667"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.8333" y="370.8333" width="208.3333" height="8.3333">
-			</bounds>
+			<bounds x="271.8333" y="370.8333" width="208.3333" height="8.3333"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.2500" y="371.2500" width="187.5000" height="7.5000">
-			</bounds>
+			<bounds x="282.2500" y="371.2500" width="187.5000" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="292.6667" y="371.6667" width="166.6667" height="6.6667">
-			</bounds>
+			<bounds x="292.6667" y="371.6667" width="166.6667" height="6.6667"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.0833" y="372.0833" width="145.8333" height="5.8333">
-			</bounds>
+			<bounds x="303.0833" y="372.0833" width="145.8333" height="5.8333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="251.0000" y="380.0000" width="250.0000" height="10.0000">
-			</bounds>
+			<bounds x="251.0000" y="380.0000" width="250.0000" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.4167" y="380.4167" width="229.1667" height="9.1667">
-			</bounds>
+			<bounds x="261.4167" y="380.4167" width="229.1667" height="9.1667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.8333" y="380.8333" width="208.3333" height="8.3333">
-			</bounds>
+			<bounds x="271.8333" y="380.8333" width="208.3333" height="8.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.2500" y="381.2500" width="187.5000" height="7.5000">
-			</bounds>
+			<bounds x="282.2500" y="381.2500" width="187.5000" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="292.6667" y="381.6667" width="166.6667" height="6.6667">
-			</bounds>
+			<bounds x="292.6667" y="381.6667" width="166.6667" height="6.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.0833" y="382.0833" width="145.8333" height="5.8333">
-			</bounds>
+			<bounds x="303.0833" y="382.0833" width="145.8333" height="5.8333"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="251.0000" y="390.0000" width="250.0000" height="10.0000">
-			</bounds>
+			<bounds x="251.0000" y="390.0000" width="250.0000" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="261.4167" y="390.4167" width="229.1667" height="9.1667">
-			</bounds>
+			<bounds x="261.4167" y="390.4167" width="229.1667" height="9.1667"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="271.8333" y="390.8333" width="208.3333" height="8.3333">
-			</bounds>
+			<bounds x="271.8333" y="390.8333" width="208.3333" height="8.3333"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="282.2500" y="391.2500" width="187.5000" height="7.5000">
-			</bounds>
+			<bounds x="282.2500" y="391.2500" width="187.5000" height="7.5000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="292.6667" y="391.6667" width="166.6667" height="6.6667">
-			</bounds>
+			<bounds x="292.6667" y="391.6667" width="166.6667" height="6.6667"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.0833" y="392.0833" width="145.8333" height="5.8333">
-			</bounds>
+			<bounds x="303.0833" y="392.0833" width="145.8333" height="5.8333"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="251" y="350" width="250" height="50">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="251" y="350" width="250" height="50"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1_border" state="0">
-			<bounds x="541" y="482" width="52" height="30">
-			</bounds>
+			<bounds x="541" y="482" width="52" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="lamp_22_1" state="0">
-			<bounds x="543" y="484" width="48" height="26">
-			</bounds>
+			<bounds x="543" y="484" width="48" height="26"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="523" y="514" width="92" height="82">
-			</bounds>
+			<bounds x="523" y="514" width="92" height="82"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="525" y="516" width="88" height="78">
-			</bounds>
+			<bounds x="525" y="516" width="88" height="78"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="239" y="12" width="52" height="42">
-			</bounds>
+			<bounds x="239" y="12" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="241" y="14" width="48" height="38">
-			</bounds>
+			<bounds x="241" y="14" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="291" y="18" width="52" height="42">
-			</bounds>
+			<bounds x="291" y="18" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="293" y="20" width="48" height="38">
-			</bounds>
+			<bounds x="293" y="20" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1_border" state="0">
-			<bounds x="343" y="13" width="52" height="42">
-			</bounds>
+			<bounds x="343" y="13" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp252" element="lamp_252_1" state="0">
-			<bounds x="345" y="15" width="48" height="38">
-			</bounds>
+			<bounds x="345" y="15" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1_border" state="0">
-			<bounds x="395" y="18" width="52" height="42">
-			</bounds>
+			<bounds x="395" y="18" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp253" element="lamp_253_1" state="0">
-			<bounds x="397" y="20" width="48" height="38">
-			</bounds>
+			<bounds x="397" y="20" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1_border" state="0">
-			<bounds x="447" y="12" width="52" height="42">
-			</bounds>
+			<bounds x="447" y="12" width="52" height="42"/>
 		</backdrop>
 		<backdrop name="lamp254" element="lamp_254_1" state="0">
-			<bounds x="449" y="14" width="48" height="38">
-			</bounds>
+			<bounds x="449" y="14" width="48" height="38"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="561" y="193" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="193" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="563" y="195" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="195" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="561" y="161" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="161" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="563" y="163" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="163" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="561" y="129" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="129" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="563" y="131" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="131" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="561" y="225" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="225" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="563" y="227" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="227" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="561" y="97" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="97" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="563" y="99" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="99" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="128" y="97" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="97" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="130" y="99" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="99" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="128" y="129" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="129" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="130" y="131" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="131" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="128" y="161" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="161" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="130" y="163" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="163" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="128" y="193" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="193" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="130" y="195" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="195" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="128" y="225" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="225" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="130" y="227" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="227" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1_border" state="0">
-			<bounds x="686" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="686" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp121" element="lamp_121_1" state="0">
-			<bounds x="688" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="688" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1_border" state="0">
-			<bounds x="624" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="624" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp122" element="lamp_122_1" state="0">
-			<bounds x="626" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="626" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="562" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="562" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="564" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="564" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1_border" state="0">
-			<bounds x="500" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="500" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp113" element="lamp_113_1" state="0">
-			<bounds x="502" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="502" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="438" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="438" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="440" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="440" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1_border" state="0">
-			<bounds x="376" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="376" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp108" element="lamp_108_1" state="0">
-			<bounds x="378" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="378" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1_border" state="0">
-			<bounds x="314" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="314" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp107" element="lamp_107_1" state="0">
-			<bounds x="316" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="316" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="252" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="252" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="254" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="254" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="190" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="190" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="192" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="192" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1_border" state="0">
-			<bounds x="128" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_1" state="0">
-			<bounds x="130" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1_border" state="0">
-			<bounds x="624" y="321" width="62" height="32">
-			</bounds>
+			<bounds x="624" y="321" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp123" element="lamp_123_1" state="0">
-			<bounds x="626" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="626" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1_border" state="0">
-			<bounds x="624" y="353" width="62" height="32">
-			</bounds>
+			<bounds x="624" y="353" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp118" element="lamp_118_1" state="0">
-			<bounds x="626" y="355" width="58" height="28">
-			</bounds>
+			<bounds x="626" y="355" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="686" y="353" width="62" height="32">
-			</bounds>
+			<bounds x="686" y="353" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="688" y="355" width="58" height="28">
-			</bounds>
+			<bounds x="688" y="355" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="686" y="321" width="62" height="32">
-			</bounds>
+			<bounds x="686" y="321" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="688" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="688" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1_border" state="0">
-			<bounds x="561" y="353" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="353" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp117" element="lamp_117_1" state="0">
-			<bounds x="563" y="355" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="355" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="561" y="321" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="321" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="563" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="128" y="353" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="353" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="130" y="355" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="355" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1_border" state="0">
-			<bounds x="128" y="321" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="321" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp103" element="lamp_103_1" state="0">
-			<bounds x="130" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="128" y="257" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="257" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="130" y="259" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="259" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1_border" state="0">
-			<bounds x="561" y="257" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="257" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp114" element="lamp_114_1" state="0">
-			<bounds x="563" y="259" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="259" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="66" y="33" width="62" height="32">
-			</bounds>
+			<bounds x="66" y="33" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="68" y="35" width="58" height="28">
-			</bounds>
+			<bounds x="68" y="35" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="128" y="1" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="1" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="130" y="3" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="3" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="128" y="33" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="33" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="130" y="35" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="35" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="66" y="1" width="62" height="32">
-			</bounds>
+			<bounds x="66" y="1" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="68" y="3" width="58" height="28">
-			</bounds>
+			<bounds x="68" y="3" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="4" y="1" width="62" height="32">
-			</bounds>
+			<bounds x="4" y="1" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="6" y="3" width="58" height="28">
-			</bounds>
+			<bounds x="6" y="3" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="4" y="33" width="62" height="32">
-			</bounds>
+			<bounds x="4" y="33" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="6" y="35" width="58" height="28">
-			</bounds>
+			<bounds x="6" y="35" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="66" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="66" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="68" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="68" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="4" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="4" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="6" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="6" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="561" y="33" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="33" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="563" y="35" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="35" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="623" y="33" width="62" height="32">
-			</bounds>
+			<bounds x="623" y="33" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="625" y="35" width="58" height="28">
-			</bounds>
+			<bounds x="625" y="35" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="685" y="33" width="62" height="32">
-			</bounds>
+			<bounds x="685" y="33" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="687" y="35" width="58" height="28">
-			</bounds>
+			<bounds x="687" y="35" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="623" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="623" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="625" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="625" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="685" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="685" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="687" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="687" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="128" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="128" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="130" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="130" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="190" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="190" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="192" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="192" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1_border" state="0">
-			<bounds x="252" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="252" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp236" element="lamp_236_1" state="0">
-			<bounds x="254" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="254" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="314" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="314" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="316" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="316" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="376" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="376" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="378" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="378" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="438" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="438" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="440" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="440" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="500" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="500" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="502" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="502" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="561" y="65" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="65" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="563" y="67" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="67" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="561" y="1" width="62" height="32">
-			</bounds>
+			<bounds x="561" y="1" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="563" y="3" width="58" height="28">
-			</bounds>
+			<bounds x="563" y="3" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="623" y="1" width="62" height="32">
-			</bounds>
+			<bounds x="623" y="1" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="625" y="3" width="58" height="28">
-			</bounds>
+			<bounds x="625" y="3" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="685" y="1" width="62" height="32">
-			</bounds>
+			<bounds x="685" y="1" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="687" y="3" width="58" height="28">
-			</bounds>
+			<bounds x="687" y="3" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="622" y="495" width="82" height="32">
-			</bounds>
+			<bounds x="622" y="495" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="624" y="497" width="78" height="28">
-			</bounds>
+			<bounds x="624" y="497" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1_border" state="0">
-			<bounds x="622" y="529" width="82" height="32">
-			</bounds>
+			<bounds x="622" y="529" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp17" element="lamp_17_1" state="0">
-			<bounds x="624" y="531" width="78" height="28">
-			</bounds>
+			<bounds x="624" y="531" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="622" y="563" width="82" height="32">
-			</bounds>
+			<bounds x="622" y="563" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="624" y="565" width="78" height="28">
-			</bounds>
+			<bounds x="624" y="565" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="622" y="597" width="82" height="32">
-			</bounds>
+			<bounds x="622" y="597" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="624" y="599" width="78" height="28">
-			</bounds>
+			<bounds x="624" y="599" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="930" y="492" width="82" height="17">
-			</bounds>
+			<bounds x="930" y="492" width="82" height="17"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="932" y="494" width="78" height="13">
-			</bounds>
+			<bounds x="932" y="494" width="78" height="13"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="930" y="31" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="31" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="932" y="33" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="33" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="930" y="84" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="84" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="932" y="86" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="86" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="930" y="118" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="118" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="932" y="120" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="120" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="930" y="152" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="152" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="932" y="154" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="154" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="930" y="186" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="186" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="932" y="188" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="188" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1_border" state="0">
-			<bounds x="930" y="220" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="220" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp135" element="lamp_135_1" state="0">
-			<bounds x="932" y="222" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="222" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="930" y="254" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="254" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="932" y="256" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="256" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="930" y="288" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="288" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="932" y="290" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="290" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="930" y="322" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="322" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="932" y="324" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="324" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="930" y="356" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="356" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="932" y="358" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="358" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="930" y="390" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="390" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="932" y="392" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="392" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="930" y="424" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="424" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="932" y="426" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="426" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="930" y="458" width="82" height="32">
-			</bounds>
+			<bounds x="930" y="458" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="932" y="460" width="78" height="28">
-			</bounds>
+			<bounds x="932" y="460" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="930" y="65" width="82" height="17">
-			</bounds>
+			<bounds x="930" y="65" width="82" height="17"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="932" y="67" width="78" height="13">
-			</bounds>
+			<bounds x="932" y="67" width="78" height="13"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="762" y="65" width="82" height="17">
-			</bounds>
+			<bounds x="762" y="65" width="82" height="17"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="764" y="67" width="78" height="13">
-			</bounds>
+			<bounds x="764" y="67" width="78" height="13"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="762" y="84" width="82" height="32">
-			</bounds>
+			<bounds x="762" y="84" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="764" y="86" width="78" height="28">
-			</bounds>
+			<bounds x="764" y="86" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="762" y="322" width="82" height="32">
-			</bounds>
+			<bounds x="762" y="322" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="764" y="324" width="78" height="28">
-			</bounds>
+			<bounds x="764" y="324" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="762" y="424" width="82" height="32">
-			</bounds>
+			<bounds x="762" y="424" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="764" y="426" width="78" height="28">
-			</bounds>
+			<bounds x="764" y="426" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="762" y="492" width="82" height="17">
-			</bounds>
+			<bounds x="762" y="492" width="82" height="17"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="764" y="494" width="78" height="13">
-			</bounds>
+			<bounds x="764" y="494" width="78" height="13"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="846" y="65" width="82" height="17">
-			</bounds>
+			<bounds x="846" y="65" width="82" height="17"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="848" y="67" width="78" height="13">
-			</bounds>
+			<bounds x="848" y="67" width="78" height="13"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="846" y="31" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="31" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="848" y="33" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="33" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1_border" state="0">
-			<bounds x="846" y="84" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="84" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp148" element="lamp_148_1" state="0">
-			<bounds x="848" y="86" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="86" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1_border" state="0">
-			<bounds x="846" y="118" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="118" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp149" element="lamp_149_1" state="0">
-			<bounds x="848" y="120" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="120" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="846" y="152" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="152" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="848" y="154" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="154" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="846" y="186" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="186" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="848" y="188" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="188" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="846" y="220" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="220" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="848" y="222" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="222" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="846" y="254" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="254" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="848" y="256" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="256" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="846" y="288" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="288" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="848" y="290" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="290" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="846" y="322" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="322" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="848" y="324" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="324" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="846" y="356" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="356" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="848" y="358" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="358" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="846" y="390" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="390" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="848" y="392" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="392" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="846" y="424" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="424" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="848" y="426" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="426" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="846" y="458" width="82" height="32">
-			</bounds>
+			<bounds x="846" y="458" width="82" height="32"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="848" y="460" width="78" height="28">
-			</bounds>
+			<bounds x="848" y="460" width="78" height="28"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="846" y="492" width="82" height="17">
-			</bounds>
+			<bounds x="846" y="492" width="82" height="17"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="848" y="494" width="78" height="13">
-			</bounds>
+			<bounds x="848" y="494" width="78" height="13"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="4" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="4" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="6" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="6" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="4" y="353" width="62" height="32">
-			</bounds>
+			<bounds x="4" y="353" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="6" y="355" width="58" height="28">
-			</bounds>
+			<bounds x="6" y="355" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="4" y="321" width="62" height="32">
-			</bounds>
+			<bounds x="4" y="321" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="6" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="6" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="66" y="321" width="62" height="32">
-			</bounds>
+			<bounds x="66" y="321" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="68" y="323" width="58" height="28">
-			</bounds>
+			<bounds x="68" y="323" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="66" y="353" width="62" height="32">
-			</bounds>
+			<bounds x="66" y="353" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="68" y="355" width="58" height="28">
-			</bounds>
+			<bounds x="68" y="355" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1_border" state="0">
-			<bounds x="66" y="289" width="62" height="32">
-			</bounds>
+			<bounds x="66" y="289" width="62" height="32"/>
 		</backdrop>
 		<backdrop name="lamp100" element="lamp_100_1" state="0">
-			<bounds x="68" y="291" width="58" height="28">
-			</bounds>
+			<bounds x="68" y="291" width="58" height="28"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1_border" state="0">
-			<bounds x="220" y="609" width="52" height="27">
-			</bounds>
+			<bounds x="220" y="609" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp53" element="lamp_53_1" state="0">
-			<bounds x="222" y="611" width="48" height="23">
-			</bounds>
+			<bounds x="222" y="611" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1_border" state="0">
-			<bounds x="274" y="609" width="52" height="27">
-			</bounds>
+			<bounds x="274" y="609" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp51" element="lamp_51_1" state="0">
-			<bounds x="276" y="611" width="48" height="23">
-			</bounds>
+			<bounds x="276" y="611" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1_border" state="0">
-			<bounds x="328" y="609" width="52" height="27">
-			</bounds>
+			<bounds x="328" y="609" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp43" element="lamp_43_1" state="0">
-			<bounds x="330" y="611" width="48" height="23">
-			</bounds>
+			<bounds x="330" y="611" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1_border" state="0">
-			<bounds x="382" y="609" width="67" height="27">
-			</bounds>
+			<bounds x="382" y="609" width="67" height="27"/>
 		</backdrop>
 		<backdrop name="lamp41" element="lamp_41_1" state="0">
-			<bounds x="384" y="611" width="63" height="23">
-			</bounds>
+			<bounds x="384" y="611" width="63" height="23"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1_border" state="0">
-			<bounds x="451" y="609" width="52" height="27">
-			</bounds>
+			<bounds x="451" y="609" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp28" element="lamp_28_1" state="0">
-			<bounds x="453" y="611" width="48" height="23">
-			</bounds>
+			<bounds x="453" y="611" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1_border" state="0">
-			<bounds x="505" y="609" width="52" height="27">
-			</bounds>
+			<bounds x="505" y="609" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp26" element="lamp_26_1" state="0">
-			<bounds x="507" y="611" width="48" height="23">
-			</bounds>
+			<bounds x="507" y="611" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="559" y="609" width="52" height="27">
-			</bounds>
+			<bounds x="559" y="609" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="561" y="611" width="48" height="23">
-			</bounds>
+			<bounds x="561" y="611" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="68" y="461" width="52" height="27">
-			</bounds>
+			<bounds x="68" y="461" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="70" y="463" width="48" height="23">
-			</bounds>
+			<bounds x="70" y="463" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="57" y="493" width="52" height="27">
-			</bounds>
+			<bounds x="57" y="493" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="59" y="495" width="48" height="23">
-			</bounds>
+			<bounds x="59" y="495" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1_border" state="0">
-			<bounds x="64" y="525" width="52" height="27">
-			</bounds>
+			<bounds x="64" y="525" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp56" element="lamp_56_1" state="0">
-			<bounds x="66" y="527" width="48" height="23">
-			</bounds>
+			<bounds x="66" y="527" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="72" y="557" width="52" height="27">
-			</bounds>
+			<bounds x="72" y="557" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="74" y="559" width="48" height="23">
-			</bounds>
+			<bounds x="74" y="559" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="89" y="589" width="52" height="27">
-			</bounds>
+			<bounds x="89" y="589" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="91" y="591" width="48" height="23">
-			</bounds>
+			<bounds x="91" y="591" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="40" y="429" width="52" height="29">
-			</bounds>
+			<bounds x="40" y="429" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="42" y="431" width="48" height="25">
-			</bounds>
+			<bounds x="42" y="431" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_157_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="764" y="4" width="75" height="27">
-			</bounds>
+			<bounds x="764" y="4" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_157" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="766" y="6" width="71" height="23">
-			</bounds>
+			<bounds x="766" y="6" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp91" element="colour_button_158_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="428" y="322" width="75" height="27">
-			</bounds>
+			<bounds x="428" y="322" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp91" element="colour_button_158" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="430" y="324" width="71" height="23">
-			</bounds>
+			<bounds x="430" y="324" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp92" element="colour_button_159_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="249" y="322" width="75" height="27">
-			</bounds>
+			<bounds x="249" y="322" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp92" element="colour_button_159" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="251" y="324" width="71" height="23">
-			</bounds>
+			<bounds x="251" y="324" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp64" element="colour_button_160_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="248" y="401" width="75" height="27">
-			</bounds>
+			<bounds x="248" y="401" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp64" element="colour_button_160" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="250" y="403" width="71" height="23">
-			</bounds>
+			<bounds x="250" y="403" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp65" element="colour_button_161_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="428" y="401" width="75" height="27">
-			</bounds>
+			<bounds x="428" y="401" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp65" element="colour_button_161" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="430" y="403" width="71" height="23">
-			</bounds>
+			<bounds x="430" y="403" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_162_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="118" y="639" width="75" height="27">
-			</bounds>
+			<bounds x="118" y="639" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_162" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="120" y="641" width="71" height="23">
-			</bounds>
+			<bounds x="120" y="641" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_163_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="536" y="640" width="75" height="27">
-			</bounds>
+			<bounds x="536" y="640" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_163" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="538" y="642" width="71" height="23">
-			</bounds>
+			<bounds x="538" y="642" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_164_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="242" y="640" width="75" height="27">
-			</bounds>
+			<bounds x="242" y="640" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_164" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="244" y="642" width="71" height="23">
-			</bounds>
+			<bounds x="244" y="642" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_165_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="335" y="640" width="75" height="27">
-			</bounds>
+			<bounds x="335" y="640" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_165" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="337" y="642" width="71" height="23">
-			</bounds>
+			<bounds x="337" y="642" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_166_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="429" y="640" width="75" height="27">
-			</bounds>
+			<bounds x="429" y="640" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_166" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="431" y="642" width="71" height="23">
-			</bounds>
+			<bounds x="431" y="642" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_167_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="637" y="640" width="80" height="27">
-			</bounds>
+			<bounds x="637" y="640" width="80" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_167" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="639" y="642" width="76" height="23">
-			</bounds>
+			<bounds x="639" y="642" width="76" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_168_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="741" y="640" width="75" height="27">
-			</bounds>
+			<bounds x="741" y="640" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_168" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="743" y="642" width="71" height="23">
-			</bounds>
+			<bounds x="743" y="642" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="214" y="429" width="323" height="27">
-			</bounds>
+			<bounds x="214" y="429" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="214" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="214" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="234" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="234" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="254" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="254" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="274" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="274" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="294" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="294" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="314" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="314" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="334" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="334" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="354" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="354" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="374" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="374" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="394" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="394" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="414" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="414" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="434" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="434" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="454" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="454" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="474" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="474" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="494" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="494" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="514" y="429" width="20" height="27">
-			</bounds>
+			<bounds x="514" y="429" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label138" element="label_138">
-			<bounds x="285" y="132" width="152" height="14">
-			</bounds>
+			<bounds x="285" y="132" width="152" height="14"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_button" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_button" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_button" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_button" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_button" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="32.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="34.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="36.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="38.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="40.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="42.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="80.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="82.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="84.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="86.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="88.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="90.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="128.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="130.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="132.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="134.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="136.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="138.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="176.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="178.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="180.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="182.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="184.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="186.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1660.0000" y="224.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1665.0000" y="226.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1670.0000" y="228.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1675.0000" y="230.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1680.0000" y="232.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1685.0000" y="234.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="sreel5" element="reel4" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1660" y="32" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1660" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel5" element="debug_stepper_value">
-			<bounds x="1660" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1660" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_4">
-			<bounds x="1740" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1740" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4cvclb.lay
+++ b/src/mame/layout/sc4cvclb.lay
@@ -8,15814 +8,9341 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_228_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_229_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_229_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_232_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_232_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_233_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_233_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_234_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_234_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_235_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_235_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_231_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_231_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_230_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_230_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
+			<color red="0.00" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
+			<color red="0.00" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
+			<color red="0.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
+			<color red="0.00" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="Igor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="Igor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_237_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_237_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="JACKPOT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_240_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_240_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Quick Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Quick Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_241_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_241_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cash Attack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cash Attack">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_242_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_242_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Crazy Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Crazy Reels">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_243_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_243_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Cash Bash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Cash Bash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_244_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_244_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Pick A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Pick A Win">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_245_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_245_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Fast Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Fast Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_246_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_246_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Reel Roulette">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Reel Roulette">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_247_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_247_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Money Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Money Belt">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_248_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_248_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Money Mountain">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Money Mountain">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_227_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_227_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="~">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="~">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_153_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_153_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_156_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_156_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_157_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_160_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_160_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_161_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_161_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_151_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_151_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_188_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_188_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<text string="All Lit Enters Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<text string="All Lit Enters Big Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_133_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_133_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_131_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_131_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_129_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_129_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_128_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_128_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_226_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_226_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_225_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_225_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_224_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_224_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_221_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_221_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_220_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_220_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 2 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 2 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_219_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_219_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_218_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_218_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="~">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="~">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_216_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_216_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_210_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_210_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_201_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_201_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_202_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_202_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_203_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_203_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_204_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_204_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_205_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_205_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_199_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_199_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_171_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_171_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_172_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_172_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_173_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_173_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_174_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_174_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 2 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_170_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_170_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_169_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_169_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 2 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 2 Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_162_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_162_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_155_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_155_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_154_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_154_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="~">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="~">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_134_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_134_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_137_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_137_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_147_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_147_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_146_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_146_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_145_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
+			<color red="0.12" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_145_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
+			<color red="1.00" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.06">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<text string="BOOST">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_144_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
+			<color red="0.50" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
+			<color red="0.12" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_144_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
+			<color red="1.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
+			<color red="0.25" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_140_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_140_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_139_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_139_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_138_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_138_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="~">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="~">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_130_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_130_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_132_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_132_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_124_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_124_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;250 Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;250 Jackpot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_120_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_120_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;50.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;50.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_119_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_119_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;40.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;40.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_116_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_116_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;30.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;30.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_115_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_115_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;25.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;25.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_112_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_112_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;20.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_109_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_109_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;18.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;18.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_106_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_106_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;15.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_105_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_105_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;12.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_102_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_102_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;10.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_101_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_101_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;9.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;9.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_98_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;8.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_27_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_27_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;7.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_23_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_23_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;5.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;4.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_19_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_19_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3.60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_16_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_16_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;3.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_13_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_13_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2.40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_10_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;2.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_9_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_9_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;1.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_251_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_251_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="win spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="win spin">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_250_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_250_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Reel Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Reel Shot">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_249_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_249_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="Link Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="Link Up">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_58_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_58_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Lose">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_66_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_66_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_68_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_68_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_67_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_67_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_70_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_70_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_71_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_71_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_73_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_73_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_72_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_72_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_78_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_78_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_77_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_77_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_80_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_80_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_81_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_81_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_83_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_83_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_82_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_82_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_85_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_85_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_86_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_86_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_88_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_88_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_87_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_87_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_90_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_90_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_91_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_91_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_93_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_93_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_92_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_92_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_96_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_96_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_97_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_97_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_75_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_75_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_76_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.06" blue="0.06">
-			</color>
+			<color red="0.06" green="0.06" blue="0.06"/>
 		</rect>
 	</element>
 	<element name="lamp_76_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.13" blue="0.13">
-			</color>
+			<color red="0.13" green="0.13" blue="0.13"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_57_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_57_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CLub">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CLub">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_55_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_55_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="CAshvania">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="CAshvania">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_64_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_64_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_61_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_61_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_60_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_60_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_59_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_59_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_24_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_24_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;6.00">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_212_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
+			<color red="0.25" green="0.13" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
+			<color red="0.06" green="0.03" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_212_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
+			<color red="0.50" green="0.25" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
+			<color red="0.13" green="0.06" blue="0.06"/>
 		</rect>
 		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.13" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.03" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.06" blue="0.06">
-			</color>
-		</rect>
-		<text string="Vul">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="ture">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_213_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
+			<color red="0.00" green="0.25" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
+			<color red="0.00" green="0.06" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_213_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
+			<color red="0.00" green="0.50" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
+			<color red="0.00" green="0.13" blue="0.25"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.25">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Feat">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_214_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_214_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="R.I.P">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_215_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
+			<color red="0.25" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
+			<color red="0.06" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="lamp_215_1" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
+			<color red="0.50" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
+			<color red="0.13" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.25" green="0.00" blue="0.50">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.06" green="0.00" blue="0.12">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="1.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.13" green="0.00" blue="0.25">
-			</color>
-		</rect>
-		<text string="x2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_217_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_217_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="+ 1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Cash">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_211_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_211_1" defstate="0">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="+ 1 ">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="Nudge">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_196_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_196_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_197_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_197_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_194_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_194_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_195_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_195_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_178_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_178_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_198_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_198_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_187_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_187_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_179_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_179_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_189_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_189_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_190_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_190_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_192_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_192_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_176_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_176_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_193_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_193_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="????">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_177_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="lamp_177_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
-		</rect>
-		<text string="&#xA3;250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_186_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_186_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_185_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_185_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_181_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_181_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_180_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_180_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_183_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_183_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_182_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_182_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="?">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_181_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_181">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_182_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_182">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Igor">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_183_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_183">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_184_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_184">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_185_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_185">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_186_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_186">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_188_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_188">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_189_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_189">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hold / lo">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_190_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_190">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hold / hi">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_191_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_191">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Hold">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_192_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_192">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Cancel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_193_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.00">
-			</color>
+			<color red="0.00" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_193">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.00">
-			</color>
+			<color red="0.00" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Nudges">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_194_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_194">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="Exchange">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_195_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_195">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="Stop">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_196_border">
 		<rect state="1">
-			<color red="0.00" green="0.25" blue="0.38">
-			</color>
+			<color red="0.00" green="0.25" blue="0.38"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.06" blue="0.09">
-			</color>
+			<color red="0.00" green="0.06" blue="0.09"/>
 		</rect>
 	</element>
 	<element name="colour_button_196">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.75">
-			</color>
+			<color red="0.00" green="0.50" blue="0.75"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.13" blue="0.19">
-			</color>
+			<color red="0.00" green="0.13" blue="0.19"/>
 		</rect>
 		<text string="Start">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel5" defstate="0">
 		<reel reelreversed="1" stateoffset="-4779" numsymbolsvisible="5" symbollist=",,,,,,,,,,,,,,,">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_153">
 		<text string="Starts Feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_154">
 		<text string="starts super feature">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_5">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="1028" height="693">
-			</bounds>
+			<bounds x="0" y="0" width="1028" height="693"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="287" y="472" width="80" height="140">
-			</bounds>
+			<bounds x="287" y="472" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="287.0000" y="472.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="287.0000" y="472.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="290.3333" y="473.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="290.3333" y="473.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="293.6667" y="475.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="293.6667" y="475.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="297.0000" y="477.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="297.0000" y="477.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="300.3333" y="479.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="300.3333" y="479.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.6667" y="481.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="303.6667" y="481.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="287.0000" y="518.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="287.0000" y="518.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="290.3333" y="520.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="290.3333" y="520.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="293.6667" y="522.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="293.6667" y="522.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="297.0000" y="524.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="297.0000" y="524.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="300.3333" y="526.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="300.3333" y="526.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.6667" y="528.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="303.6667" y="528.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="287.0000" y="565.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="287.0000" y="565.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="290.3333" y="567.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="290.3333" y="567.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="293.6667" y="569.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="293.6667" y="569.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="297.0000" y="571.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="297.0000" y="571.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="300.3333" y="573.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="300.3333" y="573.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="303.6667" y="575.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="303.6667" y="575.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="287" y="472" width="80" height="140">
-			</bounds>
+			<bounds x="287" y="472" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="369" y="472" width="80" height="140">
-			</bounds>
+			<bounds x="369" y="472" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="369.0000" y="472.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="369.0000" y="472.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="372.3333" y="473.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="372.3333" y="473.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="375.6667" y="475.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="375.6667" y="475.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="379.0000" y="477.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="379.0000" y="477.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="382.3333" y="479.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="382.3333" y="479.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="385.6667" y="481.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="385.6667" y="481.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="369.0000" y="518.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="369.0000" y="518.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="372.3333" y="520.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="372.3333" y="520.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="375.6667" y="522.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="375.6667" y="522.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="379.0000" y="524.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="379.0000" y="524.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="382.3333" y="526.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="382.3333" y="526.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="385.6667" y="528.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="385.6667" y="528.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="369.0000" y="565.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="369.0000" y="565.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="372.3333" y="567.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="372.3333" y="567.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="375.6667" y="569.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="375.6667" y="569.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="379.0000" y="571.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="379.0000" y="571.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="382.3333" y="573.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="382.3333" y="573.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="385.6667" y="575.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="385.6667" y="575.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="369" y="472" width="80" height="140">
-			</bounds>
+			<bounds x="369" y="472" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="451" y="472" width="80" height="140">
-			</bounds>
+			<bounds x="451" y="472" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="451.0000" y="472.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="451.0000" y="472.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="454.3333" y="473.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="454.3333" y="473.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="457.6667" y="475.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="457.6667" y="475.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="461.0000" y="477.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="461.0000" y="477.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="464.3333" y="479.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="464.3333" y="479.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="467.6667" y="481.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="467.6667" y="481.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="451.0000" y="518.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="451.0000" y="518.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="454.3333" y="520.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="454.3333" y="520.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="457.6667" y="522.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="457.6667" y="522.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="461.0000" y="524.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="461.0000" y="524.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="464.3333" y="526.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="464.3333" y="526.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="467.6667" y="528.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="467.6667" y="528.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="451.0000" y="565.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="451.0000" y="565.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="454.3333" y="567.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="454.3333" y="567.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="457.6667" y="569.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="457.6667" y="569.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="461.0000" y="571.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="461.0000" y="571.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="464.3333" y="573.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="464.3333" y="573.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="467.6667" y="575.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="467.6667" y="575.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="451" y="472" width="80" height="140">
-			</bounds>
+			<bounds x="451" y="472" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="533" y="472" width="80" height="140">
-			</bounds>
+			<bounds x="533" y="472" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="533.0000" y="472.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="533.0000" y="472.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="536.3333" y="473.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="536.3333" y="473.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="539.6667" y="475.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="539.6667" y="475.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="543.0000" y="477.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="543.0000" y="477.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="546.3333" y="479.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="546.3333" y="479.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="549.6667" y="481.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="549.6667" y="481.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="533.0000" y="518.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="533.0000" y="518.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="536.3333" y="520.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="536.3333" y="520.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="539.6667" y="522.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="539.6667" y="522.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="543.0000" y="524.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="543.0000" y="524.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="546.3333" y="526.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="546.3333" y="526.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="549.6667" y="528.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="549.6667" y="528.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="533.0000" y="565.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="533.0000" y="565.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="536.3333" y="567.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="536.3333" y="567.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="539.6667" y="569.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="539.6667" y="569.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="543.0000" y="571.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="543.0000" y="571.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="546.3333" y="573.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="546.3333" y="573.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="549.6667" y="575.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="549.6667" y="575.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="533" y="472" width="80" height="140">
-			</bounds>
+			<bounds x="533" y="472" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="320" y="318" width="250" height="60">
-			</bounds>
+			<bounds x="320" y="318" width="250" height="60"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="318.0000" width="250.0000" height="12.0000">
-			</bounds>
+			<bounds x="320.0000" y="318.0000" width="250.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.4167" y="318.5000" width="229.1667" height="11.0000">
-			</bounds>
+			<bounds x="330.4167" y="318.5000" width="229.1667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.8333" y="319.0000" width="208.3333" height="10.0000">
-			</bounds>
+			<bounds x="340.8333" y="319.0000" width="208.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="351.2500" y="319.5000" width="187.5000" height="9.0000">
-			</bounds>
+			<bounds x="351.2500" y="319.5000" width="187.5000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="361.6667" y="320.0000" width="166.6667" height="8.0000">
-			</bounds>
+			<bounds x="361.6667" y="320.0000" width="166.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.0833" y="320.5000" width="145.8333" height="7.0000">
-			</bounds>
+			<bounds x="372.0833" y="320.5000" width="145.8333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="330.0000" width="250.0000" height="12.0000">
-			</bounds>
+			<bounds x="320.0000" y="330.0000" width="250.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.4167" y="330.5000" width="229.1667" height="11.0000">
-			</bounds>
+			<bounds x="330.4167" y="330.5000" width="229.1667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.8333" y="331.0000" width="208.3333" height="10.0000">
-			</bounds>
+			<bounds x="340.8333" y="331.0000" width="208.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="351.2500" y="331.5000" width="187.5000" height="9.0000">
-			</bounds>
+			<bounds x="351.2500" y="331.5000" width="187.5000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="361.6667" y="332.0000" width="166.6667" height="8.0000">
-			</bounds>
+			<bounds x="361.6667" y="332.0000" width="166.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.0833" y="332.5000" width="145.8333" height="7.0000">
-			</bounds>
+			<bounds x="372.0833" y="332.5000" width="145.8333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="342.0000" width="250.0000" height="12.0000">
-			</bounds>
+			<bounds x="320.0000" y="342.0000" width="250.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.4167" y="342.5000" width="229.1667" height="11.0000">
-			</bounds>
+			<bounds x="330.4167" y="342.5000" width="229.1667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.8333" y="343.0000" width="208.3333" height="10.0000">
-			</bounds>
+			<bounds x="340.8333" y="343.0000" width="208.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="351.2500" y="343.5000" width="187.5000" height="9.0000">
-			</bounds>
+			<bounds x="351.2500" y="343.5000" width="187.5000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="361.6667" y="344.0000" width="166.6667" height="8.0000">
-			</bounds>
+			<bounds x="361.6667" y="344.0000" width="166.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.0833" y="344.5000" width="145.8333" height="7.0000">
-			</bounds>
+			<bounds x="372.0833" y="344.5000" width="145.8333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="354.0000" width="250.0000" height="12.0000">
-			</bounds>
+			<bounds x="320.0000" y="354.0000" width="250.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.4167" y="354.5000" width="229.1667" height="11.0000">
-			</bounds>
+			<bounds x="330.4167" y="354.5000" width="229.1667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.8333" y="355.0000" width="208.3333" height="10.0000">
-			</bounds>
+			<bounds x="340.8333" y="355.0000" width="208.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="351.2500" y="355.5000" width="187.5000" height="9.0000">
-			</bounds>
+			<bounds x="351.2500" y="355.5000" width="187.5000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="361.6667" y="356.0000" width="166.6667" height="8.0000">
-			</bounds>
+			<bounds x="361.6667" y="356.0000" width="166.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.0833" y="356.5000" width="145.8333" height="7.0000">
-			</bounds>
+			<bounds x="372.0833" y="356.5000" width="145.8333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="320.0000" y="366.0000" width="250.0000" height="12.0000">
-			</bounds>
+			<bounds x="320.0000" y="366.0000" width="250.0000" height="12.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="330.4167" y="366.5000" width="229.1667" height="11.0000">
-			</bounds>
+			<bounds x="330.4167" y="366.5000" width="229.1667" height="11.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.8333" y="367.0000" width="208.3333" height="10.0000">
-			</bounds>
+			<bounds x="340.8333" y="367.0000" width="208.3333" height="10.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="351.2500" y="367.5000" width="187.5000" height="9.0000">
-			</bounds>
+			<bounds x="351.2500" y="367.5000" width="187.5000" height="9.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="361.6667" y="368.0000" width="166.6667" height="8.0000">
-			</bounds>
+			<bounds x="361.6667" y="368.0000" width="166.6667" height="8.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="372.0833" y="368.5000" width="145.8333" height="7.0000">
-			</bounds>
+			<bounds x="372.0833" y="368.5000" width="145.8333" height="7.0000"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="320" y="318" width="250" height="60">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="320" y="318" width="250" height="60"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1_border" state="0">
-			<bounds x="233" y="30" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="30" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp228" element="lamp_228_1" state="0">
-			<bounds x="235" y="32" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="32" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1_border" state="0">
-			<bounds x="233" y="1" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="1" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp229" element="lamp_229_1" state="0">
-			<bounds x="235" y="3" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="3" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1_border" state="0">
-			<bounds x="181" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="181" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp232" element="lamp_232_1" state="0">
-			<bounds x="183" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="183" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1_border" state="0">
-			<bounds x="129" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="129" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp233" element="lamp_233_1" state="0">
-			<bounds x="131" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="131" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1_border" state="0">
-			<bounds x="129" y="30" width="52" height="29">
-			</bounds>
+			<bounds x="129" y="30" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp234" element="lamp_234_1" state="0">
-			<bounds x="131" y="32" width="48" height="25">
-			</bounds>
+			<bounds x="131" y="32" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1_border" state="0">
-			<bounds x="129" y="1" width="52" height="29">
-			</bounds>
+			<bounds x="129" y="1" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp235" element="lamp_235_1" state="0">
-			<bounds x="131" y="3" width="48" height="25">
-			</bounds>
+			<bounds x="131" y="3" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1_border" state="0">
-			<bounds x="181" y="30" width="52" height="29">
-			</bounds>
+			<bounds x="181" y="30" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp231" element="lamp_231_1" state="0">
-			<bounds x="183" y="32" width="48" height="25">
-			</bounds>
+			<bounds x="183" y="32" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1_border" state="0">
-			<bounds x="181" y="1" width="52" height="29">
-			</bounds>
+			<bounds x="181" y="1" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp230" element="lamp_230_1" state="0">
-			<bounds x="183" y="3" width="48" height="25">
-			</bounds>
+			<bounds x="183" y="3" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="38" y="438" width="62" height="27">
-			</bounds>
+			<bounds x="38" y="438" width="62" height="27"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="40" y="440" width="58" height="23">
-			</bounds>
+			<bounds x="40" y="440" width="58" height="23"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1_border" state="0">
-			<bounds x="3" y="1" width="122" height="37">
-			</bounds>
+			<bounds x="3" y="1" width="122" height="37"/>
 		</backdrop>
 		<backdrop name="lamp237" element="lamp_237_1" state="0">
-			<bounds x="5" y="3" width="118" height="33">
-			</bounds>
+			<bounds x="5" y="3" width="118" height="33"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1_border" state="0">
-			<bounds x="3" y="40" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="40" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="lamp_240_1" state="0">
-			<bounds x="5" y="42" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="42" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1_border" state="0">
-			<bounds x="3" y="72" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="72" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="lamp_241_1" state="0">
-			<bounds x="5" y="74" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="74" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1_border" state="0">
-			<bounds x="3" y="104" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="104" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="lamp_242_1" state="0">
-			<bounds x="5" y="106" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="106" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1_border" state="0">
-			<bounds x="3" y="136" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="136" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="lamp_243_1" state="0">
-			<bounds x="5" y="138" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="138" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1_border" state="0">
-			<bounds x="3" y="168" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="168" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="lamp_244_1" state="0">
-			<bounds x="5" y="170" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="170" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1_border" state="0">
-			<bounds x="3" y="200" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="200" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="lamp_245_1" state="0">
-			<bounds x="5" y="202" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="202" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1_border" state="0">
-			<bounds x="3" y="232" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="232" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="lamp_246_1" state="0">
-			<bounds x="5" y="234" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="234" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1_border" state="0">
-			<bounds x="3" y="264" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="264" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="lamp_247_1" state="0">
-			<bounds x="5" y="266" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="266" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1_border" state="0">
-			<bounds x="3" y="296" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="296" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="lamp_248_1" state="0">
-			<bounds x="5" y="298" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="298" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1_border" state="0">
-			<bounds x="233" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp227" element="lamp_227_1" state="0">
-			<bounds x="235" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1_border" state="0">
-			<bounds x="648" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="648" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp153" element="lamp_153_1" state="0">
-			<bounds x="650" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="650" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1_border" state="0">
-			<bounds x="648" y="30" width="52" height="29">
-			</bounds>
+			<bounds x="648" y="30" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp156" element="lamp_156_1" state="0">
-			<bounds x="650" y="32" width="48" height="25">
-			</bounds>
+			<bounds x="650" y="32" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1_border" state="0">
-			<bounds x="700" y="30" width="52" height="29">
-			</bounds>
+			<bounds x="700" y="30" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp157" element="lamp_157_1" state="0">
-			<bounds x="702" y="32" width="48" height="25">
-			</bounds>
+			<bounds x="702" y="32" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1_border" state="0">
-			<bounds x="700" y="1" width="52" height="29">
-			</bounds>
+			<bounds x="700" y="1" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp160" element="lamp_160_1" state="0">
-			<bounds x="702" y="3" width="48" height="25">
-			</bounds>
+			<bounds x="702" y="3" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1_border" state="0">
-			<bounds x="648" y="1" width="52" height="29">
-			</bounds>
+			<bounds x="648" y="1" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp161" element="lamp_161_1" state="0">
-			<bounds x="650" y="3" width="48" height="25">
-			</bounds>
+			<bounds x="650" y="3" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1_border" state="0">
-			<bounds x="700" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="700" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp151" element="lamp_151_1" state="0">
-			<bounds x="702" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="702" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1_border" state="0">
-			<bounds x="348" y="39" width="172" height="19">
-			</bounds>
+			<bounds x="348" y="39" width="172" height="19"/>
 		</backdrop>
 		<backdrop name="lamp188" element="lamp_188_1" state="0">
-			<bounds x="350" y="41" width="168" height="15">
-			</bounds>
+			<bounds x="350" y="41" width="168" height="15"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1_border" state="0">
-			<bounds x="648" y="320" width="52" height="29">
-			</bounds>
+			<bounds x="648" y="320" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp133" element="lamp_133_1" state="0">
-			<bounds x="650" y="322" width="48" height="25">
-			</bounds>
+			<bounds x="650" y="322" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1_border" state="0">
-			<bounds x="649" y="291" width="52" height="29">
-			</bounds>
+			<bounds x="649" y="291" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp131" element="lamp_131_1" state="0">
-			<bounds x="651" y="293" width="48" height="25">
-			</bounds>
+			<bounds x="651" y="293" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1_border" state="0">
-			<bounds x="701" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="701" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp129" element="lamp_129_1" state="0">
-			<bounds x="703" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="703" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1_border" state="0">
-			<bounds x="649" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="649" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp128" element="lamp_128_1" state="0">
-			<bounds x="651" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="651" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1_border" state="0">
-			<bounds x="233" y="88" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="88" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp226" element="lamp_226_1" state="0">
-			<bounds x="235" y="90" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="90" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1_border" state="0">
-			<bounds x="233" y="117" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="117" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp225" element="lamp_225_1" state="0">
-			<bounds x="235" y="119" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="119" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1_border" state="0">
-			<bounds x="233" y="146" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="146" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp224" element="lamp_224_1" state="0">
-			<bounds x="235" y="148" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="148" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1_border" state="0">
-			<bounds x="233" y="175" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="175" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp221" element="lamp_221_1" state="0">
-			<bounds x="235" y="177" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="177" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1_border" state="0">
-			<bounds x="233" y="204" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="204" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp220" element="lamp_220_1" state="0">
-			<bounds x="235" y="206" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="206" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1_border" state="0">
-			<bounds x="233" y="233" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="233" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp219" element="lamp_219_1" state="0">
-			<bounds x="235" y="235" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="235" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1_border" state="0">
-			<bounds x="233" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp218" element="lamp_218_1" state="0">
-			<bounds x="235" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1_border" state="0">
-			<bounds x="181" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="181" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp216" element="lamp_216_1" state="0">
-			<bounds x="183" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="183" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1_border" state="0">
-			<bounds x="129" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="129" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp210" element="lamp_210_1" state="0">
-			<bounds x="131" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="131" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1_border" state="0">
-			<bounds x="493" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="493" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp201" element="lamp_201_1" state="0">
-			<bounds x="495" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="495" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1_border" state="0">
-			<bounds x="441" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="441" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp202" element="lamp_202_1" state="0">
-			<bounds x="443" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="443" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1_border" state="0">
-			<bounds x="389" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="389" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp203" element="lamp_203_1" state="0">
-			<bounds x="391" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="391" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1_border" state="0">
-			<bounds x="337" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="337" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp204" element="lamp_204_1" state="0">
-			<bounds x="339" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="339" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1_border" state="0">
-			<bounds x="285" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="285" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp205" element="lamp_205_1" state="0">
-			<bounds x="287" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="287" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1_border" state="0">
-			<bounds x="545" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="545" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp199" element="lamp_199_1" state="0">
-			<bounds x="547" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="547" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1_border" state="0">
-			<bounds x="389" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="389" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp171" element="lamp_171_1" state="0">
-			<bounds x="391" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="391" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1_border" state="0">
-			<bounds x="441" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="441" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp172" element="lamp_172_1" state="0">
-			<bounds x="443" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="443" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1_border" state="0">
-			<bounds x="493" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="493" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp173" element="lamp_173_1" state="0">
-			<bounds x="495" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="495" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1_border" state="0">
-			<bounds x="545" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="545" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp174" element="lamp_174_1" state="0">
-			<bounds x="547" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="547" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1_border" state="0">
-			<bounds x="337" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="337" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp170" element="lamp_170_1" state="0">
-			<bounds x="339" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="339" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1_border" state="0">
-			<bounds x="285" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="285" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp169" element="lamp_169_1" state="0">
-			<bounds x="287" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="287" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1_border" state="0">
-			<bounds x="596" y="1" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="1" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp162" element="lamp_162_1" state="0">
-			<bounds x="598" y="3" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="3" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1_border" state="0">
-			<bounds x="596" y="30" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="30" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp155" element="lamp_155_1" state="0">
-			<bounds x="598" y="32" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="32" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1_border" state="0">
-			<bounds x="596" y="59" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="59" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp154" element="lamp_154_1" state="0">
-			<bounds x="598" y="61" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="61" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1_border" state="0">
-			<bounds x="596" y="320" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="320" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp134" element="lamp_134_1" state="0">
-			<bounds x="598" y="322" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="322" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1_border" state="0">
-			<bounds x="596" y="291" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="291" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp137" element="lamp_137_1" state="0">
-			<bounds x="598" y="293" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="293" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1_border" state="0">
-			<bounds x="596" y="88" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="88" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp147" element="lamp_147_1" state="0">
-			<bounds x="598" y="90" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="90" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1_border" state="0">
-			<bounds x="596" y="117" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="117" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp146" element="lamp_146_1" state="0">
-			<bounds x="598" y="119" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="119" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1_border" state="0">
-			<bounds x="596" y="146" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="146" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp145" element="lamp_145_1" state="0">
-			<bounds x="598" y="148" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="148" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1_border" state="0">
-			<bounds x="596" y="175" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="175" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp144" element="lamp_144_1" state="0">
-			<bounds x="598" y="177" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="177" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1_border" state="0">
-			<bounds x="596" y="204" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="204" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp140" element="lamp_140_1" state="0">
-			<bounds x="598" y="206" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="206" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1_border" state="0">
-			<bounds x="596" y="233" width="52" height="29">
-			</bounds>
+			<bounds x="596" y="233" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp139" element="lamp_139_1" state="0">
-			<bounds x="598" y="235" width="48" height="25">
-			</bounds>
+			<bounds x="598" y="235" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1_border" state="0">
-			<bounds x="597" y="262" width="52" height="29">
-			</bounds>
+			<bounds x="597" y="262" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp138" element="lamp_138_1" state="0">
-			<bounds x="599" y="264" width="48" height="25">
-			</bounds>
+			<bounds x="599" y="264" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1_border" state="0">
-			<bounds x="701" y="291" width="52" height="29">
-			</bounds>
+			<bounds x="701" y="291" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp130" element="lamp_130_1" state="0">
-			<bounds x="703" y="293" width="48" height="25">
-			</bounds>
+			<bounds x="703" y="293" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1_border" state="0">
-			<bounds x="700" y="320" width="52" height="29">
-			</bounds>
+			<bounds x="700" y="320" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp132" element="lamp_132_1" state="0">
-			<bounds x="702" y="322" width="48" height="25">
-			</bounds>
+			<bounds x="702" y="322" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1_border" state="0">
-			<bounds x="776" y="29" width="122" height="47">
-			</bounds>
+			<bounds x="776" y="29" width="122" height="47"/>
 		</backdrop>
 		<backdrop name="lamp124" element="lamp_124_1" state="0">
-			<bounds x="778" y="31" width="118" height="43">
-			</bounds>
+			<bounds x="778" y="31" width="118" height="43"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1_border" state="0">
-			<bounds x="776" y="76" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="76" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp120" element="lamp_120_1" state="0">
-			<bounds x="778" y="78" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="78" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1_border" state="0">
-			<bounds x="776" y="103" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="103" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp119" element="lamp_119_1" state="0">
-			<bounds x="778" y="105" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="105" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1_border" state="0">
-			<bounds x="776" y="130" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="130" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp116" element="lamp_116_1" state="0">
-			<bounds x="778" y="132" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="132" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1_border" state="0">
-			<bounds x="776" y="157" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="157" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp115" element="lamp_115_1" state="0">
-			<bounds x="778" y="159" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="159" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1_border" state="0">
-			<bounds x="776" y="184" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="184" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp112" element="lamp_112_1" state="0">
-			<bounds x="778" y="186" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="186" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1_border" state="0">
-			<bounds x="776" y="211" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="211" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp109" element="lamp_109_1" state="0">
-			<bounds x="778" y="213" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="213" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1_border" state="0">
-			<bounds x="776" y="238" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="238" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp106" element="lamp_106_1" state="0">
-			<bounds x="778" y="240" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="240" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1_border" state="0">
-			<bounds x="776" y="265" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="265" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp105" element="lamp_105_1" state="0">
-			<bounds x="778" y="267" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="267" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1_border" state="0">
-			<bounds x="776" y="292" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="292" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp102" element="lamp_102_1" state="0">
-			<bounds x="778" y="294" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="294" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1_border" state="0">
-			<bounds x="776" y="319" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="319" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp101" element="lamp_101_1" state="0">
-			<bounds x="778" y="321" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="321" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1_border" state="0">
-			<bounds x="776" y="346" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="346" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp98" element="lamp_98_1" state="0">
-			<bounds x="778" y="348" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="348" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1_border" state="0">
-			<bounds x="776" y="373" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="373" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp27" element="lamp_27_1" state="0">
-			<bounds x="778" y="375" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="375" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1_border" state="0">
-			<bounds x="776" y="427" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="427" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp23" element="lamp_23_1" state="0">
-			<bounds x="778" y="429" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="429" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="776" y="454" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="454" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="778" y="456" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="456" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1_border" state="0">
-			<bounds x="776" y="481" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="481" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp19" element="lamp_19_1" state="0">
-			<bounds x="778" y="483" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="483" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1_border" state="0">
-			<bounds x="776" y="508" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="508" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp16" element="lamp_16_1" state="0">
-			<bounds x="778" y="510" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="510" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1_border" state="0">
-			<bounds x="776" y="535" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="535" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp13" element="lamp_13_1" state="0">
-			<bounds x="778" y="537" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="537" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1_border" state="0">
-			<bounds x="776" y="562" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="562" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp10" element="lamp_10_1" state="0">
-			<bounds x="778" y="564" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="564" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1_border" state="0">
-			<bounds x="776" y="589" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="589" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp9" element="lamp_9_1" state="0">
-			<bounds x="778" y="591" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="591" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1_border" state="0">
-			<bounds x="3" y="392" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="392" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="lamp_251_1" state="0">
-			<bounds x="5" y="394" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="394" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1_border" state="0">
-			<bounds x="3" y="360" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="360" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="lamp_250_1" state="0">
-			<bounds x="5" y="362" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="362" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1_border" state="0">
-			<bounds x="3" y="328" width="122" height="30">
-			</bounds>
+			<bounds x="3" y="328" width="122" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="lamp_249_1" state="0">
-			<bounds x="5" y="330" width="118" height="26">
-			</bounds>
+			<bounds x="5" y="330" width="118" height="26"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1_border" state="0">
-			<bounds x="218" y="610" width="42" height="17">
-			</bounds>
+			<bounds x="218" y="610" width="42" height="17"/>
 		</backdrop>
 		<backdrop name="lamp58" element="lamp_58_1" state="0">
-			<bounds x="220" y="612" width="38" height="13">
-			</bounds>
+			<bounds x="220" y="612" width="38" height="13"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1_border" state="0">
-			<bounds x="99" y="539" width="52" height="29">
-			</bounds>
+			<bounds x="99" y="539" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp66" element="lamp_66_1" state="0">
-			<bounds x="101" y="541" width="48" height="25">
-			</bounds>
+			<bounds x="101" y="541" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1_border" state="0">
-			<bounds x="286" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="286" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="lamp_68_1" state="0">
-			<bounds x="288" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="288" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1_border" state="0">
-			<bounds x="286" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="286" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="lamp_67_1" state="0">
-			<bounds x="288" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="288" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1_border" state="0">
-			<bounds x="313" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="313" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp70" element="lamp_70_1" state="0">
-			<bounds x="315" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="315" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1_border" state="0">
-			<bounds x="313" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="313" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp71" element="lamp_71_1" state="0">
-			<bounds x="315" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="315" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1_border" state="0">
-			<bounds x="340" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="340" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="lamp_73_1" state="0">
-			<bounds x="342" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="342" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1_border" state="0">
-			<bounds x="340" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="340" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="lamp_72_1" state="0">
-			<bounds x="342" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="342" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1_border" state="0">
-			<bounds x="394" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="394" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="lamp_78_1" state="0">
-			<bounds x="396" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="396" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1_border" state="0">
-			<bounds x="394" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="394" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="lamp_77_1" state="0">
-			<bounds x="396" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="396" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1_border" state="0">
-			<bounds x="421" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="421" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp80" element="lamp_80_1" state="0">
-			<bounds x="423" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="423" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1_border" state="0">
-			<bounds x="421" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="421" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp81" element="lamp_81_1" state="0">
-			<bounds x="423" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="423" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1_border" state="0">
-			<bounds x="448" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="448" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="lamp_83_1" state="0">
-			<bounds x="450" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="450" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1_border" state="0">
-			<bounds x="448" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="448" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="lamp_82_1" state="0">
-			<bounds x="450" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="450" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1_border" state="0">
-			<bounds x="475" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="475" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp85" element="lamp_85_1" state="0">
-			<bounds x="477" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="477" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1_border" state="0">
-			<bounds x="475" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="475" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp86" element="lamp_86_1" state="0">
-			<bounds x="477" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="477" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1_border" state="0">
-			<bounds x="502" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="502" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="lamp_88_1" state="0">
-			<bounds x="504" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="504" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1_border" state="0">
-			<bounds x="502" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="502" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="lamp_87_1" state="0">
-			<bounds x="504" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="504" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1_border" state="0">
-			<bounds x="529" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="529" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp90" element="lamp_90_1" state="0">
-			<bounds x="531" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="531" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1_border" state="0">
-			<bounds x="529" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="529" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp91" element="lamp_91_1" state="0">
-			<bounds x="531" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="531" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1_border" state="0">
-			<bounds x="556" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="556" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="lamp_93_1" state="0">
-			<bounds x="558" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="558" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1_border" state="0">
-			<bounds x="556" y="406" width="27" height="30">
-			</bounds>
+			<bounds x="556" y="406" width="27" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="lamp_92_1" state="0">
-			<bounds x="558" y="408" width="23" height="26">
-			</bounds>
+			<bounds x="558" y="408" width="23" height="26"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1_border" state="0">
-			<bounds x="583" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="583" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp96" element="lamp_96_1" state="0">
-			<bounds x="585" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="585" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1_border" state="0">
-			<bounds x="583" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="583" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp97" element="lamp_97_1" state="0">
-			<bounds x="585" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="585" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1_border" state="0">
-			<bounds x="367" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="367" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp75" element="lamp_75_1" state="0">
-			<bounds x="369" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="369" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1_border" state="0">
-			<bounds x="367" y="409" width="27" height="27">
-			</bounds>
+			<bounds x="367" y="409" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp76" element="lamp_76_1" state="0">
-			<bounds x="369" y="411" width="23" height="23">
-			</bounds>
+			<bounds x="369" y="411" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1_border" state="0">
-			<bounds x="287" y="616" width="137" height="25">
-			</bounds>
+			<bounds x="287" y="616" width="137" height="25"/>
 		</backdrop>
 		<backdrop name="lamp57" element="lamp_57_1" state="0">
-			<bounds x="289" y="618" width="133" height="21">
-			</bounds>
+			<bounds x="289" y="618" width="133" height="21"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1_border" state="0">
-			<bounds x="424" y="615" width="52" height="27">
-			</bounds>
+			<bounds x="424" y="615" width="52" height="27"/>
 		</backdrop>
 		<backdrop name="lamp55" element="lamp_55_1" state="0">
-			<bounds x="426" y="617" width="48" height="23">
-			</bounds>
+			<bounds x="426" y="617" width="48" height="23"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="476" y="616" width="137" height="25">
-			</bounds>
+			<bounds x="476" y="616" width="137" height="25"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="478" y="618" width="133" height="21">
-			</bounds>
+			<bounds x="478" y="618" width="133" height="21"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1_border" state="0">
-			<bounds x="170" y="487" width="42" height="27">
-			</bounds>
+			<bounds x="170" y="487" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp64" element="lamp_64_1" state="0">
-			<bounds x="172" y="489" width="38" height="23">
-			</bounds>
+			<bounds x="172" y="489" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1_border" state="0">
-			<bounds x="187" y="516" width="42" height="27">
-			</bounds>
+			<bounds x="187" y="516" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp61" element="lamp_61_1" state="0">
-			<bounds x="189" y="518" width="38" height="23">
-			</bounds>
+			<bounds x="189" y="518" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1_border" state="0">
-			<bounds x="196" y="548" width="42" height="27">
-			</bounds>
+			<bounds x="196" y="548" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp60" element="lamp_60_1" state="0">
-			<bounds x="198" y="550" width="38" height="23">
-			</bounds>
+			<bounds x="198" y="550" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1_border" state="0">
-			<bounds x="206" y="579" width="42" height="27">
-			</bounds>
+			<bounds x="206" y="579" width="42" height="27"/>
 		</backdrop>
 		<backdrop name="lamp59" element="lamp_59_1" state="0">
-			<bounds x="208" y="581" width="38" height="23">
-			</bounds>
+			<bounds x="208" y="581" width="38" height="23"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1_border" state="0">
-			<bounds x="776" y="400" width="122" height="27">
-			</bounds>
+			<bounds x="776" y="400" width="122" height="27"/>
 		</backdrop>
 		<backdrop name="lamp24" element="lamp_24_1" state="0">
-			<bounds x="778" y="402" width="118" height="23">
-			</bounds>
+			<bounds x="778" y="402" width="118" height="23"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1_border" state="0">
-			<bounds x="129" y="320" width="52" height="29">
-			</bounds>
+			<bounds x="129" y="320" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp212" element="lamp_212_1" state="0">
-			<bounds x="131" y="322" width="48" height="25">
-			</bounds>
+			<bounds x="131" y="322" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1_border" state="0">
-			<bounds x="181" y="320" width="52" height="29">
-			</bounds>
+			<bounds x="181" y="320" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp213" element="lamp_213_1" state="0">
-			<bounds x="183" y="322" width="48" height="25">
-			</bounds>
+			<bounds x="183" y="322" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1_border" state="0">
-			<bounds x="233" y="320" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="320" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp214" element="lamp_214_1" state="0">
-			<bounds x="235" y="322" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="322" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1_border" state="0">
-			<bounds x="181" y="291" width="52" height="29">
-			</bounds>
+			<bounds x="181" y="291" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp215" element="lamp_215_1" state="0">
-			<bounds x="183" y="293" width="48" height="25">
-			</bounds>
+			<bounds x="183" y="293" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1_border" state="0">
-			<bounds x="233" y="291" width="52" height="29">
-			</bounds>
+			<bounds x="233" y="291" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp217" element="lamp_217_1" state="0">
-			<bounds x="235" y="293" width="48" height="25">
-			</bounds>
+			<bounds x="235" y="293" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1_border" state="0">
-			<bounds x="129" y="291" width="52" height="29">
-			</bounds>
+			<bounds x="129" y="291" width="52" height="29"/>
 		</backdrop>
 		<backdrop name="lamp211" element="lamp_211_1" state="0">
-			<bounds x="131" y="293" width="48" height="25">
-			</bounds>
+			<bounds x="131" y="293" width="48" height="25"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1_border" state="0">
-			<bounds x="377" y="223" width="52" height="32">
-			</bounds>
+			<bounds x="377" y="223" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp196" element="lamp_196_1" state="0">
-			<bounds x="379" y="225" width="48" height="28">
-			</bounds>
+			<bounds x="379" y="225" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1_border" state="0">
-			<bounds x="456" y="223" width="52" height="32">
-			</bounds>
+			<bounds x="456" y="223" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp197" element="lamp_197_1" state="0">
-			<bounds x="458" y="225" width="48" height="28">
-			</bounds>
+			<bounds x="458" y="225" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1_border" state="0">
-			<bounds x="298" y="159" width="52" height="32">
-			</bounds>
+			<bounds x="298" y="159" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp194" element="lamp_194_1" state="0">
-			<bounds x="300" y="161" width="48" height="28">
-			</bounds>
+			<bounds x="300" y="161" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1_border" state="0">
-			<bounds x="298" y="223" width="52" height="32">
-			</bounds>
+			<bounds x="298" y="223" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp195" element="lamp_195_1" state="0">
-			<bounds x="300" y="225" width="48" height="28">
-			</bounds>
+			<bounds x="300" y="225" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1_border" state="0">
-			<bounds x="535" y="159" width="52" height="32">
-			</bounds>
+			<bounds x="535" y="159" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp178" element="lamp_178_1" state="0">
-			<bounds x="537" y="161" width="48" height="28">
-			</bounds>
+			<bounds x="537" y="161" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1_border" state="0">
-			<bounds x="535" y="223" width="52" height="32">
-			</bounds>
+			<bounds x="535" y="223" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp198" element="lamp_198_1" state="0">
-			<bounds x="537" y="225" width="48" height="28">
-			</bounds>
+			<bounds x="537" y="225" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1_border" state="0">
-			<bounds x="349" y="126" width="27" height="27">
-			</bounds>
+			<bounds x="349" y="126" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp187" element="lamp_187_1" state="0">
-			<bounds x="351" y="128" width="23" height="23">
-			</bounds>
+			<bounds x="351" y="128" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1_border" state="0">
-			<bounds x="510" y="126" width="27" height="27">
-			</bounds>
+			<bounds x="510" y="126" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp179" element="lamp_179_1" state="0">
-			<bounds x="512" y="128" width="23" height="23">
-			</bounds>
+			<bounds x="512" y="128" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1_border" state="0">
-			<bounds x="467" y="126" width="27" height="27">
-			</bounds>
+			<bounds x="467" y="126" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp189" element="lamp_189_1" state="0">
-			<bounds x="469" y="128" width="23" height="23">
-			</bounds>
+			<bounds x="469" y="128" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1_border" state="0">
-			<bounds x="390" y="126" width="27" height="27">
-			</bounds>
+			<bounds x="390" y="126" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp190" element="lamp_190_1" state="0">
-			<bounds x="392" y="128" width="23" height="23">
-			</bounds>
+			<bounds x="392" y="128" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1_border" state="0">
-			<bounds x="377" y="95" width="52" height="32">
-			</bounds>
+			<bounds x="377" y="95" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp192" element="lamp_192_1" state="0">
-			<bounds x="379" y="97" width="48" height="28">
-			</bounds>
+			<bounds x="379" y="97" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1_border" state="0">
-			<bounds x="456" y="95" width="52" height="32">
-			</bounds>
+			<bounds x="456" y="95" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp176" element="lamp_176_1" state="0">
-			<bounds x="458" y="97" width="48" height="28">
-			</bounds>
+			<bounds x="458" y="97" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1_border" state="0">
-			<bounds x="298" y="95" width="52" height="32">
-			</bounds>
+			<bounds x="298" y="95" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp193" element="lamp_193_1" state="0">
-			<bounds x="300" y="97" width="48" height="28">
-			</bounds>
+			<bounds x="300" y="97" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1_border" state="0">
-			<bounds x="535" y="95" width="52" height="32">
-			</bounds>
+			<bounds x="535" y="95" width="52" height="32"/>
 		</backdrop>
 		<backdrop name="lamp177" element="lamp_177_1" state="0">
-			<bounds x="537" y="97" width="48" height="28">
-			</bounds>
+			<bounds x="537" y="97" width="48" height="28"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1_border" state="0">
-			<bounds x="349" y="162" width="27" height="27">
-			</bounds>
+			<bounds x="349" y="162" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp186" element="lamp_186_1" state="0">
-			<bounds x="351" y="164" width="23" height="23">
-			</bounds>
+			<bounds x="351" y="164" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1_border" state="0">
-			<bounds x="349" y="196" width="27" height="27">
-			</bounds>
+			<bounds x="349" y="196" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp185" element="lamp_185_1" state="0">
-			<bounds x="351" y="198" width="23" height="23">
-			</bounds>
+			<bounds x="351" y="198" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1_border" state="0">
-			<bounds x="509" y="196" width="27" height="27">
-			</bounds>
+			<bounds x="509" y="196" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp181" element="lamp_181_1" state="0">
-			<bounds x="511" y="198" width="23" height="23">
-			</bounds>
+			<bounds x="511" y="198" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1_border" state="0">
-			<bounds x="509" y="162" width="27" height="27">
-			</bounds>
+			<bounds x="509" y="162" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp180" element="lamp_180_1" state="0">
-			<bounds x="511" y="164" width="23" height="23">
-			</bounds>
+			<bounds x="511" y="164" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1_border" state="0">
-			<bounds x="390" y="197" width="27" height="27">
-			</bounds>
+			<bounds x="390" y="197" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp183" element="lamp_183_1" state="0">
-			<bounds x="392" y="199" width="23" height="23">
-			</bounds>
+			<bounds x="392" y="199" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1_border" state="0">
-			<bounds x="470" y="197" width="27" height="27">
-			</bounds>
+			<bounds x="470" y="197" width="27" height="27"/>
 		</backdrop>
 		<backdrop name="lamp182" element="lamp_182_1" state="0">
-			<bounds x="472" y="199" width="23" height="23">
-			</bounds>
+			<bounds x="472" y="199" width="23" height="23"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_181_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="799" y="1" width="75" height="27">
-			</bounds>
+			<bounds x="799" y="1" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp39" element="colour_button_181" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="801" y="3" width="71" height="23">
-			</bounds>
+			<bounds x="801" y="3" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp65" element="colour_button_182_border" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="32" y="465" width="75" height="27">
-			</bounds>
+			<bounds x="32" y="465" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp65" element="colour_button_182" state="0" inputtag="IN-9" inputmask="0x01">
-			<bounds x="34" y="467" width="71" height="23">
-			</bounds>
+			<bounds x="34" y="467" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp208" element="colour_button_183_border" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="319" y="294" width="62" height="22">
-			</bounds>
+			<bounds x="319" y="294" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp208" element="colour_button_183" state="0" inputtag="IN-8" inputmask="0x01">
-			<bounds x="321" y="296" width="58" height="18">
-			</bounds>
+			<bounds x="321" y="296" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp84" element="colour_button_184_border" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="510" y="379" width="62" height="22">
-			</bounds>
+			<bounds x="510" y="379" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp84" element="colour_button_184" state="0" inputtag="IN-8" inputmask="0x08">
-			<bounds x="512" y="381" width="58" height="18">
-			</bounds>
+			<bounds x="512" y="381" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp135" element="colour_button_185_border" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="510" y="295" width="62" height="22">
-			</bounds>
+			<bounds x="510" y="295" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp135" element="colour_button_185" state="0" inputtag="IN-8" inputmask="0x02">
-			<bounds x="512" y="297" width="58" height="18">
-			</bounds>
+			<bounds x="512" y="297" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp69" element="colour_button_186_border" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="318" y="379" width="62" height="22">
-			</bounds>
+			<bounds x="318" y="379" width="62" height="22"/>
 		</backdrop>
 		<backdrop name="lamp69" element="colour_button_186" state="0" inputtag="IN-8" inputmask="0x10">
-			<bounds x="320" y="381" width="58" height="18">
-			</bounds>
+			<bounds x="320" y="381" width="58" height="18"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_188_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="538" y="648" width="75" height="27">
-			</bounds>
+			<bounds x="538" y="648" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_188" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="540" y="650" width="71" height="23">
-			</bounds>
+			<bounds x="540" y="650" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_189_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="456" y="648" width="75" height="27">
-			</bounds>
+			<bounds x="456" y="648" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_189" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="458" y="650" width="71" height="23">
-			</bounds>
+			<bounds x="458" y="650" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_190_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="370" y="648" width="75" height="27">
-			</bounds>
+			<bounds x="370" y="648" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_190" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="372" y="650" width="71" height="23">
-			</bounds>
+			<bounds x="372" y="650" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_191_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="282" y="648" width="75" height="27">
-			</bounds>
+			<bounds x="282" y="648" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_191" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="284" y="650" width="71" height="23">
-			</bounds>
+			<bounds x="284" y="650" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_192_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="184" y="648" width="75" height="27">
-			</bounds>
+			<bounds x="184" y="648" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_192" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="186" y="650" width="71" height="23">
-			</bounds>
+			<bounds x="186" y="650" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp89" element="colour_button_193_border" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="641" y="358" width="75" height="27">
-			</bounds>
+			<bounds x="641" y="358" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp89" element="colour_button_193" state="0" inputtag="IN-8" inputmask="0x04">
-			<bounds x="643" y="360" width="71" height="23">
-			</bounds>
+			<bounds x="643" y="360" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_194_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="649" y="648" width="79" height="27">
-			</bounds>
+			<bounds x="649" y="648" width="79" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_194" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="651" y="650" width="75" height="23">
-			</bounds>
+			<bounds x="651" y="650" width="75" height="23"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_195_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="755" y="648" width="75" height="27">
-			</bounds>
+			<bounds x="755" y="648" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_195" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="757" y="650" width="71" height="23">
-			</bounds>
+			<bounds x="757" y="650" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_196_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="847" y="648" width="75" height="27">
-			</bounds>
+			<bounds x="847" y="648" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_196" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="849" y="650" width="71" height="23">
-			</bounds>
+			<bounds x="849" y="650" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="680" y="387" width="24" height="32">
-			</bounds>
+			<bounds x="680" y="387" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit0" element="led_digit_red">
-			<bounds x="680" y="387" width="24" height="32">
-			</bounds>
+			<bounds x="680" y="387" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="680" y="387" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="680" y="387" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="656" y="387" width="24" height="32">
-			</bounds>
+			<bounds x="656" y="387" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit2" element="led_digit_red">
-			<bounds x="656" y="387" width="24" height="32">
-			</bounds>
+			<bounds x="656" y="387" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="656" y="387" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="656" y="387" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="289" y="441" width="323" height="27">
-			</bounds>
+			<bounds x="289" y="441" width="323" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="289" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="289" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="309" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="309" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="329" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="329" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="349" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="349" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="369" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="369" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="389" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="389" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="409" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="409" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="429" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="429" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="449" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="449" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="469" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="469" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="489" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="489" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="509" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="509" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="529" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="529" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="549" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="549" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="569" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="569" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="589" y="441" width="20" height="27">
-			</bounds>
+			<bounds x="589" y="441" width="20" height="27"/>
 		</backdrop>
 		<backdrop name="label153" element="label_153">
-			<bounds x="668" y="430" width="42" height="28">
-			</bounds>
+			<bounds x="668" y="430" width="42" height="28"/>
 		</backdrop>
 		<backdrop name="label154" element="label_154">
-			<bounds x="648" y="493" width="72" height="28">
-			</bounds>
+			<bounds x="648" y="493" width="72" height="28"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_button" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_button" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_button" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_button" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_button" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_button" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_reel" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_button" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_standard" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_standard" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_standard" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_standard" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_standard" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="312.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="312.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="314.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="314.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="316.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="316.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="318.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="318.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="320.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="320.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp136" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="322.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="322.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="360.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="360.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="362.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="362.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="364.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="364.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="366.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="366.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="368.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="368.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="370.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="370.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="408.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="408.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="410.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="410.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="412.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="412.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="414.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="414.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="416.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="416.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp168" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="418.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="418.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="456.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="456.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="458.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="458.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="460.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="460.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="462.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="462.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="464.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="464.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="466.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="466.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="504.0000" width="120.0000" height="48.0000">
-			</bounds>
+			<bounds x="1100.0000" y="504.0000" width="120.0000" height="48.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="506.0000" width="110.0000" height="44.0000">
-			</bounds>
+			<bounds x="1105.0000" y="506.0000" width="110.0000" height="44.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="508.0000" width="100.0000" height="40.0000">
-			</bounds>
+			<bounds x="1110.0000" y="508.0000" width="100.0000" height="40.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="510.0000" width="90.0000" height="36.0000">
-			</bounds>
+			<bounds x="1115.0000" y="510.0000" width="90.0000" height="36.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="512.0000" width="80.0000" height="32.0000">
-			</bounds>
+			<bounds x="1120.0000" y="512.0000" width="80.0000" height="32.0000"/>
 		</backdrop>
 		<backdrop name="lamp200" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="514.0000" width="70.0000" height="28.0000">
-			</bounds>
+			<bounds x="1125.0000" y="514.0000" width="70.0000" height="28.0000"/>
 		</backdrop>
 		<backdrop name="sreel6" element="reel5" state="0">
-			<orientation rotate="90">
-			</orientation>
-			<bounds x="1100" y="312" width="120" height="240">
-			</bounds>
+			<orientation rotate="90"/>
+			<bounds x="1100" y="312" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel6" element="debug_stepper_value">
-			<bounds x="1100" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="552" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_5">
-			<bounds x="1180" y="552" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="552" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4fwpcs.lay
+++ b/src/mame/layout/sc4fwpcs.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_157_1_border" defstate="0">
 		<rect state="1">
@@ -2664,7 +2666,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1016" height="665"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/sc4monot.lay
+++ b/src/mame/layout/sc4monot.lay
@@ -8,6952 +8,5040 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_18_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_20_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_20_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_25_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_25_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="NUDGE">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
-		</text>
-		<text string="NOW">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="lamp_40_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
+			<color red="0.50" green="0.25" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
+			<color red="0.12" green="0.06" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_40_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
+			<color red="1.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
+			<color red="0.25" green="0.13" blue="0.00"/>
 		</rect>
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.00">
-			</color>
-		</rect>
-		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_104_2_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_104_2" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;25.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;25.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_74_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_74_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;4.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;4.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_69_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_69_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;2.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_84_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_84_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;8.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;8.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_89_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_89_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;12.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;12.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_99_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_99_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;15.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;15.">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_40_border">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="0.50">
-			</color>
+			<color red="0.00" green="0.00" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.12">
-			</color>
+			<color red="0.00" green="0.00" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_40">
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.25">
-			</color>
+			<color red="0.00" green="0.00" blue="0.25"/>
 		</rect>
 		<text string="STREAK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_41_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_41">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_42_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_42">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_43_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_43">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_44_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_44">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_45_border">
 		<rect state="1">
-			<color red="0.50" green="0.25" blue="0.13">
-			</color>
+			<color red="0.50" green="0.25" blue="0.13"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.06" blue="0.03">
-			</color>
+			<color red="0.12" green="0.06" blue="0.03"/>
 		</rect>
 	</element>
 	<element name="colour_button_45">
 		<rect state="1">
-			<color red="1.00" green="0.50" blue="0.25">
-			</color>
+			<color red="1.00" green="0.50" blue="0.25"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.13" blue="0.06">
-			</color>
+			<color red="0.25" green="0.13" blue="0.06"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_46_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_46">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_47_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.12">
-			</color>
+			<color red="0.12" green="0.12" blue="0.12"/>
 		</rect>
 	</element>
 	<element name="colour_button_47">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.25">
-			</color>
+			<color red="0.25" green="0.25" blue="0.25"/>
 		</rect>
-		<text string="">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="vfd0">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_6">
 		<text string="&#xA3;">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_11">
 		<text string="BANK">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_12">
 		<text string="CREDITS">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="656" height="678">
-			</bounds>
+			<bounds x="0" y="0" width="656" height="678"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="237" y="493" width="80" height="140">
-			</bounds>
+			<bounds x="237" y="493" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="237.0000" y="493.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="237.0000" y="493.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="240.3333" y="494.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="240.3333" y="494.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="243.6667" y="496.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="243.6667" y="496.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="247.0000" y="498.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="247.0000" y="498.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="250.3333" y="500.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="250.3333" y="500.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="253.6667" y="502.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="253.6667" y="502.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="237.0000" y="539.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="237.0000" y="539.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="240.3333" y="541.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="240.3333" y="541.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="243.6667" y="543.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="243.6667" y="543.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="247.0000" y="545.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="247.0000" y="545.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="250.3333" y="547.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="250.3333" y="547.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="253.6667" y="549.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="253.6667" y="549.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="237.0000" y="586.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="237.0000" y="586.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="240.3333" y="588.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="240.3333" y="588.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="243.6667" y="590.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="243.6667" y="590.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="247.0000" y="592.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="247.0000" y="592.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="250.3333" y="594.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="250.3333" y="594.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="253.6667" y="596.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="253.6667" y="596.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="237" y="493" width="80" height="140">
-			</bounds>
+			<bounds x="237" y="493" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="318" y="493" width="80" height="140">
-			</bounds>
+			<bounds x="318" y="493" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="493.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="318.0000" y="493.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="494.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="321.3333" y="494.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="496.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="324.6667" y="496.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="498.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="328.0000" y="498.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="500.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="331.3333" y="500.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="502.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="334.6667" y="502.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="539.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="318.0000" y="539.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="541.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="321.3333" y="541.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="543.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="324.6667" y="543.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="545.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="328.0000" y="545.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="547.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="331.3333" y="547.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="549.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="334.6667" y="549.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="318.0000" y="586.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="318.0000" y="586.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="321.3333" y="588.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="321.3333" y="588.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="324.6667" y="590.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="324.6667" y="590.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="328.0000" y="592.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="328.0000" y="592.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="331.3333" y="594.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="331.3333" y="594.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="334.6667" y="596.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="334.6667" y="596.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="318" y="493" width="80" height="140">
-			</bounds>
+			<bounds x="318" y="493" width="80" height="140"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="398" y="493" width="80" height="140">
-			</bounds>
+			<bounds x="398" y="493" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="398.0000" y="493.0000" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="398.0000" y="493.0000" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="401.3333" y="494.9445" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="401.3333" y="494.9445" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="404.6667" y="496.8889" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="404.6667" y="496.8889" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="408.0000" y="498.8333" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="408.0000" y="498.8333" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="411.3333" y="500.7778" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="411.3333" y="500.7778" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="414.6667" y="502.7222" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="414.6667" y="502.7222" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="398.0000" y="539.6667" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="398.0000" y="539.6667" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="401.3333" y="541.6111" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="401.3333" y="541.6111" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="404.6667" y="543.5556" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="404.6667" y="543.5556" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="408.0000" y="545.5000" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="408.0000" y="545.5000" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="411.3333" y="547.4445" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="411.3333" y="547.4445" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="414.6667" y="549.3889" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="414.6667" y="549.3889" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="398.0000" y="586.3333" width="80.0000" height="46.6667">
-			</bounds>
+			<bounds x="398.0000" y="586.3333" width="80.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="401.3333" y="588.2778" width="73.3333" height="42.7778">
-			</bounds>
+			<bounds x="401.3333" y="588.2778" width="73.3333" height="42.7778"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="404.6667" y="590.2222" width="66.6667" height="38.8889">
-			</bounds>
+			<bounds x="404.6667" y="590.2222" width="66.6667" height="38.8889"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="408.0000" y="592.1666" width="60.0000" height="35.0000">
-			</bounds>
+			<bounds x="408.0000" y="592.1666" width="60.0000" height="35.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="411.3333" y="594.1111" width="53.3333" height="31.1111">
-			</bounds>
+			<bounds x="411.3333" y="594.1111" width="53.3333" height="31.1111"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="414.6667" y="596.0555" width="46.6667" height="27.2222">
-			</bounds>
+			<bounds x="414.6667" y="596.0555" width="46.6667" height="27.2222"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="398" y="493" width="80" height="140">
-			</bounds>
+			<bounds x="398" y="493" width="80" height="140"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1_border" state="0">
-			<bounds x="86" y="396" width="35" height="35">
-			</bounds>
+			<bounds x="86" y="396" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp18" element="lamp_18_1" state="0">
-			<bounds x="88" y="398" width="31" height="31">
-			</bounds>
+			<bounds x="88" y="398" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1_border" state="0">
-			<bounds x="86" y="439" width="35" height="35">
-			</bounds>
+			<bounds x="86" y="439" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp20" element="lamp_20_1" state="0">
-			<bounds x="88" y="441" width="31" height="31">
-			</bounds>
+			<bounds x="88" y="441" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1_border" state="0">
-			<bounds x="81" y="518" width="47" height="34">
-			</bounds>
+			<bounds x="81" y="518" width="47" height="34"/>
 		</backdrop>
 		<backdrop name="lamp25" element="lamp_25_1" state="0">
-			<bounds x="83" y="520" width="43" height="30">
-			</bounds>
+			<bounds x="83" y="520" width="43" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1_border" state="0">
-			<bounds x="87" y="479" width="35" height="35">
-			</bounds>
+			<bounds x="87" y="479" width="35" height="35"/>
 		</backdrop>
 		<backdrop name="lamp40" element="lamp_40_1" state="0">
-			<bounds x="89" y="481" width="31" height="31">
-			</bounds>
+			<bounds x="89" y="481" width="31" height="31"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_2_border" state="0">
-			<bounds x="123" y="134" width="42" height="32">
-			</bounds>
+			<bounds x="123" y="134" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp104" element="lamp_104_2" state="0">
-			<bounds x="125" y="136" width="38" height="28">
-			</bounds>
+			<bounds x="125" y="136" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1_border" state="0">
-			<bounds x="123" y="255" width="42" height="32">
-			</bounds>
+			<bounds x="123" y="255" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp74" element="lamp_74_1" state="0">
-			<bounds x="125" y="257" width="38" height="28">
-			</bounds>
+			<bounds x="125" y="257" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1_border" state="0">
-			<bounds x="123" y="285" width="42" height="32">
-			</bounds>
+			<bounds x="123" y="285" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp69" element="lamp_69_1" state="0">
-			<bounds x="125" y="287" width="38" height="28">
-			</bounds>
+			<bounds x="125" y="287" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1_border" state="0">
-			<bounds x="123" y="225" width="42" height="32">
-			</bounds>
+			<bounds x="123" y="225" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp84" element="lamp_84_1" state="0">
-			<bounds x="125" y="227" width="38" height="28">
-			</bounds>
+			<bounds x="125" y="227" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1_border" state="0">
-			<bounds x="123" y="196" width="42" height="32">
-			</bounds>
+			<bounds x="123" y="196" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp89" element="lamp_89_1" state="0">
-			<bounds x="125" y="198" width="38" height="28">
-			</bounds>
+			<bounds x="125" y="198" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1_border" state="0">
-			<bounds x="123" y="165" width="42" height="32">
-			</bounds>
+			<bounds x="123" y="165" width="42" height="32"/>
 		</backdrop>
 		<backdrop name="lamp99" element="lamp_99_1" state="0">
-			<bounds x="125" y="167" width="38" height="28">
-			</bounds>
+			<bounds x="125" y="167" width="38" height="28"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_40_border" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="487" y="645" width="75" height="27">
-			</bounds>
+			<bounds x="487" y="645" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp5" element="colour_button_40" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="489" y="647" width="71" height="23">
-			</bounds>
+			<bounds x="489" y="647" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_41_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="62" y="646" width="75" height="27">
-			</bounds>
+			<bounds x="62" y="646" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_41" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="64" y="648" width="71" height="23">
-			</bounds>
+			<bounds x="64" y="648" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_42_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="148" y="646" width="75" height="27">
-			</bounds>
+			<bounds x="148" y="646" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_42" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="150" y="648" width="71" height="23">
-			</bounds>
+			<bounds x="150" y="648" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_43_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="236" y="646" width="75" height="27">
-			</bounds>
+			<bounds x="236" y="646" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_43" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="238" y="648" width="71" height="23">
-			</bounds>
+			<bounds x="238" y="648" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_44_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="319" y="646" width="75" height="27">
-			</bounds>
+			<bounds x="319" y="646" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_44" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="321" y="648" width="71" height="23">
-			</bounds>
+			<bounds x="321" y="648" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_45_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="402" y="645" width="75" height="27">
-			</bounds>
+			<bounds x="402" y="645" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_45" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="404" y="647" width="71" height="23">
-			</bounds>
+			<bounds x="404" y="647" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_46_border" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="576" y="645" width="75" height="27">
-			</bounds>
+			<bounds x="576" y="645" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp7" element="colour_button_46" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="578" y="647" width="71" height="23">
-			</bounds>
+			<bounds x="578" y="647" width="71" height="23"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_47_border" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="566" y="115" width="75" height="27">
-			</bounds>
+			<bounds x="566" y="115" width="75" height="27"/>
 		</backdrop>
 		<backdrop name="lamp-1" element="colour_button_47" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="568" y="117" width="71" height="23">
-			</bounds>
+			<bounds x="568" y="117" width="71" height="23"/>
 		</backdrop>
 		<backdrop element="vfd0_background">
-			<bounds x="248" y="456" width="227" height="27">
-			</bounds>
+			<bounds x="248" y="456" width="227" height="27"/>
 		</backdrop>
 		<backdrop name="vfd0" element="vfd0" state="0">
-			<bounds x="248" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="248" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd1" element="vfd0" state="0">
-			<bounds x="262" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="262" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd2" element="vfd0" state="0">
-			<bounds x="276" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="276" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd3" element="vfd0" state="0">
-			<bounds x="290" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="290" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd4" element="vfd0" state="0">
-			<bounds x="304" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="304" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd5" element="vfd0" state="0">
-			<bounds x="318" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="318" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd6" element="vfd0" state="0">
-			<bounds x="332" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="332" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd7" element="vfd0" state="0">
-			<bounds x="346" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="346" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd8" element="vfd0" state="0">
-			<bounds x="360" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="360" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd9" element="vfd0" state="0">
-			<bounds x="374" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="374" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd10" element="vfd0" state="0">
-			<bounds x="388" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="388" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd11" element="vfd0" state="0">
-			<bounds x="402" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="402" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd12" element="vfd0" state="0">
-			<bounds x="416" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="416" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd13" element="vfd0" state="0">
-			<bounds x="430" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="430" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd14" element="vfd0" state="0">
-			<bounds x="444" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="444" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="vfd15" element="vfd0" state="0">
-			<bounds x="458" y="456" width="14" height="27">
-			</bounds>
+			<bounds x="458" y="456" width="14" height="27"/>
 		</backdrop>
 		<backdrop name="label6" element="label_6">
-			<bounds x="602" y="76" width="20" height="37">
-			</bounds>
+			<bounds x="602" y="76" width="20" height="37"/>
 		</backdrop>
 		<backdrop name="label11" element="label_11">
-			<bounds x="247" y="435" width="56" height="24">
-			</bounds>
+			<bounds x="247" y="435" width="56" height="24"/>
 		</backdrop>
 		<backdrop name="label12" element="label_12">
-			<bounds x="388" y="434" width="88" height="24">
-			</bounds>
+			<bounds x="388" y="434" width="88" height="24"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_button" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_button" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_standard" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_standard" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_standard" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_standard" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_standard" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_standard" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_standard" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_segment" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_17" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp32" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp33" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp34" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp35" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp36" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp37" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4mspid.lay
+++ b/src/mame/layout/sc4mspid.lay
@@ -8,6586 +8,4924 @@
 <mamelayout version="2">
 	<element name="backdrop_colour">
 		<rect>
-			<color red="0.00" green="0.00" blue="0.00">
-			</color>
+			<color red="0.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_32_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
-		</rect>
-		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="lamp_54_1_border" defstate="0">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="lamp_54_1" defstate="0">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
-		</text>
-	</element>
-	<element name="_border" defstate="0">
-		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
-		</rect>
-	</element>
-	<element name="" defstate="0">
-		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
-		</rect>
-		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
-		</rect>
-		<text string="Nudge Now">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_81_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_81">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_82_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_82">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_83_border">
 		<rect state="1">
-			<color red="0.50" green="0.00" blue="0.00">
-			</color>
+			<color red="0.50" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.00" blue="0.00">
-			</color>
+			<color red="0.12" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_83">
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.00" blue="0.00">
-			</color>
+			<color red="0.25" green="0.00" blue="0.00"/>
 		</rect>
 		<text string="HOLD">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_84_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_84">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="CANCEL">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.45"/>
 		</text>
 		<text string="COLLECT">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.50" width="0.90" height="0.45">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.50" width="0.90" height="0.45"/>
 		</text>
 	</element>
 	<element name="colour_button_85_border">
 		<rect state="1">
-			<color red="0.50" green="0.50" blue="0.00">
-			</color>
+			<color red="0.50" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.12" green="0.12" blue="0.00">
-			</color>
+			<color red="0.12" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_85">
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.25" green="0.25" blue="0.00">
-			</color>
+			<color red="0.25" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="AUTO">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="colour_button_86_border">
 		<rect state="1">
-			<color red="0.00" green="0.50" blue="0.00">
-			</color>
+			<color red="0.00" green="0.50" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.12" blue="0.00">
-			</color>
+			<color red="0.00" green="0.12" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="colour_button_86">
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 		<rect state="0">
-			<color red="0.00" green="0.25" blue="0.00">
-			</color>
+			<color red="0.00" green="0.25" blue="0.00"/>
 		</rect>
 		<text string="START">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="reel_background">
 		<rect>
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="reel0" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel1" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel2" defstate="0">
 		<reel reelreversed="0" stateoffset="-4779" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="reel3" defstate="0">
 		<reel reelreversed="0" stateoffset="0" numsymbolsvisible="3" symbollist="reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel,reel">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</reel>
 	</element>
 	<element name="led_background">
 		<rect>
-			<color red="0.4" green="0.0" blue="0.0">
-			</color>
+			<color red="0.4" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_on">
 		<rect state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_on">
 		<disk state="1">
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_off">
 		<rect state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_dot_off">
 		<disk state="0">
-			<color red="0.5" green="0.0" blue="0.0">
-			</color>
+			<color red="0.5" green="0.0" blue="0.0"/>
 		</disk>
 	</element>
 	<element name="led_digit_rect_black">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_red">
 		<rect>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_green">
 		<rect>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_rect_blue">
 		<rect>
-			<color red="0.0" green="0.0" blue="1.0">
-			</color>
+			<color red="0.0" green="0.0" blue="1.0"/>
 		</rect>
 	</element>
 	<element name="led_digit_red">
 		<led7seg>
-			<color red="1.0" green="0.0" blue="0.0">
-			</color>
+			<color red="1.0" green="0.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_green">
 		<led7seg>
-			<color red="0.0" green="1.0" blue="0.0">
-			</color>
+			<color red="0.0" green="1.0" blue="0.0"/>
 		</led7seg>
 	</element>
 	<element name="led_digit_blue">
 		<led7seg>
-			<color red="0.0" green="0.5" blue="1.0">
-			</color>
+			<color red="0.0" green="0.5" blue="1.0"/>
 		</led7seg>
 	</element>
 	<element name="reel_lamp_layer_0" defstate="0">
 		<rect>
-			<color red="0.40" green="0.40" blue="0.40">
-			</color>
+			<color red="0.40" green="0.40" blue="0.40"/>
 		</rect>
 		<disk state="1">
-			<color red="0.50" green="0.50" blue="0.50">
-			</color>
+			<color red="0.50" green="0.50" blue="0.50"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_1" defstate="0">
 		<disk state="1">
-			<color red="0.60" green="0.60" blue="0.60">
-			</color>
+			<color red="0.60" green="0.60" blue="0.60"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_2" defstate="0">
 		<disk state="1">
-			<color red="0.70" green="0.70" blue="0.70">
-			</color>
+			<color red="0.70" green="0.70" blue="0.70"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_3" defstate="0">
 		<disk state="1">
-			<color red="0.80" green="0.80" blue="0.80">
-			</color>
+			<color red="0.80" green="0.80" blue="0.80"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_4" defstate="0">
 		<disk state="1">
-			<color red="0.90" green="0.90" blue="0.90">
-			</color>
+			<color red="0.90" green="0.90" blue="0.90"/>
 		</disk>
 	</element>
 	<element name="reel_lamp_layer_5" defstate="0">
 		<disk state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</disk>
 	</element>
 	<element name="label_34">
 		<text string="Money">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_35">
 		<text string="Spider">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_36">
 		<text string="&#xA3;25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_37">
 		<text string="&#xA3;3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_38">
 		<text string="&#xA3;2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_39">
 		<text string="&#xA3;1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_40">
 		<text string="&#xA3;5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="label_62">
 		<text string="Plays">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_backdrop_colour">
 		<rect>
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
+			<color red="0.0" green="0.0" blue="0.0"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_standard">
 		<rect state="0">
-			<color red="0.00" green="0.20" blue="0.00">
-			</color>
+			<color red="0.00" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="1.00" blue="0.00">
-			</color>
+			<color red="0.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_reel">
 		<rect state="0">
-			<color red="0.00" green="0.00" blue="0.20">
-			</color>
+			<color red="0.00" green="0.00" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="0.00" green="0.00" blue="1.00">
-			</color>
+			<color red="0.00" green="0.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_segment">
 		<rect state="0">
-			<color red="0.20" green="0.00" blue="0.00">
-			</color>
+			<color red="0.20" green="0.00" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="0.00" blue="0.00">
-			</color>
+			<color red="1.00" green="0.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_button">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_lamp_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_64">
 		<text string="64">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_65">
 		<text string="65">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_66">
 		<text string="66">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_67">
 		<text string="67">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_68">
 		<text string="68">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_69">
 		<text string="69">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_70">
 		<text string="70">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_71">
 		<text string="71">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_72">
 		<text string="72">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_73">
 		<text string="73">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_74">
 		<text string="74">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_75">
 		<text string="75">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_76">
 		<text string="76">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_77">
 		<text string="77">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_78">
 		<text string="78">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_79">
 		<text string="79">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_80">
 		<text string="80">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_81">
 		<text string="81">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_82">
 		<text string="82">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_83">
 		<text string="83">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_84">
 		<text string="84">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_85">
 		<text string="85">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_86">
 		<text string="86">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_87">
 		<text string="87">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_88">
 		<text string="88">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_89">
 		<text string="89">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_90">
 		<text string="90">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_91">
 		<text string="91">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_92">
 		<text string="92">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_93">
 		<text string="93">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_94">
 		<text string="94">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_95">
 		<text string="95">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_96">
 		<text string="96">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_97">
 		<text string="97">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_98">
 		<text string="98">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_99">
 		<text string="99">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_100">
 		<text string="100">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_101">
 		<text string="101">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_102">
 		<text string="102">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_103">
 		<text string="103">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_104">
 		<text string="104">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_105">
 		<text string="105">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_106">
 		<text string="106">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_107">
 		<text string="107">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_108">
 		<text string="108">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_109">
 		<text string="109">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_110">
 		<text string="110">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_111">
 		<text string="111">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_112">
 		<text string="112">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_113">
 		<text string="113">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_114">
 		<text string="114">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_115">
 		<text string="115">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_116">
 		<text string="116">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_117">
 		<text string="117">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_118">
 		<text string="118">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_119">
 		<text string="119">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_120">
 		<text string="120">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_121">
 		<text string="121">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_122">
 		<text string="122">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_123">
 		<text string="123">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_124">
 		<text string="124">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_125">
 		<text string="125">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_126">
 		<text string="126">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_127">
 		<text string="127">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_128">
 		<text string="128">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_129">
 		<text string="129">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_130">
 		<text string="130">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_131">
 		<text string="131">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_132">
 		<text string="132">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_133">
 		<text string="133">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_134">
 		<text string="134">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_135">
 		<text string="135">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_136">
 		<text string="136">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_137">
 		<text string="137">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_138">
 		<text string="138">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_139">
 		<text string="139">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_140">
 		<text string="140">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_141">
 		<text string="141">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_142">
 		<text string="142">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_143">
 		<text string="143">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_144">
 		<text string="144">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_145">
 		<text string="145">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_146">
 		<text string="146">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_147">
 		<text string="147">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_148">
 		<text string="148">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_149">
 		<text string="149">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_150">
 		<text string="150">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_151">
 		<text string="151">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_152">
 		<text string="152">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_153">
 		<text string="153">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_154">
 		<text string="154">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_155">
 		<text string="155">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_156">
 		<text string="156">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_157">
 		<text string="157">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_158">
 		<text string="158">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_159">
 		<text string="159">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_160">
 		<text string="160">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_161">
 		<text string="161">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_162">
 		<text string="162">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_163">
 		<text string="163">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_164">
 		<text string="164">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_165">
 		<text string="165">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_166">
 		<text string="166">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_167">
 		<text string="167">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_168">
 		<text string="168">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_169">
 		<text string="169">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_170">
 		<text string="170">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_171">
 		<text string="171">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_172">
 		<text string="172">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_173">
 		<text string="173">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_174">
 		<text string="174">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_175">
 		<text string="175">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_176">
 		<text string="176">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_177">
 		<text string="177">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_178">
 		<text string="178">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_179">
 		<text string="179">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_180">
 		<text string="180">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_181">
 		<text string="181">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_182">
 		<text string="182">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_183">
 		<text string="183">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_184">
 		<text string="184">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_185">
 		<text string="185">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_186">
 		<text string="186">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_187">
 		<text string="187">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_188">
 		<text string="188">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_189">
 		<text string="189">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_190">
 		<text string="190">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_191">
 		<text string="191">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_192">
 		<text string="192">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_193">
 		<text string="193">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_194">
 		<text string="194">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_195">
 		<text string="195">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_196">
 		<text string="196">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_197">
 		<text string="197">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_198">
 		<text string="198">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_199">
 		<text string="199">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_200">
 		<text string="200">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_201">
 		<text string="201">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_202">
 		<text string="202">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_203">
 		<text string="203">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_204">
 		<text string="204">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_205">
 		<text string="205">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_206">
 		<text string="206">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_207">
 		<text string="207">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_208">
 		<text string="208">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_209">
 		<text string="209">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_210">
 		<text string="210">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_211">
 		<text string="211">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_212">
 		<text string="212">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_213">
 		<text string="213">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_214">
 		<text string="214">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_215">
 		<text string="215">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_216">
 		<text string="216">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_217">
 		<text string="217">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_218">
 		<text string="218">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_219">
 		<text string="219">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_220">
 		<text string="220">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_221">
 		<text string="221">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_222">
 		<text string="222">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_223">
 		<text string="223">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_224">
 		<text string="224">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_225">
 		<text string="225">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_226">
 		<text string="226">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_227">
 		<text string="227">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_228">
 		<text string="228">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_229">
 		<text string="229">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_230">
 		<text string="230">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_231">
 		<text string="231">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_232">
 		<text string="232">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_233">
 		<text string="233">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_234">
 		<text string="234">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_235">
 		<text string="235">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_236">
 		<text string="236">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_237">
 		<text string="237">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_238">
 		<text string="238">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_239">
 		<text string="239">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_240">
 		<text string="240">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_241">
 		<text string="241">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_242">
 		<text string="242">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_243">
 		<text string="243">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_244">
 		<text string="244">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_245">
 		<text string="245">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_246">
 		<text string="246">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_247">
 		<text string="247">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_248">
 		<text string="248">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_249">
 		<text string="249">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_250">
 		<text string="250">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_251">
 		<text string="251">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_252">
 		<text string="252">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_253">
 		<text string="253">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_254">
 		<text string="254">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_lamp_label_255">
 		<text string="255">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_standard">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.00">
-			</color>
+			<color red="0.20" green="0.20" blue="0.00"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="0.00">
-			</color>
+			<color red="1.00" green="1.00" blue="0.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_unreferenced">
 		<rect state="0">
-			<color red="0.20" green="0.20" blue="0.20">
-			</color>
+			<color red="0.20" green="0.20" blue="0.20"/>
 		</rect>
 		<rect state="1">
-			<color red="1.00" green="1.00" blue="1.00">
-			</color>
+			<color red="1.00" green="1.00" blue="1.00"/>
 		</rect>
 	</element>
 	<element name="debug_button_label_0">
 		<text string="0">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_1">
 		<text string="1">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_2">
 		<text string="2">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_3">
 		<text string="3">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_4">
 		<text string="4">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_5">
 		<text string="5">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_6">
 		<text string="6">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_7">
 		<text string="7">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_8">
 		<text string="8">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_9">
 		<text string="9">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_10">
 		<text string="10">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_11">
 		<text string="11">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_12">
 		<text string="12">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_13">
 		<text string="13">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_14">
 		<text string="14">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_15">
 		<text string="15">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_16">
 		<text string="16">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_17">
 		<text string="17">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_18">
 		<text string="18">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_19">
 		<text string="19">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_20">
 		<text string="20">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_21">
 		<text string="21">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_22">
 		<text string="22">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_23">
 		<text string="23">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_24">
 		<text string="24">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_25">
 		<text string="25">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_26">
 		<text string="26">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_27">
 		<text string="27">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_28">
 		<text string="28">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_29">
 		<text string="29">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_30">
 		<text string="30">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_31">
 		<text string="31">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_32">
 		<text string="32">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_33">
 		<text string="33">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_34">
 		<text string="34">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_35">
 		<text string="35">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_36">
 		<text string="36">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_37">
 		<text string="37">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_38">
 		<text string="38">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_39">
 		<text string="39">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_40">
 		<text string="40">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_41">
 		<text string="41">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_42">
 		<text string="42">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_43">
 		<text string="43">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_44">
 		<text string="44">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_45">
 		<text string="45">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_46">
 		<text string="46">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_47">
 		<text string="47">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_48">
 		<text string="48">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_49">
 		<text string="49">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_50">
 		<text string="50">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_51">
 		<text string="51">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_52">
 		<text string="52">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_53">
 		<text string="53">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_54">
 		<text string="54">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_55">
 		<text string="55">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_56">
 		<text string="56">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_57">
 		<text string="57">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_58">
 		<text string="58">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_59">
 		<text string="59">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_60">
 		<text string="60">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_61">
 		<text string="61">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_62">
 		<text string="62">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_button_label_63">
 		<text string="63">
-			<color red="0.0" green="0.0" blue="0.0">
-			</color>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90">
-			</bounds>
+			<color red="0.0" green="0.0" blue="0.0"/>
+			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
 		</text>
 	</element>
 	<element name="debug_vfd">
 		<led14segsc>
-			<color red="0.0" green="1.0" blue="1.0">
-			</color>
+			<color red="0.0" green="1.0" blue="1.0"/>
 		</led14segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</simplecounter>
 	</element>
 	<element name="debug_reel_symbol_count_0">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_1">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_2">
 		<text string="16">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 	<element name="debug_reel_symbol_count_3">
 		<text string="20">
-			<color red="1.0" green="1.0" blue="1.0">
-			</color>
+			<color red="1.0" green="1.0" blue="1.0"/>
 		</text>
 	</element>
 
 	<view name="AWP Simulated Video">
 		<backdrop element="backdrop_colour">
-			<bounds x="0" y="0" width="736" height="538">
-			</bounds>
+			<bounds x="0" y="0" width="736" height="538"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="241" y="309" width="90" height="150">
-			</bounds>
+			<bounds x="241" y="309" width="90" height="150"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="309.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="241.0000" y="309.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.7500" y="311.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="244.7500" y="311.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.5000" y="313.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="248.5000" y="313.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.2500" y="315.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="252.2500" y="315.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="256.0000" y="317.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="256.0000" y="317.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="259.7500" y="319.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="259.7500" y="319.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="359.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="241.0000" y="359.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.7500" y="361.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="244.7500" y="361.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.5000" y="363.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="248.5000" y="363.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.2500" y="365.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="252.2500" y="365.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="256.0000" y="367.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="256.0000" y="367.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="259.7500" y="369.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="259.7500" y="369.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="241.0000" y="409.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="241.0000" y="409.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="244.7500" y="411.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="244.7500" y="411.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="248.5000" y="413.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="248.5000" y="413.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="252.2500" y="415.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="252.2500" y="415.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="256.0000" y="417.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="256.0000" y="417.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="259.7500" y="419.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="259.7500" y="419.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="241" y="309" width="90" height="150">
-			</bounds>
+			<bounds x="241" y="309" width="90" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="333" y="309" width="90" height="150">
-			</bounds>
+			<bounds x="333" y="309" width="90" height="150"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="309.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="333.0000" y="309.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.7500" y="311.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="336.7500" y="311.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.5000" y="313.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="340.5000" y="313.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="344.2500" y="315.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="344.2500" y="315.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.0000" y="317.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="348.0000" y="317.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.7500" y="319.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="351.7500" y="319.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="359.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="333.0000" y="359.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.7500" y="361.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="336.7500" y="361.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.5000" y="363.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="340.5000" y="363.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="344.2500" y="365.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="344.2500" y="365.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.0000" y="367.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="348.0000" y="367.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.7500" y="369.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="351.7500" y="369.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="409.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="333.0000" y="409.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.7500" y="411.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="336.7500" y="411.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="340.5000" y="413.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="340.5000" y="413.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="344.2500" y="415.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="344.2500" y="415.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="348.0000" y="417.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="348.0000" y="417.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="351.7500" y="419.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="351.7500" y="419.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="333" y="309" width="90" height="150">
-			</bounds>
+			<bounds x="333" y="309" width="90" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="425" y="309" width="90" height="150">
-			</bounds>
+			<bounds x="425" y="309" width="90" height="150"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="309.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="425.0000" y="309.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="428.7500" y="311.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="428.7500" y="311.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="432.5000" y="313.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="432.5000" y="313.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="436.2500" y="315.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="436.2500" y="315.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="440.0000" y="317.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="440.0000" y="317.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="443.7500" y="319.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="443.7500" y="319.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="359.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="425.0000" y="359.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="428.7500" y="361.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="428.7500" y="361.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="432.5000" y="363.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="432.5000" y="363.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="436.2500" y="365.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="436.2500" y="365.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="440.0000" y="367.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="440.0000" y="367.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="443.7500" y="369.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="443.7500" y="369.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="425.0000" y="409.0000" width="90.0000" height="50.0000">
-			</bounds>
+			<bounds x="425.0000" y="409.0000" width="90.0000" height="50.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="428.7500" y="411.0833" width="82.5000" height="45.8333">
-			</bounds>
+			<bounds x="428.7500" y="411.0833" width="82.5000" height="45.8333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="432.5000" y="413.1667" width="75.0000" height="41.6667">
-			</bounds>
+			<bounds x="432.5000" y="413.1667" width="75.0000" height="41.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="436.2500" y="415.2500" width="67.5000" height="37.5000">
-			</bounds>
+			<bounds x="436.2500" y="415.2500" width="67.5000" height="37.5000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="440.0000" y="417.3333" width="60.0000" height="33.3333">
-			</bounds>
+			<bounds x="440.0000" y="417.3333" width="60.0000" height="33.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="443.7500" y="419.4167" width="52.5000" height="29.1667">
-			</bounds>
+			<bounds x="443.7500" y="419.4167" width="52.5000" height="29.1667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="425" y="309" width="90" height="150">
-			</bounds>
+			<bounds x="425" y="309" width="90" height="150"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="333" y="138" width="80" height="80">
-			</bounds>
+			<bounds x="333" y="138" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="138.0000" width="80.0000" height="26.6667">
-			</bounds>
+			<bounds x="333.0000" y="138.0000" width="80.0000" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="139.1111" width="73.3333" height="24.4444">
-			</bounds>
+			<bounds x="336.3333" y="139.1111" width="73.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="140.2222" width="66.6667" height="22.2222">
-			</bounds>
+			<bounds x="339.6667" y="140.2222" width="66.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="141.3333" width="60.0000" height="20.0000">
-			</bounds>
+			<bounds x="343.0000" y="141.3333" width="60.0000" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="142.4444" width="53.3333" height="17.7778">
-			</bounds>
+			<bounds x="346.3333" y="142.4444" width="53.3333" height="17.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="143.5556" width="46.6667" height="15.5556">
-			</bounds>
+			<bounds x="349.6667" y="143.5556" width="46.6667" height="15.5556"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="164.6667" width="80.0000" height="26.6667">
-			</bounds>
+			<bounds x="333.0000" y="164.6667" width="80.0000" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="165.7778" width="73.3333" height="24.4444">
-			</bounds>
+			<bounds x="336.3333" y="165.7778" width="73.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="166.8889" width="66.6667" height="22.2222">
-			</bounds>
+			<bounds x="339.6667" y="166.8889" width="66.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="168.0000" width="60.0000" height="20.0000">
-			</bounds>
+			<bounds x="343.0000" y="168.0000" width="60.0000" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="169.1111" width="53.3333" height="17.7778">
-			</bounds>
+			<bounds x="346.3333" y="169.1111" width="53.3333" height="17.7778"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="170.2222" width="46.6667" height="15.5556">
-			</bounds>
+			<bounds x="349.6667" y="170.2222" width="46.6667" height="15.5556"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="333.0000" y="191.3333" width="80.0000" height="26.6667">
-			</bounds>
+			<bounds x="333.0000" y="191.3333" width="80.0000" height="26.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="336.3333" y="192.4444" width="73.3333" height="24.4444">
-			</bounds>
+			<bounds x="336.3333" y="192.4444" width="73.3333" height="24.4444"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="339.6667" y="193.5556" width="66.6667" height="22.2222">
-			</bounds>
+			<bounds x="339.6667" y="193.5556" width="66.6667" height="22.2222"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="343.0000" y="194.6667" width="60.0000" height="20.0000">
-			</bounds>
+			<bounds x="343.0000" y="194.6667" width="60.0000" height="20.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="346.3333" y="195.7778" width="53.3333" height="17.7778">
-			</bounds>
+			<bounds x="346.3333" y="195.7778" width="53.3333" height="17.7778"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="349.6667" y="196.8889" width="46.6667" height="15.5556">
-			</bounds>
+			<bounds x="349.6667" y="196.8889" width="46.6667" height="15.5556"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="333" y="138" width="80" height="80">
-			</bounds>
+			<bounds x="333" y="138" width="80" height="80"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1_border" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="634" y="22" width="52" height="52">
-			</bounds>
+			<bounds x="634" y="22" width="52" height="52"/>
 		</backdrop>
 		<backdrop name="lamp32" element="lamp_32_1" state="0" inputtag="IN-COIN" inputmask="0x01">
-			<bounds x="636" y="24" width="48" height="48">
-			</bounds>
+			<bounds x="636" y="24" width="48" height="48"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1_border" state="0">
-			<bounds x="104" y="402" width="102" height="27">
-			</bounds>
+			<bounds x="104" y="402" width="102" height="27"/>
 		</backdrop>
 		<backdrop name="lamp54" element="lamp_54_1" state="0">
-			<bounds x="106" y="404" width="98" height="23">
-			</bounds>
+			<bounds x="106" y="404" width="98" height="23"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_81_border" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="431" y="473" width="75" height="38">
-			</bounds>
+			<bounds x="431" y="473" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp2" element="colour_button_81" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="433" y="475" width="71" height="34">
-			</bounds>
+			<bounds x="433" y="475" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_82_border" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="337" y="473" width="75" height="38">
-			</bounds>
+			<bounds x="337" y="473" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp1" element="colour_button_82" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="339" y="475" width="71" height="34">
-			</bounds>
+			<bounds x="339" y="475" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_83_border" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="247" y="472" width="75" height="38">
-			</bounds>
+			<bounds x="247" y="472" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp0" element="colour_button_83" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="249" y="474" width="71" height="34">
-			</bounds>
+			<bounds x="249" y="474" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_84_border" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="148" y="471" width="75" height="38">
-			</bounds>
+			<bounds x="148" y="471" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp3" element="colour_button_84" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="150" y="473" width="71" height="34">
-			</bounds>
+			<bounds x="150" y="473" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_85_border" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="522" y="473" width="75" height="38">
-			</bounds>
+			<bounds x="522" y="473" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp4" element="colour_button_85" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="524" y="475" width="71" height="34">
-			</bounds>
+			<bounds x="524" y="475" width="71" height="34"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_86_border" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="609" y="473" width="75" height="38">
-			</bounds>
+			<bounds x="609" y="473" width="75" height="38"/>
 		</backdrop>
 		<backdrop name="lamp6" element="colour_button_86" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="611" y="475" width="71" height="34">
-			</bounds>
+			<bounds x="611" y="475" width="71" height="34"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="357" y="259" width="24" height="32">
-			</bounds>
+			<bounds x="357" y="259" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit20" element="led_digit_red">
-			<bounds x="357" y="259" width="24" height="32">
-			</bounds>
+			<bounds x="357" y="259" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="357" y="259" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="357" y="259" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_black">
-			<bounds x="376" y="259" width="24" height="32">
-			</bounds>
+			<bounds x="376" y="259" width="24" height="32"/>
 		</backdrop>
 		<backdrop name="digit22" element="led_digit_red">
-			<bounds x="376" y="259" width="24" height="32">
-			</bounds>
+			<bounds x="376" y="259" width="24" height="32"/>
 		</backdrop>
 		<backdrop element="led_digit_rect_red">
-			<bounds x="376" y="259" width="24" height="32">
-			</bounds>
-			<color alpha="0.1">
-			</color>
+			<bounds x="376" y="259" width="24" height="32"/>
+			<color alpha="0.1"/>
 		</backdrop>
 		<backdrop name="label34" element="label_34">
-			<bounds x="518" y="112" width="146" height="67">
-			</bounds>
+			<bounds x="518" y="112" width="146" height="67"/>
 		</backdrop>
 		<backdrop name="label35" element="label_35">
-			<bounds x="520" y="176" width="150" height="67">
-			</bounds>
+			<bounds x="520" y="176" width="150" height="67"/>
 		</backdrop>
 		<backdrop name="label36" element="label_36">
-			<bounds x="53" y="18" width="96" height="67">
-			</bounds>
+			<bounds x="53" y="18" width="96" height="67"/>
 		</backdrop>
 		<backdrop name="label37" element="label_37">
-			<bounds x="155" y="162" width="37" height="38">
-			</bounds>
+			<bounds x="155" y="162" width="37" height="38"/>
 		</backdrop>
 		<backdrop name="label38" element="label_38">
-			<bounds x="155" y="193" width="37" height="38">
-			</bounds>
+			<bounds x="155" y="193" width="37" height="38"/>
 		</backdrop>
 		<backdrop name="label39" element="label_39">
-			<bounds x="155" y="226" width="37" height="38">
-			</bounds>
+			<bounds x="155" y="226" width="37" height="38"/>
 		</backdrop>
 		<backdrop name="label40" element="label_40">
-			<bounds x="155" y="131" width="37" height="38">
-			</bounds>
+			<bounds x="155" y="131" width="37" height="38"/>
 		</backdrop>
 		<backdrop name="label62" element="label_62">
-			<bounds x="295" y="262" width="46" height="27">
-			</bounds>
+			<bounds x="295" y="262" width="46" height="27"/>
 		</backdrop>
 	</view>
 
 	<view name="MFME2MAME Debug">
 		<backdrop element="debug_backdrop_colour">
-			<bounds x="0" y="0" width="1920" height="1080">
-			</bounds>
+			<bounds x="0" y="0" width="1920" height="1080"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_lamp_button" state="0">
-			<bounds x="32" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_0" element="debug_lamp_label_0">
-			<bounds x="47" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_lamp_button" state="0">
-			<bounds x="96" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_1" element="debug_lamp_label_1">
-			<bounds x="111" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_lamp_button" state="0">
-			<bounds x="160" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_2" element="debug_lamp_label_2">
-			<bounds x="175" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_lamp_button" state="0">
-			<bounds x="224" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_3" element="debug_lamp_label_3">
-			<bounds x="239" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_lamp_button" state="0">
-			<bounds x="288" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_4" element="debug_lamp_label_4">
-			<bounds x="303" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp5" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_5" element="debug_lamp_label_5">
-			<bounds x="367" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_lamp_button" state="0">
-			<bounds x="416" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_6" element="debug_lamp_label_6">
-			<bounds x="431" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp7" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_7" element="debug_lamp_label_7">
-			<bounds x="495" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp8" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_8" element="debug_lamp_label_8">
-			<bounds x="559" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp9" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_9" element="debug_lamp_label_9">
-			<bounds x="623" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp10" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_10" element="debug_lamp_label_10">
-			<bounds x="687" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp11" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_11" element="debug_lamp_label_11">
-			<bounds x="751" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp12" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_12" element="debug_lamp_label_12">
-			<bounds x="815" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp13" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_13" element="debug_lamp_label_13">
-			<bounds x="879" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp14" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_14" element="debug_lamp_label_14">
-			<bounds x="943" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp15" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="32" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="32" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_15" element="debug_lamp_label_15">
-			<bounds x="1007" y="47" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="47" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp16" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_16" element="debug_lamp_label_16">
-			<bounds x="47" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp17" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_17" element="debug_lamp_label_17">
-			<bounds x="111" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp18" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_18" element="debug_lamp_label_18">
-			<bounds x="175" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp19" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_19" element="debug_lamp_label_19">
-			<bounds x="239" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp20" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_20" element="debug_lamp_label_20">
-			<bounds x="303" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp21" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_21" element="debug_lamp_label_21">
-			<bounds x="367" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp22" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_22" element="debug_lamp_label_22">
-			<bounds x="431" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp23" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_23" element="debug_lamp_label_23">
-			<bounds x="495" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp24" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_24" element="debug_lamp_label_24">
-			<bounds x="559" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp25" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_25" element="debug_lamp_label_25">
-			<bounds x="623" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp26" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_26" element="debug_lamp_label_26">
-			<bounds x="687" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp27" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_27" element="debug_lamp_label_27">
-			<bounds x="751" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp28" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_28" element="debug_lamp_label_28">
-			<bounds x="815" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp29" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_29" element="debug_lamp_label_29">
-			<bounds x="879" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp30" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_30" element="debug_lamp_label_30">
-			<bounds x="943" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp31" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="96" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="96" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_31" element="debug_lamp_label_31">
-			<bounds x="1007" y="111" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="111" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp32" element="debug_lamp_standard" state="0">
-			<bounds x="32" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_32" element="debug_lamp_label_32">
-			<bounds x="47" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp33" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_33" element="debug_lamp_label_33">
-			<bounds x="111" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp34" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_34" element="debug_lamp_label_34">
-			<bounds x="175" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp35" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_35" element="debug_lamp_label_35">
-			<bounds x="239" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp36" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_36" element="debug_lamp_label_36">
-			<bounds x="303" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp37" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_37" element="debug_lamp_label_37">
-			<bounds x="367" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp38" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_38" element="debug_lamp_label_38">
-			<bounds x="431" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp39" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_39" element="debug_lamp_label_39">
-			<bounds x="495" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp40" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_40" element="debug_lamp_label_40">
-			<bounds x="559" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp41" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_41" element="debug_lamp_label_41">
-			<bounds x="623" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp42" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_42" element="debug_lamp_label_42">
-			<bounds x="687" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp43" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_43" element="debug_lamp_label_43">
-			<bounds x="751" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp44" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_44" element="debug_lamp_label_44">
-			<bounds x="815" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp45" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_45" element="debug_lamp_label_45">
-			<bounds x="879" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp46" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_46" element="debug_lamp_label_46">
-			<bounds x="943" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp47" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="160" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="160" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_47" element="debug_lamp_label_47">
-			<bounds x="1007" y="175" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="175" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp48" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_48" element="debug_lamp_label_48">
-			<bounds x="47" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp49" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_49" element="debug_lamp_label_49">
-			<bounds x="111" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp50" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_50" element="debug_lamp_label_50">
-			<bounds x="175" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp51" element="debug_lamp_reel" state="0">
-			<bounds x="224" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_51" element="debug_lamp_label_51">
-			<bounds x="239" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp52" element="debug_lamp_reel" state="0">
-			<bounds x="288" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_52" element="debug_lamp_label_52">
-			<bounds x="303" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp53" element="debug_lamp_reel" state="0">
-			<bounds x="352" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_53" element="debug_lamp_label_53">
-			<bounds x="367" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp54" element="debug_lamp_standard" state="0">
-			<bounds x="416" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_54" element="debug_lamp_label_54">
-			<bounds x="431" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp55" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_55" element="debug_lamp_label_55">
-			<bounds x="495" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp56" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_56" element="debug_lamp_label_56">
-			<bounds x="559" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp57" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_57" element="debug_lamp_label_57">
-			<bounds x="623" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp58" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_58" element="debug_lamp_label_58">
-			<bounds x="687" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp59" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_59" element="debug_lamp_label_59">
-			<bounds x="751" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp60" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_60" element="debug_lamp_label_60">
-			<bounds x="815" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp61" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_61" element="debug_lamp_label_61">
-			<bounds x="879" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp62" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_62" element="debug_lamp_label_62">
-			<bounds x="943" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp63" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="224" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="224" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_63" element="debug_lamp_label_63">
-			<bounds x="1007" y="239" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="239" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp64" element="debug_lamp_reel" state="0">
-			<bounds x="32" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_64" element="debug_lamp_label_64">
-			<bounds x="47" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp65" element="debug_lamp_reel" state="0">
-			<bounds x="96" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_65" element="debug_lamp_label_65">
-			<bounds x="111" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp66" element="debug_lamp_reel" state="0">
-			<bounds x="160" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_66" element="debug_lamp_label_66">
-			<bounds x="175" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp67" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_67" element="debug_lamp_label_67">
-			<bounds x="239" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp68" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_68" element="debug_lamp_label_68">
-			<bounds x="303" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp69" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_69" element="debug_lamp_label_69">
-			<bounds x="367" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp70" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_70" element="debug_lamp_label_70">
-			<bounds x="431" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp71" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_71" element="debug_lamp_label_71">
-			<bounds x="495" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp72" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_72" element="debug_lamp_label_72">
-			<bounds x="559" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp73" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_73" element="debug_lamp_label_73">
-			<bounds x="623" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp74" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_74" element="debug_lamp_label_74">
-			<bounds x="687" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp75" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_75" element="debug_lamp_label_75">
-			<bounds x="751" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp76" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_76" element="debug_lamp_label_76">
-			<bounds x="815" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp77" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_77" element="debug_lamp_label_77">
-			<bounds x="879" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp78" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_78" element="debug_lamp_label_78">
-			<bounds x="943" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp79" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="288" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="288" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_79" element="debug_lamp_label_79">
-			<bounds x="1007" y="303" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="303" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp80" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_80" element="debug_lamp_label_80">
-			<bounds x="47" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp81" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_81" element="debug_lamp_label_81">
-			<bounds x="111" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp82" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_82" element="debug_lamp_label_82">
-			<bounds x="175" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp83" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_83" element="debug_lamp_label_83">
-			<bounds x="239" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp84" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_84" element="debug_lamp_label_84">
-			<bounds x="303" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp85" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_85" element="debug_lamp_label_85">
-			<bounds x="367" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp86" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_86" element="debug_lamp_label_86">
-			<bounds x="431" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp87" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_87" element="debug_lamp_label_87">
-			<bounds x="495" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp88" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_88" element="debug_lamp_label_88">
-			<bounds x="559" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp89" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_89" element="debug_lamp_label_89">
-			<bounds x="623" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp90" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_90" element="debug_lamp_label_90">
-			<bounds x="687" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp91" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_91" element="debug_lamp_label_91">
-			<bounds x="751" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp92" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_92" element="debug_lamp_label_92">
-			<bounds x="815" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp93" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_93" element="debug_lamp_label_93">
-			<bounds x="879" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp94" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_94" element="debug_lamp_label_94">
-			<bounds x="943" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp95" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="352" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="352" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_95" element="debug_lamp_label_95">
-			<bounds x="1007" y="367" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="367" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp96" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_96" element="debug_lamp_label_96">
-			<bounds x="47" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp97" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_97" element="debug_lamp_label_97">
-			<bounds x="111" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp98" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_98" element="debug_lamp_label_98">
-			<bounds x="175" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp99" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_99" element="debug_lamp_label_99">
-			<bounds x="239" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp100" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_100" element="debug_lamp_label_100">
-			<bounds x="303" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp101" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_101" element="debug_lamp_label_101">
-			<bounds x="367" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp102" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_102" element="debug_lamp_label_102">
-			<bounds x="431" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp103" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_103" element="debug_lamp_label_103">
-			<bounds x="495" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp104" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_104" element="debug_lamp_label_104">
-			<bounds x="559" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp105" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_105" element="debug_lamp_label_105">
-			<bounds x="623" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp106" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_106" element="debug_lamp_label_106">
-			<bounds x="687" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp107" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_107" element="debug_lamp_label_107">
-			<bounds x="751" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp108" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_108" element="debug_lamp_label_108">
-			<bounds x="815" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp109" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_109" element="debug_lamp_label_109">
-			<bounds x="879" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp110" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_110" element="debug_lamp_label_110">
-			<bounds x="943" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp111" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="416" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="416" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_111" element="debug_lamp_label_111">
-			<bounds x="1007" y="431" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="431" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp112" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_112" element="debug_lamp_label_112">
-			<bounds x="47" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp113" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_113" element="debug_lamp_label_113">
-			<bounds x="111" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp114" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_114" element="debug_lamp_label_114">
-			<bounds x="175" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp115" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_115" element="debug_lamp_label_115">
-			<bounds x="239" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp116" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_116" element="debug_lamp_label_116">
-			<bounds x="303" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp117" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_117" element="debug_lamp_label_117">
-			<bounds x="367" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp118" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_118" element="debug_lamp_label_118">
-			<bounds x="431" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp119" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_119" element="debug_lamp_label_119">
-			<bounds x="495" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp120" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_120" element="debug_lamp_label_120">
-			<bounds x="559" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp121" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_121" element="debug_lamp_label_121">
-			<bounds x="623" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp122" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_122" element="debug_lamp_label_122">
-			<bounds x="687" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp123" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_123" element="debug_lamp_label_123">
-			<bounds x="751" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp124" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_124" element="debug_lamp_label_124">
-			<bounds x="815" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp125" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_125" element="debug_lamp_label_125">
-			<bounds x="879" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp126" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_126" element="debug_lamp_label_126">
-			<bounds x="943" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp127" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="480" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="480" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_127" element="debug_lamp_label_127">
-			<bounds x="1007" y="495" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="495" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp128" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_128" element="debug_lamp_label_128">
-			<bounds x="47" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp129" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_129" element="debug_lamp_label_129">
-			<bounds x="111" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp130" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_130" element="debug_lamp_label_130">
-			<bounds x="175" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp131" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_131" element="debug_lamp_label_131">
-			<bounds x="239" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp132" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_132" element="debug_lamp_label_132">
-			<bounds x="303" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp133" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_133" element="debug_lamp_label_133">
-			<bounds x="367" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp134" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_134" element="debug_lamp_label_134">
-			<bounds x="431" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp135" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_135" element="debug_lamp_label_135">
-			<bounds x="495" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp136" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_136" element="debug_lamp_label_136">
-			<bounds x="559" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp137" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_137" element="debug_lamp_label_137">
-			<bounds x="623" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp138" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_138" element="debug_lamp_label_138">
-			<bounds x="687" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp139" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_139" element="debug_lamp_label_139">
-			<bounds x="751" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp140" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_140" element="debug_lamp_label_140">
-			<bounds x="815" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp141" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_141" element="debug_lamp_label_141">
-			<bounds x="879" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp142" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_142" element="debug_lamp_label_142">
-			<bounds x="943" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp143" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="544" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="544" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_143" element="debug_lamp_label_143">
-			<bounds x="1007" y="559" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="559" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp144" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_144" element="debug_lamp_label_144">
-			<bounds x="47" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp145" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_145" element="debug_lamp_label_145">
-			<bounds x="111" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp146" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_146" element="debug_lamp_label_146">
-			<bounds x="175" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp147" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_147" element="debug_lamp_label_147">
-			<bounds x="239" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp148" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_148" element="debug_lamp_label_148">
-			<bounds x="303" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp149" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_149" element="debug_lamp_label_149">
-			<bounds x="367" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp150" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_150" element="debug_lamp_label_150">
-			<bounds x="431" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp151" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_151" element="debug_lamp_label_151">
-			<bounds x="495" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp152" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_152" element="debug_lamp_label_152">
-			<bounds x="559" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp153" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_153" element="debug_lamp_label_153">
-			<bounds x="623" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp154" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_154" element="debug_lamp_label_154">
-			<bounds x="687" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp155" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_155" element="debug_lamp_label_155">
-			<bounds x="751" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp156" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_156" element="debug_lamp_label_156">
-			<bounds x="815" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp157" element="debug_lamp_reel" state="0">
-			<bounds x="864" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_157" element="debug_lamp_label_157">
-			<bounds x="879" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp158" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_158" element="debug_lamp_label_158">
-			<bounds x="943" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp159" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="608" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="608" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_159" element="debug_lamp_label_159">
-			<bounds x="1007" y="623" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="623" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp160" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_160" element="debug_lamp_label_160">
-			<bounds x="47" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp161" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_161" element="debug_lamp_label_161">
-			<bounds x="111" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp162" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_162" element="debug_lamp_label_162">
-			<bounds x="175" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp163" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_163" element="debug_lamp_label_163">
-			<bounds x="239" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp164" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_164" element="debug_lamp_label_164">
-			<bounds x="303" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp165" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_165" element="debug_lamp_label_165">
-			<bounds x="367" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp166" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_166" element="debug_lamp_label_166">
-			<bounds x="431" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp167" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_167" element="debug_lamp_label_167">
-			<bounds x="495" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp168" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_168" element="debug_lamp_label_168">
-			<bounds x="559" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp169" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_169" element="debug_lamp_label_169">
-			<bounds x="623" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp170" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_170" element="debug_lamp_label_170">
-			<bounds x="687" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp171" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_171" element="debug_lamp_label_171">
-			<bounds x="751" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp172" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_172" element="debug_lamp_label_172">
-			<bounds x="815" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp173" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_173" element="debug_lamp_label_173">
-			<bounds x="879" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp174" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_174" element="debug_lamp_label_174">
-			<bounds x="943" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp175" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="672" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="672" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_175" element="debug_lamp_label_175">
-			<bounds x="1007" y="687" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="687" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp176" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_176" element="debug_lamp_label_176">
-			<bounds x="47" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp177" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_177" element="debug_lamp_label_177">
-			<bounds x="111" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp178" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_178" element="debug_lamp_label_178">
-			<bounds x="175" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp179" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_179" element="debug_lamp_label_179">
-			<bounds x="239" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp180" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_180" element="debug_lamp_label_180">
-			<bounds x="303" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp181" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_181" element="debug_lamp_label_181">
-			<bounds x="367" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp182" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_182" element="debug_lamp_label_182">
-			<bounds x="431" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp183" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_183" element="debug_lamp_label_183">
-			<bounds x="495" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp184" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_184" element="debug_lamp_label_184">
-			<bounds x="559" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp185" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_185" element="debug_lamp_label_185">
-			<bounds x="623" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp186" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_186" element="debug_lamp_label_186">
-			<bounds x="687" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp187" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_187" element="debug_lamp_label_187">
-			<bounds x="751" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp188" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_188" element="debug_lamp_label_188">
-			<bounds x="815" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp189" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_189" element="debug_lamp_label_189">
-			<bounds x="879" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp190" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_190" element="debug_lamp_label_190">
-			<bounds x="943" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp191" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="736" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="736" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_191" element="debug_lamp_label_191">
-			<bounds x="1007" y="751" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="751" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp192" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_192" element="debug_lamp_label_192">
-			<bounds x="47" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp193" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_193" element="debug_lamp_label_193">
-			<bounds x="111" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp194" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_194" element="debug_lamp_label_194">
-			<bounds x="175" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp195" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_195" element="debug_lamp_label_195">
-			<bounds x="239" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp196" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_196" element="debug_lamp_label_196">
-			<bounds x="303" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp197" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_197" element="debug_lamp_label_197">
-			<bounds x="367" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp198" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_198" element="debug_lamp_label_198">
-			<bounds x="431" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp199" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_199" element="debug_lamp_label_199">
-			<bounds x="495" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp200" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_200" element="debug_lamp_label_200">
-			<bounds x="559" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp201" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_201" element="debug_lamp_label_201">
-			<bounds x="623" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp202" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_202" element="debug_lamp_label_202">
-			<bounds x="687" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp203" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_203" element="debug_lamp_label_203">
-			<bounds x="751" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp204" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_204" element="debug_lamp_label_204">
-			<bounds x="815" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp205" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_205" element="debug_lamp_label_205">
-			<bounds x="879" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp206" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_206" element="debug_lamp_label_206">
-			<bounds x="943" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp207" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="800" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="800" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_207" element="debug_lamp_label_207">
-			<bounds x="1007" y="815" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="815" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp208" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_208" element="debug_lamp_label_208">
-			<bounds x="47" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp209" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_209" element="debug_lamp_label_209">
-			<bounds x="111" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp210" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_210" element="debug_lamp_label_210">
-			<bounds x="175" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp211" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_211" element="debug_lamp_label_211">
-			<bounds x="239" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp212" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_212" element="debug_lamp_label_212">
-			<bounds x="303" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp213" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_213" element="debug_lamp_label_213">
-			<bounds x="367" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp214" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_214" element="debug_lamp_label_214">
-			<bounds x="431" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp215" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_215" element="debug_lamp_label_215">
-			<bounds x="495" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp216" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_216" element="debug_lamp_label_216">
-			<bounds x="559" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp217" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_217" element="debug_lamp_label_217">
-			<bounds x="623" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp218" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_218" element="debug_lamp_label_218">
-			<bounds x="687" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp219" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_219" element="debug_lamp_label_219">
-			<bounds x="751" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp220" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_220" element="debug_lamp_label_220">
-			<bounds x="815" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp221" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_221" element="debug_lamp_label_221">
-			<bounds x="879" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp222" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_222" element="debug_lamp_label_222">
-			<bounds x="943" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp223" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="864" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="864" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_223" element="debug_lamp_label_223">
-			<bounds x="1007" y="879" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="879" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp224" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_224" element="debug_lamp_label_224">
-			<bounds x="47" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp225" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_225" element="debug_lamp_label_225">
-			<bounds x="111" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp226" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_226" element="debug_lamp_label_226">
-			<bounds x="175" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp227" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_227" element="debug_lamp_label_227">
-			<bounds x="239" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp228" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_228" element="debug_lamp_label_228">
-			<bounds x="303" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp229" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_229" element="debug_lamp_label_229">
-			<bounds x="367" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp230" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_230" element="debug_lamp_label_230">
-			<bounds x="431" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp231" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_231" element="debug_lamp_label_231">
-			<bounds x="495" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp232" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_232" element="debug_lamp_label_232">
-			<bounds x="559" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp233" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_233" element="debug_lamp_label_233">
-			<bounds x="623" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp234" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_234" element="debug_lamp_label_234">
-			<bounds x="687" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp235" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_235" element="debug_lamp_label_235">
-			<bounds x="751" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp236" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_236" element="debug_lamp_label_236">
-			<bounds x="815" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp237" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_237" element="debug_lamp_label_237">
-			<bounds x="879" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp238" element="debug_lamp_unreferenced" state="0">
-			<bounds x="928" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_238" element="debug_lamp_label_238">
-			<bounds x="943" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp239" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="928" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="928" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_239" element="debug_lamp_label_239">
-			<bounds x="1007" y="943" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="943" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp240" element="debug_lamp_unreferenced" state="0">
-			<bounds x="32" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="32" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_240" element="debug_lamp_label_240">
-			<bounds x="47" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="47" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp241" element="debug_lamp_unreferenced" state="0">
-			<bounds x="96" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="96" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_241" element="debug_lamp_label_241">
-			<bounds x="111" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="111" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp242" element="debug_lamp_unreferenced" state="0">
-			<bounds x="160" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="160" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_242" element="debug_lamp_label_242">
-			<bounds x="175" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="175" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp243" element="debug_lamp_unreferenced" state="0">
-			<bounds x="224" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="224" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_243" element="debug_lamp_label_243">
-			<bounds x="239" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="239" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp244" element="debug_lamp_unreferenced" state="0">
-			<bounds x="288" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="288" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_244" element="debug_lamp_label_244">
-			<bounds x="303" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="303" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp245" element="debug_lamp_unreferenced" state="0">
-			<bounds x="352" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="352" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_245" element="debug_lamp_label_245">
-			<bounds x="367" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="367" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp246" element="debug_lamp_unreferenced" state="0">
-			<bounds x="416" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="416" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_246" element="debug_lamp_label_246">
-			<bounds x="431" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="431" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp247" element="debug_lamp_unreferenced" state="0">
-			<bounds x="480" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="480" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_247" element="debug_lamp_label_247">
-			<bounds x="495" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="495" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp248" element="debug_lamp_unreferenced" state="0">
-			<bounds x="544" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="544" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_248" element="debug_lamp_label_248">
-			<bounds x="559" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="559" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp249" element="debug_lamp_unreferenced" state="0">
-			<bounds x="608" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="608" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_249" element="debug_lamp_label_249">
-			<bounds x="623" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="623" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp250" element="debug_lamp_unreferenced" state="0">
-			<bounds x="672" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="672" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_250" element="debug_lamp_label_250">
-			<bounds x="687" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="687" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp251" element="debug_lamp_unreferenced" state="0">
-			<bounds x="736" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="736" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_251" element="debug_lamp_label_251">
-			<bounds x="751" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="751" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp252" element="debug_lamp_unreferenced" state="0">
-			<bounds x="800" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="800" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_252" element="debug_lamp_label_252">
-			<bounds x="815" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="815" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp253" element="debug_lamp_unreferenced" state="0">
-			<bounds x="864" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="864" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_253" element="debug_lamp_label_253">
-			<bounds x="879" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="879" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp254" element="debug_lamp_standard" state="0">
-			<bounds x="928" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="928" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_254" element="debug_lamp_label_254">
-			<bounds x="943" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="943" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="lamp255" element="debug_lamp_unreferenced" state="0">
-			<bounds x="992" y="992" width="60" height="60">
-			</bounds>
+			<bounds x="992" y="992" width="60" height="60"/>
 		</backdrop>
 		<backdrop name="debug_lamp_label_255" element="debug_lamp_label_255">
-			<bounds x="1007" y="1007" width="30" height="30">
-			</bounds>
+			<bounds x="1007" y="1007" width="30" height="30"/>
 		</backdrop>
 		<backdrop name="debug_button_0" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x01">
-			<bounds x="1100" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_0" element="debug_button_label_0">
-			<bounds x="1120" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_1" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x02">
-			<bounds x="1184" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_1" element="debug_button_label_1">
-			<bounds x="1204" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_2" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x04">
-			<bounds x="1268" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_2" element="debug_button_label_2">
-			<bounds x="1288" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_3" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x08">
-			<bounds x="1352" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_3" element="debug_button_label_3">
-			<bounds x="1372" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_4" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x10">
-			<bounds x="1436" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_4" element="debug_button_label_4">
-			<bounds x="1456" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_5" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x20">
-			<bounds x="1520" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_5" element="debug_button_label_5">
-			<bounds x="1540" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_6" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x40">
-			<bounds x="1604" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_6" element="debug_button_label_6">
-			<bounds x="1624" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_7" element="debug_button_unreferenced" state="0" inputtag="IN-0" inputmask="0x80">
-			<bounds x="1688" y="660" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="660" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_7" element="debug_button_label_7">
-			<bounds x="1708" y="671" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="671" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp0" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x01">
-			<bounds x="1100" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_8" element="debug_button_label_8">
-			<bounds x="1120" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp1" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x02">
-			<bounds x="1184" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_9" element="debug_button_label_9">
-			<bounds x="1204" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp2" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x04">
-			<bounds x="1268" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_10" element="debug_button_label_10">
-			<bounds x="1288" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp3" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x08">
-			<bounds x="1352" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_11" element="debug_button_label_11">
-			<bounds x="1372" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp4" element="debug_button_standard" state="0" inputtag="IN-1" inputmask="0x10">
-			<bounds x="1436" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_12" element="debug_button_label_12">
-			<bounds x="1456" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_13" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x20">
-			<bounds x="1520" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_13" element="debug_button_label_13">
-			<bounds x="1540" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_14" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x40">
-			<bounds x="1604" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_14" element="debug_button_label_14">
-			<bounds x="1624" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_15" element="debug_button_unreferenced" state="0" inputtag="IN-1" inputmask="0x80">
-			<bounds x="1688" y="708" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="708" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_15" element="debug_button_label_15">
-			<bounds x="1708" y="719" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="719" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_16" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x01">
-			<bounds x="1100" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_16" element="debug_button_label_16">
-			<bounds x="1120" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="lamp6" element="debug_button_standard" state="0" inputtag="IN-2" inputmask="0x02">
-			<bounds x="1184" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_17" element="debug_button_label_17">
-			<bounds x="1204" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_18" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x04">
-			<bounds x="1268" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_18" element="debug_button_label_18">
-			<bounds x="1288" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_19" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x08">
-			<bounds x="1352" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_19" element="debug_button_label_19">
-			<bounds x="1372" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_20" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x10">
-			<bounds x="1436" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_20" element="debug_button_label_20">
-			<bounds x="1456" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_21" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x20">
-			<bounds x="1520" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_21" element="debug_button_label_21">
-			<bounds x="1540" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_22" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x40">
-			<bounds x="1604" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_22" element="debug_button_label_22">
-			<bounds x="1624" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_23" element="debug_button_unreferenced" state="0" inputtag="IN-2" inputmask="0x80">
-			<bounds x="1688" y="756" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="756" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_23" element="debug_button_label_23">
-			<bounds x="1708" y="767" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="767" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_24" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x01">
-			<bounds x="1100" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_24" element="debug_button_label_24">
-			<bounds x="1120" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_25" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x02">
-			<bounds x="1184" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_25" element="debug_button_label_25">
-			<bounds x="1204" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_26" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x04">
-			<bounds x="1268" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_26" element="debug_button_label_26">
-			<bounds x="1288" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_27" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x08">
-			<bounds x="1352" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_27" element="debug_button_label_27">
-			<bounds x="1372" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_28" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x10">
-			<bounds x="1436" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_28" element="debug_button_label_28">
-			<bounds x="1456" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_29" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x20">
-			<bounds x="1520" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_29" element="debug_button_label_29">
-			<bounds x="1540" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_30" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x40">
-			<bounds x="1604" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_30" element="debug_button_label_30">
-			<bounds x="1624" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_31" element="debug_button_unreferenced" state="0" inputtag="IN-3" inputmask="0x80">
-			<bounds x="1688" y="804" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="804" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_31" element="debug_button_label_31">
-			<bounds x="1708" y="815" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="815" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_32" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x01">
-			<bounds x="1100" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_32" element="debug_button_label_32">
-			<bounds x="1120" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_33" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x02">
-			<bounds x="1184" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_33" element="debug_button_label_33">
-			<bounds x="1204" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_34" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x04">
-			<bounds x="1268" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_34" element="debug_button_label_34">
-			<bounds x="1288" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_35" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x08">
-			<bounds x="1352" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_35" element="debug_button_label_35">
-			<bounds x="1372" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_36" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x10">
-			<bounds x="1436" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_36" element="debug_button_label_36">
-			<bounds x="1456" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_37" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x20">
-			<bounds x="1520" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_37" element="debug_button_label_37">
-			<bounds x="1540" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_38" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x40">
-			<bounds x="1604" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_38" element="debug_button_label_38">
-			<bounds x="1624" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_39" element="debug_button_unreferenced" state="0" inputtag="IN-4" inputmask="0x80">
-			<bounds x="1688" y="852" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="852" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_39" element="debug_button_label_39">
-			<bounds x="1708" y="863" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="863" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_40" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x01">
-			<bounds x="1100" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_40" element="debug_button_label_40">
-			<bounds x="1120" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_41" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x02">
-			<bounds x="1184" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_41" element="debug_button_label_41">
-			<bounds x="1204" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_42" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x04">
-			<bounds x="1268" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_42" element="debug_button_label_42">
-			<bounds x="1288" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_43" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x08">
-			<bounds x="1352" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_43" element="debug_button_label_43">
-			<bounds x="1372" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_44" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x10">
-			<bounds x="1436" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_44" element="debug_button_label_44">
-			<bounds x="1456" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_45" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x20">
-			<bounds x="1520" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_45" element="debug_button_label_45">
-			<bounds x="1540" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_46" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x40">
-			<bounds x="1604" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_46" element="debug_button_label_46">
-			<bounds x="1624" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_47" element="debug_button_unreferenced" state="0" inputtag="IN-5" inputmask="0x80">
-			<bounds x="1688" y="900" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="900" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_47" element="debug_button_label_47">
-			<bounds x="1708" y="911" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="911" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_48" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x01">
-			<bounds x="1100" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_48" element="debug_button_label_48">
-			<bounds x="1120" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_49" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x02">
-			<bounds x="1184" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_49" element="debug_button_label_49">
-			<bounds x="1204" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_50" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x04">
-			<bounds x="1268" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_50" element="debug_button_label_50">
-			<bounds x="1288" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_51" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x08">
-			<bounds x="1352" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_51" element="debug_button_label_51">
-			<bounds x="1372" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_52" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x10">
-			<bounds x="1436" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_52" element="debug_button_label_52">
-			<bounds x="1456" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_53" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x20">
-			<bounds x="1520" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_53" element="debug_button_label_53">
-			<bounds x="1540" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_54" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x40">
-			<bounds x="1604" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_54" element="debug_button_label_54">
-			<bounds x="1624" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_55" element="debug_button_unreferenced" state="0" inputtag="IN-6" inputmask="0x80">
-			<bounds x="1688" y="948" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="948" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_55" element="debug_button_label_55">
-			<bounds x="1708" y="959" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="959" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_56" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x01">
-			<bounds x="1100" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1100" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_56" element="debug_button_label_56">
-			<bounds x="1120" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1120" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_57" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x02">
-			<bounds x="1184" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1184" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_57" element="debug_button_label_57">
-			<bounds x="1204" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1204" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_58" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x04">
-			<bounds x="1268" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1268" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_58" element="debug_button_label_58">
-			<bounds x="1288" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1288" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_59" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x08">
-			<bounds x="1352" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1352" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_59" element="debug_button_label_59">
-			<bounds x="1372" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1372" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_60" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x10">
-			<bounds x="1436" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1436" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_60" element="debug_button_label_60">
-			<bounds x="1456" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1456" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_61" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x20">
-			<bounds x="1520" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1520" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_61" element="debug_button_label_61">
-			<bounds x="1540" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1540" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_62" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x40">
-			<bounds x="1604" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1604" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_62" element="debug_button_label_62">
-			<bounds x="1624" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1624" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="debug_button_63" element="debug_button_unreferenced" state="0" inputtag="IN-7" inputmask="0x80">
-			<bounds x="1688" y="996" width="80" height="44">
-			</bounds>
+			<bounds x="1688" y="996" width="80" height="44"/>
 		</backdrop>
 		<backdrop name="debug_button_label_63" element="debug_button_label_63">
-			<bounds x="1708" y="1007" width="40" height="22">
-			</bounds>
+			<bounds x="1708" y="1007" width="40" height="22"/>
 		</backdrop>
 		<backdrop name="vfd0" element="debug_vfd" state="0">
-			<bounds x="1150" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1150" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd1" element="debug_vfd" state="0">
-			<bounds x="1182" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1182" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd2" element="debug_vfd" state="0">
-			<bounds x="1214" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1214" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd3" element="debug_vfd" state="0">
-			<bounds x="1246" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1246" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd4" element="debug_vfd" state="0">
-			<bounds x="1278" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1278" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd5" element="debug_vfd" state="0">
-			<bounds x="1310" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1310" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd6" element="debug_vfd" state="0">
-			<bounds x="1342" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1342" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd7" element="debug_vfd" state="0">
-			<bounds x="1374" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1374" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd8" element="debug_vfd" state="0">
-			<bounds x="1406" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1406" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd9" element="debug_vfd" state="0">
-			<bounds x="1438" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1438" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd10" element="debug_vfd" state="0">
-			<bounds x="1470" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1470" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd11" element="debug_vfd" state="0">
-			<bounds x="1502" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1502" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd12" element="debug_vfd" state="0">
-			<bounds x="1534" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1534" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd13" element="debug_vfd" state="0">
-			<bounds x="1566" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1566" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd14" element="debug_vfd" state="0">
-			<bounds x="1598" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1598" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop name="vfd15" element="debug_vfd" state="0">
-			<bounds x="1630" y="600" width="32" height="48">
-			</bounds>
+			<bounds x="1630" y="600" width="32" height="48"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp50" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp49" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_0" state="0">
-			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1100.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_1" state="0">
-			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1105.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_2" state="0">
-			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1110.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_3" state="0">
-			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1115.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_4" state="0">
-			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1120.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp48" element="reel_lamp_layer_5" state="0">
-			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1125.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel1" element="reel0" state="0">
-			<bounds x="1100" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1100" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp53" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp52" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_0" state="0">
-			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1240.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_1" state="0">
-			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1245.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_2" state="0">
-			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1250.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_3" state="0">
-			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1255.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_4" state="0">
-			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1260.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp51" element="reel_lamp_layer_5" state="0">
-			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1265.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel2" element="reel1" state="0">
-			<bounds x="1240" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1240" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp66" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp65" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_0" state="0">
-			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1380.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_1" state="0">
-			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1385.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_2" state="0">
-			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1390.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_3" state="0">
-			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1395.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_4" state="0">
-			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1400.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp64" element="reel_lamp_layer_5" state="0">
-			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1405.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel3" element="reel2" state="0">
-			<bounds x="1380" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1380" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop element="reel_background">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="32.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="35.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="38.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="42.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="45.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="48.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="112.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="115.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="118.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="122.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="125.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp157" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="128.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_0" state="0">
-			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000">
-			</bounds>
+			<bounds x="1520.0000" y="192.0000" width="120.0000" height="80.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_1" state="0">
-			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333">
-			</bounds>
+			<bounds x="1525.0000" y="195.3333" width="110.0000" height="73.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_2" state="0">
-			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667">
-			</bounds>
+			<bounds x="1530.0000" y="198.6667" width="100.0000" height="66.6667"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_3" state="0">
-			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000">
-			</bounds>
+			<bounds x="1535.0000" y="202.0000" width="90.0000" height="60.0000"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_4" state="0">
-			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333">
-			</bounds>
+			<bounds x="1540.0000" y="205.3333" width="80.0000" height="53.3333"/>
 		</backdrop>
 		<backdrop name="lamp-2" element="reel_lamp_layer_5" state="0">
-			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667">
-			</bounds>
+			<bounds x="1545.0000" y="208.6667" width="70.0000" height="46.6667"/>
 		</backdrop>
 		<backdrop name="sreel4" element="reel3" state="0">
-			<bounds x="1520" y="32" width="120" height="240">
-			</bounds>
+			<bounds x="1520" y="32" width="120" height="240"/>
 		</backdrop>
 		<backdrop name="reel1" element="debug_stepper_value">
-			<bounds x="1100" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1100" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel2" element="debug_stepper_value">
-			<bounds x="1240" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1240" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel3" element="debug_stepper_value">
-			<bounds x="1380" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1380" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="reel4" element="debug_stepper_value">
-			<bounds x="1520" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1520" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_0">
-			<bounds x="1180" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1180" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_1">
-			<bounds x="1320" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1320" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_2">
-			<bounds x="1460" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1460" y="272" width="50" height="30"/>
 		</backdrop>
 		<backdrop name="debug_reel_symbol_count" element="debug_reel_symbol_count_3">
-			<bounds x="1600" y="272" width="50" height="30">
-			</bounds>
+			<bounds x="1600" y="272" width="50" height="30"/>
 		</backdrop>
 	</view>
 </mamelayout>

--- a/src/mame/layout/sc4roksc.lay
+++ b/src/mame/layout/sc4roksc.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_10_1_border" defstate="0">
 		<rect state="1">
@@ -4478,7 +4480,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="1014" height="670"/>
 		</backdrop>
 		<backdrop element="reel_background">

--- a/src/mame/layout/sc4srrca.lay
+++ b/src/mame/layout/sc4srrca.lay
@@ -6,8 +6,10 @@
 <!--  ****************************************************  -->
 
 <mamelayout version="2">
-	<element name="backdrop">
-		<image file="backdrop.png"/>
+	<element name="backdrop_colour">
+		<rect>
+			<color red="0.00" green="0.00" blue="0.00"/>
+		</rect>
 	</element>
 	<element name="lamp_98_1_border" defstate="0">
 		<rect state="1">
@@ -2472,7 +2474,7 @@
 	</element>
 
 	<view name="AWP Simulated Video">
-		<backdrop element="backdrop">
+		<backdrop element="backdrop_colour">
 			<bounds x="0" y="0" width="646" height="569"/>
 		</backdrop>
 		<backdrop element="reel_background">


### PR DESCRIPTION
These changes differ between drivers, as the layouts for the drivers were originally generated at different stages of the Converter's development.

General summary:

All: fixed bug where a png was referenced, now correctly uses a coloured rect.
Some: more compact terminators for innermost tags
Some: removed redundant elements
Some: added the new "MFME2MAME Debug" view
j2: Changed to 16 segment display